### PR TITLE
fix: add word break styles to container for text wrapping

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
@@ -383,6 +383,9 @@
 
 .toastui-editor-contents table td {
   border: 1px solid #eaeaea;
+  word-break: break-all; /* Break text at any character, including between letters */
+  overflow-wrap: break-word; /* Ensure text will break in the middle of words if needed */
+  white-space: normal;
 }
 
 .toastui-editor-contents table th {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.scss
@@ -60,3 +60,8 @@ $typography: map.get(gio.$mat-theme, typography);
     gap: 8px;
   }
 }
+::ng-deep table td {
+  word-break: break-all; /* Break text at any character, including between letters */
+  overflow-wrap: break-word; /* Ensure text will break in the middle of words if needed */
+  white-space: normal;
+}

--- a/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
@@ -24,7 +24,7 @@ pre {
 }
 
 table td {
-  overflow-wrap: break-word !important; /* Ensure text will break in the middle of words if needed */
-  word-break: break-all !important; /* Break text at any character, including between letters */
+  overflow-wrap: break-word !important;
   white-space: normal !important;
+  word-break: break-all !important;
 }

--- a/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,4 +21,10 @@ pre {
   white-space: pre-wrap;
   white-space: -moz-pre-wrap;
   word-wrap: break-word;
+}
+
+table td {
+  overflow-wrap: break-word !important; /* Ensure text will break in the middle of words if needed */
+  word-break: break-all !important; /* Break text at any character, including between letters */
+  white-space: normal !important;
 }

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -100,3 +100,9 @@ app-gv-markdown-toc {
   color: var(--gv-theme-font-color-light, #ffffff);
   padding-top: 6px;
 }
+
+:host ::ng-deep table td {
+  word-break: break-all; /* Break text at any character, including between letters */
+  overflow-wrap: break-word; /* Ensure text will break in the middle of words if needed */
+  white-space: normal;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7688

## Description
Added word break styles to container for text wrapping

### Webui next
Before:
<img width="1728" alt="Screenshot 2025-01-29 at 12 29 49 AM" src="https://github.com/user-attachments/assets/8e1c5d1e-0238-4c5b-801e-efe4f21f2fe6" />
After:
<img width="1728" alt="Screenshot 2025-01-28 at 11 51 35 PM" src="https://github.com/user-attachments/assets/2d591c72-7b4f-4860-81cf-fd68263f1141" />


### webui portal:
Before:
<img width="1728" alt="Screenshot 2025-01-29 at 12 32 50 AM" src="https://github.com/user-attachments/assets/63fbc4b0-80c4-4858-9ed6-e214b451b628" />
After:
<img width="1728" alt="Screenshot 2025-01-28 at 11 50 56 PM" src="https://github.com/user-attachments/assets/9220bf08-b7aa-432e-9a23-bf8282b8554a" />


### webui console
Before:
<img width="1728" alt="Screenshot 2025-01-29 at 12 35 30 AM" src="https://github.com/user-attachments/assets/2282c704-25b8-48d3-9f7f-c0ed9a6c078c" />
After:
<img width="1728" alt="Screenshot 2025-01-28 at 11 50 37 PM" src="https://github.com/user-attachments/assets/4e56e00f-e477-4f81-b85f-112f91a1275f" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rwewwxhmkb.chromatic.com)
<!-- Storybook placeholder end -->
