### PR TITLE
CI improvements about docker images

### DIFF
--- a/.circleci/ci/src/commands/cmd-build-ui-image.ts
+++ b/.circleci/ci/src/commands/cmd-build-ui-image.ts
@@ -50,6 +50,7 @@ export class BuildUiImageCommand {
         name: 'Build UI docker image',
         command: `docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \\
 -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:${tag} \\
+-t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:${tag} \\
 .`,
         working_directory: '<< parameters.apim-ui-project >>',
       }),
@@ -85,11 +86,11 @@ export class BuildUiImageCommand {
         new reusable.ReusedCommand(orbs.aquasec.commands['install_billy']),
         new reusable.ReusedCommand(orbs.aquasec.commands['pull_aqua_scanner_image']),
         new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
-          artifact_to_register: `graviteeio.azurecr.io/<< parameters.docker-image-name >>:${tag}`,
+          artifact_to_register: `graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:${tag}`,
           debug: true,
         }),
         new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
-          docker_image_to_scan: `graviteeio.azurecr.io/<< parameters.docker-image-name >>:${tag}`,
+          docker_image_to_scan: `graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:${tag}`,
           scanner_url: config.aqua.scannerUrl,
         }),
       );

--- a/.circleci/ci/src/jobs/job-build-backend-images.ts
+++ b/.circleci/ci/src/jobs/job-build-backend-images.ts
@@ -45,10 +45,12 @@ export class BuildBackendImagesJob {
         name: 'Build rest api and gateway docker images',
         command: `docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \\
 -t graviteeio.azurecr.io/apim-management-api:${tag} \\
+-t graviteeio.azurecr.io/dev-apim-management-api:${tag} \\
 rest-api-docker-context
 
 docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \\
 -t graviteeio.azurecr.io/apim-gateway:${tag} \\
+-t graviteeio.azurecr.io/dev-apim-gateway:${tag} \\
 gateway-docker-context`,
       }),
     ];
@@ -84,19 +86,19 @@ gateway-docker-context`,
         new reusable.ReusedCommand(orbs.aquasec.commands['install_billy']),
         new reusable.ReusedCommand(orbs.aquasec.commands['pull_aqua_scanner_image']),
         new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
-          artifact_to_register: `graviteeio.azurecr.io/apim-management-api:${tag}`,
+          artifact_to_register: `graviteeio.azurecr.io/dev-apim-management-api:${tag}`,
           debug: true,
         }),
         new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
-          artifact_to_register: `graviteeio.azurecr.io/apim-gateway:${tag}`,
+          artifact_to_register: `graviteeio.azurecr.io/dev-apim-gateway:${tag}`,
           debug: true,
         }),
         new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
-          docker_image_to_scan: `graviteeio.azurecr.io/apim-management-api:${tag}`,
+          docker_image_to_scan: `graviteeio.azurecr.io/dev-apim-management-api:${tag}`,
           scanner_url: config.aqua.scannerUrl,
         }),
         new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
-          docker_image_to_scan: `graviteeio.azurecr.io/apim-gateway:${tag}`,
+          docker_image_to_scan: `graviteeio.azurecr.io/dev-apim-gateway:${tag}`,
           scanner_url: config.aqua.scannerUrl,
         }),
       );

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -24,7 +24,7 @@ describe('Full release tests', () => {
     ${'4.2.x'} | ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-latest.yml'}
     ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'release-4-2-0-alpha.yml'}
   `(
-    'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version graviteeioVersion',
+    'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version $graviteeioVersion',
     ({ baseBranch, branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {
       const result = generateFullReleaseConfig({
         action: 'release',

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -174,6 +102,13 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-create-docker-context:
+    steps:
+      - run:
+          name: Create docker context for buildx
+          command: |-
+            docker context create tls-env
+            docker buildx create tls-env --use
 jobs:
   job-setup:
     docker:
@@ -239,9 +174,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +212,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -787,9 +716,9 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@4.1.0
   aws-cli: circleci/aws-cli@5.1.2
   helm: circleci/helm@3.0.0
   gh: circleci/github-cli@1.0.5
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -174,6 +102,13 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-create-docker-context:
+    steps:
+      - run:
+          name: Create docker context for buildx
+          command: |-
+            docker context create tls-env
+            docker buildx create tls-env --use
 jobs:
   job-setup:
     docker:
@@ -239,9 +174,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +212,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -777,9 +706,9 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@4.1.0
   aws-cli: circleci/aws-cli@5.1.2
   helm: circleci/helm@3.0.0
   gh: circleci/github-cli@1.0.5
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -174,6 +102,13 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-create-docker-context:
+    steps:
+      - run:
+          name: Create docker context for buildx
+          command: |-
+            docker context create tls-env
+            docker buildx create tls-env --use
 jobs:
   job-setup:
     docker:
@@ -239,9 +174,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +212,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -789,9 +718,9 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@4.1.0
   aws-cli: circleci/aws-cli@5.1.2
   helm: circleci/helm@3.0.0
   gh: circleci/github-cli@1.0.5
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -174,6 +102,13 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-create-docker-context:
+    steps:
+      - run:
+          name: Create docker context for buildx
+          command: |-
+            docker context create tls-env
+            docker buildx create tls-env --use
 jobs:
   job-setup:
     docker:
@@ -239,9 +174,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +212,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -789,9 +718,9 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@4.1.0
   aws-cli: circleci/aws-cli@5.1.2
   helm: circleci/helm@3.0.0
   gh: circleci/github-cli@1.0.5
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -133,6 +133,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - keeper/env-export:
@@ -156,10 +157,10 @@ commands:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
 jobs:
@@ -229,10 +230,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest \
             gateway-docker-context
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
@@ -255,16 +258,16 @@ jobs:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-management-api:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest
           debug: true
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-gateway:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-management-api:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-gateway:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
   job-console-webui-build:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -134,6 +134,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:apim-1234-branch-name-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - cmd-docker-azure-logout
@@ -204,10 +205,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:apim-1234-branch-name-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:apim-1234-branch-name-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:apim-1234-branch-name-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:apim-1234-branch-name-latest \
             gateway-docker-context
       - cmd-docker-azure-logout
   job-console-webui-build:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -133,6 +133,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - keeper/env-export:
@@ -156,10 +157,10 @@ commands:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
 jobs:
@@ -229,10 +230,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:master-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:master-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:master-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:master-latest \
             gateway-docker-context
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
@@ -255,16 +258,16 @@ jobs:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-management-api:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-management-api:master-latest
           debug: true
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-gateway:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-gateway:master-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-management-api:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-management-api:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-gateway:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-gateway:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
   job-console-webui-build:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -133,6 +133,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - keeper/env-export:
@@ -156,10 +157,10 @@ commands:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
 jobs:
@@ -709,10 +710,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:4.1.x-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest \
             gateway-docker-context
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
@@ -735,16 +738,16 @@ jobs:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-management-api:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest
           debug: true
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-gateway:4.1.x-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-management-api:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-management-api:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-gateway:4.1.x-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-gateway:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -62,52 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-my-custom-branch-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -201,9 +155,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -62,52 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-my-custom-branch-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -212,9 +166,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -91,52 +91,6 @@ commands:
           key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project >>/yarn.lock" }}
           paths:
             - ./<< parameters.apim-ui-project >>/node_modules
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-my-custom-branch-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - cmd-docker-azure-logout
 jobs:
   job-test-apim-charts:
     parameters:
@@ -546,9 +500,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -659,9 +610,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -133,6 +133,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - keeper/env-export:
@@ -156,10 +157,10 @@ commands:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
 jobs:
@@ -709,10 +710,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:master-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:master-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:master-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:master-latest \
             gateway-docker-context
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
@@ -735,16 +738,16 @@ jobs:
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-management-api:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-management-api:master-latest
           debug: true
       - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/apim-gateway:master-latest
+          artifact_to_register: graviteeio.azurecr.io/dev-apim-gateway:master-latest
           debug: true
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-management-api:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-management-api:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/apim-gateway:master-latest
+          docker_image_to_scan: graviteeio.azurecr.io/dev-apim-gateway:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -91,52 +91,6 @@ commands:
           key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project >>/yarn.lock" }}
           paths:
             - ./<< parameters.apim-ui-project >>/node_modules
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:mergify-bp-4.0.x-pr-1234-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - cmd-docker-azure-logout
 jobs:
   job-test-apim-charts:
     parameters:
@@ -546,9 +500,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -659,9 +610,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -134,6 +134,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:apim-1234-run-e2e-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - cmd-docker-azure-logout
@@ -692,10 +693,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:apim-1234-run-e2e-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:apim-1234-run-e2e-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:apim-1234-run-e2e-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:apim-1234-run-e2e-latest \
             gateway-docker-context
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -239,9 +167,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +205,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -460,5 +382,4 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -239,9 +167,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +205,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -462,5 +384,4 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -62,78 +62,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-create-docker-context:
-    steps:
-      - run:
-          name: Create docker context for buildx
-          command: |-
-            docker context create tls-env
-            docker buildx create tls-env --use
-  cmd-docker-azure-login:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
-          var-name: AZURE_DOCKER_REGISTRY_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-          var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-      - run:
-          name: Login to Azure Container Registry
-          command: echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
-    description: Login to Azure Container Registry
-  cmd-docker-azure-logout:
-    steps:
-      - run:
-          name: Logout from Azure Container Registry
-          command: docker logout graviteeio.azurecr.io
-    description: Logout from Azure Container Registry
-  cmd-build-ui-image:
-    parameters:
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-      apim-ui-project:
-        type: string
-        default: ""
-        description: the name of the UI project to build
-    steps:
-      - cmd-create-docker-context
-      - cmd-docker-azure-login
-      - run:
-          name: Build UI docker image
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest \
-            .
-          working_directory: << parameters.apim-ui-project >>
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - aquasec/install_billy
-      - aquasec/pull_aqua_scanner_image
-      - aquasec/register_artifact:
-          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          debug: true
-      - aquasec/scan_docker_image:
-          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.x-latest
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-      - cmd-docker-azure-logout
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -239,9 +167,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-console-webui
-      - cmd-build-ui-image:
-          docker-image-name: apim-management-ui
-          apim-ui-project: gravitee-apim-console-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -280,9 +205,6 @@ jobs:
           environment:
             NODE_OPTIONS: --max_old_space_size=4086
           working_directory: gravitee-apim-portal-webui-next
-      - cmd-build-ui-image:
-          docker-image-name: apim-portal-ui
-          apim-ui-project: gravitee-apim-portal-webui
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
@@ -462,5 +384,4 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -134,6 +134,7 @@ commands:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-latest \
+            -t graviteeio.azurecr.io/dev-<< parameters.docker-image-name >>:apim-xxx-test-latest \
             .
           working_directory: << parameters.apim-ui-project >>
       - cmd-docker-azure-logout
@@ -204,10 +205,12 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-rest-api/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-management-api:apim-xxx-test-latest \
+            -t graviteeio.azurecr.io/dev-apim-management-api:apim-xxx-test-latest \
             rest-api-docker-context
 
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f gravitee-apim-gateway/docker/Dockerfile \
             -t graviteeio.azurecr.io/apim-gateway:apim-xxx-test-latest \
+            -t graviteeio.azurecr.io/dev-apim-gateway:apim-xxx-test-latest \
             gateway-docker-context
       - cmd-docker-azure-logout
   job-console-webui-build:

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -42,10 +42,10 @@ export class FullReleaseWorkflow {
     const slackAnnouncementJob = SlackAnnouncementJob.create(dynamicConfig);
     dynamicConfig.addJob(slackAnnouncementJob);
 
-    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(consoleWebuiBuildJob);
 
-    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
     const webuiPublishArtifactoryJob = WebuiPublishArtifactoryJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
@@ -29,10 +29,10 @@ export class PublishDockerImagesWorkflow {
     const buildBackendImagesJob = BuildBackendImagesJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(buildBackendImagesJob);
 
-    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(consoleWebuiBuildJob);
 
-    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
     const publishPrEnvUrlsJob = PublishPrEnvUrlsJob.create(dynamicConfig);

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -53,18 +53,22 @@ import { orbs } from '../orbs';
 export class PullRequestsWorkflow {
   static create(dynamicConfig: Config, environment: CircleCIEnvironment): Workflow {
     let jobs: workflow.WorkflowJob[] = [];
+    const shouldBuildDockerImages: boolean = isSupportBranchOrMaster(environment.branch) || isE2EBranch(environment.branch);
     // Needed to publish helm chart in internal repository
     environment.isDryRun = true;
     if (isSupportBranchOrMaster(environment.branch)) {
       jobs.push(
-        ...this.getCommonJobs(dynamicConfig, environment, false, false),
+        ...this.getCommonJobs(dynamicConfig, environment, false, false, shouldBuildDockerImages),
         ...this.getE2EJobs(dynamicConfig, environment),
         ...this.getMasterAndSupportJobs(dynamicConfig, environment),
       );
     } else if (isE2EBranch(environment.branch)) {
-      jobs.push(...this.getCommonJobs(dynamicConfig, environment, false, true), ...this.getE2EJobs(dynamicConfig, environment));
+      jobs.push(
+        ...this.getCommonJobs(dynamicConfig, environment, false, true, shouldBuildDockerImages),
+        ...this.getE2EJobs(dynamicConfig, environment),
+      );
     } else {
-      jobs = this.getCommonJobs(dynamicConfig, environment, true, true);
+      jobs = this.getCommonJobs(dynamicConfig, environment, true, true, shouldBuildDockerImages);
     }
     return new Workflow('pull_requests', jobs);
   }
@@ -74,6 +78,7 @@ export class PullRequestsWorkflow {
     environment: CircleCIEnvironment,
     filterJobs: boolean,
     addValidationJob: boolean,
+    shouldBuildDockerImages: boolean,
   ): workflow.WorkflowJob[] {
     dynamicConfig.importOrb(orbs.keeper).importOrb(orbs.aquasec);
 
@@ -277,7 +282,7 @@ export class PullRequestsWorkflow {
       const webuiLintTestJob = WebuiLintTestJob.create(dynamicConfig);
       dynamicConfig.addJob(webuiLintTestJob);
 
-      const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+      const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment, shouldBuildDockerImages);
       dynamicConfig.addJob(consoleWebuiBuildJob);
 
       const storybookConsoleJob = StorybookConsoleJob.create(dynamicConfig);
@@ -325,7 +330,7 @@ export class PullRequestsWorkflow {
       const webuiLintTestJob = WebuiLintTestJob.create(dynamicConfig);
       dynamicConfig.addJob(webuiLintTestJob);
 
-      const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+      const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, shouldBuildDockerImages);
       dynamicConfig.addJob(portalWebuiBuildJob);
 
       const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-release.ts
+++ b/.circleci/ci/src/workflows/workflow-release.ts
@@ -36,10 +36,10 @@ export class ReleaseWorkflow {
     const slackAnnouncementJob = SlackAnnouncementJob.create(dynamicConfig);
     dynamicConfig.addJob(slackAnnouncementJob);
 
-    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(consoleWebuiBuildJob);
 
-    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
     const webuiPublishArtifactoryJob = WebuiPublishArtifactoryJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-run-e2e-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-run-e2e-tests.ts
@@ -39,10 +39,10 @@ export class RunE2ETestsWorkflow {
     const buildBackendImagesJob = BuildBackendImagesJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(buildBackendImagesJob);
 
-    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(consoleWebuiBuildJob);
 
-    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
     const e2eGenerateSdkJob = E2EGenerateSDKJob.create(dynamicConfig);


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-8605

## Description
 - only build UI dev docker images when needed (i.e. to run e2e tests and for the "PR environment")
 - change tag name of our dev docker images, to reflect the fact that they are dev images (i.e. build with the "bundle-dev" profile). The "old" tag name is kept in order to not break our dev environments.