### PR TITLE
APIM 7247 fix get api id from selection

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page/gv-page.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page/gv-page.component.ts
@@ -50,6 +50,8 @@ export class GvPageComponent implements OnChanges, OnDestroy {
 
   @Input() pages: Page[];
 
+  @Input() apiId?: any;
+
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
     private portalService: PortalService,
@@ -107,11 +109,15 @@ export class GvPageComponent implements OnChanges, OnDestroy {
   }
 
   private _loadPageWithContent(page: Page): Promise<Page> {
-    const apiId = this.route.snapshot.params.apiId;
+    const apiId = this.getApiId();
     if (apiId) {
       return this.apiService.getPageByApiIdAndPageId({ apiId, pageId: page.id, include: ['content'] }).toPromise();
     } else {
       return this.portalService.getPageByPageId({ pageId: page.id, include: ['content'] }).toPromise();
     }
+  }
+
+  private getApiId() {
+    return this.route.snapshot.params.apiId ?? this.apiId;
   }
 }

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.html
@@ -98,6 +98,7 @@
             class="application-creation__subscription-form__plans__gcu"
             [page]="getCurrentGeneralConditions()"
             (loaded)="refeshGeneralCondition()"
+            [apiId]="apiId"
           ></app-gv-page>
 
           <gv-checkbox

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.ts
@@ -65,6 +65,7 @@ export class ApplicationCreationStep3Component implements OnInit, OnDestroy {
   subscriptionListOptions: any;
   entrypointOptions: { label: string; value: string }[];
   selectedEntrypointSchema: Record<string, unknown>;
+  apiId?: any;
 
   private updateStepsTimer: any;
   private unsubscribe$ = new Subject();
@@ -241,6 +242,7 @@ export class ApplicationCreationStep3Component implements OnInit, OnDestroy {
 
   async onSelectApi({ detail }) {
     const api = this.apiList.find(a => a.id === detail.id).data;
+    this.apiId = api.id;
     this.planForm.get('apiId').setValue(api.id);
     this.planForm.get('channel').reset();
     this.planForm.get('entrypoint').reset();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7247

## Description

When you want to fetch a page, you need to call the right resource.

When we search an API, we have the API's id and **/apis/apiId/pages** should get called.

Earlier: **/enviroments/envId/pages** was getting called and we were getting Page Not Found Exception because of below:

![image](https://github.com/user-attachments/assets/2d8501b7-38a5-4d81-a402-4e99992e12e8).

We need to find the page by API as well as pageId and not just pageId since here we are dealing with API.

So, here in the code we bring the api id from step 3, when we select the api while creating application.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

