### PR TITLE
fix: generate http-proxy endpoint default shared config when importing

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -39,6 +40,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Schema(name = "ConnectorPluginEntityV4")
+@SuperBuilder
 public class ConnectorPluginEntity extends PlatformPluginEntity {
 
     private ApiType supportedApiType;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
@@ -117,7 +117,7 @@ public class OAIToImportApiUseCase {
     }
 
     private ImportDefinition addEndpointGroupSharedConfiguration(ImportDefinition importDefinition) {
-        var sharedConfiguration = endpointConnectorPluginService.getSharedConfigurationSchema("http-proxy");
+        var sharedConfiguration = endpointConnectorPluginService.getDefaultSharedConfiguration("http-proxy");
         var endpointGroups = importDefinition.getApiExport().getEndpointGroups();
         if (endpointGroups == null || endpointGroups.isEmpty()) {
             return importDefinition;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/EndpointConnectorPluginDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/EndpointConnectorPluginDomainService.java
@@ -16,5 +16,10 @@
 package io.gravitee.apim.core.plugin.domain_service;
 
 public interface EndpointConnectorPluginDomainService {
-    String getSharedConfigurationSchema(String connectorId);
+    /**
+     * Return the default shared configuration for the given connector based on the plugin schema.
+     * @param connectorId The connector ID
+     * @return The default shared configuration
+     */
+    String getDefaultSharedConfiguration(String connectorId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plugin/EndpointConnectorPluginLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plugin/EndpointConnectorPluginLegacyWrapper.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.plugin;
 
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ public class EndpointConnectorPluginLegacyWrapper implements EndpointConnectorPl
     private final EndpointConnectorPluginService endpointConnectorPluginService;
 
     @Override
-    public String getSharedConfigurationSchema(String connectorId) {
-        return endpointConnectorPluginService.getSharedConfigurationSchema(connectorId);
+    public String getDefaultSharedConfiguration(String connectorId) {
+        return endpointConnectorPluginService.validateSharedConfiguration(ConnectorPluginEntity.builder().id(connectorId).build(), "{}");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -34,11 +34,11 @@ import inmemory.TagQueryServiceInMemory;
 import io.gravitee.apim.core.api.exception.InvalidImportWithOASValidationPolicyException;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.apim.core.tag.model.Tag;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
-import io.gravitee.apim.infra.domain_service.plugin.EndpointConnectorPluginLegacyWrapper;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
@@ -69,7 +69,7 @@ class OAIToImportApiUseCaseTest {
     private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
     private final PolicyOperationVisitorManagerImpl policyOperationVisitorManager = new PolicyOperationVisitorManagerImpl();
     private final OAIDomainServiceImpl oaiDomainService = new OAIDomainServiceImpl(policyOperationVisitorManager);
-    private final EndpointConnectorPluginLegacyWrapper endpointConnectorPluginService = mock(EndpointConnectorPluginLegacyWrapper.class);
+    private final EndpointConnectorPluginDomainService endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
     private OAIToImportApiUseCase useCase;
     ImportDefinitionCreateDomainServiceTestInitializer importDefinitionCreateDomainServiceTestInitializer;
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
@@ -87,7 +87,7 @@ class OAIToImportApiUseCaseTest {
             )
         );
 
-        when(endpointConnectorPluginService.getSharedConfigurationSchema(anyString())).thenReturn(SHARED_CONFIGURATION);
+        when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn(SHARED_CONFIGURATION);
 
         importDefinitionCreateDomainServiceTestInitializer.parametersQueryService.initWith(
             List.of(
@@ -164,7 +164,7 @@ class OAIToImportApiUseCaseTest {
 
     @Test
     @SneakyThrows
-    void should_add_shared_configuration_in_endpoint_group() {
+    void should_add_default_shared_configuration_in_endpoint_group() {
         // Given
         var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
         var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7877

## Description

When we were importing an OpenAPI spec to create an API, we were setting the endpoint JSON Schema as value for the endpoint group shared config. It was wrong but had no impact on the gateway that was ignoring unknown attributes. However, the scoring feature was throwing an error because the produced GraviteeDefinition was not a well-formed JSON object.

A workaround (https://github.com/gravitee-io/gravitee-api-management/pull/10117) has been implemented, but the original cause was we should use the JSON schema as value for the endpoint group shared config.

This commit fixes this by relying on the JSON Schema validator that will generate a valid configuration with default values


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

