### PR TITLE
test(mongodb): fix mongo encryption test

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/resources/graviteeTest.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/resources/graviteeTest.yml
@@ -16,3 +16,6 @@ management:
         - type: local
           local:
             key: s1LSgcxwixnMWuPMWuNQpZZVHbaaT9pbyAuqrExk38gmcgg9DomK7IoYsvWpG+aZcOB7MfGTdRVILjNWL4mbEQ00f0Kz+W6f9Hu+npzOpMsbkH3SC/FlJEaeWrwavNQZ
+      keyVault:
+        collectionName: __dataKeysForTest
+        keyAlternativeName: encryption-test


### PR DESCRIPTION
## Issue

N/A

## Description

Fix mongodb encryption test by configuring the right key alternative name in the properties.
Indeed, even if this value is set in the dev bean, it's also used [here](https://github.com/gravitee-io/gravitee-api-management/blob/4.6.x/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/encryption/EncryptionConfiguration.java#L182).
So we have to set the environment property for the tests