### PR TITLE
Apim 6236 return v2 and v4 logs to new portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.html
@@ -36,7 +36,7 @@
         <mat-label i18n="@@applicationLogsHttpMethods">HTTP Methods</mat-label>
         <mat-select (selectionChange)="selectHttpMethods($event)" multiple [value]="filters().methods" aria-label="Filter by HTTP Method">
           @for (method of httpMethods; track method) {
-            <mat-option [value]="method">{{ method.label }}</mat-option>
+            <mat-option [value]="method">{{ method }}</mat-option>
           }
         </mat-select>
       </mat-form-field>
@@ -118,8 +118,8 @@
             }
           }
           @if (filters().methods) {
-            @for (method of filters().methods; track method.value) {
-              <mat-chip>{{ method.label }}</mat-chip>
+            @for (method of filters().methods; track method) {
+              <mat-chip>{{ method }}</mat-chip>
             }
           }
           @if (filters().responseTimes) {

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
@@ -1045,51 +1045,52 @@ describe('ApplicationLogTableComponent', () => {
       });
     });
 
-    describe('Message text', () => {
-      describe('Message text defined in query params', () => {
-        const MESSAGE_TEXT = 'find me';
-        beforeEach(async () => {
-          await init({ messageText: MESSAGE_TEXT });
-
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*${MESSAGE_TEXT}*`);
-          expectGetSubscriptions(fakeSubscriptionResponse());
-          fixture.detectChanges();
-        });
-
-        it('should have message text pre-filled', async () => {
-          expect(await noChipFiltersDisplayed()).toEqual(false);
-          const chips = await harnessLoader.getAllHarnesses(MatChipHarness);
-          expect(chips).toHaveLength(1);
-          expect(await chips[0].getText()).toEqual(`Message body includes: ${MESSAGE_TEXT}`);
-
-          await openMoreFiltersDialog();
-          const dialog = await rootHarnessLoader.getHarness(MoreFiltersDialogHarness);
-          const messageTextInput = await dialog.getMessageTextInput();
-          expect(await messageTextInput.getValue()).toEqual(MESSAGE_TEXT);
-        });
-
-        it('should change message text filter', async () => {
-          await openMoreFiltersDialog();
-          const dialog = await rootHarnessLoader.getHarness(MoreFiltersDialogHarness);
-          const messageTextInput = await dialog.getMessageTextInput();
-          await messageTextInput.setValue('actually find this');
-          await dialog.applyFilters();
-
-          const searchButton = await getSearchButton();
-          expect(await searchButton.isDisabled()).toEqual(false);
-
-          await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*actually find this*`);
-        });
-        it('should reset filter', async () => {
-          const resetButton = await getResetFilterButton();
-          expect(await resetButton.isDisabled()).toEqual(false);
-          await resetButton.click();
-
-          expect(await noChipFiltersDisplayed()).toEqual(true);
-        });
-      });
-    });
+    // TODO: Move tests back into test suite once the backend can handle searching in response bodies
+    // describe('Message text', () => {
+    //   describe('Message text defined in query params', () => {
+    //     const MESSAGE_TEXT = 'find me';
+    //     beforeEach(async () => {
+    //       await init({ messageText: MESSAGE_TEXT });
+    //
+    //       expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*${MESSAGE_TEXT}*`);
+    //       expectGetSubscriptions(fakeSubscriptionResponse());
+    //       fixture.detectChanges();
+    //     });
+    //
+    //     it('should have message text pre-filled', async () => {
+    //       expect(await noChipFiltersDisplayed()).toEqual(false);
+    //       const chips = await harnessLoader.getAllHarnesses(MatChipHarness);
+    //       expect(chips).toHaveLength(1);
+    //       expect(await chips[0].getText()).toEqual(`Message body includes: ${MESSAGE_TEXT}`);
+    //
+    //       await openMoreFiltersDialog();
+    //       const dialog = await rootHarnessLoader.getHarness(MoreFiltersDialogHarness);
+    //       const messageTextInput = await dialog.getMessageTextInput();
+    //       expect(await messageTextInput.getValue()).toEqual(MESSAGE_TEXT);
+    //     });
+    //
+    //     it('should change message text filter', async () => {
+    //       await openMoreFiltersDialog();
+    //       const dialog = await rootHarnessLoader.getHarness(MoreFiltersDialogHarness);
+    //       const messageTextInput = await dialog.getMessageTextInput();
+    //       await messageTextInput.setValue('actually find this');
+    //       await dialog.applyFilters();
+    //
+    //       const searchButton = await getSearchButton();
+    //       expect(await searchButton.isDisabled()).toEqual(false);
+    //
+    //       await searchButton.click();
+    //       expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*actually find this*`);
+    //     });
+    //     it('should reset filter', async () => {
+    //       const resetButton = await getResetFilterButton();
+    //       expect(await resetButton.isDisabled()).toEqual(false);
+    //       await resetButton.click();
+    //
+    //       expect(await noChipFiltersDisplayed()).toEqual(true);
+    //     });
+    //   });
+    // });
 
     describe('Path', () => {
       describe('Path defined in query params', () => {

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-tab-logs.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-tab-logs.service.ts
@@ -15,7 +15,7 @@
  */
 import { Injectable } from '@angular/core';
 
-import { ApplicationLogService, HttpMethodVM } from '../../../../services/application-log.service';
+import { ApplicationLogService } from '../../../../services/application-log.service';
 
 export interface ResponseTimeVM {
   value: string;
@@ -39,7 +39,7 @@ export interface HttpStatusVM {
   providedIn: 'root',
 })
 export class ApplicationTabLogsService {
-  get httpMethods(): HttpMethodVM[] {
+  get httpMethods(): string[] {
     return ApplicationLogService.METHODS;
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.html
@@ -59,12 +59,13 @@
         </mat-select>
       </mat-form-field>
     </div>
-    <div class="content__row">
-      <mat-form-field appearance="outline">
-        <mat-label i18n="@@moreFiltersDialogSearchText">Search Text in Message Bodies</mat-label>
-        <input matInput [(ngModel)]="messageText" aria-label="Filter by Message Text" />
-      </mat-form-field>
-    </div>
+    <!--          TODO: Reimplement when backend can handle message search in body -->
+    <!--    <div class="content__row">-->
+    <!--      <mat-form-field appearance="outline">-->
+    <!--        <mat-label i18n="@@moreFiltersDialogSearchText">Search Text in Message Bodies</mat-label>-->
+    <!--        <input matInput [(ngModel)]="messageText" aria-label="Filter by Message Text" />-->
+    <!--      </mat-form-field>-->
+    <!--    </div>-->
     <div class="content__row">
       <mat-form-field appearance="outline">
         <mat-label i18n="@@moreFiltersDialogPath">Path</mat-label>

--- a/gravitee-apim-portal-webui-next/src/services/application-log.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-log.service.spec.ts
@@ -209,6 +209,26 @@ describe('ApplicationLogService', () => {
       req.flush(logsResponse);
     });
 
+    // TODO: Fix test when backend can handle searching text in response body
+    // it('should return logs list with specified message text', done => {
+    //   const logsResponse: LogsResponse = fakeLogsResponse();
+    //   const currentDateInMilliseconds = Date.now();
+    //   const yesterdayInMilliseconds = currentDateInMilliseconds - 86400000;
+    //   const messageText = 'find me';
+    //   service.search(APP_ID,1, 10, { messageText }).subscribe(response => {
+    //     expect(response).toMatchObject(logsResponse);
+    //     done();
+    //   });
+    //
+    //   const req = httpTestingController.expectOne(
+    //     `${TESTING_BASE_URL}/applications/${APP_ID}/logs/_search?page=1&size=10&order=DESC&field=@timestamp` +
+    //       `&query=body:*${messageText}*`,
+    //   );
+    //   expect(req.request.method).toEqual('POST');
+    //
+    //   req.flush(logsResponse);
+    // });
+
     it('should return logs list with specified path', done => {
       const logsResponse: LogsResponse = fakeLogsResponse();
       const currentDateInMilliseconds = Date.now();

--- a/gravitee-apim-portal-webui-next/src/services/application-log.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-log.service.ts
@@ -20,26 +20,20 @@ import { Observable } from 'rxjs';
 import { ConfigService } from './config.service';
 import { Log, LogsResponse } from '../entities/log/log';
 
-/* eslint-disable no-useless-escape */
-
-export interface HttpMethodVM {
-  value: string;
-  label: string;
-}
-
-export interface ApplicationLogsListParameters {
-  page?: number;
-  size?: number;
+export interface ResponseTimeRange {
   to?: number;
   from?: number;
-  order?: 'ASC' | 'DESC';
-  field?: string;
-  apis?: string[];
-  methods?: HttpMethodVM[];
-  responseTimes?: string[];
+}
+
+export interface SearchApplicationLogsParameters {
+  to?: number;
+  from?: number;
+  apiIds?: string[];
+  methods?: string[];
+  responseTimeRanges?: ResponseTimeRange[];
   requestId?: string;
   transactionId?: string;
-  httpStatuses?: string[];
+  statuses?: string[];
   messageText?: string;
   path?: string;
 }
@@ -48,126 +42,42 @@ export interface ApplicationLogsListParameters {
   providedIn: 'root',
 })
 export class ApplicationLogService {
-  public static METHODS: HttpMethodVM[] = [
-    { value: '3', label: 'GET' },
-    { value: '7', label: 'POST' },
-    { value: '8', label: 'PUT' },
-    { value: '2', label: 'DELETE' },
-    { value: '6', label: 'PATCH' },
-    { value: '5', label: 'OPTIONS' },
-    { value: '4', label: 'HEAD' },
-    { value: '9', label: 'TRACE' },
-    { value: '1', label: 'CONNECT' },
-    { value: '0', label: 'OTHER' },
-  ];
+  public static METHODS: string[] = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'TRACE', 'CONNECT', 'OTHER'];
   constructor(
     private readonly http: HttpClient,
     private configService: ConfigService,
   ) {}
 
-  list(applicationId: string, params: ApplicationLogsListParameters): Observable<LogsResponse> {
+  search(
+    applicationId: string,
+    page: number = 1,
+    pageSize: number = 10,
+    params: SearchApplicationLogsParameters = {},
+  ): Observable<LogsResponse> {
     const paramsList = [];
-    paramsList.push(`page=${params.page ?? 1}`);
-    paramsList.push(`size=${params.size ?? 10}`);
+    paramsList.push(`page=${page}`);
+    paramsList.push(`size=${pageSize}`);
+    const paginationParams = `page=${page}&size=${pageSize}`;
 
     const currentDate = Date.now();
     const yesterdayDate = new Date();
     yesterdayDate.setDate(yesterdayDate.getDate() - 1);
 
-    paramsList.push(`from=${params.from ?? yesterdayDate.getTime()}`);
-    paramsList.push(`to=${params.to ?? currentDate}`);
-    paramsList.push(`order=${params.order ?? 'DESC'}`);
-
-    paramsList.push(`field=${params.field ?? '@timestamp'}`);
-
-    const query = this.serializeLogListQuery({ ...params });
-    if (query.length) {
-      paramsList.push(`query=${query}`);
-    }
-
-    return this.http.get<LogsResponse>(`${this.configService.baseURL}/applications/${applicationId}/logs?${paramsList.join('&')}`);
+    return this.http.post<LogsResponse>(`${this.configService.baseURL}/applications/${applicationId}/logs/_search?${paginationParams}`, {
+      from: params.from ?? yesterdayDate.getTime(),
+      to: params.to ?? currentDate,
+      ...(params.apiIds?.length ? { apiIds: params.apiIds } : {}),
+      ...(params.methods?.length ? { methods: params.methods } : {}),
+      ...(params.requestId ? { requestIds: [params.requestId] } : {}),
+      ...(params.transactionId ? { transactionIds: [params.transactionId] } : {}),
+      ...(params.statuses?.length ? { statuses: params.statuses } : {}),
+      ...(params.messageText ? { messageText: params.messageText } : {}),
+      ...(params.path ? { path: params.path } : {}),
+      ...(params.responseTimeRanges?.length ? { responseTimeRanges: params.responseTimeRanges } : {}),
+    });
   }
 
   get(applicationId: string, logId: string, timestamp: string): Observable<Log> {
     return this.http.get<Log>(`${this.configService.baseURL}/applications/${applicationId}/logs/${logId}?timestamp=${timestamp}`);
-  }
-
-  private serializeLogListQuery(params: ApplicationLogsListParameters): string {
-    const queryList: string[] = [];
-    const apisQuerySegment = this.createQuotationsListQuerySegment('api', params.apis);
-    if (apisQuerySegment) {
-      queryList.push(apisQuerySegment);
-    }
-
-    const methodsQuerySegment = this.createQuotationsListQuerySegment(
-      'method',
-      params.methods?.map(m => m.value),
-    );
-    if (methodsQuerySegment) {
-      queryList.push(methodsQuerySegment);
-    }
-
-    const responseTimesQuerySegment = this.createListQuerySegment('response-time', params.responseTimes);
-    if (responseTimesQuerySegment) {
-      queryList.push(responseTimesQuerySegment);
-    }
-
-    const requestIdQuerySegment = this.createQuotationsQuerySegment('_id', params.requestId);
-    if (requestIdQuerySegment) {
-      queryList.push(requestIdQuerySegment);
-    }
-
-    const transactionIdQuerySegment = this.createQuotationsQuerySegment('transaction', params.transactionId);
-    if (transactionIdQuerySegment) {
-      queryList.push(transactionIdQuerySegment);
-    }
-
-    const httpStatusesQuerySegment = this.createQuotationsListQuerySegment('status', params.httpStatuses);
-    if (httpStatusesQuerySegment) {
-      queryList.push(httpStatusesQuerySegment);
-    }
-
-    const messageTextQuerySegment = this.createAsteriskQuerySegment('body', params.messageText);
-    if (messageTextQuerySegment) {
-      queryList.push(messageTextQuerySegment);
-    }
-
-    const pathQuerySegment = this.createAsteriskQuerySegment('uri', params.path);
-    if (pathQuerySegment) {
-      queryList.push(pathQuerySegment);
-    }
-
-    return queryList.join(' AND ');
-  }
-
-  private createQuotationsQuerySegment(root: string, value?: string) {
-    if (value && value.length) {
-      return `${root}\:\\"${value}\\"`;
-    }
-    return undefined;
-  }
-
-  private createQuotationsListQuerySegment(root: string, values?: string[]) {
-    if (values?.length) {
-      const queryContent = values.map(v => `\\"${v}\\"`).join(' OR ');
-      return `${root}\:(${queryContent})`;
-    }
-    return undefined;
-  }
-
-  private createListQuerySegment(root: string, values?: string[]) {
-    if (values?.length) {
-      const queryContent = values.map(v => `[${v}]`).join(' OR ');
-      return `${root}\:(${queryContent})`;
-    }
-    return undefined;
-  }
-
-  private createAsteriskQuerySegment(root: string, value?: string) {
-    if (value && value.length) {
-      const cleanValue = value.replaceAll('/', '\\\\/');
-      return `${root}\:*${cleanValue}*`;
-    }
-    return undefined;
   }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
@@ -44,5 +44,8 @@ public class ConnectionLogQuery {
         private Set<Integer> statuses;
         private Set<String> entrypointIds;
         private Set<String> apiIds;
+        private Set<String> requestIds;
+        private Set<String> transactionIds;
+        private String uri;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
@@ -36,7 +36,6 @@ public class ConnectionLogQuery {
     @Builder
     public static class Filter {
 
-        private String apiId;
         private Long from;
         private Long to;
         private Set<String> applicationIds;
@@ -44,5 +43,6 @@ public class ConnectionLogQuery {
         private Set<HttpMethod> methods;
         private Set<Integer> statuses;
         private Set<String> entrypointIds;
+        private Set<String> apiIds;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.log.v4.model.connection;
 
 import io.gravitee.common.http.HttpMethod;
+import java.util.List;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
@@ -47,5 +48,14 @@ public class ConnectionLogQuery {
         private Set<String> requestIds;
         private Set<String> transactionIds;
         private String uri;
+        private List<ResponseTimeRange> responseTimeRanges;
+
+        @Data
+        @Builder
+        public static class ResponseTimeRange {
+
+            private Long to;
+            private Long from;
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/ConnectionLogField.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/ConnectionLogField.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.connection;
+
+/**
+ * Centralization of fields used for Connection Logs.
+ * <p>
+ * Some fields are shared between indexes, i.e. @timestamp.
+ * While others have different values depending upon the index.
+ * <p>
+ * There are currently two indexes possible for queries: <br>
+ * - Request -- used by V2 APIs <br>
+ * - Metrics -- used by V4 APIs
+ *
+ */
+public class ConnectionLogField {
+
+    // Fields with same name in both indexes: Request + Metrics
+    public static final String TIMESTAMP = "@timestamp";
+    public static final String STATUS = "status";
+    public static final String GATEWAY = "gateway";
+    public static final String URI = "uri";
+
+    // Fields with different names in each index
+    public static final Field REQUEST_ID = new Field("_id", "request-id");
+    public static final Field APPLICATION_ID = new Field("application", "application-id");
+    public static final Field API_ID = new Field("api", "api-id");
+    public static final Field PLAN_ID = new Field("plan", "plan-id");
+    public static final Field CLIENT_IDENTIFIER = new Field("subscription", "client-identifier");
+    public static final Field TRANSACTION_ID = new Field("transaction", "transaction-id");
+    public static final Field HTTP_METHOD = new Field("method", "http-method");
+    public static final Field GATEWAY_RESPONSE_TIME = new Field("response-time", "gateway-response-time-ms");
+    public static final Field ENTRYPOINT_ID = new Field(null, "entrypoint-id");
+    public static final Field REQUEST_ENDED = new Field(null, "request-ended");
+
+    public record Field(String v2Request, String v4Metrics) {}
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
@@ -53,7 +53,7 @@ public class SearchConnectionLogQueryAdapter {
 
         var mustFilterList = new ArrayList<JsonObject>();
 
-        addApiIdFilter(filter, mustFilterList);
+        addApisFilter(filter, mustFilterList);
 
         addFromAndToFilters(filter, mustFilterList);
 
@@ -74,13 +74,9 @@ public class SearchConnectionLogQueryAdapter {
         return null;
     }
 
-    private static void addApiIdFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
-        if (filter.getApiId() != null) {
-            var apiShouldTerms = new ArrayList<JsonObject>();
-            apiShouldTerms.add(JsonObject.of("term", JsonObject.of("api-id", filter.getApiId())));
-            apiShouldTerms.add(JsonObject.of("term", JsonObject.of("api", filter.getApiId())));
-
-            mustFilterList.add(buildShould(apiShouldTerms));
+    private static void addApisFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getApiIds())) {
+            mustFilterList.add(buildV2AndV4Terms("api", "api-id", filter.getApiIds()));
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
@@ -21,11 +21,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import org.springframework.util.CollectionUtils;
 
 public class SearchConnectionLogQueryAdapter {
@@ -76,37 +74,41 @@ public class SearchConnectionLogQueryAdapter {
 
     private static void addApisFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getApiIds())) {
-            mustFilterList.add(buildV2AndV4Terms("api", "api-id", filter.getApiIds()));
+            mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.API_ID, filter.getApiIds()));
         }
     }
 
     private static void addEntrypointIdsFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getEntrypointIds())) {
-            mustFilterList.add(JsonObject.of("terms", JsonObject.of("entrypoint-id", filter.getEntrypointIds())));
+            mustFilterList.add(
+                JsonObject.of("terms", JsonObject.of(ConnectionLogField.ENTRYPOINT_ID.v4Metrics(), filter.getEntrypointIds()))
+            );
         }
     }
 
     private static void addStatusesFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getStatuses())) {
-            mustFilterList.add(JsonObject.of("terms", JsonObject.of("status", filter.getStatuses())));
+            mustFilterList.add(JsonObject.of("terms", JsonObject.of(ConnectionLogField.STATUS, filter.getStatuses())));
         }
     }
 
     private static void addHttpMethodsFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getMethods())) {
-            mustFilterList.add(buildV2AndV4Terms("method", "http-method", filter.getMethods().stream().map(HttpMethod::code).toList()));
+            mustFilterList.add(
+                buildV2AndV4Terms(ConnectionLogField.HTTP_METHOD, filter.getMethods().stream().map(HttpMethod::code).toList())
+            );
         }
     }
 
     private static void addPlansFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getPlanIds())) {
-            mustFilterList.add(buildV2AndV4Terms("plan", "plan-id", filter.getPlanIds()));
+            mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.PLAN_ID, filter.getPlanIds()));
         }
     }
 
     private static void addApplicationsFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getApplicationIds())) {
-            mustFilterList.add(buildV2AndV4Terms("application", "application-id", filter.getApplicationIds()));
+            mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.APPLICATION_ID, filter.getApplicationIds()));
         }
     }
 
@@ -119,18 +121,18 @@ public class SearchConnectionLogQueryAdapter {
             if (filter.getTo() != null) {
                 timestampJsonObject.put("lte", new Date(filter.getTo()));
             }
-            mustFilterList.add(JsonObject.of("range", JsonObject.of("@timestamp", timestampJsonObject)));
+            mustFilterList.add(JsonObject.of("range", JsonObject.of(ConnectionLogField.TIMESTAMP, timestampJsonObject)));
         }
     }
 
     private static JsonObject buildSort() {
-        return JsonObject.of("@timestamp", JsonObject.of("order", "desc"));
+        return JsonObject.of(ConnectionLogField.TIMESTAMP, JsonObject.of("order", "desc"));
     }
 
-    private static JsonObject buildV2AndV4Terms(String v2RequestIndexRef, String v4MetricsIndexRef, Collection<?> value) {
+    private static JsonObject buildV2AndV4Terms(ConnectionLogField.Field field, Collection<?> value) {
         var terms = new ArrayList<JsonObject>();
-        terms.add(JsonObject.of("terms", JsonObject.of(v2RequestIndexRef, value.toArray())));
-        terms.add(JsonObject.of("terms", JsonObject.of(v4MetricsIndexRef, value.toArray())));
+        terms.add(JsonObject.of("terms", JsonObject.of(field.v2Request(), value.toArray())));
+        terms.add(JsonObject.of("terms", JsonObject.of(field.v4Metrics(), value.toArray())));
         return buildShould(terms);
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
@@ -65,6 +65,12 @@ public class SearchConnectionLogQueryAdapter {
 
         addEntrypointIdsFilter(filter, mustFilterList);
 
+        addRequestIdsFilter(filter, mustFilterList);
+
+        addTransactionIdsFilter(filter, mustFilterList);
+
+        addUriFilter(filter, mustFilterList);
+
         if (!mustFilterList.isEmpty()) {
             return JsonObject.of("bool", JsonObject.of("must", JsonArray.of(mustFilterList.toArray())));
         }
@@ -75,6 +81,30 @@ public class SearchConnectionLogQueryAdapter {
     private static void addApisFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getApiIds())) {
             mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.API_ID, filter.getApiIds()));
+        }
+    }
+
+    private static void addRequestIdsFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getRequestIds())) {
+            mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.REQUEST_ID, filter.getRequestIds()));
+        }
+    }
+
+    private static void addTransactionIdsFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getTransactionIds())) {
+            mustFilterList.add(buildV2AndV4Terms(ConnectionLogField.TRANSACTION_ID, filter.getTransactionIds()));
+        }
+    }
+
+    private static void addUriFilter(ConnectionLogQuery.Filter filter, List<JsonObject> mustFilterList) {
+        var uriKeyword = filter.getUri();
+        if (uriKeyword != null && !uriKeyword.isBlank()) {
+            var beginningSlash = uriKeyword.startsWith("/") ? "" : "/";
+            var endingWildcard = uriKeyword.endsWith("*") ? "" : "*";
+
+            mustFilterList.add(
+                JsonObject.of("wildcard", JsonObject.of(ConnectionLogField.URI, beginningSlash + uriKeyword + endingWildcard))
+            );
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogResponseAdapter.java
@@ -46,36 +46,36 @@ public class SearchConnectionLogResponseAdapter {
     private static ConnectionLog buildFromSource(String index, String id, JsonNode json) {
         var connectionLog = ConnectionLog
             .builder()
-            .timestamp(asTextOrNull(json.get("@timestamp")))
-            .status(asIntOr(json.get("status"), 0))
-            .gateway(asTextOrNull(json.get("gateway")))
-            .uri(asTextOrNull(json.get("uri")));
+            .timestamp(asTextOrNull(json.get(ConnectionLogField.TIMESTAMP)))
+            .status(asIntOr(json.get(ConnectionLogField.STATUS), 0))
+            .gateway(asTextOrNull(json.get(ConnectionLogField.GATEWAY)))
+            .uri(asTextOrNull(json.get(ConnectionLogField.URI)));
 
         if (index.contains(Type.REQUEST.getType())) {
             return connectionLog
                 .requestId(id)
-                .applicationId(asTextOrNull(json.get("application")))
-                .apiId(asTextOrNull(json.get("api")))
-                .planId(asTextOrNull(json.get("plan")))
-                .clientIdentifier(asTextOrNull(json.get("subscription")))
-                .transactionId(asTextOrNull(json.get("transaction")))
-                .method(HttpMethod.get(asIntOr(json.get("method"), 0)))
+                .applicationId(asTextOrNull(json.get(ConnectionLogField.APPLICATION_ID.v2Request())))
+                .apiId(asTextOrNull(json.get(ConnectionLogField.API_ID.v2Request())))
+                .planId(asTextOrNull(json.get(ConnectionLogField.PLAN_ID.v2Request())))
+                .clientIdentifier(asTextOrNull(json.get(ConnectionLogField.CLIENT_IDENTIFIER.v2Request())))
+                .transactionId(asTextOrNull(json.get(ConnectionLogField.TRANSACTION_ID.v2Request())))
+                .method(HttpMethod.get(asIntOr(json.get(ConnectionLogField.HTTP_METHOD.v2Request()), 0)))
                 .requestEnded(true)
                 .entrypointId(null)
-                .gatewayResponseTime(json.get("response-time").asLong(0L))
+                .gatewayResponseTime(json.get(ConnectionLogField.GATEWAY_RESPONSE_TIME.v2Request()).asLong(0L))
                 .build();
         }
         return connectionLog
-            .requestId(json.get("request-id").asText())
-            .applicationId(asTextOrNull(json.get("application-id")))
-            .apiId(asTextOrNull(json.get("api-id")))
-            .planId(asTextOrNull(json.get("plan-id")))
-            .clientIdentifier(asTextOrNull(json.get("client-identifier")))
-            .transactionId(asTextOrNull(json.get("transaction-id")))
-            .method(HttpMethod.get(asIntOr(json.get("http-method"), 0)))
-            .requestEnded(asBooleanOrFalse(json.get("request-ended")))
-            .entrypointId(asTextOrNull(json.get("entrypoint-id")))
-            .gatewayResponseTime(json.get("gateway-response-time-ms").asLong(0L))
+            .requestId(json.get(ConnectionLogField.REQUEST_ID.v4Metrics()).asText())
+            .applicationId(asTextOrNull(json.get(ConnectionLogField.APPLICATION_ID.v4Metrics())))
+            .apiId(asTextOrNull(json.get(ConnectionLogField.API_ID.v4Metrics())))
+            .planId(asTextOrNull(json.get(ConnectionLogField.PLAN_ID.v4Metrics())))
+            .clientIdentifier(asTextOrNull(json.get(ConnectionLogField.CLIENT_IDENTIFIER.v4Metrics())))
+            .transactionId(asTextOrNull(json.get(ConnectionLogField.TRANSACTION_ID.v4Metrics())))
+            .method(HttpMethod.get(asIntOr(json.get(ConnectionLogField.HTTP_METHOD.v4Metrics()), 0)))
+            .requestEnded(asBooleanOrFalse(json.get(ConnectionLogField.REQUEST_ENDED.v4Metrics())))
+            .entrypointId(asTextOrNull(json.get(ConnectionLogField.ENTRYPOINT_ID.v4Metrics())))
+            .gatewayResponseTime(json.get(ConnectionLogField.GATEWAY_RESPONSE_TIME.v4Metrics()).asLong(0L))
             .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
@@ -75,7 +75,11 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         void should_return_the_1st_page_of_connection_logs_of_an_api() {
             var result = logV4Repository.searchConnectionLogs(
                 queryContext,
-                ConnectionLogQuery.builder().filter(Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()).size(2).build(),
+                ConnectionLogQuery
+                    .builder()
+                    .filter(Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).build())
+                    .size(2)
+                    .build(),
                 List.of(DefinitionVersion.V4)
             );
             assertThat(result).isNotNull();
@@ -127,7 +131,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                     .builder()
                     .page(3)
                     .size(2)
-                    .filter(Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build())
+                    .filter(Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).build())
                     .build(),
                 List.of(DefinitionVersion.V4)
             );
@@ -369,7 +373,11 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         void should_return_the_1st_page_of_connection_logs_of_a_v4_api() {
             var result = logV4Repository.searchConnectionLogs(
                 queryContext,
-                ConnectionLogQuery.builder().filter(Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()).size(2).build(),
+                ConnectionLogQuery
+                    .builder()
+                    .filter(Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).build())
+                    .size(2)
+                    .build(),
                 List.of(DefinitionVersion.V4, DefinitionVersion.V2)
             );
             assertThat(result).isNotNull();
@@ -421,7 +429,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                     .builder()
                     .page(3)
                     .size(2)
-                    .filter(Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build())
+                    .filter(Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).build())
                     .build(),
                 List.of(DefinitionVersion.V4, DefinitionVersion.V2)
             );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
@@ -82,7 +82,7 @@ class SearchConnectionLogQueryAdapterTest {
     private static Stream<Arguments> getFilters() {
         return Stream.of(
             Arguments.of(
-                ConnectionLogQuery.Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build(),
+                ConnectionLogQuery.Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).build(),
                 """
                              {
                                  "from": 0,
@@ -94,12 +94,12 @@ class SearchConnectionLogQueryAdapterTest {
                                              "bool": {
                                                 "should": [
                                                     {
-                                                         "term": {
-                                                             "api-id": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                         "terms": {
+                                                             "api-id": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                          }
                                                     }, {
-                                                         "term": {
-                                                             "api": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                         "terms": {
+                                                             "api": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                          }
                                                     }
                                                 ]
@@ -118,7 +118,7 @@ class SearchConnectionLogQueryAdapterTest {
             Arguments.of(
                 ConnectionLogQuery.Filter
                     .builder()
-                    .apiId("f1608475-dd77-4603-a084-75dd775603e9")
+                    .apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9"))
                     .from(1695081660000L)
                     .to(1695167999000L)
                     .build(),
@@ -133,12 +133,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                  "bool": {
                                                     "should": [
                                                         {
-                                                             "term": {
-                                                                 "api-id": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api-id": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }, {
-                                                             "term": {
-                                                                 "api": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }
                                                     ]
@@ -246,7 +246,7 @@ class SearchConnectionLogQueryAdapterTest {
                              """
             ),
             Arguments.of(
-                ConnectionLogQuery.Filter.builder().apiId("1").applicationIds(Set.of("2", "3")).build(),
+                ConnectionLogQuery.Filter.builder().apiIds(Set.of("1")).applicationIds(Set.of("2", "3")).build(),
                 """
                              {
                                  "from": 0,
@@ -258,12 +258,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                  "bool": {
                                                     "should": [
                                                         {
-                                                             "term": {
-                                                                 "api-id": "1"
+                                                             "terms": {
+                                                                 "api-id": [ "1" ]
                                                              }
                                                         }, {
-                                                             "term": {
-                                                                 "api": "1"
+                                                             "terms": {
+                                                                 "api": [ "1" ]
                                                              }
                                                         }
                                                     ]
@@ -297,7 +297,7 @@ class SearchConnectionLogQueryAdapterTest {
             Arguments.of(
                 ConnectionLogQuery.Filter
                     .builder()
-                    .apiId("f1608475-dd77-4603-a084-75dd775603e9")
+                    .apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9"))
                     .planIds(Set.of("plan-1", "plan-2"))
                     .build(),
                 """
@@ -311,12 +311,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                  "bool": {
                                                     "should": [
                                                         {
-                                                             "term": {
-                                                                 "api-id": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api-id": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }, {
-                                                             "term": {
-                                                                 "api": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }
                                                     ]
@@ -350,7 +350,7 @@ class SearchConnectionLogQueryAdapterTest {
             Arguments.of(
                 ConnectionLogQuery.Filter
                     .builder()
-                    .apiId("f1608475-dd77-4603-a084-75dd775603e9")
+                    .apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9"))
                     .planIds(Set.of("plan-1", "plan-2"))
                     .applicationIds(Set.of("app-1", "app-2", "app-3"))
                     .build(),
@@ -365,12 +365,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                  "bool": {
                                                     "should": [
                                                         {
-                                                             "term": {
-                                                                 "api-id": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api-id": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }, {
-                                                             "term": {
-                                                                 "api": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                             "terms": {
+                                                                 "api": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                              }
                                                         }
                                                     ]
@@ -416,7 +416,7 @@ class SearchConnectionLogQueryAdapterTest {
                              """
             ),
             Arguments.of(
-                ConnectionLogQuery.Filter.builder().apiId("1").methods(Set.of(HttpMethod.GET, HttpMethod.CONNECT)).build(),
+                ConnectionLogQuery.Filter.builder().apiIds(Set.of("1")).methods(Set.of(HttpMethod.GET, HttpMethod.CONNECT)).build(),
                 """
                                      {
                                          "from": 0,
@@ -428,12 +428,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                      "bool": {
                                                         "should": [
                                                             {
-                                                                 "term": {
-                                                                     "api-id": "1"
+                                                                 "terms": {
+                                                                     "api-id": [ "1" ]
                                                                  }
                                                             }, {
-                                                                 "term": {
-                                                                     "api": "1"
+                                                                 "terms": {
+                                                                     "api": [ "1" ]
                                                                  }
                                                             }
                                                         ]
@@ -465,7 +465,11 @@ class SearchConnectionLogQueryAdapterTest {
                                      """
             ),
             Arguments.of(
-                ConnectionLogQuery.Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").statuses(Set.of(200, 202)).build(),
+                ConnectionLogQuery.Filter
+                    .builder()
+                    .apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9"))
+                    .statuses(Set.of(200, 202))
+                    .build(),
                 """
                                      {
                                          "from": 0,
@@ -477,12 +481,12 @@ class SearchConnectionLogQueryAdapterTest {
                                                      "bool": {
                                                         "should": [
                                                             {
-                                                                 "term": {
-                                                                     "api-id": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                                 "terms": {
+                                                                     "api-id": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                                  }
                                                             }, {
-                                                                 "term": {
-                                                                     "api": "f1608475-dd77-4603-a084-75dd775603e9"
+                                                                 "terms": {
+                                                                     "api": [ "f1608475-dd77-4603-a084-75dd775603e9" ]
                                                                  }
                                                             }
                                                         ]

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
@@ -20,6 +20,7 @@ import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLogQuery;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
@@ -580,6 +581,67 @@ class SearchConnectionLogQueryAdapterTest {
                                                      {
                                                          "wildcard": {
                                                              "uri": "/my-path*"
+                                                         }
+                                                     }
+                                                 ]
+                                             }
+                                         },
+                                         "sort": {
+                                             "@timestamp": {
+                                                 "order": "desc"
+                                             }
+                                         }
+                                      }
+            """
+            ),
+            Arguments.of(
+                ConnectionLogQuery.Filter
+                    .builder()
+                    .responseTimeRanges(
+                        List.of(
+                            ConnectionLogQuery.Filter.ResponseTimeRange.builder().to(10L).build(),
+                            ConnectionLogQuery.Filter.ResponseTimeRange.builder().from(400L).to(500L).build()
+                        )
+                    )
+                    .build(),
+                """
+                                     {
+                                         "from": 0,
+                                         "size": 20,
+                                         "query": {
+                                             "bool": {
+                                                 "must": [
+                                                     {
+                                                         "bool": {
+                                                            "should": [
+                                                                {
+                                                                     "range": {
+                                                                         "response-time": {
+                                                                            "lte": 10
+                                                                         }
+                                                                     }
+                                                                }, {
+                                                                     "range": {
+                                                                         "gateway-response-time-ms": {
+                                                                            "lte": 10
+                                                                         }
+                                                                     }
+                                                                }, {
+                                                                     "range": {
+                                                                         "response-time": {
+                                                                            "lte": 500,
+                                                                            "gte": 400
+                                                                         }
+                                                                     }
+                                                                }, {
+                                                                     "range": {
+                                                                         "gateway-response-time-ms": {
+                                                                            "lte": 500,
+                                                                            "gte": 400
+                                                                         }
+                                                                     }
+                                                                }
+                                                            ]
                                                          }
                                                      }
                                                  ]

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
@@ -532,6 +532,66 @@ class SearchConnectionLogQueryAdapterTest {
                                          }
                                       }
             """
+            ),
+            Arguments.of(
+                ConnectionLogQuery.Filter
+                    .builder()
+                    .requestIds(Set.of("req-1", "req-2"))
+                    .transactionIds(Set.of("t-1"))
+                    .uri("my-path")
+                    .build(),
+                """
+                                     {
+                                         "from": 0,
+                                         "size": 20,
+                                         "query": {
+                                             "bool": {
+                                                 "must": [
+                                                     {
+                                                         "bool": {
+                                                            "should": [
+                                                                {
+                                                                     "terms": {
+                                                                         "_id": [ "req-1", "req-2" ]
+                                                                     }
+                                                                }, {
+                                                                     "terms": {
+                                                                         "request-id": [ "req-1", "req-2" ]
+                                                                     }
+                                                                }
+                                                            ]
+                                                         }
+                                                     },
+                                                     {
+                                                         "bool": {
+                                                            "should": [
+                                                                {
+                                                                     "terms": {
+                                                                         "transaction": [ "t-1" ]
+                                                                     }
+                                                                }, {
+                                                                     "terms": {
+                                                                         "transaction-id": [ "t-1" ]
+                                                                     }
+                                                                }
+                                                            ]
+                                                         }
+                                                     },
+                                                     {
+                                                         "wildcard": {
+                                                             "uri": "/my-path*"
+                                                         }
+                                                     }
+                                                 ]
+                                             }
+                                         },
+                                         "sort": {
+                                             "@timestamp": {
+                                                 "order": "desc"
+                                             }
+                                         }
+                                      }
+            """
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/Range.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/Range.java
@@ -15,23 +15,4 @@
  */
 package io.gravitee.rest.api.model.analytics;
 
-import io.gravitee.common.http.HttpMethod;
-import java.util.List;
-import java.util.Set;
-import lombok.Builder;
-
-@Builder(toBuilder = true)
-public record SearchLogsFilters(
-    Long from,
-    Long to,
-    Set<String> applicationIds,
-    Set<String> planIds,
-    Set<HttpMethod> methods,
-    Set<Integer> statuses,
-    Set<String> entrypointIds,
-    Set<String> apiIds,
-    Set<String> requestIds,
-    Set<String> transactionIds,
-    List<Range> responseTimeRanges,
-    String uri
-) {}
+public record Range(Long from, Long to) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
@@ -19,7 +19,7 @@ import io.gravitee.common.http.HttpMethod;
 import java.util.Set;
 import lombok.Builder;
 
-@Builder
+@Builder(toBuilder = true)
 public record SearchLogsFilters(
     Long from,
     Long to,
@@ -27,5 +27,9 @@ public record SearchLogsFilters(
     Set<String> planIds,
     Set<HttpMethod> methods,
     Set<Integer> statuses,
-    Set<String> entrypointIds
+    Set<String> entrypointIds,
+    Set<String> apiIds,
+    Set<String> requestIds,
+    Set<String> transactionIds,
+    String uri
 ) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -244,6 +244,12 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-test-fixtures</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
 		<!-- Json Path Find-->
 		<dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/LogMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/LogMapper.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.apim.core.log.model.ConnectionLog;
+import io.gravitee.rest.api.model.analytics.Range;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import io.gravitee.rest.api.model.log.ApplicationRequest;
 import io.gravitee.rest.api.model.log.ApplicationRequestItem;
@@ -23,6 +24,7 @@ import io.gravitee.rest.api.portal.rest.model.HttpMethod;
 import io.gravitee.rest.api.portal.rest.model.Log;
 import io.gravitee.rest.api.portal.rest.model.Request;
 import io.gravitee.rest.api.portal.rest.model.Response;
+import io.gravitee.rest.api.portal.rest.resource.param.ResponseTimeRange;
 import io.gravitee.rest.api.portal.rest.resource.param.SearchApplicationLogsParam;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -132,7 +134,16 @@ public class LogMapper {
             .requestIds(searchLogsParam.getRequestIds())
             .transactionIds(searchLogsParam.getTransactionIds())
             .uri(searchLogsParam.getPath())
+            .responseTimeRanges(convertResponseTimeRanges(searchLogsParam.getResponseTimeRanges()))
             .build();
+    }
+
+    private List<Range> convertResponseTimeRanges(List<ResponseTimeRange> responseTimeRanges) {
+        if (responseTimeRanges == null) {
+            return new ArrayList<>();
+        }
+
+        return responseTimeRanges.stream().map(r -> new Range(r.getFrom(), r.getTo())).toList();
     }
 
     public Set<io.gravitee.common.http.HttpMethod> convert(Set<HttpMethod> httpMethod) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/ResponseTimeRange.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/ResponseTimeRange.java
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.analytics;
+package io.gravitee.rest.api.portal.rest.resource.param;
 
-import io.gravitee.common.http.HttpMethod;
-import java.util.List;
-import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Builder(toBuilder = true)
-public record SearchLogsFilters(
-    Long from,
-    Long to,
-    Set<String> applicationIds,
-    Set<String> planIds,
-    Set<HttpMethod> methods,
-    Set<Integer> statuses,
-    Set<String> entrypointIds,
-    Set<String> apiIds,
-    Set<String> requestIds,
-    Set<String> transactionIds,
-    List<Range> responseTimeRanges,
-    String uri
-) {}
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseTimeRange {
+
+    private Long from;
+    private Long to;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/SearchApplicationLogsParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/SearchApplicationLogsParam.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.BadRequestException;
+import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -73,6 +74,9 @@ public class SearchApplicationLogsParam {
 
     @Parameter(name = "path", description = "Filter by API path")
     private String path;
+
+    @Parameter(name = "responseTimeRanges", description = "Filter by ranges of request response times")
+    private List<ResponseTimeRange> responseTimeRanges;
 
     public void validate() {
         if (from >= to) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/SearchApplicationLogsParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/SearchApplicationLogsParam.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.param;
+
+import io.gravitee.rest.api.portal.rest.model.HttpMethod;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.ws.rs.BadRequestException;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchApplicationLogsParam {
+
+    @NotNull
+    @PositiveOrZero
+    @Parameter(name = "from", description = "Timestamp used to define the start date of the time window to query")
+    private long from;
+
+    @NotNull
+    @PositiveOrZero
+    @Parameter(name = "to", description = "Timestamp used to define the end date of the time window to query")
+    private long to;
+
+    @Parameter(name = "planIds", description = "Filter by plan IDs")
+    private Set<String> planIds;
+
+    @Parameter(name = "methods", description = "Filter by HTTP methods")
+    private Set<HttpMethod> methods;
+
+    @Parameter(name = "statuses", description = "Filter by HTTP response statuses")
+    private Set<@Min(value = 100, message = "'statuses' must contain values greater than or equal to 100") @Max(
+        value = 599,
+        message = "'statuses' must contain values lesser than or equal to 599"
+    ) Integer> statuses;
+
+    @Parameter(name = "apiIds", description = "Filter by API IDs")
+    private Set<String> apiIds;
+
+    @Parameter(name = "requestIds", description = "Filter by request IDs")
+    private Set<String> requestIds;
+
+    @Parameter(name = "transactionIds", description = "Filter by transaction IDs")
+    private Set<String> transactionIds;
+
+    @Parameter(name = "path", description = "Filter by API path")
+    private String path;
+
+    public void validate() {
+        if (from >= to) {
+            throw new BadRequestException("'from' query parameter value must not be greater than 'to'");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3610,9 +3610,23 @@ components:
               path:
                   description: Filter with path used for the request
                   type: string
+              responseTimeRanges:
+                type: array
+                description: List of filters for response time ranges
+                items:
+                  $ref: "#/components/schemas/ResponseTimeRange"
           required:
             - to
             - from
+
+        ResponseTimeRange:
+          properties:
+            from:
+              type: integer
+              description: Lower limit in milliseconds
+            to:
+              type: integer
+              description: Upper limit in milliseconds
         ApplicationsResponse:
             properties:
                 data:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1439,6 +1439,7 @@ paths:
         parameters:
             - $ref: "#/components/parameters/applicationIdParam"
         get:
+            deprecated: true
             tags:
                 - Application
                 - Analytics
@@ -1453,9 +1454,48 @@ paths:
             summary: Get Application logs
             description: |
                 Get the application logs.
+                Deprecated: Use POST /applications/{applicationId}/logs/_search instead for more results and refined search.
 
                 User must have the APPLICATION_LOG[READ] permission.
             operationId: getApplicationLogs
+            responses:
+                200:
+                    description: List of logs
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/LogsResponse"
+                400:
+                    description: Invalid query params.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ErrorResponse"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
+    /applications/{applicationId}/logs/_search:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+        post:
+            tags:
+                - Application
+                - Analytics
+            parameters:
+                - $ref: "#/components/parameters/pageNumberParam"
+                - $ref: "#/components/parameters/pageSizeParam"
+            requestBody:
+                $ref: "#/components/requestBodies/searchApplicationLogsRequestBody"
+            summary: Search Application logs
+            description: |
+                Search an application's logs.
+
+                User must have the APPLICATION_LOG[READ] permission.
+            operationId: searchApplicationLogs
             responses:
                 200:
                     description: List of logs
@@ -2945,6 +2985,14 @@ components:
                     schema:
                         type: string
                         format: binary
+        searchApplicationLogsRequestBody:
+            description: Use to search application logs
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SearchApplicationsLogsParams"
+            required: true
+
     parameters:
         ##############
         # Path Param #
@@ -3511,6 +3559,60 @@ components:
                     $ref: "#/components/schemas/MetadataMap"
                 links:
                     $ref: "#/components/schemas/Links"
+        SearchApplicationsLogsParams:
+          type: object
+          description: Search filters for application logs
+          properties:
+              from:
+                description: Timestamp in ms for the connection log date lower limit
+                type: integer
+                example: 1460222528644
+              to:
+                description: Timestamp in ms for the connection log date upper limit. Must be superior to the timestamp provided in the 'to' parameter
+                type: integer
+                example: 1460222528644
+              applicationIds:
+                  description: Filter with list of application IDs
+                  type: array
+                  items:
+                    type: string
+              planIds:
+                  description: Filter with list of plan IDs
+                  type: array
+                  items:
+                    type: string
+              methods:
+                  description: Filter with list of HTTP methods
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/HttpMethod"
+              statuses:
+                  description: Filter with list of response statuses
+                  example: [ 200 ]
+                  type: array
+                  items:
+                    type: integer
+              apiIds:
+                  description: Filter with list of API IDs
+                  type: array
+                  items:
+                    type: string
+              requestIds:
+                  description: Filter with list of connection log request IDs
+                  type: array
+                  items:
+                    type: string
+              transactionIds:
+                  description: Filter with list of connection log transaction IDs
+                  type: array
+                  items:
+                    type: string
+              path:
+                  description: Filter with path used for the request
+                  type: string
+          required:
+            - to
+            - from
         ApplicationsResponse:
             properties:
                 data:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationLogsResourceTest.java
@@ -21,26 +21,46 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+import fixtures.repository.ConnectionLogFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.ConnectionLogsCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.analytics.query.LogQuery;
 import io.gravitee.rest.api.model.log.ApplicationRequest;
 import io.gravitee.rest.api.model.log.ApplicationRequestItem;
 import io.gravitee.rest.api.model.log.SearchLogResponse;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.portal.rest.model.Links;
 import io.gravitee.rest.api.portal.rest.model.Log;
 import io.gravitee.rest.api.portal.rest.model.LogsResponse;
+import io.gravitee.rest.api.portal.rest.resource.param.SearchApplicationLogsParam;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -53,8 +73,36 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
         return "applications/";
     }
 
-    private static final String APPLICATION = "my-application";
+    @Autowired
+    ApplicationCrudServiceInMemory applicationCrudServiceInMemory;
+
+    @Autowired
+    ApiCrudServiceInMemory apiCrudServiceInMemory;
+
+    @Autowired
+    PlanCrudServiceInMemory planCrudServiceInMemory;
+
+    @Autowired
+    ConnectionLogsCrudServiceInMemory connectionLogsCrudServiceInMemory;
+
+    private static final String APPLICATION_ID = "my-application";
     private static final String LOG = "my-log";
+    private static final ApplicationEntity APPLICATION = ApplicationEntity.builder().id(APPLICATION_ID).build();
+
+    private static final String API_1_ID = "api-1";
+    private static final String API_2_ID = "api-2";
+    private static final Api API_1 = Api.builder().id(API_1_ID).name("API 1").version("1.1").build();
+    private static final Api API_2 = Api.builder().id(API_2_ID).name("API 2").version("2.2").build();
+
+    private static final String PLAN_1_ID = "plan-1";
+    private static final String PLAN_2_ID = "plan-2";
+    private static final Plan PLAN_1 = Plan.builder().id(PLAN_1_ID).definitionVersion(DefinitionVersion.V4).name("Plan 1").build();
+    private static final Plan PLAN_2 = Plan.builder().id(PLAN_2_ID).definitionVersion(DefinitionVersion.V4).name("Plan 2").build();
+
+    private static final Long FIRST_FEBRUARY_2020 = Instant.parse("2020-02-01T00:01:00.00Z").toEpochMilli();
+    private static final Long SECOND_FEBRUARY_2020 = Instant.parse("2020-02-02T23:59:59.00Z").toEpochMilli();
+
+    ConnectionLogFixtures connectionLogFixtures = new ConnectionLogFixtures(API_1_ID, APPLICATION_ID, PLAN_1_ID);
 
     private Map<String, Map<String, String>> metadata;
     private SearchLogResponse<ApplicationRequestItem> searchResponse;
@@ -72,39 +120,54 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
 
         metadata = new HashMap<String, Map<String, String>>();
         HashMap<String, String> appMetadata = new HashMap<String, String>();
-        appMetadata.put(APPLICATION, APPLICATION);
-        metadata.put(APPLICATION, appMetadata);
+        appMetadata.put(APPLICATION_ID, APPLICATION_ID);
+        metadata.put(APPLICATION_ID, appMetadata);
         searchResponse.setMetadata(metadata);
 
-        doReturn(searchResponse).when(logsService).findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION), any());
+        doReturn(searchResponse).when(logsService).findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
 
         doReturn(new Log()).when(logMapper).convert(any(ApplicationRequestItem.class));
         doReturn(new Log()).when(logMapper).convert(any(ApplicationRequest.class));
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+
+        when(logMapper.convert(eq(APPLICATION_ID), any(SearchApplicationLogsParam.class))).thenCallRealMethod();
+        when(logMapper.convert(any(List.class))).thenCallRealMethod();
+        applicationCrudServiceInMemory.initWith(List.of(APPLICATION));
+        apiCrudServiceInMemory.initWith(List.of(API_1, API_2));
+        planCrudServiceInMemory.initWith(List.of(PLAN_1, PLAN_2));
+    }
+
+    @After
+    public void cleanUp() {
+        Stream
+            .of(applicationCrudServiceInMemory, apiCrudServiceInMemory, planCrudServiceInMemory, connectionLogsCrudServiceInMemory)
+            .forEach(InMemoryAlternative::reset);
     }
 
     @Test
     public void shouldGetLogs() {
-        final Response response = target(APPLICATION)
+        final Response response = target(APPLICATION_ID)
             .path("logs")
             .queryParam("page", 1)
             .queryParam("size", 10)
-            .queryParam("query", APPLICATION)
+            .queryParam("query", APPLICATION_ID)
             .queryParam("from", 0)
             .queryParam("to", 100)
-            .queryParam("field", APPLICATION)
+            .queryParam("field", APPLICATION_ID)
             .queryParam("order", "ASC")
             .request()
             .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         ArgumentCaptor<LogQuery> logQueryCaptor = ArgumentCaptor.forClass(LogQuery.class);
-        Mockito.verify(logsService).findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION), logQueryCaptor.capture());
+        Mockito
+            .verify(logsService)
+            .findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), logQueryCaptor.capture());
         final LogQuery logQuery = logQueryCaptor.getValue();
-        assertEquals(APPLICATION, logQuery.getField());
+        assertEquals(APPLICATION_ID, logQuery.getField());
         assertEquals(0, logQuery.getFrom());
         assertEquals(1, logQuery.getPage());
-        assertEquals(APPLICATION, logQuery.getQuery());
+        assertEquals(APPLICATION_ID, logQuery.getQuery());
         assertEquals(10, logQuery.getSize());
         assertEquals(100, logQuery.getTo());
         assertTrue(logQuery.isOrder());
@@ -114,7 +177,7 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
 
         Map<String, Map<String, Object>> logsMetadata = logsResponse.getMetadata();
         assertEquals(2, logsMetadata.size());
-        assertEquals(APPLICATION, logsMetadata.get(APPLICATION).get(APPLICATION));
+        assertEquals(APPLICATION_ID, logsMetadata.get(APPLICATION_ID).get(APPLICATION_ID));
         assertEquals(2, logsMetadata.get(AbstractResource.METADATA_DATA_KEY).get(AbstractResource.METADATA_DATA_TOTAL_KEY));
 
         Links links = logsResponse.getLinks();
@@ -127,16 +190,16 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
         emptySearchResponse.setLogs(Collections.emptyList());
         doReturn(emptySearchResponse)
             .when(logsService)
-            .findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION), any());
+            .findByApplication(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
 
-        final Response response = target(APPLICATION)
+        final Response response = target(APPLICATION_ID)
             .path("logs")
             .queryParam("page", 1)
             .queryParam("size", 10)
-            .queryParam("query", APPLICATION)
+            .queryParam("query", APPLICATION_ID)
             .queryParam("from", 0)
             .queryParam("to", 100)
-            .queryParam("field", APPLICATION)
+            .queryParam("field", APPLICATION_ID)
             .queryParam("order", "ASC")
             .request()
             .get();
@@ -155,13 +218,13 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
         toBeReturned.setId(LOG);
         doReturn(toBeReturned)
             .when(logsService)
-            .findApplicationLog(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION), eq(LOG), any());
+            .findApplicationLog(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), eq(LOG), any());
 
-        final Response response = target(APPLICATION).path("logs").path(LOG).queryParam("timestamp", 1).request().get();
+        final Response response = target(APPLICATION_ID).path("logs").path(LOG).queryParam("timestamp", 1).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         Mockito.verify(logMapper).convert(toBeReturned);
-        Mockito.verify(logsService).findApplicationLog(GraviteeContext.getExecutionContext(), APPLICATION, LOG, 1L);
+        Mockito.verify(logsService).findApplicationLog(GraviteeContext.getExecutionContext(), APPLICATION_ID, LOG, 1L);
 
         Log Log = response.readEntity(Log.class);
         assertNotNull(Log);
@@ -170,15 +233,15 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldExportLogs() {
         doReturn("EXPORT").when(logsService).exportAsCsv(eq(GraviteeContext.getExecutionContext()), any());
-        final Response response = target(APPLICATION)
+        final Response response = target(APPLICATION_ID)
             .path("logs")
             .path("_export")
             .queryParam("page", 1)
             .queryParam("size", 10)
-            .queryParam("query", APPLICATION)
+            .queryParam("query", APPLICATION_ID)
             .queryParam("from", 0)
             .queryParam("to", 100)
-            .queryParam("field", APPLICATION)
+            .queryParam("field", APPLICATION_ID)
             .queryParam("order", "DESC")
             .request()
             .post(null);
@@ -189,6 +252,221 @@ public class ApplicationLogsResourceTest extends AbstractResourceTest {
         String exportString = response.readEntity(String.class);
         assertEquals("EXPORT", exportString);
         final MultivaluedMap<String, Object> headers = response.getHeaders();
-        assertTrue(((String) headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).startsWith("attachment;filename=logs-" + APPLICATION));
+        assertTrue(((String) headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)).startsWith("attachment;filename=logs-" + APPLICATION_ID));
+    }
+
+    /**
+     * Search Application Logs
+     */
+
+    @Test
+    public void should_not_allow_invalid_to_and_from_search() {
+        var body = SearchApplicationLogsParam.builder().to(0).from(100).build();
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        var errorResponse = response.readEntity(ErrorResponse.class);
+        assertNotNull(errorResponse.getErrors());
+        assertEquals(1, errorResponse.getErrors().size());
+        assertEquals("'from' query parameter value must not be greater than 'to'", errorResponse.getErrors().getFirst().getMessage());
+    }
+
+    @Test
+    public void should_not_allow_status_less_than_100_in_search() {
+        var body = SearchApplicationLogsParam.builder().to(100).from(0).statuses(Set.of(100, 1)).build();
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        var errorResponse = response.readEntity(ErrorResponse.class);
+        assertNotNull(errorResponse.getErrors());
+        assertEquals(1, errorResponse.getErrors().size());
+        assertNotNull(errorResponse.getErrors().getFirst().getMessage());
+        assertTrue(
+            errorResponse.getErrors().getFirst().getMessage().contains("'statuses' must contain values greater than or equal to 100")
+        );
+    }
+
+    @Test
+    public void should_not_allow_status_greater_than_599_in_search() {
+        var body = SearchApplicationLogsParam.builder().to(100).from(0).statuses(Set.of(100, 900)).build();
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        var errorResponse = response.readEntity(ErrorResponse.class);
+        assertNotNull(errorResponse.getErrors());
+        assertEquals(1, errorResponse.getErrors().size());
+        assertNotNull(errorResponse.getErrors().getFirst().getMessage());
+        assertTrue(
+            errorResponse.getErrors().getFirst().getMessage().contains("'statuses' must contain values lesser than or equal to 599")
+        );
+    }
+
+    @Test
+    public void should_return_empty_list_of_logs_in_search() {
+        var body = SearchApplicationLogsParam.builder().to(100).from(0).build();
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        var logsResponse = response.readEntity(LogsResponse.class);
+        assertNotNull(logsResponse.getData());
+        assertEquals(0, logsResponse.getData().size());
+        assertEquals(Map.of("data", Map.of("total", 0)), logsResponse.getMetadata());
+    }
+
+    @Test
+    public void should_return_list_of_logs_in_search() {
+        // Given
+        connectionLogsCrudServiceInMemory.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1"),
+                connectionLogFixtures.aConnectionLog().toBuilder().applicationId("other-application").build()
+            )
+        );
+
+        // When
+        var body = SearchApplicationLogsParam.builder().to(SECOND_FEBRUARY_2020).from(FIRST_FEBRUARY_2020).build();
+
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        var logsResponse = response.readEntity(LogsResponse.class);
+        assertNotNull(logsResponse.getData());
+        assertEquals(1, logsResponse.getData().size());
+        assertEquals(
+            Map.of(
+                "data",
+                Map.of("total", 1),
+                API_1_ID,
+                Map.of("name", API_1.getName(), "version", API_1.getVersion()),
+                PLAN_1_ID,
+                Map.of("name", PLAN_1.getName())
+            ),
+            logsResponse.getMetadata()
+        );
+    }
+
+    @Test
+    public void should_return_list_of_logs_in_search_with_unknown_api_and_unknown_plan() {
+        // Given
+        connectionLogsCrudServiceInMemory.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().apiId("unknown-api").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().planId("unknown-plan").build()
+            )
+        );
+
+        // When
+        var body = SearchApplicationLogsParam.builder().to(SECOND_FEBRUARY_2020).from(FIRST_FEBRUARY_2020).build();
+
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        var logsResponse = response.readEntity(LogsResponse.class);
+        assertNotNull(logsResponse.getData());
+        assertEquals(2, logsResponse.getData().size());
+        assertEquals(
+            Map.of(
+                "data",
+                Map.of("total", 2),
+                API_1_ID,
+                Map.of("name", API_1.getName(), "version", API_1.getVersion()),
+                "unknown-api",
+                Map.of("name", "Unknown API (not found)", "unknown", "true"),
+                PLAN_1_ID,
+                Map.of("name", PLAN_1.getName()),
+                "unknown-plan",
+                Map.of("name", "Unknown plan", "unknown", "true")
+            ),
+            logsResponse.getMetadata()
+        );
+    }
+
+    @Test
+    public void should_return_filtered_list_of_logs_in_search() {
+        // Given
+        connectionLogsCrudServiceInMemory.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1"),
+                connectionLogFixtures.aConnectionLog().toBuilder().apiId(API_2_ID).build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().apiId("other-api").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().planId(PLAN_2_ID).build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().planId("other-plan").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().method(HttpMethod.DELETE).build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().status(400).build()
+            )
+        );
+
+        // When
+        var body = SearchApplicationLogsParam
+            .builder()
+            .to(SECOND_FEBRUARY_2020)
+            .from(FIRST_FEBRUARY_2020)
+            .apiIds(Set.of(API_1_ID, API_2_ID))
+            .planIds(Set.of(PLAN_1_ID, PLAN_2_ID))
+            .methods(
+                Set.of(io.gravitee.rest.api.portal.rest.model.HttpMethod.GET, io.gravitee.rest.api.portal.rest.model.HttpMethod.CONNECT)
+            )
+            .statuses(Set.of(200, 201))
+            .build();
+
+        final Response response = target(APPLICATION_ID)
+            .path("logs/_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(body));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        var logsResponse = response.readEntity(LogsResponse.class);
+        assertNotNull(logsResponse.getData());
+        assertEquals(4, logsResponse.getData().size());
+        assertEquals(
+            Map.of(
+                "data",
+                Map.of("total", 4),
+                API_1_ID,
+                Map.of("name", API_1.getName(), "version", API_1.getVersion()),
+                PLAN_1_ID,
+                Map.of("name", PLAN_1.getName()),
+                API_2_ID,
+                Map.of("name", API_2.getName(), "version", API_2.getVersion()),
+                PLAN_2_ID,
+                Map.of("name", PLAN_2.getName())
+            ),
+            logsResponse.getMetadata()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/ConnectionLogsCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/ConnectionLogsCrudService.java
@@ -33,5 +33,11 @@ public interface ConnectionLogsCrudService {
         Pageable pageable,
         List<DefinitionVersion> definitionVersions
     );
+    SearchLogsResponse<BaseConnectionLog> searchApplicationConnectionLogs(
+        ExecutionContext executionContext,
+        String applicationId,
+        SearchLogsFilters logsFilters,
+        Pageable pageable
+    );
     Optional<ConnectionLogDetail> searchApiConnectionLog(ExecutionContext executionContext, String apiId, String requestId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/BaseConnectionLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/BaseConnectionLog.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.v4.log.connection;
+package io.gravitee.apim.core.log.model;
 
 import io.gravitee.common.http.HttpMethod;
 import lombok.AllArgsConstructor;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/ConnectionLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/ConnectionLog.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.v4.log.connection;
+package io.gravitee.apim.core.log.model;
 
-import io.gravitee.common.http.HttpMethod;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,20 +27,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
-public class BaseConnectionLog {
+public class ConnectionLog extends BaseConnectionLog {
 
-    private String apiId;
-    private String requestId;
-    private String timestamp;
-    private String applicationId;
-    private String planId;
-    private String clientIdentifier;
-    private String transactionId;
-    private HttpMethod method;
-    private int status;
-    private boolean requestEnded;
-    private String entrypointId;
-    private String gateway;
-    private String uri;
-    private long gatewayResponseTime;
+    private Api api;
+    private Plan plan;
+    private BaseApplicationEntity application;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchApplicationConnectionLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchApplicationConnectionLogsUseCase.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.log.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.log.model.ConnectionLog;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class SearchApplicationConnectionLogsUseCase {
+
+    private static final String UNKNOWN = "Unknown";
+    private final ConnectionLogsCrudService connectionLogsCrudService;
+    private final ApplicationCrudService applicationCrudService;
+    private final PlanCrudService planCrudService;
+    private final ApiCrudService apiCrudService;
+    private final String UNKNOWN_SERVICE = "1";
+
+    public Output execute(Input input) {
+        // Will throw exception if application does not exist for the given environment
+        var application = applicationCrudService.findById(input.applicationId(), input.environmentId());
+
+        var pageable = input.pageable.orElse(new PageableImpl(1, 20));
+
+        var response = connectionLogsCrudService.searchApplicationConnectionLogs(
+            new ExecutionContext(input.organizationId(), input.environmentId()),
+            input.applicationId(),
+            input.logsFilters(),
+            pageable
+        );
+        return mapToResponse(application, response);
+    }
+
+    private Output mapToResponse(BaseApplicationEntity application, SearchLogsResponse<BaseConnectionLog> logs) {
+        var total = logs.total();
+        var data = logs.logs().stream().map(log -> mapToModel(log, application)).toList();
+
+        return new Output(total, data);
+    }
+
+    private ConnectionLog mapToModel(BaseConnectionLog connectionLog, BaseApplicationEntity application) {
+        return ConnectionLog
+            .builder()
+            .applicationId(connectionLog.getApplicationId())
+            .application(application)
+            .apiId(connectionLog.getApiId())
+            .api(getApiInfo(connectionLog.getApiId()))
+            .requestId(connectionLog.getRequestId())
+            .timestamp(connectionLog.getTimestamp())
+            .clientIdentifier(connectionLog.getClientIdentifier() != null ? connectionLog.getClientIdentifier() : UNKNOWN)
+            .method(connectionLog.getMethod())
+            .planId(connectionLog.getPlanId())
+            .plan(getPlanInfo(connectionLog.getPlanId()))
+            .requestEnded(connectionLog.isRequestEnded())
+            .transactionId(connectionLog.getTransactionId())
+            .status(connectionLog.getStatus())
+            .uri(connectionLog.getUri())
+            .gateway(connectionLog.getGateway())
+            .gatewayResponseTime(connectionLog.getGatewayResponseTime())
+            .build();
+    }
+
+    private Api getApiInfo(String apiId) {
+        var unknownApi = Api.builder().id(UNKNOWN_SERVICE).build();
+        if (apiId == null) {
+            return unknownApi;
+        }
+
+        try {
+            return apiCrudService.get(apiId);
+        } catch (ApiNotFoundException | TechnicalManagementException e) {
+            return unknownApi;
+        }
+    }
+
+    private Plan getPlanInfo(String planId) {
+        var unknownPlan = Plan.builder().id(UNKNOWN_SERVICE).build();
+        if (planId == null) {
+            return unknownPlan;
+        }
+        try {
+            return planCrudService.getById(planId);
+        } catch (PlanNotFoundException | TechnicalManagementException e) {
+            return unknownPlan;
+        }
+    }
+
+    public record Input(
+        String applicationId,
+        String organizationId,
+        String environmentId,
+        SearchLogsFilters logsFilters,
+        Optional<Pageable> pageable
+    ) {
+        public Input(String applicationId, String organizationId, String environmentId, SearchLogsFilters logsFilters) {
+            this(applicationId, organizationId, environmentId, logsFilters, Optional.empty());
+        }
+        public Input(String applicationId, String organizationId, String environmentId, SearchLogsFilters logsFilters, Pageable pageable) {
+            this(applicationId, organizationId, environmentId, logsFilters, Optional.of(pageable));
+        }
+    }
+
+    public record Output(long total, List<ConnectionLog> data) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
+import io.gravitee.repository.log.v4.model.connection.ConnectionLogQuery;
+import io.gravitee.rest.api.model.analytics.Range;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
 import java.util.List;
@@ -35,4 +37,7 @@ public interface ConnectionLogAdapter {
     List<BaseConnectionLog> toEntitiesList(List<ConnectionLog> connectionLogs);
 
     ConnectionLogDetail toEntity(io.gravitee.repository.log.v4.model.connection.ConnectionLogDetail connectionLogDetail);
+
+    ConnectionLogQuery.Filter.ResponseTimeRange convert(Range range);
+    List<ConnectionLogQuery.Filter.ResponseTimeRange> convert(List<Range> range);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -64,7 +65,7 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
                     .filter(
                         ConnectionLogQuery.Filter
                             .builder()
-                            .apiId(apiId)
+                            .apiIds(Set.of(apiId))
                             .from(logsFilters.from())
                             .to(logsFilters.to())
                             .applicationIds(logsFilters.applicationIds())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -136,7 +136,8 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .entrypointIds(searchLogsFilters.entrypointIds())
             .requestIds(searchLogsFilters.requestIds())
             .transactionIds(searchLogsFilters.transactionIds())
-            .uri(searchLogsFilters.uri());
+            .uri(searchLogsFilters.uri())
+            .responseTimeRanges(ConnectionLogAdapter.INSTANCE.convert(searchLogsFilters.responseTimeRanges()));
     }
 
     private @NotNull LogResponse<ConnectionLog> getConnectionLogsResponse(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
@@ -160,6 +160,20 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
         if (!CollectionUtils.isEmpty(logsFilters.entrypointIds())) {
             predicate = predicate.and(connectionLog -> logsFilters.entrypointIds().contains(connectionLog.getEntrypointId()));
         }
+
+        if (!CollectionUtils.isEmpty(logsFilters.responseTimeRanges())) {
+            predicate =
+                predicate.and(connectionLog ->
+                    logsFilters
+                        .responseTimeRanges()
+                        .stream()
+                        .anyMatch(range ->
+                            (range.to() == null || range.to() >= connectionLog.getGatewayResponseTime()) &&
+                            (range.from() == null || range.from() <= connectionLog.getGatewayResponseTime())
+                        )
+                );
+        }
+
         return predicate;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchApplicationConnectionLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchApplicationConnectionLogsUseCaseTest.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.log.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import fixtures.core.model.PlanFixtures;
+import fixtures.repository.ConnectionLogFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.ConnectionLogsCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.log.model.ConnectionLog;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchApplicationConnectionLogsUseCaseTest {
+
+    private static final String API_ID = "api-1";
+    private static final String APPLICATION_ID = "app1";
+    private static final String ORG_ID = "my-org";
+    private static final String ENV_ID = "my-env";
+    private static final Plan PLAN_1 = PlanFixtures.aPlanHttpV4().toBuilder().id("plan1").name("1st plan").build();
+    private static final Plan PLAN_2 = PlanFixtures.aPlanHttpV4().toBuilder().id("plan2").name("2nd plan").build();
+    private static final BaseApplicationEntity APPLICATION_1 = BaseApplicationEntity
+        .builder()
+        .id(APPLICATION_ID)
+        .name("an application name")
+        .build();
+
+    private static final Api API_1 = Api.builder().id("api-1").name("api-name").version("1.1").build();
+    private static final Api API_2 = Api.builder().id("api-2").name("api-name-2").version("2.2").build();
+
+    private static final Long FIRST_FEBRUARY_2020 = Instant.parse("2020-02-01T00:01:00.00Z").toEpochMilli();
+    private static final Long SECOND_FEBRUARY_2020 = Instant.parse("2020-02-02T23:59:59.00Z").toEpochMilli();
+    private static final Long FOURTH_FEBRUARY_2020 = Instant.parse("2020-02-04T00:01:00.00Z").toEpochMilli();
+    private static final Long FIFTH_FEBRUARY_2020 = Instant.parse("2020-02-05T00:01:00.00Z").toEpochMilli();
+
+    ConnectionLogFixtures connectionLogFixtures = new ConnectionLogFixtures(API_1.getId(), APPLICATION_ID, PLAN_1.getId());
+
+    ConnectionLogsCrudServiceInMemory logStorageService = new ConnectionLogsCrudServiceInMemory();
+    PlanCrudServiceInMemory planStorageService = new PlanCrudServiceInMemory();
+    ApplicationCrudServiceInMemory applicationStorageService = new ApplicationCrudServiceInMemory();
+    ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+
+    SearchApplicationConnectionLogsUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut =
+            new SearchApplicationConnectionLogsUseCase(
+                logStorageService,
+                applicationStorageService,
+                planStorageService,
+                apiCrudServiceInMemory
+            );
+
+        planStorageService.initWith(List.of(PLAN_1, PLAN_2));
+        applicationStorageService.initWith(List.of(APPLICATION_1));
+        apiCrudServiceInMemory.initWith(List.of(API_1, API_2));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(logStorageService, planStorageService, applicationStorageService).forEach(InMemoryAlternative::reset);
+
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    void should_return_connection_logs_of_an_application() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1"),
+                connectionLogFixtures
+                    .aConnectionLog()
+                    .toBuilder()
+                    .apiId("other-api")
+                    .planId("other-plan")
+                    .applicationId("other-application")
+                    .build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build(),
+                Optional.empty()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isOne();
+            soft
+                .assertThat(result.data())
+                .isEqualTo(
+                    List.of(
+                        ConnectionLog
+                            .builder()
+                            .requestId("req1")
+                            .apiId(API_ID)
+                            .api(API_1)
+                            .applicationId(APPLICATION_ID)
+                            .application(APPLICATION_1)
+                            .plan(PLAN_1)
+                            .timestamp("2020-02-01T20:00:00.00Z")
+                            .requestEnded(true)
+                            .method(HttpMethod.GET)
+                            .clientIdentifier("client-identifier")
+                            .transactionId("transaction-id")
+                            .status(200)
+                            .build()
+                    )
+                );
+        });
+    }
+
+    @Test
+    void should_return_application_connection_logs_sorted_by_desc_timestamp() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(FIFTH_FEBRUARY_2020).build()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isEqualTo(3);
+            soft
+                .assertThat(result.data())
+                .extracting(ConnectionLog::getRequestId, ConnectionLog::getTimestamp)
+                .containsExactly(
+                    tuple("req3", "2020-02-04T20:00:00.00Z"),
+                    tuple("req2", "2020-02-02T20:00:00.00Z"),
+                    tuple("req1", "2020-02-01T20:00:00.00Z")
+                );
+        });
+    }
+
+    @Test
+    void should_return_the_page_requested() {
+        var expectedTotal = 15;
+        var pageNumber = 2;
+        var pageSize = 5;
+        logStorageService.initWithConnectionLogs(
+            IntStream.range(0, expectedTotal).mapToObj(i -> connectionLogFixtures.aConnectionLog(String.valueOf(i))).toList()
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build(),
+                new PageableImpl(pageNumber, pageSize)
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isEqualTo(expectedTotal);
+            soft.assertThat(result.data()).extracting(ConnectionLog::getRequestId).containsExactly("5", "6", "7", "8", "9");
+        });
+    }
+
+    @Test
+    void should_return_application_connection_logs_with_only_plan_id_if_plan_cannot_be_found() {
+        var unknownPlan = "unknown";
+
+        logStorageService.initWithConnectionLogs(List.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(unknownPlan).build()));
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build()
+            )
+        );
+        assertThat(result.data()).extracting(ConnectionLog::getPlan).isEqualTo(List.of(Plan.builder().id("1").build()));
+    }
+
+    @Test
+    void should_return_application_connection_logs_with_only_available_info() {
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(null).clientIdentifier(null).build())
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build()
+            )
+        );
+        assertThat(result.data()).extracting(ConnectionLog::getPlan).isEqualTo(List.of(Plan.builder().id("1").build()));
+    }
+
+    @Test
+    void should_return_application_connection_logs_with_only_api_id_if_application_cannot_be_found() {
+        var unknownApi = "unknown";
+
+        logStorageService.initWithConnectionLogs(List.of(connectionLogFixtures.aConnectionLog().toBuilder().apiId(unknownApi).build()));
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build()
+            )
+        );
+        assertThat(result.data()).extracting(ConnectionLog::getApi).isEqualTo(List.of(Api.builder().id("1").build()));
+    }
+
+    @Test
+    void should_return_application_connection_logs_for_apis() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").apiId("api-1").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req2").apiId("api-1").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req3").apiId("api-2").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req4").apiId("already-deleted").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().apiIds(Set.of("api-1", "api-2")).build()
+            )
+        );
+        assertThat(result.data())
+            .extracting(ConnectionLog::getRequestId, ConnectionLog::getApi)
+            .containsExactlyInAnyOrder(tuple("req1", API_1), tuple("req2", API_1), tuple("req3", API_2));
+    }
+
+    @Test
+    void should_return_application_connection_logs_for_plans() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").planId("plan1").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req2").planId("plan1").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req3").planId("plan2").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req4").planId("plan3").build(),
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req5").planId("plan3").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().planIds(Set.of("plan1", "plan2")).build()
+            )
+        );
+        assertThat(result.data())
+            .extracting(ConnectionLog::getRequestId, ConnectionLog::getPlan)
+            .containsExactlyInAnyOrder(tuple("req1", PLAN_1), tuple("req2", PLAN_1), tuple("req3", PLAN_2));
+    }
+
+    @Test
+    void should_return_application_connection_logs_filtered_by_timestamp_date_range() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(FOURTH_FEBRUARY_2020).build(),
+                Optional.empty()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isEqualTo(2);
+            soft
+                .assertThat(result.data())
+                .extracting(ConnectionLog::getRequestId, ConnectionLog::getTimestamp)
+                .containsExactly(tuple("req2", "2020-02-02T20:00:00.00Z"), tuple("req1", "2020-02-01T20:00:00.00Z"));
+        });
+    }
+
+    @Test
+    void should_return_application_connection_logs_from_timestamp() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().from(FOURTH_FEBRUARY_2020).build(),
+                Optional.empty()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isOne();
+            soft
+                .assertThat(result.data())
+                .extracting(ConnectionLog::getRequestId, ConnectionLog::getTimestamp)
+                .containsExactly(tuple("req3", "2020-02-04T20:00:00.00Z"));
+        });
+    }
+
+    @Test
+    void should_return_application_connection_logs_to_timestamp() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
+                connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().to(FOURTH_FEBRUARY_2020).build(),
+                Optional.empty()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isEqualTo(2);
+            soft
+                .assertThat(result.data())
+                .extracting(ConnectionLog::getRequestId, ConnectionLog::getTimestamp)
+                .containsExactly(tuple("req2", "2020-02-02T20:00:00.00Z"), tuple("req1", "2020-02-01T20:00:00.00Z"));
+        });
+    }
+
+    @Test
+    void should_return_application_connection_logs_for_entrypoint() {
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog("req1").toBuilder().entrypointId("http-get").build(),
+                connectionLogFixtures.aConnectionLog("req2").toBuilder().entrypointId("http-post").build()
+            )
+        );
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().entrypointIds(Set.of("http-get")).build(),
+                Optional.empty()
+            )
+        );
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isEqualTo(1);
+            soft.assertThat(result.data()).extracting(ConnectionLog::getRequestId).containsExactly("req1");
+        });
+    }
+
+    @Test
+    void should_return_logs_with_metadata_with_api_and_plan_found() {
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").apiId("api-1").planId("plan1").build())
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(
+                APPLICATION_ID,
+                ORG_ID,
+                ENV_ID,
+                SearchLogsFilters.builder().apiIds(Set.of("api-1")).planIds(Set.of("plan1")).build()
+            )
+        );
+        assertThat(result.data())
+            .extracting(ConnectionLog::getRequestId, ConnectionLog::getApi, ConnectionLog::getPlan, ConnectionLog::getApplication)
+            .containsExactlyInAnyOrder(tuple("req1", API_1, PLAN_1, APPLICATION_1));
+    }
+
+    @Test
+    void should_return_logs_with_metadata_with_api_and_plan_not_found() {
+        String apiNotFoundId = "not-found";
+        String planNotFoundId = "missing";
+        logStorageService.initWithConnectionLogs(
+            List.of(
+                connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").apiId(apiNotFoundId).planId(planNotFoundId).build()
+            )
+        );
+
+        var result = cut.execute(
+            new SearchApplicationConnectionLogsUseCase.Input(APPLICATION_ID, ORG_ID, ENV_ID, SearchLogsFilters.builder().build())
+        );
+        assertThat(result.data())
+            .extracting(ConnectionLog::getRequestId, ConnectionLog::getApi, ConnectionLog::getPlan, ConnectionLog::getApplication)
+            .containsExactlyInAnyOrder(tuple("req1", Api.builder().id("1").build(), Plan.builder().id("1").build(), APPLICATION_1));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6236

## Description

- Create the `SearchApplicationConnectionLogsUseCase` to return a page of connection logs for a given application.
- Create new endpoint `/applications/{applicationId}/logs/_search` for new search mechanism in PAPI
- Implement new _search endpoint in portal-next

Note: User can click on the v4 logs in portal next but the error message is shown for now. PR incoming...

https://github.com/user-attachments/assets/79ccc6fb-3fe2-484b-bd98-a3d56d6e2fc2


Next PRs:
- Re-integrate feature for V2 APIs --- search in message body
- Return a v4 connection log in the service + adapt UI in portal-next

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

