### PR TITLE
feat: add documentation pages collapse and display in the breadcrumb

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
@@ -16,26 +16,18 @@
 
 -->
 @if (pages.length) {
-  <div class="api-tab-documentation__side-bar">
-    <app-page-tree class="api-tab-documentation__side-bar__tree" [activePage]="page" [pages]="pageNodes" (openFile)="showPage($event)" />
+  <div [ngClass]="isSidebarExpanded() ? 'api-tab-documentation__side-bar' : 'api-tab-documentation__side-bar--hidden'">
+    <app-drawer [isOpen]="isSidebarExpanded()" (collapse)="isSidebarExpanded.set($event)">
+      <app-page-tree
+        class="api-tab-documentation__side-bar__tree"
+        [activePage]="pageId()"
+        [pages]="pageNodes"
+        (openFile)="showPage($event)" />
+    </app-drawer>
   </div>
-
-  <div class="api-tab-documentation__page-content">
-    @if (selectedPageData$ | async; as selectedPageData) {
-      @if (selectedPageData.result) {
-        <app-page
-          class="api-tab-documentation__page-content__container"
-          [page]="selectedPageData.result"
-          [pages]="pages"
-          [apiId]="apiId"></app-page>
-      }
-      @if (selectedPageData.error) {
-        <div i18n="@@apiDocumentationError">An error has occurred.</div>
-      }
-    } @else {
-      <app-loader />
-    }
-  </div>
+  @if (apiId && pageId(); as pageId) {
+    <app-api-documentation [apiId]="apiId" [pages]="pages" [pageId]="pageId"></app-api-documentation>
+  }
 } @else {
   <div i18n="@@apiDocumentationEmpty" class="api-tab-documentation__empty">Documentation for this API is missing.</div>
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AsyncPipe } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { Component, Input, OnInit, signal, WritableSignal } from '@angular/core';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { catchError, map, Observable, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
-import { LoaderComponent } from '../../../../components/loader/loader.component';
-import { PageComponent } from '../../../../components/page/page.component';
+import { ApiDocumentationComponent } from './components/api-documentation/api-documentation.component';
+import { DrawerComponent } from '../../../../components/drawer/drawer.component';
 import { PageTreeComponent, PageTreeNode } from '../../../../components/page-tree/page-tree.component';
 import { Page } from '../../../../entities/page/page';
 import { PageService } from '../../../../services/page.service';
@@ -33,49 +33,35 @@ interface SelectedPageData {
 @Component({
   selector: 'app-api-tab-documentation',
   standalone: true,
-  imports: [PageTreeComponent, AsyncPipe, PageComponent, RouterModule, LoaderComponent],
+  imports: [PageTreeComponent, RouterModule, ApiDocumentationComponent, MatSidenavModule, DrawerComponent, NgClass],
   templateUrl: './api-tab-documentation.component.html',
   styleUrl: './api-tab-documentation.component.scss',
 })
-export class ApiTabDocumentationComponent implements OnInit, OnChanges {
-  @Input()
-  page!: string;
+export class ApiTabDocumentationComponent implements OnInit {
   @Input()
   apiId!: string;
   @Input()
   pages!: Page[];
   pageNodes: PageTreeNode[] = [];
   selectedPageData$: Observable<SelectedPageData> = of();
+  pageId = signal<string | undefined>(undefined);
+  isSidebarExpanded: WritableSignal<boolean> = signal(true);
 
   constructor(
-    private pageService: PageService,
-    private router: Router,
-    private activatedRoute: ActivatedRoute,
+    private readonly pageService: PageService,
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
   ) {}
 
   ngOnInit() {
     this.pageNodes = this.pageService.mapToPageTreeNode(undefined, this.pages);
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['page'] && !!changes['page'].currentValue) {
-      this.selectedPageData$ = this.getSelectedPage$(changes['page'].currentValue);
+    if (this.pageNodes.length == 1) {
+      this.isSidebarExpanded.set(false);
     }
   }
 
-  showPage(page: string) {
-    this.router.navigate(['.'], { queryParams: { page }, relativeTo: this.activatedRoute });
-  }
-
-  private getSelectedPage$(pageId: string): Observable<SelectedPageData> {
-    return this.pageService.getByApiIdAndId(this.apiId, pageId, true).pipe(
-      map(result => ({ result })),
-      catchError((error: HttpErrorResponse) => {
-        if (error.status === 404) {
-          this.router.navigate(['404']);
-        }
-        return of({ error });
-      }),
-    );
+  showPage(pageId: string) {
+    this.pageId.set(pageId);
+    this.router.navigate(['.', pageId], { relativeTo: this.activatedRoute });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="page-content">
+  @if (selectedPageData$ | async; as selectedPageData) {
+    @if (selectedPageData.result) {
+      <app-page class="page-content__container" [page]="selectedPageData.result" [pages]="pages()" [apiId]="apiId()"></app-page>
+    }
+    @if (selectedPageData.error) {
+      <div i18n="@@apiDocumentationError">An error has occurred.</div>
+    }
+  } @else {
+    <app-loader />
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.scss
@@ -13,23 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  gap: 36px;
-}
 
-.api-tab-documentation {
-  &__side-bar {
-    min-width: 276px;
-    transition: margin-left 350ms ease-in-out;
+.page-content {
+  width: 100%;
 
-    &--hidden {
-      min-width: unset;
-    }
-
-    &__tree {
-      position: sticky;
-      top: 96px;
-    }
+  &__container {
+    min-width: 0;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncPipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, effect, inject, input, InputSignal } from '@angular/core';
+import { Router, RouterModule } from '@angular/router';
+import { catchError, map, Observable, of, tap } from 'rxjs';
+import { BreadcrumbService } from 'xng-breadcrumb';
+
+import { LoaderComponent } from '../../../../../../components/loader/loader.component';
+import { PageComponent } from '../../../../../../components/page/page.component';
+import { Page } from '../../../../../../entities/page/page';
+import { PageService } from '../../../../../../services/page.service';
+
+interface SelectedPageData {
+  result?: Page;
+  error?: unknown;
+}
+
+@Component({
+  selector: 'app-api-documentation',
+  standalone: true,
+  imports: [AsyncPipe, PageComponent, RouterModule, LoaderComponent],
+  templateUrl: './api-documentation.component.html',
+  styleUrl: './api-documentation.component.scss',
+})
+export class ApiDocumentationComponent {
+  pageId: InputSignal<string> = input.required<string>();
+  apiId: InputSignal<string> = input.required<string>();
+  pages: InputSignal<Page[]> = input.required<Page[]>();
+  selectedPageData$: Observable<SelectedPageData> = of();
+  destroyRef = inject(DestroyRef);
+
+  constructor(
+    private readonly pageService: PageService,
+    private readonly router: Router,
+    private readonly breadcrumbService: BreadcrumbService,
+  ) {
+    effect(() => {
+      this.selectedPageData$ = this.getSelectedPage$(this.pageId());
+    });
+  }
+
+  private getSelectedPage$(pageId: string): Observable<SelectedPageData> {
+    return this.pageService.getByApiIdAndId(this.apiId(), pageId, true).pipe(
+      tap(page => {
+        this.breadcrumbService.set('@pageName', page.name);
+      }),
+      map(result => ({ result })),
+      catchError((error: HttpErrorResponse) => {
+        return of({ error });
+      }),
+    );
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { Routes } from '@angular/router';
 import { ApiDetailsComponent } from './api/api-details/api-details.component';
 import { ApiTabDetailsComponent } from './api/api-details/api-tab-details/api-tab-details.component';
 import { ApiTabDocumentationComponent } from './api/api-details/api-tab-documentation/api-tab-documentation.component';
+import { ApiDocumentationComponent } from './api/api-details/api-tab-documentation/components/api-documentation/api-documentation.component';
 import { ApiTabSubscriptionsComponent } from './api/api-details/api-tab-subscriptions/api-tab-subscriptions.component';
 import { SubscriptionsDetailsComponent } from './api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
 import { SubscriptionsTableComponent } from './api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component';
@@ -72,7 +73,14 @@ export const routes: Routes = [
               {
                 path: 'documentation',
                 component: ApiTabDocumentationComponent,
-                data: { breadcrumb: { skip: true } },
+                data: { breadcrumb: { label: 'Documentation', disable: true } },
+                children: [
+                  {
+                    path: ':pageId',
+                    component: ApiDocumentationComponent,
+                    data: { breadcrumb: { alias: 'pageName' } },
+                  },
+                ],
               },
               {
                 path: 'subscriptions',

--- a/gravitee-apim-portal-webui-next/src/app/guides/guides.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/guides/guides.component.spec.ts
@@ -108,8 +108,8 @@ describe('GuidesComponent', () => {
 
       const tree = await harnessLoader.getHarness(PageTreeHarness);
       const displayedItems = await tree.displayedItems();
-      expect(displayedItems).toHaveLength(2);
-      expect(displayedItems).toEqual(['a valid folder', 'valid page']);
+      expect(displayedItems).toHaveLength(1);
+      expect(displayedItems).toEqual(['a valid folder']);
     });
     it('should not show page with parentId defined but invalid', async () => {
       expectGetPages(
@@ -137,7 +137,7 @@ describe('GuidesComponent', () => {
       const markdown = await harnessLoader.getHarnessOrNull(PageMarkdownHarness);
       expect(markdown).toBeTruthy();
     });
-    it('should show folder + inner page', async () => {
+    it('should not show folder + inner page', async () => {
       expectGetPages(
         fakePagesResponse({
           data: [
@@ -151,8 +151,8 @@ describe('GuidesComponent', () => {
 
       const tree = await harnessLoader.getHarness(PageTreeHarness);
       const displayedItems = await tree.displayedItems();
-      expect(displayedItems).toHaveLength(2);
-      expect(displayedItems).toEqual(['valid folder', 'valid page']);
+      expect(displayedItems).toHaveLength(1);
+      expect(displayedItems).toEqual(['valid folder']);
 
       const markdown = await harnessLoader.getHarnessOrNull(PageMarkdownHarness);
       expect(markdown).toBeTruthy();

--- a/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.html
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<button mat-icon-button class="btn_container" (click)="close()">
+  <div class="btn_container__btn">
+    <mat-icon>
+      {{ isOpen ? 'keyboard_double_arrow_left' : 'menu' }}
+    </mat-icon>
+  </div>
+</button>
+
+<div [ngClass]="isOpen ? 'drawer-container__content' : 'drawer-container__content--hidden'">
+  <ng-content></ng-content>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.scss
@@ -13,23 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  gap: 36px;
-}
 
-.api-tab-documentation {
-  &__side-bar {
-    min-width: 276px;
-    transition: margin-left 350ms ease-in-out;
+.drawer-container {
+  &__content {
+    transition: all 300ms;
 
     &--hidden {
-      min-width: unset;
-    }
-
-    &__tree {
-      position: sticky;
-      top: 96px;
+      display: none;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.spec.ts
@@ -13,23 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  gap: 36px;
-}
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-.api-tab-documentation {
-  &__side-bar {
-    min-width: 276px;
-    transition: margin-left 350ms ease-in-out;
+import { DrawerComponent } from './drawer.component';
 
-    &--hidden {
-      min-width: unset;
-    }
+describe('DrawerComponent', () => {
+  let component: DrawerComponent;
+  let fixture: ComponentFixture<DrawerComponent>;
 
-    &__tree {
-      position: sticky;
-      top: 96px;
-    }
-  }
-}
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DrawerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/drawer/drawer.component.ts
@@ -13,23 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  gap: 36px;
-}
+import { NgClass } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
-.api-tab-documentation {
-  &__side-bar {
-    min-width: 276px;
-    transition: margin-left 350ms ease-in-out;
+@Component({
+  selector: 'app-drawer',
+  standalone: true,
+  imports: [NgClass, MatIcon, MatButtonModule],
+  templateUrl: './drawer.component.html',
+  styleUrl: './drawer.component.scss',
+})
+export class DrawerComponent {
+  @Input({ required: true }) isOpen: boolean = true;
+  @Output() collapse: EventEmitter<boolean> = new EventEmitter();
 
-    &--hidden {
-      min-width: unset;
-    }
-
-    &__tree {
-      position: sticky;
-      top: 96px;
-    }
+  close(): void {
+    this.collapse.emit(!this.isOpen);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.spec.ts
@@ -60,14 +60,14 @@ describe('PageTreeComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should be expanded by default', async () => {
+  it('should not be expanded by default', async () => {
     const fileTree = await harnessLoader.getHarness(MatTreeHarness);
-    expect(await fileTree.getNodes().then(nodes => nodes[0].isExpanded())).toEqual(true);
+    expect(await fileTree.getNodes().then(nodes => nodes[0].isExpanded())).toEqual(false);
   });
 
   it('should create a node for each page', async () => {
     const fileTree = await harnessLoader.getHarness(MatTreeHarness);
-    expect(await fileTree.getNodes().then(nodes => nodes.length)).toEqual(5);
+    expect(await fileTree.getNodes().then(nodes => nodes.length)).toEqual(2);
   });
 
   it('should select file when page has no children', async () => {
@@ -79,7 +79,7 @@ describe('PageTreeComponent', () => {
     const clickableNode = await fileTree.getNodes().then(nodes => nodes[1].host());
     await clickableNode.click();
 
-    expect(emitted).toEqual('child');
+    expect(emitted).toEqual('lone-node');
   });
 
   it('should not select file when a page has children', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
@@ -75,7 +75,6 @@ export class PageTreeComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.dataSource.data = this.pages;
-    this.treeControl.expandAll();
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6957
https://gravitee.atlassian.net/browse/APIM-6650

Description

Add documentation list collapse
Display the current page name in the breadcrumb

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tqpmmjpmxe.chromatic.com)
<!-- Storybook placeholder end -->
