### PR TITLE
refactor: use new ApiExportDomainService to export API

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/Selector.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/Selector.java
@@ -17,11 +17,8 @@ package io.gravitee.definition.model.v4.flow.selector;
 
 import static io.gravitee.definition.model.v4.flow.selector.Selector.*;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import jakarta.validation.constraints.NotNull;
-import java.io.Serializable;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMediaRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMediaRepository.java
@@ -22,8 +22,6 @@ import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.search.MediaCriteria;
 import io.gravitee.repository.media.api.MediaRepository;
 import io.gravitee.repository.media.model.Media;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,7 +31,6 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Repository;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DateMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DateMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -28,17 +29,19 @@ public interface DateMapper {
     DateMapper INSTANCE = Mappers.getMapper(DateMapper.class);
 
     default OffsetDateTime map(Date value) {
-        if (Objects.isNull(value)) {
-            return null;
-        }
-        return value.toInstant().atOffset(ZoneOffset.UTC);
+        return Objects.isNull(value) ? null : value.toInstant().atOffset(ZoneOffset.UTC);
     }
 
     default Date map(OffsetDateTime offsetDateTime) {
-        if (Objects.isNull(offsetDateTime)) {
-            return null;
-        }
-        return Date.from(offsetDateTime.toInstant());
+        return Objects.isNull(offsetDateTime) ? null : Date.from(offsetDateTime.toInstant());
+    }
+
+    default OffsetDateTime map(Instant value) {
+        return Objects.isNull(value) ? null : value.atOffset(ZoneOffset.UTC);
+    }
+
+    default Instant mapToInstant(OffsetDateTime value) {
+        return Objects.isNull(value) ? null : value.toInstant();
     }
 
     @Named("mapTimestamp")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
@@ -15,36 +15,126 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
+import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.EndpointV4;
+import io.gravitee.rest.api.management.v2.rest.model.Entrypoint;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.Member;
 import io.gravitee.rest.api.management.v2.rest.model.Metadata;
-import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
 import io.gravitee.rest.api.model.ApiMetadataEntity;
 import io.gravitee.rest.api.model.MemberEntity;
-import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.model.v4.api.ExportApiEntity;
-import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
-import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
-import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = { ApiMapper.class, DateMapper.class, MemberMapper.class, MetadataMapper.class, PageMapper.class, PlanMapper.class })
+@Mapper(
+    uses = {
+        ApiMapper.class, DateMapper.class, MemberMapper.class, MetadataMapper.class, PageMapper.class, PlanMapper.class, FlowMapper.class,
+    }
+)
 public interface ImportExportApiMapper {
     ImportExportApiMapper INSTANCE = Mappers.getMapper(ImportExportApiMapper.class);
+    GraviteeMapper JSON_MAPPER = new GraviteeMapper();
 
-    @Mapping(target = "apiPicture", source = "apiEntity.picture")
-    @Mapping(target = "apiBackground", source = "apiEntity.background")
-    @Mapping(target = "api", source = "apiEntity")
-    @Mapping(target = "plans", source = "plans", qualifiedByName = "toPlanV4Nullable")
-    ExportApiV4 map(ExportApiEntity exportApiEntityV4);
+    default ExportApiV4 map(GraviteeDefinition src) {
+        return switch (src) {
+            case null -> null;
+            case GraviteeDefinition.V4 v4 -> map(v4);
+            case GraviteeDefinition.Native natV4 -> map(natV4);
+            case GraviteeDefinition.GraviteeDefinitionFederated fed -> throw new IllegalStateException("Unexpected API: " + src);
+        };
+    }
+
+    ExportApiV4 map(GraviteeDefinition.V4 exportApiEntityV4);
+
+    ExportApiV4 map(GraviteeDefinition.Native exportApiEntityV4);
+
+    default ApiV4 map(ApiDescriptor src) {
+        return switch (src) {
+            case null -> null;
+            case ApiDescriptor.ApiDescriptorV4 v4 -> map(v4);
+            case ApiDescriptor.ApiDescriptorNative natV4 -> map(natV4);
+            case ApiDescriptor.ApiDescriptorFederated fed -> throw new IllegalStateException("Unexpected API: " + src);
+        };
+    }
+
+    ApiV4 map(ApiDescriptor.ApiDescriptorV4 src);
+
+    @Mapping(target = "type", constant = "NATIVE")
+    ApiV4 map(ApiDescriptor.ApiDescriptorNative src);
+
+    default io.gravitee.rest.api.management.v2.rest.model.Listener map(Listener src) {
+        return switch (src) {
+            case null -> null;
+            case HttpListener http -> new io.gravitee.rest.api.management.v2.rest.model.Listener(mapHttpListener(http));
+            case SubscriptionListener subscription -> new io.gravitee.rest.api.management.v2.rest.model.Listener(
+                mapSubscriptionListener(subscription)
+            );
+            case TcpListener tcp -> new io.gravitee.rest.api.management.v2.rest.model.Listener(mapTcpListener(tcp));
+            default -> throw new IllegalStateException("Unexpected value: " + src);
+        };
+    }
+
+    io.gravitee.rest.api.management.v2.rest.model.HttpListener mapHttpListener(HttpListener http);
+    io.gravitee.rest.api.management.v2.rest.model.SubscriptionListener mapSubscriptionListener(SubscriptionListener subscription);
+    io.gravitee.rest.api.management.v2.rest.model.TcpListener mapTcpListener(TcpListener tcp);
+
+    default io.gravitee.rest.api.management.v2.rest.model.Listener map(NativeListener src) {
+        return switch (src) {
+            case null -> null;
+            case KafkaListener kafka -> new io.gravitee.rest.api.management.v2.rest.model.Listener(mapKafkaListener(kafka));
+            default -> throw new IllegalStateException("Unexpected value: " + src);
+        };
+    }
+
+    io.gravitee.rest.api.management.v2.rest.model.KafkaListener mapKafkaListener(KafkaListener kafka);
+
+    @SneakyThrows
+    @AfterMapping
+    default void mapConfiguration(Object ignored, @MappingTarget Entrypoint target) {
+        if (target.getConfiguration() instanceof String conf) {
+            target.setConfiguration(JSON_MAPPER.readTree(conf));
+        }
+    }
+
+    @SneakyThrows
+    @AfterMapping
+    default void mapConfiguration(Object ignored, @MappingTarget EndpointV4 target) {
+        if (target.getConfiguration() instanceof String conf) {
+            target.setConfiguration(JSON_MAPPER.readTree(conf));
+        }
+    }
+
+    default Map<String, Map<String, io.gravitee.rest.api.management.v2.rest.model.ResponseTemplate>> map(
+        Map<String, Map<String, ResponseTemplate>> value
+    ) {
+        return stream(value.entrySet())
+            .map(e ->
+                Map.entry(e.getKey(), stream(e.getValue().entrySet()).collect(Collectors.toMap(Map.Entry::getKey, o -> map(o.getValue()))))
+            )
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    io.gravitee.rest.api.management.v2.rest.model.ResponseTemplate map(ResponseTemplate value);
 
     @Mapping(target = "apiExport", expression = "java(buildApiExport(exportApiV4))")
     ImportDefinition toImportDefinition(ExportApiV4 exportApiV4);
@@ -59,14 +149,6 @@ public interface ImportExportApiMapper {
         apiExport.setPicture(exportApiV4.getApiPicture());
         apiExport.setBackground(exportApiV4.getApiBackground());
         return apiExport;
-    }
-
-    @Named("toPlanV4Nullable")
-    default Set<PlanV4> toPlanV4Nullable(Set<? extends GenericPlanEntity> plans) {
-        if (plans == null) {
-            return null;
-        }
-        return PlanMapper.INSTANCE.map(plans);
     }
 
     @Mapping(target = "apiId", expression = "java(apiId)")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.model.crd.PageCRD;
+import io.gravitee.apim.core.api.model.import_definition.PageExport;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.use_case.ApiUpdateDocumentationPageUseCase;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -101,7 +102,7 @@ public interface PageMapper {
     @Mapping(target = "createdAt", source = "createAt")
     Media mapMedia(MediaEntity mediaEntity);
 
-    @Mapping(target = "uploadDate", source = "createdAt")
+    @Mapping(target = "createAt", source = "createdAt")
     MediaEntity mapMedia(Media media);
 
     @Mapping(target = "type", source = "type")
@@ -180,4 +181,16 @@ public interface PageMapper {
         }
         return null;
     }
+
+    @Mapping(target = "hash", source = "mediaHash")
+    @Mapping(target = "name", source = "mediaName")
+    PageMedia map(io.gravitee.apim.core.documentation.model.PageMedia pageEntity);
+
+    @Mapping(target = "source.configuration", qualifiedByName = "deserializeConfiguration")
+    @Mapping(target = "contentRevision", source = "contentRevisionId")
+    @Mapping(target = "translations", source = "translations")
+    io.gravitee.rest.api.management.v2.rest.model.Page mapPage(PageExport src);
+
+    @Mapping(target = "createAt", source = "createdAt")
+    MediaEntity mapMedia(io.gravitee.apim.core.media.model.Media media);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
 import io.gravitee.apim.core.plan.model.PlanUpdates;
 import io.gravitee.apim.core.plan.model.PlanWithFlows;
 import io.gravitee.apim.core.utils.CollectionUtils;
@@ -94,6 +95,16 @@ public interface PlanMapper {
     @Mapping(target = "flows", expression = "java(computeFlows(source))")
     @Mapping(target = "definitionVersion", constant = "V4")
     PlanV4 map(PlanWithFlows source);
+
+    default <T extends PlanDescriptor> PlanV4 map(T source) {
+        return switch (source) {
+            case PlanDescriptor.PlanDescriptorV4 v4 -> map(v4);
+        };
+    }
+
+    @Mapping(target = "security.type", source = "security.type", qualifiedByName = "mapToPlanSecurityType")
+    @Mapping(target = "security.configuration", source = "security.configuration", qualifiedByName = "deserializeConfiguration")
+    PlanV4 map(PlanDescriptor.PlanDescriptorV4 source);
 
     @Mapping(target = "status", source = "federatedPlanDefinition.status")
     @Mapping(target = "mode", source = "federatedPlanDefinition.mode")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
+import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
@@ -87,7 +87,6 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.model.v4.api.ExportApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
@@ -109,7 +108,6 @@ import io.gravitee.rest.api.service.exceptions.InvalidLicenseException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiImagesService;
-import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
@@ -171,7 +169,7 @@ public class ApiResource extends AbstractResource {
     private ApiImagesService apiImagesService;
 
     @Inject
-    private ApiImportExportService apiImportExportService;
+    private ExportApiUseCase exportApiUseCase;
 
     @Inject
     private SubscriptionService subscriptionService;
@@ -476,24 +474,15 @@ public class ApiResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.READ) })
     public Response exportApiDefinition(
-        @Context HttpHeaders headers,
         @PathParam("apiId") String apiId,
         @QueryParam("excludeAdditionalData") Set<String> excludeAdditionalData
     ) {
-        if (excludeAdditionalData == null) {
-            excludeAdditionalData = Set.of();
-        }
-
-        ExportApiEntity exportApiEntity = apiImportExportService.exportApi(
-            GraviteeContext.getExecutionContext(),
-            apiId,
-            getAuthenticatedUser(),
-            excludeAdditionalData
-        );
+        var input = ExportApiUseCase.Input.of(apiId, getAuditInfo(), excludeAdditionalData);
+        var export = exportApiUseCase.execute(input);
 
         return Response
-            .ok(ImportExportApiMapper.INSTANCE.map(exportApiEntity))
-            .header(HttpHeaders.CONTENT_DISPOSITION, format("attachment;filename=%s", getExportFilename(exportApiEntity.getApiEntity())))
+            .ok(ImportExportApiMapper.INSTANCE.map(export.definition()))
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=%s".formatted(export.filename()))
             .build();
     }
 
@@ -988,16 +977,6 @@ public class ApiResource extends AbstractResource {
                 throw new BadRequestException("API cannot be started without being reviewed");
             }
         }
-    }
-
-    private String getExportFilename(GenericApiEntity apiEntity) {
-        return format("%s-%s.%s", apiEntity.getName(), apiEntity.getApiVersion(), "json")
-            .trim()
-            .toLowerCase()
-            .replaceAll(" +", " ")
-            .replaceAll(" ", "-")
-            .replaceAll("[^\\w\\s\\.]", "-")
-            .replaceAll("-+", "-");
     }
 
     private Response imageResponse(final Request request, InlinePictureEntity image) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3153,6 +3153,17 @@ components:
         ExportApiV4:
             type: object
             properties:
+                export:
+                  type: object
+                  properties:
+                    date:
+                      type: string
+                      format: date-time
+                      description: The datetime of export.
+                      example: 2023-05-25T12:40:46.184Z
+                    apimVersion:
+                      type: string
+                      description: API management version of export.
                 api:
                     $ref: "#/components/schemas/ApiV4"
                 members:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -34,11 +34,10 @@ import inmemory.PrimaryOwnerDomainServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
-import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.group.model.Group;
-import io.gravitee.apim.core.specgen.service_provider.SpecGenProvider;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -62,7 +61,6 @@ import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
-import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
 import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
@@ -111,7 +109,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected io.gravitee.rest.api.service.v4.ApiImagesService apiImagesService;
 
     @Autowired
-    protected ApiImportExportService apiImportExportService;
+    protected ExportApiUseCase exportApiUseCase;
 
     @Autowired
     protected PermissionService permissionService;
@@ -217,9 +215,6 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected SpecGenRequestUseCase specGenRequestUseCase;
-
-    @Autowired
-    protected ApiExportDomainService apiExportDomainService;
 
     @Autowired
     protected GroupCrudServiceInMemory groupCrudServiceInMemory;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -43,7 +43,7 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
         Mockito.reset(
             apiSearchServiceV4,
             apiImagesService,
-            apiImportExportService,
+            exportApiUseCase,
             apiStateServiceV4,
             parameterService,
             workflowService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
@@ -18,22 +18,25 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.doThrow;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.gravitee.apim.core.api.model.NewApiMetadata;
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.api.model.import_definition.ApiMember;
+import io.gravitee.apim.core.api.model.import_definition.ApiMemberRole;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
+import io.gravitee.apim.core.api.model.import_definition.PageExport;
+import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
+import io.gravitee.apim.core.documentation.model.AccessControl;
+import io.gravitee.apim.core.documentation.model.PageMedia;
+import io.gravitee.apim.core.documentation.model.PageSource;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpMethod;
-import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.Properties;
-import io.gravitee.definition.model.Proxy;
-import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.flow.Operator;
-import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -69,40 +72,25 @@ import io.gravitee.rest.api.management.v2.rest.model.PageType;
 import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
 import io.gravitee.rest.api.management.v2.rest.model.PlanValidation;
 import io.gravitee.rest.api.management.v2.rest.model.Role;
-import io.gravitee.rest.api.model.AccessControlEntity;
-import io.gravitee.rest.api.model.ApiMetadataEntity;
-import io.gravitee.rest.api.model.MediaEntity;
-import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MetadataFormat;
 import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.model.PageMediaEntity;
-import io.gravitee.rest.api.model.PageSourceEntity;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.model.v4.api.ExportApiEntity;
-import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
-import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanType;
-import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import jakarta.ws.rs.core.Response;
-import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -110,8 +98,6 @@ import org.junit.jupiter.api.Test;
  * @author GraviteeSource Team
  */
 public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
-
-    private static final Set<String> EXCLUDE_ADDITIONAL_DATA = Set.of();
 
     @Override
     protected String contextPath() {
@@ -130,126 +116,96 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         )
             .thenReturn(false);
         Response response = rootTarget().request().get();
-        assertEquals(FORBIDDEN_403, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
     }
 
     @Test
     public void should_not_export_v2_apis() {
-        doThrow(new ApiDefinitionVersionNotSupportedException("2.0.0"))
-            .when(apiImportExportService)
-            .exportApi(GraviteeContext.getExecutionContext(), API, USER_NAME, EXCLUDE_ADDITIONAL_DATA);
+        when(exportApiUseCase.execute(any())).thenThrow(new ApiDefinitionVersionNotSupportedException("2.0.0"));
         Response response = rootTarget().request().get();
-        assertEquals(BAD_REQUEST_400, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
     }
 
     @Test
-    public void should_export_ApiEntityV4() throws JsonProcessingException {
-        when(apiImportExportService.exportApi(GraviteeContext.getExecutionContext(), API, USER_NAME, EXCLUDE_ADDITIONAL_DATA))
-            .thenReturn(this.fakeExportApiEntity(fakeApiEntityV4()));
+    public void should_export_ApiEntityV4() {
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(fakeExportApiEntity(fakeApiEntityV4())));
 
         Response response = rootTarget().request().get();
-        assertEquals(OK_200, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(OK_200);
 
         final ExportApiV4 export = response.readEntity(ExportApiV4.class);
-        assertNotNull(export.getMembers());
-        assertNotNull(export.getMetadata());
-        assertNotNull(export.getPlans());
-        assertNotNull(export.getPages());
-        assertNotNull(export.getApi());
+        assertThat(export.getMembers()).isNotNull();
+        assertThat(export.getMetadata()).isNotNull();
+        assertThat(export.getPlans()).isNotNull();
+        assertThat(export.getPages()).isNotNull();
+        assertThat(export.getApi()).isNotNull();
 
-        final ApiV4 api = export.getApi();
-        testReturnedApi(api);
+        testReturnedApi(export.getApi());
 
-        final Set<Member> members = export.getMembers();
-        testReturnedMembers(members);
+        testReturnedMembers(export.getMembers());
 
-        final Set<Metadata> metadata = export.getMetadata();
-        testReturnedMetadata(metadata);
+        testReturnedMetadata(export.getMetadata());
 
-        final Set<PlanV4> plans = export.getPlans();
-        testReturnedPlans(plans);
+        testReturnedPlans(export.getPlans());
 
-        final Set<Page> pages = export.getPages();
-        final List<Media> mediaList = export.getApiMedia();
-        testReturnedPages(pages);
-        testReturnedMedia(mediaList);
+        testReturnedPages(export.getPages());
+        assertThat(export.getApiMedia()).hasSize(1).have(testReturnedMedia());
     }
 
     @Test
-    public void should_export_NativeApiEntityV4() throws JsonProcessingException {
-        when(apiImportExportService.exportApi(GraviteeContext.getExecutionContext(), API, USER_NAME, EXCLUDE_ADDITIONAL_DATA))
-            .thenReturn(this.fakeExportApiEntity(fakeNativeApiEntityV4()));
+    public void should_export_NativeApiEntityV4() {
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(fakeExportApiEntity(fakeNativeApiEntityV4())));
 
         Response response = rootTarget().request().get();
-        assertEquals(OK_200, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(OK_200);
 
-        final ExportApiV4 export = response.readEntity(ExportApiV4.class);
-        assertNotNull(export.getMembers());
-        assertNotNull(export.getMetadata());
-        assertNotNull(export.getPlans());
-        assertNotNull(export.getPages());
-        assertNotNull(export.getApi());
+        var export = response.readEntity(ExportApiV4.class);
+        assertThat(export.getMembers()).isNotNull();
+        assertThat(export.getMetadata()).isNotNull();
+        assertThat(export.getPlans()).isNotNull();
+        assertThat(export.getPages()).isNotNull();
+        assertThat(export.getApi()).isNotNull();
 
-        final ApiV4 api = export.getApi();
-        testReturnedNativeApi(api);
+        testReturnedNativeApi(export.getApi());
 
-        final Set<Member> members = export.getMembers();
-        testReturnedMembers(members);
+        testReturnedMembers(export.getMembers());
 
-        final Set<Metadata> metadata = export.getMetadata();
-        testReturnedMetadata(metadata);
+        testReturnedMetadata(export.getMetadata());
 
-        final Set<PlanV4> plans = export.getPlans();
-        testReturnedPlans(plans);
+        testReturnedPlans(export.getPlans());
 
-        final Set<Page> pages = export.getPages();
-        final List<Media> mediaList = export.getApiMedia();
-        testReturnedPages(pages);
-        testReturnedMedia(mediaList);
+        testReturnedPages(export.getPages());
+        assertThat(export.getApiMedia()).hasSize(1).have(testReturnedMedia());
     }
 
-    // Fakers
-    private io.gravitee.rest.api.model.api.ApiEntity fakeApiEntityV2() {
-        var apiEntity = new io.gravitee.rest.api.model.api.ApiEntity();
-        apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
-        apiEntity.setId(API);
-        apiEntity.setName(API);
-
-        var proxy = new Proxy();
-        proxy.setVirtualHosts(List.of(new VirtualHost("host.io", "/test")));
-        apiEntity.setProxy(proxy);
-        var properties = new Properties();
-        properties.setProperties(List.of(new io.gravitee.definition.model.Property("key", "value")));
-        apiEntity.setProperties(properties);
-        apiEntity.setServices(new Services());
-        apiEntity.setResources(List.of(new io.gravitee.definition.model.plugins.resources.Resource()));
-        apiEntity.setResponseTemplates(Map.of("key", new HashMap<>()));
-        apiEntity.setUpdatedAt(new Date());
-
-        return apiEntity;
+    private GraviteeDefinition fakeExportApiEntity(ApiDescriptor apiEntity) {
+        return switch (apiEntity) {
+            case ApiDescriptor.ApiDescriptorV4 v4 -> new GraviteeDefinition.V4(
+                v4,
+                fakeApiMembers(),
+                fakeApiMetadata(),
+                fakeApiPages(),
+                fakeApiPlans(),
+                fakeApiMedia(),
+                null,
+                null
+            );
+            case ApiDescriptor.ApiDescriptorNative v4Native -> new GraviteeDefinition.Native(
+                v4Native,
+                fakeApiMembers(),
+                fakeApiMetadata(),
+                fakeApiPages(),
+                fakeApiPlans(),
+                fakeApiMedia(),
+                null,
+                null
+            );
+            case null, default -> throw new RuntimeException("Unsupported api descriptor");
+        };
     }
 
-    private ExportApiEntity fakeExportApiEntity(GenericApiEntity apiEntity) {
-        var exportApiEntity = new ExportApiEntity();
-        exportApiEntity.setApiEntity(apiEntity);
-        exportApiEntity.setApiMedia(fakeApiMedia());
-        exportApiEntity.setMembers(fakeApiMembers());
-        exportApiEntity.setMetadata(fakeApiMetadata());
-        exportApiEntity.setPages(fakeApiPages());
-        exportApiEntity.setPlans(fakeApiPlans());
-
-        return exportApiEntity;
-    }
-
-    private ApiEntity fakeApiEntityV4() {
-        var apiEntity = new ApiEntity();
-        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
-        apiEntity.setId(API);
-        apiEntity.setName(API);
-        apiEntity.setApiVersion("v1.0");
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("my.fake.host", "/test")));
-        httpListener.setPathMappings(Set.of("/test"));
+    private ApiDescriptor.ApiDescriptorV4 fakeApiEntityV4() {
+        var httpListener = HttpListener.builder().paths(List.of(new Path("my.fake.host", "/test"))).pathMappings(Set.of("/test")).build();
 
         SubscriptionListener subscriptionListener = new SubscriptionListener();
         Entrypoint entrypoint = new Entrypoint();
@@ -264,36 +220,28 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         tcpListener.setType(ListenerType.TCP);
         tcpListener.setEntrypoints(List.of(entrypoint));
 
-        apiEntity.setListeners(List.of(httpListener, subscriptionListener, tcpListener));
-        apiEntity.setProperties(List.of(new Property()));
-        apiEntity.setServices(new ApiServices());
-        apiEntity.setResources(List.of(new Resource()));
-        apiEntity.setResponseTemplates(Map.of("key", new HashMap<>()));
-        apiEntity.setUpdatedAt(new Date());
-        apiEntity.setAnalytics(new Analytics());
-
-        EndpointGroup endpointGroup = new EndpointGroup();
-        endpointGroup.setType("http-get");
-        Endpoint endpoint = new Endpoint();
-        endpoint.setType("http-get");
-        endpoint.setConfiguration(
-            "{\n" +
-            "                        \"bootstrapServers\": \"kafka:9092\",\n" +
-            "                        \"topics\": [\n" +
-            "                            \"demo\"\n" +
-            "                        ],\n" +
-            "                        \"producer\": {\n" +
-            "                            \"enabled\": false\n" +
-            "                        },\n" +
-            "                        \"consumer\": {\n" +
-            "                            \"encodeMessageId\": true,\n" +
-            "                            \"enabled\": true,\n" +
-            "                            \"autoOffsetReset\": \"earliest\"\n" +
-            "                        }\n" +
-            "                    }"
-        );
-        endpointGroup.setEndpoints(List.of(endpoint));
-        apiEntity.setEndpointGroups(List.of(endpointGroup));
+        var endpoint = Endpoint
+            .builder()
+            .type("http-get")
+            .configuration(
+                """
+                        {
+                                                "bootstrapServers": "kafka:9092",
+                                                "topics": [
+                                                    "demo"
+                                                ],
+                                                "producer": {
+                                                    "enabled": false
+                                                },
+                                                "consumer": {
+                                                    "encodeMessageId": true,
+                                                    "enabled": true,
+                                                    "autoOffsetReset": "earliest"
+                                                }
+                                            }"""
+            )
+            .build();
+        var endpointGroup = EndpointGroup.builder().type("http-get").endpoints(List.of(endpoint)).build();
 
         Flow flow = new Flow();
         flow.setName("flowName");
@@ -321,131 +269,84 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         conditionSelector.setCondition("my-condition");
 
         flow.setSelectors(List.of(httpSelector, channelSelector, conditionSelector));
-        apiEntity.setFlows(List.of(flow));
 
-        return apiEntity;
+        return ApiDescriptor.ApiDescriptorV4
+            .builder()
+            .id(API)
+            .name(API)
+            .apiVersion("v1.0")
+            .listeners(List.of(httpListener, subscriptionListener, tcpListener))
+            .properties(List.of(new Property()))
+            .services(new ApiServices())
+            .resources(List.of(new Resource()))
+            .responseTemplates(Map.of("key", new HashMap<>()))
+            .updatedAt(Instant.now())
+            .analytics(new Analytics())
+            .endpointGroups(List.of(endpointGroup))
+            .flows(List.of(flow))
+            .build();
     }
 
-    private NativeApiEntity fakeNativeApiEntityV4() {
-        var apiEntity = new NativeApiEntity();
-        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
-        apiEntity.setId(API);
-        apiEntity.setName(API);
-        apiEntity.setApiVersion("v1.0");
-        KafkaListener kafkaListener = new KafkaListener();
-        kafkaListener.setHost("my.fake.host");
+    private ApiDescriptor.ApiDescriptorNative fakeNativeApiEntityV4() {
+        var endpoint = NativeEndpoint.builder().type("kafka").configuration("{\"bootstrapServers\": \"kafka:9092\"}").build();
+        var endpointGroup = NativeEndpointGroup.builder().type("kafka").endpoints(List.of(endpoint)).build();
 
-        SubscriptionListener subscriptionListener = new SubscriptionListener();
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("Entrypoint type");
-        entrypoint.setQos(Qos.AT_LEAST_ONCE);
-        entrypoint.setDlq(new Dlq("my-endpoint"));
-        entrypoint.setConfiguration("{\n \"nice\" : \"configuration\"\n}");
-        subscriptionListener.setEntrypoints(List.of(entrypoint));
-        subscriptionListener.setType(ListenerType.SUBSCRIPTION);
+        var kafkaListener = KafkaListener.builder().host("my.fake.host").build();
+        var step = Step.builder().enabled(true).policy("my-policy").condition("my-condition").build();
 
-        TcpListener tcpListener = new TcpListener();
-        tcpListener.setType(ListenerType.TCP);
-        tcpListener.setEntrypoints(List.of(entrypoint));
+        var flow = NativeFlow.builder().name("flowName").enabled(true).interact(List.of(step)).tags(Set.of("tag1", "tag2")).build();
 
-        apiEntity.setListeners(List.of(kafkaListener));
-        apiEntity.setProperties(List.of(new Property()));
-        apiEntity.setResources(List.of(new Resource()));
-        apiEntity.setUpdatedAt(new Date());
-
-        NativeEndpointGroup endpointGroup = new NativeEndpointGroup();
-        endpointGroup.setType("kafka");
-        NativeEndpoint endpoint = new NativeEndpoint();
-        endpoint.setType("kafka");
-        endpoint.setConfiguration("{\"bootstrapServers\": \"kafka:9092\"}");
-        endpointGroup.setEndpoints(List.of(endpoint));
-        apiEntity.setEndpointGroups(List.of(endpointGroup));
-
-        NativeFlow flow = new NativeFlow();
-        flow.setName("flowName");
-        flow.setEnabled(true);
-
-        Step step = new Step();
-        step.setEnabled(true);
-        step.setPolicy("my-policy");
-        step.setCondition("my-condition");
-        flow.setInteract(List.of(step));
-        flow.setTags(Set.of("tag1", "tag2"));
-
-        HttpSelector httpSelector = new HttpSelector();
-        httpSelector.setPath("/test");
-        httpSelector.setMethods(Set.of(HttpMethod.GET, HttpMethod.POST));
-        httpSelector.setPathOperator(Operator.STARTS_WITH);
-
-        apiEntity.setFlows(List.of(flow));
-
-        return apiEntity;
+        return ApiDescriptor.ApiDescriptorNative
+            .builder()
+            .id(API)
+            .name(API)
+            .apiVersion("v1.0")
+            .listeners(List.of(kafkaListener))
+            .properties(List.of(new Property()))
+            .resources(List.of(new Resource()))
+            .updatedAt(Instant.now())
+            .endpointGroups(List.of(endpointGroup))
+            .flows(List.of(flow))
+            .build();
     }
 
-    private Set<MemberEntity> fakeApiMembers() {
-        var role = new RoleEntity();
-        role.setName("OWNER");
-        var userMember = new MemberEntity();
+    private Set<ApiMember> fakeApiMembers() {
+        var userMember = new ApiMember();
         userMember.setId("memberId");
         userMember.setDisplayName("John Doe");
-        userMember.setRoles(List.of(role));
+        userMember.setRoles(List.of(ApiMemberRole.builder().name("OWNER").build()));
         userMember.setType(MembershipMemberType.USER);
 
-        var poRole = new RoleEntity();
-        poRole.setName("PRIMARY_OWNER");
-        var poUserMember = new MemberEntity();
+        var poUserMember = new ApiMember();
         poUserMember.setId("poMemberId");
         poUserMember.setDisplayName("Thomas Pesquet");
-        poUserMember.setRoles(List.of(poRole));
+        poUserMember.setRoles(List.of(ApiMemberRole.builder().name("PRIMARY_OWNER").build()));
         poUserMember.setType(MembershipMemberType.USER);
 
         return Set.of(userMember, poUserMember);
     }
 
-    private Set<ApiMetadataEntity> fakeApiMetadata() {
-        ApiMetadataEntity firstMetadata = new ApiMetadataEntity();
+    private Set<NewApiMetadata> fakeApiMetadata() {
+        var firstMetadata = new NewApiMetadata();
         firstMetadata.setApiId(API);
         firstMetadata.setKey("my-metadata-1");
         firstMetadata.setName("My first metadata");
-        firstMetadata.setFormat(MetadataFormat.NUMERIC);
+        firstMetadata.setFormat(io.gravitee.apim.core.metadata.model.Metadata.MetadataFormat.NUMERIC);
         firstMetadata.setValue("1");
         firstMetadata.setDefaultValue("5");
 
-        ApiMetadataEntity secondMetadata = new ApiMetadataEntity();
+        var secondMetadata = new NewApiMetadata();
         secondMetadata.setApiId(API);
         secondMetadata.setKey("my-metadata-2");
         secondMetadata.setName("My second metadata");
-        secondMetadata.setFormat(MetadataFormat.STRING);
+        secondMetadata.setFormat(io.gravitee.apim.core.metadata.model.Metadata.MetadataFormat.STRING);
         secondMetadata.setValue("Very important data !!");
         secondMetadata.setDefaultValue("Important data");
 
         return Set.of(firstMetadata, secondMetadata);
     }
 
-    private Set<PlanEntity> fakeApiPlans() {
-        PlanEntity planEntity = new PlanEntity();
-        planEntity.setApiId(API);
-        planEntity.setCharacteristics(List.of("characteristic1", "characteristic2"));
-        planEntity.setCommentMessage("commentMessage");
-        planEntity.setCommentRequired(true);
-        planEntity.setCrossId("crossId");
-        planEntity.setCreatedAt(new Date(5025000));
-        planEntity.setClosedAt(null);
-        planEntity.setDescription("description");
-        planEntity.setExcludedGroups(List.of("excludedGroup"));
-        planEntity.setGeneralConditions("generalConditions");
-        planEntity.setId("planId");
-        planEntity.setName("planName");
-        planEntity.setNeedRedeployAt(null);
-        planEntity.setOrder(1);
-        planEntity.setPublishedAt(new Date(5026000));
-        planEntity.setStatus(PlanStatus.PUBLISHED);
-        planEntity.setSelectionRule(null);
-        planEntity.setTags(Set.of("tag1", "tag2"));
-        planEntity.setType(PlanType.API);
-        planEntity.setUpdatedAt(new Date(5027000));
-        planEntity.setValidation(PlanValidationType.AUTO);
-
+    private Set<PlanDescriptor.PlanDescriptorV4> fakeApiPlans() {
         Step step = new Step();
         step.setName("stepName");
         step.setDescription("stepDescription");
@@ -470,26 +371,41 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         planFlow.setSelectors(List.of(httpSelector));
         planFlow.setTags(null);
 
-        planEntity.setFlows(List.of(planFlow));
-
-        PlanSecurity planSecurity = new PlanSecurity();
-        planSecurity.setType("key-less");
-        planSecurity.setConfiguration("{}");
-        planEntity.setSecurity(planSecurity);
-
-        return Set.of(planEntity);
+        return Set.of(
+            PlanDescriptor.PlanDescriptorV4
+                .builder()
+                .apiId(API)
+                .characteristics(List.of("characteristic1", "characteristic2"))
+                .commentMessage("commentMessage")
+                .commentRequired(true)
+                .crossId("crossId")
+                .createdAt(Instant.ofEpochMilli(5025000))
+                .closedAt(null)
+                .description("description")
+                .excludedGroups(List.of("excludedGroup"))
+                .generalConditions("generalConditions")
+                .id("planId")
+                .name("planName")
+                //.needRedeployAt(null)
+                .order(1)
+                .publishedAt(Instant.ofEpochMilli(5026000))
+                .status(PlanStatus.PUBLISHED)
+                .selectionRule(null)
+                .tags(Set.of("tag1", "tag2"))
+                .type(Plan.PlanType.API)
+                .updatedAt(Instant.ofEpochMilli(5027000))
+                .validation(Plan.PlanValidationType.AUTO)
+                .security(PlanSecurity.builder().type("key-less").configuration("{}").build())
+                .flows(List.of(planFlow))
+                .build()
+        );
     }
 
-    private List<PageEntity> fakeApiPages() {
-        PageEntity pageEntity = new PageEntity();
-        AccessControlEntity accessControlEntity = new AccessControlEntity();
-        accessControlEntity.setReferenceId("role-id");
-        accessControlEntity.setReferenceType("ROLE");
+    private List<PageExport> fakeApiPages() {
+        PageExport pageEntity = new PageExport();
+        var accessControlEntity = new AccessControl("role-id", "ROLE");
         pageEntity.setAccessControls(Set.of(accessControlEntity));
-        PageMediaEntity pageMediaEntity = new PageMediaEntity();
-        pageMediaEntity.setMediaHash("media-hash");
-        pageMediaEntity.setMediaName("media-name");
-        pageMediaEntity.setAttachedAt(new Date(0));
+        PageMedia pageMediaEntity = new PageMedia("media-hash", "media-name", new Date(0));
         pageEntity.setAttachedMedia(List.of(pageMediaEntity));
         pageEntity.setConfiguration(Map.of("page-config-key", "page-config-value"));
         pageEntity.setContent("#content");
@@ -502,7 +418,7 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         pageEntity.setHomepage(false);
         pageEntity.setId("page-id");
         pageEntity.setLastContributor("last-contributor-id");
-        pageEntity.setLastModificationDate(new Date(0));
+        pageEntity.setUpdatedAt(Instant.EPOCH);
         pageEntity.setMessages(List.of("message1", "message2"));
         pageEntity.setMetadata(Map.of("page-metadata-key", "page-metadata-value"));
         pageEntity.setName("page-name");
@@ -511,207 +427,170 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         pageEntity.setParentPath("parent-path");
         pageEntity.setPublished(true);
         pageEntity.setReferenceId("reference-id");
-        pageEntity.setReferenceType("reference-type");
-        PageSourceEntity pageSourceEntity = new PageSourceEntity();
-        pageSourceEntity.setType("GITHUB");
-        pageSourceEntity.setConfiguration(JsonNodeFactory.instance.objectNode());
+        pageEntity.setReferenceType(io.gravitee.apim.core.documentation.model.Page.ReferenceType.API);
+        PageSource pageSourceEntity = new PageSource("GITHUB", "{}", Map.of());
         pageEntity.setSource(pageSourceEntity);
-        pageEntity.setType("MARKDOWN");
-        pageEntity.setTranslations(Collections.emptyList());
-        pageEntity.setVisibility(Visibility.PUBLIC);
+        pageEntity.setType(io.gravitee.apim.core.documentation.model.Page.Type.MARKDOWN);
+        pageEntity.setTranslations(List.of());
+        pageEntity.setVisibility(io.gravitee.apim.core.documentation.model.Page.Visibility.PUBLIC);
 
         return List.of(pageEntity);
     }
 
-    private List<MediaEntity> fakeApiMedia() {
-        MediaEntity mediaEntity = new MediaEntity();
+    private List<io.gravitee.apim.core.media.model.Media> fakeApiMedia() {
+        var mediaEntity = new io.gravitee.apim.core.media.model.Media();
         mediaEntity.setId("media-id");
         mediaEntity.setHash("media-hash");
-        mediaEntity.setSize(1_000);
+        mediaEntity.setSize(1_000L);
         mediaEntity.setFileName("media-file-name");
         mediaEntity.setType("media-type");
         mediaEntity.setSubType("media-sub-type");
-        mediaEntity.setData("media-data".getBytes(StandardCharsets.UTF_8));
-        mediaEntity.setUploadDate(new Date(0));
+        mediaEntity.setData("media-data".getBytes(UTF_8));
+        mediaEntity.setCreatedAt(new Date(0));
 
         return List.of(mediaEntity);
     }
 
     // Tests
-    private void testReturnedApi(ApiV4 responseApi) throws JsonProcessingException {
-        assertNotNull(responseApi);
-        assertEquals(API, responseApi.getName());
-        assertEquals(API, responseApi.getId());
-        assertNull(responseApi.getLinks());
-        assertNotNull(responseApi.getProperties());
-        assertEquals(1, responseApi.getProperties().size());
-        assertNotNull(responseApi.getServices());
-        assertNotNull(responseApi.getResources());
-        assertEquals(1, responseApi.getResources().size());
-        assertNotNull(responseApi.getResponseTemplates());
-        assertEquals(1, responseApi.getResponseTemplates().size());
+    private void testReturnedApi(ApiV4 responseApi) {
+        assertThat(responseApi).isNotNull();
+        assertThat(responseApi.getName()).isEqualTo(API);
+        assertThat(responseApi.getId()).isEqualTo(API);
+        assertThat(responseApi.getLinks()).isNull();
+        assertThat(responseApi.getProperties()).hasSize(1);
+        assertThat(responseApi.getServices()).isNotNull();
+        assertThat(responseApi.getResources()).hasSize(1);
+        assertThat(responseApi.getResponseTemplates()).hasSize(1);
 
-        assertNotNull(responseApi.getListeners());
-        assertEquals(3, responseApi.getListeners().size());
+        assertThat(responseApi.getListeners()).hasSize(3);
 
-        io.gravitee.rest.api.management.v2.rest.model.HttpListener httpListener = responseApi.getListeners().get(0).getHttpListener();
-        assertNotNull(httpListener);
-        assertNotNull(httpListener.getPathMappings());
-        assertNotNull(httpListener.getPaths());
-        assertNotNull(httpListener.getPaths().get(0).getHost());
+        var httpListener = responseApi.getListeners().getFirst().getHttpListener();
+        assertThat(httpListener).isNotNull();
+        assertThat(httpListener.getPathMappings()).isNotNull();
+        assertThat(httpListener.getPaths()).isNotNull();
+        assertThat(httpListener.getPaths().getFirst().getHost()).isNotNull();
 
-        io.gravitee.rest.api.management.v2.rest.model.SubscriptionListener subscriptionListener = responseApi
-            .getListeners()
-            .get(1)
-            .getSubscriptionListener();
-        assertNotNull(subscriptionListener);
-        assertNotNull(subscriptionListener.getEntrypoints());
-        var foundEntrypoint = subscriptionListener.getEntrypoints().get(0);
-        assertNotNull(foundEntrypoint);
+        var subscriptionListener = responseApi.getListeners().get(1).getSubscriptionListener();
+        assertThat(subscriptionListener).isNotNull();
+        assertThat(subscriptionListener.getEntrypoints()).isNotNull();
+        var foundEntrypoint = subscriptionListener.getEntrypoints().getFirst();
+        assertThat(foundEntrypoint).isNotNull();
         LinkedHashMap subscriptionConfig = (LinkedHashMap) foundEntrypoint.getConfiguration();
-        assertEquals("configuration", subscriptionConfig.get("nice"));
-        assertEquals("Entrypoint type", foundEntrypoint.getType());
-        assertEquals("SUBSCRIPTION", subscriptionListener.getType().toString());
+        assertThat(subscriptionConfig.get("nice")).isEqualTo("configuration");
+        assertThat(foundEntrypoint.getType()).isEqualTo("Entrypoint type");
+        assertThat(subscriptionListener.getType().toString()).isEqualTo("SUBSCRIPTION");
 
-        io.gravitee.rest.api.management.v2.rest.model.TcpListener tcpListener = responseApi.getListeners().get(2).getTcpListener();
-        assertNotNull(tcpListener);
-        assertNotNull(tcpListener.getEntrypoints());
-        var tcpFoundEntrypoint = tcpListener.getEntrypoints().get(0);
-        assertNotNull(tcpFoundEntrypoint);
+        var tcpListener = responseApi.getListeners().get(2).getTcpListener();
+        assertThat(tcpListener).isNotNull();
+        assertThat(tcpListener.getEntrypoints()).isNotNull();
+        var tcpFoundEntrypoint = tcpListener.getEntrypoints().getFirst();
+        assertThat(tcpFoundEntrypoint).isNotNull();
         LinkedHashMap tcpConfig = (LinkedHashMap) tcpFoundEntrypoint.getConfiguration();
-        assertEquals("configuration", tcpConfig.get("nice"));
-        assertEquals("Entrypoint type", tcpFoundEntrypoint.getType());
-        assertEquals("TCP", tcpListener.getType().toString());
+        assertThat(tcpConfig.get("nice")).isEqualTo("configuration");
+        assertThat(tcpFoundEntrypoint.getType()).isEqualTo("Entrypoint type");
+        assertThat(tcpListener.getType().toString()).isEqualTo("TCP");
 
-        assertNotNull(responseApi.getEndpointGroups());
-        assertEquals(1, responseApi.getEndpointGroups().size());
-        assertNotNull(responseApi.getEndpointGroups().get(0));
-        assertNotNull(responseApi.getEndpointGroups().get(0).getEndpoints());
-        assertEquals(1, responseApi.getEndpointGroups().get(0).getEndpoints().size());
+        assertThat(responseApi.getEndpointGroups()).hasSize(1);
+        assertThat(responseApi.getEndpointGroups().getFirst()).isNotNull();
+        assertThat(responseApi.getEndpointGroups().getFirst().getEndpoints()).hasSize(1);
 
-        var endpoint = responseApi.getEndpointGroups().get(0).getEndpoints().get(0);
-        assertNotNull(endpoint);
-        assertEquals("http-get", endpoint.getType());
+        var endpoint = responseApi.getEndpointGroups().getFirst().getEndpoints().getFirst();
+        assertThat(endpoint).isNotNull();
+        assertThat(endpoint.getType()).isEqualTo("http-get");
 
         LinkedHashMap endpointConfig = (LinkedHashMap) endpoint.getConfiguration();
-        assertEquals("kafka:9092", endpointConfig.get("bootstrapServers"));
-        assertEquals(List.of("demo"), endpointConfig.get("topics"));
+        assertThat(endpointConfig.get("bootstrapServers")).isEqualTo("kafka:9092");
+        assertThat(endpointConfig.get("topics")).isEqualTo(List.of("demo"));
 
-        assertNotNull(responseApi.getFlows());
-        assertEquals(1, responseApi.getFlows().size());
+        assertThat(responseApi.getFlows()).hasSize(1);
 
-        var flow = responseApi.getFlows().get(0);
-        assertNotNull(flow);
-        assertEquals("flowName", flow.getName());
-        assertEquals(Boolean.TRUE, flow.getEnabled());
-        assertNotNull(flow.getTags());
-        assertEquals(2, flow.getTags().size());
-        assertEquals(Set.of("tag1", "tag2"), flow.getTags());
-        assertNotNull(flow.getRequest());
-        assertEquals(1, flow.getRequest().size());
+        var flow = responseApi.getFlows().getFirst();
+        assertThat(flow).isNotNull();
+        assertThat(flow.getName()).isEqualTo("flowName");
+        assertThat(flow.getEnabled()).isTrue();
+        assertThat(flow.getTags()).containsOnly("tag1", "tag2");
+        assertThat(flow.getRequest()).hasSize(1);
 
-        var step = flow.getRequest().get(0);
-        assertNotNull(step);
-        assertEquals(Boolean.TRUE, step.getEnabled());
-        assertEquals("my-policy", step.getPolicy());
-        assertEquals("my-condition", step.getCondition());
+        var step = flow.getRequest().getFirst();
+        assertThat(step).isNotNull();
+        assertThat(step.getEnabled()).isTrue();
+        assertThat(step.getPolicy()).isEqualTo("my-policy");
+        assertThat(step.getCondition()).isEqualTo("my-condition");
 
-        assertNotNull(flow.getSelectors());
-        assertEquals(3, flow.getSelectors().size());
+        assertThat(flow.getSelectors()).hasSize(3);
 
-        var httpSelector = flow.getSelectors().get(0).getHttpSelector();
-        assertNotNull(httpSelector);
-        assertEquals("/test", httpSelector.getPath());
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH, httpSelector.getPathOperator());
-        assertEquals(2, httpSelector.getMethods().size());
-        assertEquals(
-            Set.of(
+        var httpSelector = flow.getSelectors().getFirst().getHttpSelector();
+        assertThat(httpSelector).isNotNull();
+        assertThat(httpSelector.getPath()).isEqualTo("/test");
+        assertThat(httpSelector.getPathOperator()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH);
+        assertThat(httpSelector.getMethods())
+            .containsOnly(
                 io.gravitee.rest.api.management.v2.rest.model.HttpMethod.GET,
                 io.gravitee.rest.api.management.v2.rest.model.HttpMethod.POST
-            ),
-            httpSelector.getMethods()
-        );
+            );
 
         var channelSelector = flow.getSelectors().get(1).getChannelSelector();
-        assertEquals("my-channel", channelSelector.getChannel());
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH, channelSelector.getChannelOperator());
-        assertEquals(1, channelSelector.getOperations().size());
-        assertEquals(
-            Set.of(io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.SUBSCRIBE),
-            channelSelector.getOperations()
-        );
-        assertEquals(1, channelSelector.getEntrypoints().size());
-        assertEquals(Set.of("my-entrypoint"), channelSelector.getEntrypoints());
+        assertThat(channelSelector.getChannel()).isEqualTo("my-channel");
+        assertThat(channelSelector.getChannelOperator()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH);
+        assertThat(channelSelector.getOperations())
+            .containsOnly(io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.SUBSCRIBE);
+        assertThat(channelSelector.getEntrypoints()).containsOnly("my-entrypoint");
 
         var conditionSelector = flow.getSelectors().get(2).getConditionSelector();
-        assertEquals("my-condition", conditionSelector.getCondition());
+        assertThat(conditionSelector.getCondition()).isEqualTo("my-condition");
     }
 
-    private void testReturnedNativeApi(ApiV4 responseApi) throws JsonProcessingException {
-        assertNotNull(responseApi);
-        assertEquals(API, responseApi.getName());
-        assertEquals(API, responseApi.getId());
-        assertNull(responseApi.getLinks());
-        assertNotNull(responseApi.getProperties());
-        assertEquals(1, responseApi.getProperties().size());
-        assertNotNull(responseApi.getResources());
-        assertEquals(1, responseApi.getResources().size());
+    private void testReturnedNativeApi(ApiV4 responseApi) {
+        assertThat(responseApi).isNotNull();
+        assertThat(responseApi.getName()).isEqualTo(API);
+        assertThat(responseApi.getId()).isEqualTo(API);
+        assertThat(responseApi.getLinks()).isNull();
+        assertThat(responseApi.getProperties()).hasSize(1);
+        assertThat(responseApi.getResources()).hasSize(1);
 
-        assertNotNull(responseApi.getListeners());
-        assertEquals(1, responseApi.getListeners().size());
+        assertThat(responseApi.getListeners()).hasSize(1);
 
-        io.gravitee.rest.api.management.v2.rest.model.KafkaListener kafkaListener = responseApi.getListeners().get(0).getKafkaListener();
-        assertNotNull(kafkaListener);
-        assertNotNull(kafkaListener.getHost());
-        assertEquals("my.fake.host", kafkaListener.getHost());
+        var kafkaListener = responseApi.getListeners().getFirst().getKafkaListener();
+        assertThat(kafkaListener).isNotNull();
+        assertThat(kafkaListener.getHost()).isEqualTo("my.fake.host");
 
-        assertNotNull(responseApi.getEndpointGroups());
-        assertEquals(1, responseApi.getEndpointGroups().size());
-        assertNotNull(responseApi.getEndpointGroups().get(0));
-        assertNotNull(responseApi.getEndpointGroups().get(0).getEndpoints());
-        assertEquals(1, responseApi.getEndpointGroups().get(0).getEndpoints().size());
+        assertThat(responseApi.getEndpointGroups()).hasSize(1);
+        assertThat(responseApi.getEndpointGroups().getFirst()).isNotNull();
+        assertThat(responseApi.getEndpointGroups().getFirst().getEndpoints()).hasSize(1);
 
-        var endpoint = responseApi.getEndpointGroups().get(0).getEndpoints().get(0);
-        assertNotNull(endpoint);
-        assertEquals("kafka", endpoint.getType());
+        var endpoint = responseApi.getEndpointGroups().getFirst().getEndpoints().getFirst();
+        assertThat(endpoint).isNotNull();
+        assertThat(endpoint.getType()).isEqualTo("kafka");
 
-        LinkedHashMap endpointConfig = (LinkedHashMap) endpoint.getConfiguration();
-        assertEquals("kafka:9092", endpointConfig.get("bootstrapServers"));
+        var endpointConfig = (LinkedHashMap) endpoint.getConfiguration();
+        assertThat(endpointConfig).containsOnly(Map.entry("bootstrapServers", "kafka:9092"));
 
-        assertNotNull(responseApi.getFlows());
-        assertEquals(1, responseApi.getFlows().size());
+        assertThat(responseApi.getFlows()).hasSize(1);
 
-        var flow = responseApi.getFlows().get(0);
-        assertNotNull(flow);
-        assertEquals("flowName", flow.getName());
-        assertEquals(Boolean.TRUE, flow.getEnabled());
-        assertNotNull(flow.getTags());
-        assertEquals(2, flow.getTags().size());
-        assertEquals(Set.of("tag1", "tag2"), flow.getTags());
-        assertNotNull(flow.getInteract());
-        assertEquals(1, flow.getInteract().size());
+        var flow = responseApi.getFlows().getFirst();
+        assertThat(flow).isNotNull();
+        assertThat(flow.getName()).isEqualTo("flowName");
+        assertThat(flow.getEnabled()).isTrue();
+        assertThat(flow.getTags()).containsOnly("tag1", "tag2");
+        assertThat(flow.getInteract()).hasSize(1);
 
-        var step = flow.getInteract().get(0);
-        assertNotNull(step);
-        assertEquals(Boolean.TRUE, step.getEnabled());
-        assertEquals("my-policy", step.getPolicy());
-        assertEquals("my-condition", step.getCondition());
+        var step = flow.getInteract().getFirst();
+        assertThat(step).isNotNull();
+        assertThat(step.getEnabled()).isTrue();
+        assertThat(step.getPolicy()).isEqualTo("my-policy");
+        assertThat(step.getCondition()).isEqualTo("my-condition");
 
-        assertNull(flow.getSelectors());
+        assertThat(flow.getSelectors()).isNull();
     }
 
     private void testReturnedMembers(Set<Member> members) {
-        assertEquals(2, members.size());
-
         var userMember = new Member().displayName("John Doe").id("memberId").roles(List.of(new Role().name("OWNER")));
         var poUserMember = new Member().displayName("Thomas Pesquet").id("poMemberId").roles(List.of(new Role().name("PRIMARY_OWNER")));
 
-        assertEquals(Set.of(userMember, poUserMember), members);
+        assertThat(members).containsOnly(userMember, poUserMember);
     }
 
     private void testReturnedMetadata(Set<Metadata> metadata) {
-        assertEquals(2, metadata.size());
-
         var firstMetadata = new Metadata()
             .key("my-metadata-1")
             .name("My first metadata")
@@ -726,156 +605,143 @@ public class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
             .value("Very important data !!")
             .defaultValue("Important data");
 
-        assertEquals(Set.of(firstMetadata, secondMetadata), metadata);
+        assertThat(metadata).containsOnly(firstMetadata, secondMetadata);
     }
 
     private void testReturnedPlans(Set<PlanV4> plans) {
-        assertEquals(1, plans.size());
+        assertThat(plans).hasSize(1);
 
         var plan = plans.iterator().next();
-        assertEquals(API, plan.getApiId());
-        assertEquals(List.of("characteristic1", "characteristic2"), plan.getCharacteristics());
-        assertEquals("commentMessage", plan.getCommentMessage());
-        assertEquals(true, plan.getCommentRequired());
-        assertEquals("crossId", plan.getCrossId());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 1, 23, 45, 0, ZoneOffset.UTC), plan.getCreatedAt());
-        assertNull(plan.getClosedAt());
-        assertEquals("description", plan.getDescription());
-        assertEquals(List.of("excludedGroup"), plan.getExcludedGroups());
-        assertEquals("generalConditions", plan.getGeneralConditions());
-        assertEquals("planId", plan.getId());
-        assertEquals("planName", plan.getName());
-        assertEquals(1, plan.getOrder().intValue());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 1, 23, 46, 0, ZoneOffset.UTC), plan.getPublishedAt());
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.PUBLISHED, plan.getStatus());
-        assertNull(plan.getSelectionRule());
-        assertEquals(List.of("tag1", "tag2"), plan.getTags().stream().sorted().collect(Collectors.toList()));
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.PlanType.API, plan.getType());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 1, 23, 47, 0, ZoneOffset.UTC), plan.getUpdatedAt());
-        assertEquals(PlanValidation.AUTO, plan.getValidation());
+        assertThat(plan.getApiId()).isEqualTo(API);
+        assertThat(plan.getCharacteristics()).containsOnly("characteristic1", "characteristic2");
+        assertThat(plan.getCommentMessage()).isEqualTo("commentMessage");
+        assertThat(plan.getCommentRequired()).isTrue();
+        assertThat(plan.getCrossId()).isEqualTo("crossId");
+        assertThat(plan.getCreatedAt()).isEqualTo(OffsetDateTime.of(1970, 1, 1, 1, 23, 45, 0, ZoneOffset.UTC));
+        assertThat(plan.getClosedAt()).isNull();
+        assertThat(plan.getDescription()).isEqualTo("description");
+        assertThat(plan.getExcludedGroups()).containsOnly("excludedGroup");
+        assertThat(plan.getGeneralConditions()).isEqualTo("generalConditions");
+        assertThat(plan.getId()).isEqualTo("planId");
+        assertThat(plan.getName()).isEqualTo("planName");
+        assertThat(plan.getOrder()).isEqualTo(1);
+        assertThat(plan.getPublishedAt()).isEqualTo(OffsetDateTime.of(1970, 1, 1, 1, 23, 46, 0, ZoneOffset.UTC));
+        assertThat(plan.getStatus()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.PUBLISHED);
+        assertThat(plan.getSelectionRule()).isNull();
+        assertThat(plan.getTags()).containsOnly("tag1", "tag2");
+        assertThat(plan.getType()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.PlanType.API);
+        assertThat(plan.getUpdatedAt()).isEqualTo(OffsetDateTime.of(1970, 1, 1, 1, 23, 47, 0, ZoneOffset.UTC));
+        assertThat(plan.getValidation()).isEqualTo(PlanValidation.AUTO);
 
-        assertNotNull(plan.getFlows());
-        assertEquals(1, plan.getFlows().size());
+        assertThat(plan.getFlows()).hasSize(1);
 
-        var flowV4 = plan.getFlows().get(0);
-        assertNotNull(flowV4);
-        assertEquals(true, flowV4.getEnabled());
-        assertEquals("planFlowName", flowV4.getName());
-        assertNull(flowV4.getPublish());
+        var flowV4 = plan.getFlows().getFirst();
+        assertThat(flowV4).isNotNull();
+        assertThat(flowV4.getEnabled()).isTrue();
+        assertThat(flowV4.getName()).isEqualTo("planFlowName");
+        assertThat(flowV4.getPublish()).isNull();
 
-        assertNotNull(flowV4.getRequest());
-        assertEquals(1, flowV4.getRequest().size());
+        assertThat(flowV4.getRequest()).hasSize(1);
 
-        var step = flowV4.getRequest().get(0);
-        assertEquals(true, step.getEnabled());
-        assertEquals(new LinkedHashMap<>(Map.of("nice", "configuration")), step.getConfiguration());
-        assertEquals("stepDescription", step.getDescription());
-        assertEquals("stepName", step.getName());
-        assertEquals("stepCondition", step.getCondition());
-        assertEquals("stepPolicy", step.getPolicy());
-        assertEquals("stepMessageCondition", step.getMessageCondition());
+        var step = flowV4.getRequest().getFirst();
+        assertThat(step.getEnabled()).isTrue();
+        assertThat(step.getConfiguration()).isEqualTo(Map.of("nice", "configuration"));
+        assertThat(step.getDescription()).isEqualTo("stepDescription");
+        assertThat(step.getName()).isEqualTo("stepName");
+        assertThat(step.getCondition()).isEqualTo("stepCondition");
+        assertThat(step.getPolicy()).isEqualTo("stepPolicy");
+        assertThat(step.getMessageCondition()).isEqualTo("stepMessageCondition");
 
-        assertNull(flowV4.getResponse());
-        assertNull(flowV4.getSubscribe());
-        assertNull(flowV4.getTags());
+        assertThat(flowV4.getResponse()).isNull();
+        assertThat(flowV4.getSubscribe()).isNull();
+        assertThat(flowV4.getTags()).isNull();
 
-        assertNotNull(flowV4.getSelectors());
-        assertEquals(1, flowV4.getSelectors().size());
+        assertThat(flowV4.getSelectors()).hasSize(1);
 
-        var httpSelector = flowV4.getSelectors().get(0).getHttpSelector();
-        assertNotNull(httpSelector);
-        assertEquals("/test", httpSelector.getPath());
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH, httpSelector.getPathOperator());
-        assertEquals(2, httpSelector.getMethods().size());
-        assertEquals(
-            Set.of(
+        var httpSelector = flowV4.getSelectors().getFirst().getHttpSelector();
+        assertThat(httpSelector).isNotNull();
+        assertThat(httpSelector.getPath()).isEqualTo("/test");
+        assertThat(httpSelector.getPathOperator()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.Operator.STARTS_WITH);
+        assertThat(httpSelector.getMethods())
+            .containsOnly(
                 io.gravitee.rest.api.management.v2.rest.model.HttpMethod.GET,
                 io.gravitee.rest.api.management.v2.rest.model.HttpMethod.POST
-            ),
-            httpSelector.getMethods()
-        );
+            );
 
-        assertNotNull(plan.getSecurity());
+        assertThat(plan.getSecurity()).isNotNull();
         var planSecurity = plan.getSecurity();
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.KEY_LESS, planSecurity.getType());
-        assertEquals(new LinkedHashMap<>(), planSecurity.getConfiguration());
+        assertThat(planSecurity.getType()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.KEY_LESS);
+        assertThat(planSecurity.getConfiguration()).isEqualTo(new LinkedHashMap<>());
     }
 
     private void testReturnedPages(Set<Page> pages) {
-        assertEquals(1, pages.size());
+        assertThat(pages).hasSize(1);
 
         var page = pages.iterator().next();
-        assertNotNull(page.getAccessControls());
-        assertEquals(1, page.getAccessControls().size());
+        assertThat(page.getAccessControls()).hasSize(1);
 
-        var accessControl = page.getAccessControls().get(0);
-        assertNotNull(accessControl);
-        assertEquals("role-id", accessControl.getReferenceId());
-        assertEquals("ROLE", accessControl.getReferenceType());
+        var accessControl = page.getAccessControls().getFirst();
+        assertThat(accessControl).isNotNull();
+        assertThat(accessControl.getReferenceId()).isEqualTo("role-id");
+        assertThat(accessControl.getReferenceType()).isEqualTo("ROLE");
 
-        assertNotNull(page.getAttachedMedia());
-        assertEquals(1, page.getAttachedMedia().size());
+        assertThat(page.getAttachedMedia()).hasSize(1);
 
-        var pageMedia = page.getAttachedMedia().get(0);
-        assertNotNull(pageMedia);
-        assertEquals("media-hash", pageMedia.getHash());
-        assertEquals("media-name", pageMedia.getName());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), pageMedia.getAttachedAt());
+        var pageMedia = page.getAttachedMedia().getFirst();
+        assertThat(pageMedia).isNotNull();
+        assertThat(pageMedia.getHash()).isEqualTo("media-hash");
+        assertThat(pageMedia.getName()).isEqualTo("media-name");
+        assertThat(pageMedia.getAttachedAt()).isEqualTo(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
 
-        assertEquals(Map.of("page-config-key", "page-config-value"), page.getConfiguration());
-        assertEquals("#content", page.getContent());
+        assertThat(page.getConfiguration()).hasSize(1).containsEntry("page-config-key", "page-config-value");
+        assertThat(page.getContent()).isEqualTo("#content");
 
-        assertNotNull(page.getContentRevision());
+        assertThat(page.getContentRevision()).isNotNull();
         var contentRevision = page.getContentRevision();
-        assertEquals("page-revision-id", contentRevision.getId());
-        assertEquals(1, contentRevision.getRevision().intValue());
+        assertThat(contentRevision.getId()).isEqualTo("page-revision-id");
+        assertThat(contentRevision.getRevision()).isEqualTo(1);
 
-        assertEquals("text/markdown", page.getContentType());
-        assertEquals("crossId", page.getCrossId());
+        assertThat(page.getContentType()).isEqualTo("text/markdown");
+        assertThat(page.getCrossId()).isEqualTo("crossId");
 
-        assertEquals(false, page.getExcludedAccessControls());
-        assertNotNull(page.getAccessControls());
-        assertEquals(1, page.getAccessControls().size());
-        assertEquals("role-id", page.getAccessControls().get(0).getReferenceId());
-        assertEquals("ROLE", page.getAccessControls().get(0).getReferenceType());
+        assertThat(page.getExcludedAccessControls()).isFalse();
 
-        assertEquals(false, page.getHomepage());
-        assertEquals("page-id", page.getId());
-        assertEquals("last-contributor-id", page.getLastContributor());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), page.getUpdatedAt());
-        assertEquals(Map.of("page-metadata-key", "page-metadata-value"), page.getMetadata());
-        assertEquals("page-name", page.getName());
-        assertEquals(1, page.getOrder().intValue());
-        assertEquals("parent-id", page.getParentId());
-        assertEquals("parent-path", page.getParentPath());
-        assertEquals(true, page.getPublished());
+        assertThat(page.getHomepage()).isFalse();
+        assertThat(page.getId()).isEqualTo("page-id");
+        assertThat(page.getLastContributor()).isEqualTo("last-contributor-id");
+        assertThat(page.getUpdatedAt()).isEqualTo(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+        assertThat(page.getMetadata()).hasSize(1).containsEntry("page-metadata-key", "page-metadata-value");
+        assertThat(page.getName()).isEqualTo("page-name");
+        assertThat(page.getOrder()).isEqualTo(1);
+        assertThat(page.getParentId()).isEqualTo("parent-id");
+        assertThat(page.getParentPath()).isEqualTo("parent-path");
+        assertThat(page.getPublished()).isTrue();
 
-        assertNotNull(page.getSource());
+        assertThat(page.getSource()).isNotNull();
         var source = page.getSource();
-        assertEquals("GITHUB", source.getType());
-        assertEquals(new LinkedHashMap<>(), source.getConfiguration());
+        assertThat(source.getType()).isEqualTo("GITHUB");
+        assertThat(source.getConfiguration()).isEqualTo(new LinkedHashMap<>());
 
-        assertEquals(PageType.MARKDOWN, page.getType());
+        assertThat(page.getType()).isEqualTo(PageType.MARKDOWN);
 
-        assertNotNull(page.getTranslations());
-        assertEquals(0, page.getTranslations().size());
-
-        assertEquals(io.gravitee.rest.api.management.v2.rest.model.Visibility.PUBLIC, page.getVisibility());
+        assertThat(page.getTranslations()).isEmpty();
+        assertThat(page.getVisibility()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.Visibility.PUBLIC);
     }
 
-    private void testReturnedMedia(List<Media> mediaList) {
-        assertEquals(1, mediaList.size());
-
-        var media = mediaList.get(0);
-        assertNotNull(media);
-
-        assertEquals("media-id", media.getId());
-        assertEquals("media-hash", media.getHash());
-        assertEquals(1_000, media.getSize().longValue());
-        assertEquals("media-file-name", media.getFileName());
-        assertEquals("media-type", media.getType());
-        assertEquals("media-sub-type", media.getSubType());
-        assertArrayEquals("media-data".getBytes(StandardCharsets.UTF_8), media.getData());
-        assertEquals(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), media.getCreatedAt());
+    private Condition<Media> testReturnedMedia() {
+        var created = OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        return new Condition<>(
+            media ->
+                media != null &&
+                "media-id".equals(media.getId()) &&
+                "media-hash".equals(media.getHash()) &&
+                Objects.equals(1_000L, media.getSize()) &&
+                "media-file-name".equals(media.getFileName()) &&
+                "media-type".equals(media.getType()) &&
+                "media-sub-type".equals(media.getSubType()) &&
+                Arrays.equals("media-data".getBytes(UTF_8), media.getData()) &&
+                created.equals(media.getCreatedAt()),
+            "media-id"
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -46,6 +46,7 @@ import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
+import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
@@ -133,7 +134,6 @@ import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
-import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
 import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
@@ -197,8 +197,8 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApiImportExportService apiImportExportService() {
-        return mock(ApiImportExportService.class);
+    public ExportApiUseCase exportApiUseCase() {
+        return mock(ExportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResource.java
@@ -123,7 +123,7 @@ public class ApiPageMediaResource extends AbstractResource {
             .attachMedia(page, mediaId, fileName == null ? originalFileName : fileName)
             .flatMap(pageEntity -> pageEntity.getAttachedMedia().stream().filter(media -> media.getMediaHash().equals(mediaId)).findFirst())
             .ifPresent(createdMedia -> {
-                mediaEntity.setUploadDate(createdMedia.getAttachedAt());
+                mediaEntity.setCreateAt(createdMedia.getAttachedAt());
                 mediaEntity.setHash(createdMedia.getMediaHash());
             });
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResource.java
@@ -122,7 +122,7 @@ public class PortalPageMediaResource extends AbstractResource {
                     .filter(media -> media.getMediaHash().equals(mediaId))
                     .findFirst()
                     .ifPresent(createdMedia -> {
-                        mediaEntity.setUploadDate(createdMedia.getAttachedAt());
+                        mediaEntity.setCreateAt(createdMedia.getAttachedAt());
                         mediaEntity.setHash(createdMedia.getMediaHash());
                     })
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MediaEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MediaEntity.java
@@ -16,124 +16,30 @@
 package io.gravitee.rest.api.model;
 
 import java.util.Date;
-import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
-/**
- * @author Guillaume GILLON
- */
+@Setter
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class MediaEntity {
 
+    @EqualsAndHashCode.Include
     private String id;
+
     private String hash;
     private String type;
     private String subType;
     private String fileName;
+
+    @Setter
     private Date createAt;
+
     private long size;
     private byte[] data;
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getSubType() {
-        return subType;
-    }
-
-    public void setSubType(String subType) {
-        this.subType = subType;
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-
-    public Date getCreateAt() {
-        return createAt;
-    }
-
-    public void setUploadDate(Date createAt) {
-        this.createAt = createAt;
-    }
-
-    public long getSize() {
-        return size;
-    }
-
-    public void setSize(long size) {
-        this.size = size;
-    }
-
-    public byte[] getData() {
-        return data;
-    }
-
-    public void setData(byte[] data) {
-        this.data = data;
-    }
-
     public String getMimeType() {
         return this.type + '/' + this.subType;
-    }
-
-    public String getHash() {
-        return hash;
-    }
-
-    public void setHash(String hash) {
-        this.hash = hash;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MediaEntity mediaEntity = (MediaEntity) o;
-        return Objects.equals(id, mediaEntity.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "MediaEntity{" +
-            "id='" +
-            id +
-            '\'' +
-            ", type='" +
-            type +
-            '\'' +
-            ", subType='" +
-            subType +
-            '\'' +
-            ", filename='" +
-            fileName +
-            '\'' +
-            ", createAt=" +
-            createAt +
-            ", size=" +
-            size +
-            '}'
-        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewApiMetadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewApiMetadata.java
@@ -32,4 +32,5 @@ public class NewApiMetadata {
     Metadata.MetadataFormat format = Metadata.MetadataFormat.STRING;
 
     String value;
+    String defaultValue;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiMember.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiMember.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api.model.import_definition;
 
+import io.gravitee.rest.api.model.MembershipMemberType;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,4 +31,5 @@ public class ApiMember {
     private String id;
     private String displayName;
     private List<ApiMemberRole> roles;
+    private MembershipMemberType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/GraviteeDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/GraviteeDefinition.java
@@ -120,9 +120,9 @@ public sealed interface GraviteeDefinition {
         }
     }
 
-    record Export(Instant date, String exportVersion, String apimVersion) {
+    record Export(Instant date, String apimVersion) {
         public Export() {
-            this(TimeProvider.instantNow(), "1", Version.RUNTIME_VERSION.MAJOR_VERSION);
+            this(TimeProvider.instantNow(), Version.RUNTIME_VERSION.MAJOR_VERSION);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PageExport.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PageExport.java
@@ -19,8 +19,9 @@ import io.gravitee.apim.core.documentation.model.AccessControl;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.documentation.model.PageMedia;
 import io.gravitee.apim.core.documentation.model.PageSource;
+import io.gravitee.rest.api.model.PageEntity;
 import java.time.Instant;
-import java.util.Date;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,4 +71,13 @@ public class PageExport {
     private Map<String, String> metadata;
     private Boolean useAutoFetch; // use Boolean to avoid default value of primitive type
     private List<PageMedia> attachedMedia;
+
+    private String contentType;
+    private String parentPath;
+
+    private Collection<String> excludedGroups;
+    private Collection<String> messages;
+    private PageEntity.PageRevisionId contentRevisionId;
+
+    private Collection<PageExport> translations;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PlanDescriptor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PlanDescriptor.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -72,7 +71,7 @@ public sealed interface PlanDescriptor {
         String commentMessage,
         String generalConditions,
 
-        List<AbstractFlow> flows
+        List<? extends AbstractFlow> flows
     )
         implements PlanDescriptor {
         @JsonProperty("tags")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ExportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ExportApiUseCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+import static java.util.Objects.requireNonNull;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import jakarta.annotation.Nullable;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ExportApiUseCase {
+
+    private final ApiExportDomainService apiExportDomainService;
+
+    public Output execute(Input input) {
+        var exported = apiExportDomainService.export(input.apiId(), input.auditInfo(), input.excluded());
+        return switch (exported) {
+            case GraviteeDefinition.V4 v4 -> new Output(v4);
+            case GraviteeDefinition.Native nativeV4 -> new Output(nativeV4);
+            case null -> throw new ApiNotFoundException(input.apiId());
+            default -> throw new ApiDefinitionVersionNotSupportedException(exported.api().definitionVersion().getLabel());
+        };
+    }
+
+    public record Input(String apiId, AuditInfo auditInfo, @Nullable Collection<ApiExportDomainService.Excludable> excluded) {
+        public static Input of(String apiId, AuditInfo auditInfo, @Nullable Collection<String> excluded) {
+            return new Input(
+                requireNonNull(apiId, "apiId should not be null"),
+                requireNonNull(auditInfo, "auditInfo should not be null"),
+                stream(excluded).map(ApiExportDomainService.Excludable::valueOf).toList()
+            );
+        }
+    }
+
+    public record Output(GraviteeDefinition definition, String filename) {
+        public Output(GraviteeDefinition definition) {
+            this(definition, getExportFilename(definition.api()));
+        }
+    }
+
+    private static String getExportFilename(ApiDescriptor api) {
+        return "%s-%s.json".formatted(api.name(), api.apiVersion()).trim().toLowerCase().replaceAll("[^\\w\\r\\n\\t\\f\\v.]+", "-");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/media/query_service/MediaQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/media/query_service/MediaQueryService.java
@@ -13,28 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.media.model;
+package io.gravitee.apim.core.media.query_service;
 
-import java.util.Date;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import io.gravitee.apim.core.media.model.Media;
+import java.util.List;
 
-@Data
-@Builder(toBuilder = true)
-@NoArgsConstructor
-@AllArgsConstructor
-public class Media {
-
-    private String id;
-    private String hash;
-    private String type;
-    private String subType;
-    private String fileName;
-    private Date createdAt;
-    private Long size;
-    private byte[] data;
-
-    private String apiId;
+public interface MediaQueryService {
+    List<Media> findAllByApiId(String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -27,10 +27,7 @@ import io.gravitee.apim.core.media.model.Media;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.core.plan.model.Plan;
-import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
-import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.rest.api.model.MediaEntity;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import jakarta.annotation.Nullable;
@@ -54,8 +51,6 @@ public interface GraviteeDefinitionAdapter {
 
     List<PageExport> mapPage(Collection<Page> source);
 
-    List<Media> mapMedia(Collection<MediaEntity> src);
-
     @Mapping(target = "security", expression = "java(mapPlanSecurity(source.getPlanDefinitionHttpV4().getSecurity()))")
     @Mapping(target = "mode", source = "planDefinitionHttpV4.mode")
     @Mapping(target = "status", source = "planDefinitionHttpV4.status")
@@ -76,6 +71,7 @@ public interface GraviteeDefinitionAdapter {
     io.gravitee.rest.api.model.PrimaryOwnerEntity map(PrimaryOwnerEntity src);
 
     @Mapping(target = "id", source = "apiEntity.id")
+    @Mapping(target = "apiVersion", source = "apiEntity.version")
     @Mapping(target = "type", source = "apiEntity.type")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
@@ -100,6 +96,7 @@ public interface GraviteeDefinitionAdapter {
     );
 
     @Mapping(target = "id", source = "apiEntity.id")
+    @Mapping(target = "apiVersion", source = "apiEntity.version")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
     @Mapping(target = "listeners", source = "apiEntity.apiDefinitionNativeV4.listeners")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MediaAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MediaAdapter.java
@@ -17,8 +17,10 @@ package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.apim.core.media.model.Media;
 import io.gravitee.rest.api.model.MediaEntity;
+import java.util.Collection;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -30,4 +32,9 @@ public interface MediaAdapter {
 
     MediaEntity toEntity(Media media);
     List<MediaEntity> toEntities(List<Media> mediaList);
+
+    List<Media> mapMedia(Collection<io.gravitee.repository.media.model.Media> src);
+
+    @Mapping(target = "apiId", source = "api")
+    Media mediaToMedia(io.gravitee.repository.media.model.Media media);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
@@ -38,6 +38,7 @@ import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import io.gravitee.apim.core.media.model.Media;
+import io.gravitee.apim.core.media.query_service.MediaQueryService;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
@@ -51,7 +52,6 @@ import io.gravitee.apim.infra.adapter.MemberAdapter;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -69,7 +69,7 @@ import org.springframework.stereotype.Service;
 public class ApiExportDomainServiceImpl implements ApiExportDomainService {
 
     private final PermissionService permissionService;
-    private final MediaService mediaService;
+    private final MediaQueryService mediaService;
 
     private final WorkflowCrudService workflowCrudService;
     private final MembershipCrudService membershipCrudService;
@@ -159,7 +159,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
 
     private List<Media> exportApiMedia(String apiId) {
         return permissionService.hasPermission(GraviteeContext.getExecutionContext(), API_DOCUMENTATION, apiId, READ)
-            ? GraviteeDefinitionAdapter.INSTANCE.mapMedia(mediaService.findAllByApiId(apiId))
+            ? mediaService.findAllByApiId(apiId)
             : null;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/media/MediaQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/media/MediaQueryServiceImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.media;
+
+import io.gravitee.apim.core.media.model.Media;
+import io.gravitee.apim.core.media.query_service.MediaQueryService;
+import io.gravitee.apim.infra.adapter.GraviteeDefinitionAdapter;
+import io.gravitee.apim.infra.adapter.MediaAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.media.api.MediaRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MediaQueryServiceImpl implements MediaQueryService {
+
+    private final MediaRepository mediaRepository;
+
+    @Override
+    public List<Media> findAllByApiId(String apiId) {
+        try {
+            return MediaAdapter.INSTANCE.mapMedia(mediaRepository.findAllByApi(apiId));
+        } catch (TechnicalException e) {
+            log.error("An error as occurred trying to find medias for API " + apiId, e);
+            throw new TechnicalManagementException("An error as occurred trying to find medias", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
@@ -26,9 +26,7 @@ import io.gravitee.rest.api.model.MediaEntity;
 import io.gravitee.rest.api.model.PageMediaEntity;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.MediaService;
-import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiMediaNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -110,7 +108,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             }
         } catch (TechnicalException | NoSuchAlgorithmException ex) {
             LOGGER.error("An error has occurred while trying to create media " + mediaEntity, ex);
-            throw new TechnicalManagementException("An error occurs while trying create media");
+            throw new TechnicalManagementException("An error occurs while trying create media", ex);
         }
     }
 
@@ -131,7 +129,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .orElse(null);
         } catch (TechnicalException e) {
             LOGGER.error("An error has occurred trying to find media with hash " + hash, e);
-            throw new TechnicalManagementException("An error has occurred trying to find media");
+            throw new TechnicalManagementException("An error has occurred trying to find media", e);
         }
     }
 
@@ -144,7 +142,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .orElse(null);
         } catch (TechnicalException e) {
             LOGGER.error("An error as occurred trying to find media for API " + apiId + " with hash " + hash, e);
-            throw new TechnicalManagementException("An error as occurred trying to find media");
+            throw new TechnicalManagementException("An error as occurred trying to find media", e);
         }
     }
 
@@ -165,7 +163,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .orElse(null);
         } catch (TechnicalException e) {
             LOGGER.error("An error as occurred trying to find media with hash " + hash, e);
-            throw new TechnicalManagementException("An error has occurred trying to find media");
+            throw new TechnicalManagementException("An error has occurred trying to find media", e);
         }
     }
 
@@ -178,7 +176,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .orElse(null);
         } catch (TechnicalException e) {
             LOGGER.error("An error as occurred trying to find media for API " + api + " with hash " + hash, e);
-            throw new TechnicalManagementException("An error as occurred trying to find media");
+            throw new TechnicalManagementException("An error as occurred trying to find media", e);
         }
     }
 
@@ -204,7 +202,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                     if (foundMedia.isPresent()) {
                         MediaEntity me = convert(foundMedia.get());
                         me.setFileName(pme.getMediaName());
-                        me.setUploadDate(pme.getAttachedAt());
+                        me.setCreateAt(pme.getAttachedAt());
                         result.add(me);
                     }
                 }
@@ -212,7 +210,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             return result;
         } catch (TechnicalException e) {
             LOGGER.error("An error as occurred trying to find medias with criteria " + mediaCriteria, e);
-            throw new TechnicalManagementException("An error as occurred trying to find medias");
+            throw new TechnicalManagementException("An error as occurred trying to find medias", e);
         }
     }
 
@@ -227,7 +225,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             return mediaRepository.findAllByApi(apiId).stream().map(MediaServiceImpl::convert).toList();
         } catch (TechnicalException e) {
             LOGGER.error("An error as occurred trying to find medias for API " + apiId, e);
-            throw new TechnicalManagementException("An error as occurred trying to find medias");
+            throw new TechnicalManagementException("An error as occurred trying to find medias", e);
         }
     }
 
@@ -238,7 +236,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             return saveApiMedia(executionContext, api, media);
         } catch (JsonProcessingException e) {
             LOGGER.error("An error as occurred while trying to JSON deserialize the media " + mediaDefinition, e);
-            throw new TechnicalManagementException("An error has occurred while trying to create media");
+            throw new TechnicalManagementException("An error has occurred while trying to create media", e);
         }
     }
 
@@ -248,7 +246,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             mediaRepository.deleteAllByApi(apiId);
         } catch (TechnicalException e) {
             LOGGER.error("An error has occurred while trying delete medias for API " + apiId, e);
-            throw new TechnicalManagementException("An error occurred trying to delete medias");
+            throw new TechnicalManagementException("An error occurred trying to delete medias", e);
         }
     }
 
@@ -260,7 +258,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             mediaRepository.deleteByHashAndApi(media.getHash(), apiId);
         } catch (TechnicalException e) {
             LOGGER.error("An error has occurred trying to delete media for API " + apiId + " with hash " + hash, e);
-            throw new TechnicalManagementException("An error has occurred trying to delete media");
+            throw new TechnicalManagementException("An error has occurred trying to delete media", e);
         }
     }
 
@@ -278,7 +276,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             mediaRepository.deleteByHashAndEnvironment(media.getHash(), executionContext.getEnvironmentId());
         } catch (TechnicalException e) {
             LOGGER.error("An error has occurred trying to delete media with hash " + hash, e);
-            throw new TechnicalManagementException("An error has occurred trying to delete media");
+            throw new TechnicalManagementException("An error has occurred trying to delete media", e);
         }
     }
 
@@ -306,7 +304,7 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
         mediaEntity.setSubType(media.getSubType());
         mediaEntity.setFileName(media.getFileName());
         mediaEntity.setSize(media.getSize());
-        mediaEntity.setUploadDate(media.getCreatedAt());
+        mediaEntity.setCreateAt(media.getCreatedAt());
         mediaEntity.setHash(media.getHash());
         return mediaEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MediaQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MediaQueryServiceInMemory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.media.model.Media;
+import io.gravitee.apim.core.media.query_service.MediaQueryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MediaQueryServiceInMemory implements MediaQueryService, InMemoryAlternative<Media> {
+
+    private final List<Media> storage = new ArrayList<>();
+
+    @Override
+    public List<Media> findAllByApiId(String apiId) {
+        return storage.stream().filter(media -> media.getApiId().equals(apiId)).toList();
+    }
+
+    @Override
+    public void initWith(List<Media> items) {
+        reset();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Media> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ExportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ExportApiUseCaseTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.MediaQueryServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.PageQueryServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import inmemory.WorkflowCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.domain_service.api.ApiExportDomainServiceImpl;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.federation.FederatedApi;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ExportApiUseCaseTest {
+
+    static final String ORG_ID = "MyOrg";
+    static final String API_ID = "apiId";
+    static final String API_NAME = "MyAPI";
+    static final String API_VERSION = "3.14.159";
+
+    @Mock
+    PermissionService permissionService;
+
+    MediaQueryServiceInMemory mediaService = new MediaQueryServiceInMemory();
+
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+
+    AuditDomainService auditService;
+
+    GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+
+    ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
+
+    WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
+    MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    PageQueryServiceInMemory pageQueryService = new PageQueryServiceInMemory();
+    PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+
+    ApiExportDomainService apiExportDomainService;
+
+    @InjectMocks
+    ExportApiUseCase sut;
+
+    AuditInfo auditInfo = AuditInfo.builder().organizationId(ORG_ID).build();
+
+    @BeforeEach
+    void setUp() {
+        auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        apiPrimaryOwnerDomainService =
+            new ApiPrimaryOwnerDomainService(
+                auditService,
+                groupQueryService,
+                membershipCrudService,
+                membershipQueryService,
+                roleQueryService,
+                userCrudService
+            );
+        apiExportDomainService =
+            new ApiExportDomainServiceImpl(
+                permissionService,
+                mediaService,
+                workflowCrudService,
+                membershipCrudService,
+                metadataCrudService,
+                pageQueryService,
+                apiCrudService,
+                apiPrimaryOwnerDomainService,
+                planCrudService
+            );
+        sut = new ExportApiUseCase(apiExportDomainService);
+        roleQueryService.initWith(
+            List.of(
+                Role
+                    .builder()
+                    .id("role-id")
+                    .scope(Role.Scope.API)
+                    .referenceType(Role.ReferenceType.ORGANIZATION)
+                    .referenceId(ORG_ID)
+                    .name("PRIMARY_OWNER")
+                    .build()
+            )
+        );
+        membershipQueryService.initWith(
+            List.of(
+                Membership
+                    .builder()
+                    .referenceType(Membership.ReferenceType.API)
+                    .referenceId(API_ID)
+                    .roleId("role-id")
+                    .memberType(Membership.Type.USER)
+                    .memberId("user id")
+                    .build()
+            )
+        );
+        userCrudService.initWith(List.of(BaseUserEntity.builder().id("user id").build()));
+        lenient().when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(
+                groupQueryService,
+                membershipCrudService,
+                membershipQueryService,
+                roleQueryService,
+                userCrudService,
+                workflowCrudService,
+                metadataCrudService,
+                pageQueryService,
+                apiCrudService,
+                planCrudService
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = "|",
+        textBlock = """
+        MyAPI     |  3.14.159  | myapi-3.14.159.json
+        My API    |  3.14 .159 | my-api-3.14-.159.json
+        My    API |  3.14.159  | my-api-3.14.159.json
+     """
+    )
+    void should_generate_excepted_filename(String name, String version, String expectedFilename) {
+        // Given
+        apiCrudService.initWith(List.of(v4Api(name, version)));
+        var input = ExportApiUseCase.Input.of(API_ID, auditInfo, Set.of());
+
+        // When
+        var output = sut.execute(input);
+
+        // Then
+        assertThat(output.filename()).isEqualTo(expectedFilename);
+    }
+
+    @Test
+    void should_export_native_api() {
+        // Given
+        apiCrudService.initWith(List.of(nativeApi()));
+        var input = ExportApiUseCase.Input.of(API_ID, auditInfo, Set.of());
+
+        // When
+        var output = sut.execute(input);
+
+        // Then
+        assertThat(output.definition().api().name()).isEqualTo(API_NAME);
+    }
+
+    @Test
+    void should_not_export_federated_API() {
+        // Given
+        apiCrudService.initWith(List.of(federatedApi()));
+        var input = ExportApiUseCase.Input.of(API_ID, auditInfo, Set.of());
+
+        // When
+        var throwable = catchThrowable(() -> sut.execute(input));
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiDefinitionVersionNotSupportedException.class);
+    }
+
+    /**
+     * It’s not the current behaviour of ApiExportDomainService, but it can become in future
+     */
+    @Test
+    void should_throw_API_not_found_exception_if_export_return_null() {
+        // Given
+        var mockedApiExportDomainService = mock(ApiExportDomainService.class);
+        sut = new ExportApiUseCase(mockedApiExportDomainService);
+        var input = ExportApiUseCase.Input.of(API_ID, auditInfo, Set.of());
+
+        // When
+        var throwable = catchThrowable(() -> sut.execute(input));
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    private static Api federatedApi() {
+        return Api
+            .builder()
+            .id(API_ID)
+            .version(API_VERSION)
+            .name(API_NAME)
+            .type(ApiType.PROXY)
+            .definitionVersion(DefinitionVersion.FEDERATED)
+            .federatedApiDefinition(FederatedApi.builder().apiVersion(API_VERSION).build())
+            .build();
+    }
+
+    private static Api v4Api(String name, String version) {
+        return Api
+            .builder()
+            .id(API_ID)
+            .version(version)
+            .name(name)
+            .type(ApiType.PROXY)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionHttpV4(io.gravitee.definition.model.v4.Api.builder().apiVersion(version).build())
+            .build();
+    }
+
+    private static Api nativeApi() {
+        return Api
+            .builder()
+            .id(API_ID)
+            .version(API_VERSION)
+            .name(API_NAME)
+            .type(ApiType.NATIVE)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionNativeV4(NativeApi.builder().apiVersion(API_VERSION).build())
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
+import io.gravitee.apim.core.media.query_service.MediaQueryService;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
@@ -37,7 +38,6 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.EnumSet;
@@ -56,9 +56,6 @@ class ApiExportDomainServiceImplTest {
 
     @Mock
     PermissionService permissionService;
-
-    @Mock
-    MediaService mediaService;
 
     @Mock
     WorkflowCrudService workflowCrudService;
@@ -80,6 +77,9 @@ class ApiExportDomainServiceImplTest {
 
     @Mock
     PlanCrudService planCrudService;
+
+    @Mock
+    MediaQueryService mediaService;
 
     @InjectMocks
     ApiExportDomainServiceImpl sut;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/media/MediaQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/media/MediaQueryServiceImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.media.model.Media;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.media.api.MediaRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MediaQueryServiceImplTest {
+
+    @Mock
+    MediaRepository mediaRepository;
+
+    @InjectMocks
+    MediaQueryServiceImpl sut;
+
+    @Nested
+    class FindAllByApiId {
+
+        @Test
+        public void shouldCorrectlyWapTheResult() throws TechnicalException {
+            // Given
+            var media = new io.gravitee.repository.media.model.Media("type", "sub type", "file name", 12L);
+            media.setId("ID");
+            media.setApi("api-id");
+            when(mediaRepository.findAllByApi(anyString())).thenReturn(List.of(media));
+
+            // When
+            List<Media> allByApiId = sut.findAllByApiId("api-id");
+
+            // Then
+            assertThat(allByApiId).containsOnly(new Media("ID", null, "type", "sub type", "file name", null, 12L, null, "api-id"));
+        }
+
+        @Test
+        public void shouldWrapException() throws TechnicalException {
+            // Given
+            when(mediaRepository.findAllByApi(anyString())).thenThrow(new TechnicalException("error"));
+
+            // When
+            var th = catchThrowable(() -> sut.findAllByApiId("api-id"));
+
+            // Then
+            assertThat(th).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MediaServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MediaServiceTest.java
@@ -524,7 +524,7 @@ public class MediaServiceTest extends TestCase {
         mediaEntity.setType(MEDIA_TYPE);
         mediaEntity.setSize(MEDIA_SIZE);
         mediaEntity.setHash(MEDIA_HASH);
-        mediaEntity.setUploadDate(MEDIA_DATE);
+        mediaEntity.setCreateAt(MEDIA_DATE);
         if (includeContent) {
             mediaEntity.setData(readBytes());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiImportExportServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiImportExportServiceImplTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -170,7 +169,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_only_api_when_only_definition_permission() throws JsonProcessingException {
+    public void should_export_only_api_when_only_definition_permission() {
         mockPermissions(false, false, false, false);
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
 
@@ -189,7 +188,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_members_and_api_when_member_and_definition_permission() throws JsonProcessingException {
+    public void should_export_members_and_api_when_member_and_definition_permission() {
         mockPermissions(true, false, false, false);
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
         doReturn(this.fakeApiMembers())
@@ -212,7 +211,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_metadata_and_api_when_metadata_and_definition_permission() throws JsonProcessingException {
+    public void should_export_metadata_and_api_when_metadata_and_definition_permission() {
         mockPermissions(false, true, false, false);
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
         doReturn(new ArrayList<>(this.fakeApiMetadata()))
@@ -236,7 +235,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_plans_and_api_when_plan_and_definition_permission() throws JsonProcessingException {
+    public void should_export_plans_and_api_when_plan_and_definition_permission() {
         mockPermissions(false, false, true, false);
 
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
@@ -259,7 +258,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_pages_and_api_when_documentation_and_definition_permission() throws JsonProcessingException {
+    public void should_export_pages_and_api_when_documentation_and_definition_permission() {
         mockPermissions(false, false, false, true);
 
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
@@ -283,7 +282,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_api_and_exclude_all_additional_data() throws JsonProcessingException {
+    public void should_export_api_and_exclude_all_additional_data() {
         doReturn(this.fakeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
 
         var EXCLUDE_ALL_ADDITIONAL_DATA = Set.of("members", "metadata", "plans", "pages", "groups");
@@ -297,7 +296,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_native_api_and_exclude_all_additional_data() throws JsonProcessingException {
+    public void should_export_native_api_and_exclude_all_additional_data() {
         doReturn(this.fakeNativeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
 
         var EXCLUDE_ALL_ADDITIONAL_DATA = Set.of("members", "metadata", "plans", "pages", "groups");
@@ -311,7 +310,7 @@ public class ApiImportExportServiceImplTest {
     }
 
     @Test
-    public void should_export_native_api_with_members_metadata_nativePlans_pages() throws JsonProcessingException {
+    public void should_export_native_api_with_members_metadata_nativePlans_pages() {
         mockPermissions(true, true, true, true);
         doReturn(this.fakeNativeApiEntityV4()).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API_ID);
         doReturn(this.fakeApiMembers())
@@ -552,20 +551,21 @@ public class ApiImportExportServiceImplTest {
         Endpoint endpoint = new Endpoint();
         endpoint.setType("http-get");
         endpoint.setConfiguration(
-            "{\n" +
-            "                        \"bootstrapServers\": \"kafka:9092\",\n" +
-            "                        \"topics\": [\n" +
-            "                            \"demo\"\n" +
-            "                        ],\n" +
-            "                        \"producer\": {\n" +
-            "                            \"enabled\": false\n" +
-            "                        },\n" +
-            "                        \"consumer\": {\n" +
-            "                            \"encodeMessageId\": true,\n" +
-            "                            \"enabled\": true,\n" +
-            "                            \"autoOffsetReset\": \"earliest\"\n" +
-            "                        }\n" +
-            "                    }"
+            """
+                        {
+                                                "bootstrapServers": "kafka:9092",
+                                                "topics": [
+                                                    "demo"
+                                                ],
+                                                "producer": {
+                                                    "enabled": false
+                                                },
+                                                "consumer": {
+                                                    "encodeMessageId": true,
+                                                    "enabled": true,
+                                                    "autoOffsetReset": "earliest"
+                                                }
+                                            }"""
         );
         endpointGroup.setEndpoints(List.of(endpoint));
         apiEntity.setEndpointGroups(List.of(endpointGroup));
@@ -862,7 +862,7 @@ public class ApiImportExportServiceImplTest {
         mediaEntity.setType("media-type");
         mediaEntity.setSubType("media-sub-type");
         mediaEntity.setData("media-data".getBytes(StandardCharsets.UTF_8));
-        mediaEntity.setUploadDate(new Date(0));
+        mediaEntity.setCreateAt(new Date(0));
 
         return List.of(mediaEntity);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8349

Mostly rework mapping of export to take GraviteeDefinition as input.

I add some mssing fields but `needRedeployAt` seems not interesrting as export.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vuyxvdsqsz.chromatic.com)
<!-- Storybook placeholder end -->
