### PR TITLE
fix: revert map endpoint headers to map on v2 crd export

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
@@ -171,7 +171,7 @@ public class ApiDefinitionResource extends CustomResource<ObjectNode> {
         if (spec.hasNonNull(PROXY_FIELD)) {
             var proxy = getSpec().get(PROXY_FIELD);
             if (proxy.hasNonNull(ENDPOINT_GROUPS_FIELD)) {
-                proxy.get(ENDPOINT_GROUPS_FIELD).forEach(this::prepareEndpointGroup);
+                proxy.get(ENDPOINT_GROUPS_FIELD).forEach(this::removeUnsupportedEndpointGroupFields);
             }
         }
     }
@@ -189,30 +189,5 @@ public class ApiDefinitionResource extends CustomResource<ObjectNode> {
             pagesMap.set(key.asText(), ((ObjectNode) page).remove(UNSUPPORTED_PAGE_FIELDS));
         }
         return pagesMap;
-    }
-
-    private void prepareEndpointGroup(JsonNode group) {
-        removeUnsupportedEndpointGroupFields(group);
-        replaceEndpointHeaders((ObjectNode) group);
-        if (group.hasNonNull(ENDPOINTS_FIELD)) {
-            var endpoints = (ArrayNode) group.get(ENDPOINTS_FIELD);
-            endpoints.forEach(endpoint -> replaceEndpointHeaders((ObjectNode) endpoint));
-        }
-    }
-
-    private void replaceEndpointHeaders(ObjectNode endpoint) {
-        if (endpoint.has("headers")) {
-            endpoint.replace("headers", mapHeaders((ArrayNode) endpoint.get("headers")));
-        }
-    }
-
-    private ObjectNode mapHeaders(ArrayNode headers) {
-        var headerMap = JsonNodeFactory.instance.objectNode();
-        headers.forEach(header -> {
-            var name = header.get("name").asText();
-            var value = header.get("value").asText();
-            headerMap.put(name, value);
-        });
-        return headerMap;
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
@@ -88,19 +88,6 @@ class ApiDefinitionResourceTest {
     }
 
     @Test
-    void shouldMapHeadersToMap() throws Exception {
-        var resource = new ApiDefinitionResource("api-definition", readDefinition("api-definition.json"));
-        var proxy = (ObjectNode) resource.getSpec().get("proxy");
-        assertTrue(proxy.has("groups"));
-        var groups = (ArrayNode) proxy.get("groups");
-        assertEquals(1, groups.size());
-        var group = groups.get(0);
-        assertTrue(group.has("headers"));
-        var headers = group.get("headers");
-        assertEquals("true", headers.get("x-test").asText());
-    }
-
-    @Test
     public void shouldMapPageWithoutName() throws Exception {
         ApiDefinitionResource resource = new ApiDefinitionResource(
             "api-definition",

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/resources/io/gravitee/definition/model/kubernetes/v1alpha1/api-definition.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/resources/io/gravitee/definition/model/kubernetes/v1alpha1/api-definition.json
@@ -146,13 +146,7 @@
           "maxConcurrentConnections": 100,
           "useCompression": true,
           "followRedirects": false
-        },
-        "headers": [
-          {
-            "name": "x-test",
-            "value": "true"
-          }
-        ]
+        }
       }
     ]
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.apim.core.api.model.Path;
 import io.gravitee.common.component.Lifecycle;


### PR DESCRIPTION
This reverts commit c024fdaa0194155aee48108086a51cc4eb646dd9.
