### PR TITLE
fix: bump entrypoint-webhook version to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <gravitee-entrypoint-http-get.version>1.2.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.2.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>4.1.0</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>3.1.1</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>3.1.2</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.10.2</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.2.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8562

## Description

upgrading version of entrypoint webhook to 3.1.2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xgkkwvchxm.chromatic.com)
<!-- Storybook placeholder end -->
