### PR TITLE
fix: access public APIs listed in a category when user is logged out

### DIFF
--- a/gravitee-apim-e2e/api-test/src/portal/mapi-v1/portal-api-view-and-search.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/portal/mapi-v1/portal-api-view-and-search.spec.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, beforeAll, describe, test, expect } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
 
-import { forManagementAsAdminUser, forPortalAsAdminUser } from '@gravitee/utils/configuration';
+import { ANONYMOUS, forManagementAsAdminUser, forPortal, forPortalAsAdminUser } from '@gravitee/utils/configuration';
 import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
 import { UpdateApiEntity, UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
@@ -26,6 +26,8 @@ import { FilterApiQuery } from '@gravitee/portal-webclient-sdk/src/lib/models/Fi
 import { ApiLifecycleState } from '@gravitee/management-webclient-sdk/src/lib/models/ApiLifecycleState';
 import { ConfigurationApi } from '@gravitee/management-webclient-sdk/src/lib/apis/ConfigurationApi';
 import { CategoryEntity } from '@gravitee/management-webclient-sdk/src/lib/models/CategoryEntity';
+import { Visibility } from '../../../../lib/management-v2-webclient-sdk/src/lib';
+import faker from '@faker-js/faker';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -33,6 +35,7 @@ const envId = 'DEFAULT';
 const apisManagementApiAsAdmin = new APIsApi(forManagementAsAdminUser());
 const apiPortalApiAsAdmin = new ApiApi(forPortalAsAdminUser());
 const configurationApiAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
+const portalApiAsAnonymous = new ApiApi(forPortal({ auth: ANONYMOUS }));
 
 async function createAndPublish(apiManagementClient: APIsApi, attributes?: Partial<UpdateApiEntity>): Promise<ApiEntity> {
   let createdApi = await apiManagementClient.createApi({
@@ -54,7 +57,9 @@ describe('Portal - View and search APIs', () => {
   let apiWith2Labels: ApiEntity;
   let apiFeatured: ApiEntity;
   let apiWithCategory: ApiEntity;
+  let privateApiWithCategory: ApiEntity;
   let createdCategory: CategoryEntity;
+  const cat1 = `cat-${faker.datatype.uuid()}`;
 
   beforeAll(async () => {
     // create all APIs needed for testing
@@ -62,10 +67,15 @@ describe('Portal - View and search APIs', () => {
       configurationApiAsAdmin.createCategoryRaw({
         orgId,
         envId,
-        newCategoryEntity: { name: 'cat1' },
+        newCategoryEntity: { name: cat1 },
       }),
     );
-    apiWithCategory = await createAndPublish(apisManagementApiAsAdmin, { categories: ['cat1'], description: 'API with one category' });
+    apiWithCategory = await createAndPublish(apisManagementApiAsAdmin, { categories: [cat1], description: 'API with one category' });
+    privateApiWithCategory = await createAndPublish(apisManagementApiAsAdmin, {
+      categories: [cat1],
+      description: 'Private API with one category',
+      visibility: Visibility.PRIVATE,
+    });
     apiWith1Label = await createAndPublish(apisManagementApiAsAdmin, { labels: ['testlabel1'], description: 'API with one label' });
     apiWith2Labels = await createAndPublish(apisManagementApiAsAdmin, {
       labels: ['testlabel1', 'testlabel2'],
@@ -81,6 +91,8 @@ describe('Portal - View and search APIs', () => {
     await apisManagementApiAsAdmin.deleteApi({ orgId, envId, api: apiWith2Labels.id });
     await apisManagementApiAsAdmin.deleteApi({ orgId, envId, api: apiFeatured.id });
     await apisManagementApiAsAdmin.deleteApi({ orgId, envId, api: apiWithCategory.id });
+    await apisManagementApiAsAdmin.deleteApi({ orgId, envId, api: privateApiWithCategory.id });
+    await configurationApiAsAdmin.deleteTopApiRaw({ orgId, envId, topAPI: privateApiWithCategory.id });
     await configurationApiAsAdmin.deleteTopApiRaw({ orgId, envId, topAPI: apiFeatured.id });
     await configurationApiAsAdmin.deleteCategory({ orgId, envId, categoryId: createdCategory.id });
   });
@@ -89,11 +101,12 @@ describe('Portal - View and search APIs', () => {
     describe('Filter API list regarding FilterApiQuery', () => {
       test('should list all published APIs', async () => {
         const getApisResponse = await succeed(apiPortalApiAsAdmin.getApisRaw({ filter: FilterApiQuery.ALL }));
-        expect(getApisResponse.data).toHaveLength(4);
+        expect(getApisResponse.data).toHaveLength(5);
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWith1Label.id)).toBeTruthy();
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWith2Labels.id)).toBeTruthy();
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiFeatured.id)).toBeTruthy();
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWithCategory.id)).toBeTruthy();
+        expect(getApisResponse.data.some((filteredApi) => filteredApi.id === privateApiWithCategory.id)).toBeTruthy();
       });
 
       test('should only list featured APIs', async () => {
@@ -106,18 +119,25 @@ describe('Portal - View and search APIs', () => {
     describe('Exclude APIs from list', function () {
       test('should exclude APIs with certain query param', async () => {
         const getApisResponse = await succeed(apiPortalApiAsAdmin.getApisRaw({ filter2: FilterApiQuery.FEATURED }));
-        expect(getApisResponse.data).toHaveLength(3);
+        expect(getApisResponse.data).toHaveLength(4);
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWith1Label.id)).toBeTruthy();
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWith2Labels.id)).toBeTruthy();
         expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWithCategory.id)).toBeTruthy();
+        expect(getApisResponse.data.some((filteredApi) => filteredApi.id === privateApiWithCategory.id)).toBeTruthy();
       });
     });
 
     describe('Filter API list regarding category', function () {
       test('should list all APIs with certain category', async () => {
-        let getApisResponse = await succeed(apiPortalApiAsAdmin.getApisRaw({ category: 'cat1' }));
-        expect(getApisResponse.data).toHaveLength(1);
-        expect(getApisResponse.data[0].id).toBe(apiWithCategory.id);
+        let getApisResponse = await succeed(apiPortalApiAsAdmin.getApisRaw({ category: cat1 }));
+        expect(getApisResponse.data).toHaveLength(2);
+        expect(getApisResponse.data.some((filteredApi) => filteredApi.id === apiWithCategory.id)).toBeTruthy();
+        expect(getApisResponse.data.some((filteredApi) => filteredApi.id === privateApiWithCategory.id)).toBeTruthy();
+      });
+
+      test('should list no APIs for anonymous user because all APIs are private', async () => {
+        let getApisResponse = await succeed(portalApiAsAnonymous.getApisRaw({ category: cat1 }));
+        expect(getApisResponse.data).toHaveLength(0);
       });
     });
 
@@ -149,7 +169,7 @@ describe('Portal - View and search APIs', () => {
 
       test('should show certain page when limiting API to certain value', async () => {
         const getApisResponse = await succeed(apiPortalApiAsAdmin.getApisRaw({ size: 3, page: 2 }));
-        expect(getApisResponse.data).toHaveLength(1);
+        expect(getApisResponse.data).toHaveLength(2);
       });
     });
   });
@@ -170,6 +190,20 @@ describe('Portal - View and search APIs', () => {
     test('should not find any APIs if search string does not match anything', async () => {
       const searchResponse = await succeed(apiPortalApiAsAdmin.searchApisRaw({ q: 'unmatchedString' }));
       expect(searchResponse.data).toHaveLength(0);
+    });
+  });
+
+  describe('Update apiWithCategory visibility and fetch APIs', () => {
+    test('should get public API only when user is anonymous', async () => {
+      const publicApiWithCategory = await createAndPublish(apisManagementApiAsAdmin, {
+        categories: [cat1],
+        description: 'API with one category',
+        visibility: 'PUBLIC',
+      });
+      let getApisResponse = await succeed(portalApiAsAnonymous.getApisRaw({ category: cat1 }));
+      expect(getApisResponse.data).toHaveLength(1);
+      expect(getApisResponse.data.some((foundApi) => foundApi.id === publicApiWithCategory.id)).toBeTruthy();
+      await apisManagementApiAsAdmin.deleteApi({ orgId, envId, api: publicApiWithCategory.id });
     });
   });
 });

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -480,16 +480,12 @@ class DebugReactorEventListenerTest {
         final HttpClient mockHttpClient = mock(HttpClient.class);
         when(vertx.createHttpClient(any(HttpClientOptions.class))).thenReturn(mockHttpClient);
 
-        // Mock successful Buffer body in HttpClientResponse
-        final HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
-        when(httpClientResponse.statusCode()).thenReturn(200);
-        final Buffer bodyBuffer = Buffer.buffer("response body");
-        when(httpClientResponse.rxBody()).thenReturn(Single.just(bodyBuffer));
-
         // Mock successful HttpClientRequest
         final HttpClientRequest httpClientRequest = mock(HttpClientRequest.class);
         when(mockHttpClient.rxRequest(any())).thenReturn(Single.just(httpClientRequest));
         when(httpClientRequest.setChunked(true)).thenReturn(httpClientRequest);
+        // Mock successful HttpClientResponse
+        final HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
         when(httpClientRequest.rxSend(any(String.class))).thenReturn(Single.just(httpClientResponse));
 
         debugReactorEventListener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, reactableWrapper));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -39,12 +39,24 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.filtering.FilteringService;
 import io.gravitee.rest.api.service.v4.ApiCategoryService;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -241,7 +253,7 @@ public class ApisResource extends AbstractResource<Api, String> {
             );
         }
         return getCategoryApisUseCase
-            .execute(new GetCategoryApisUseCase.Input(executionContext, apisParam.getCategory(), getAuthenticatedUser(), false, true))
+            .execute(new GetCategoryApisUseCase.Input(executionContext, apisParam.getCategory(), getAuthenticatedUserOrNull(), false, true))
             .results()
             .stream()
             .map(result -> result.api().getId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceNotAuthenticatedTest.java
@@ -16,11 +16,19 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCategoryOrderQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.portal.rest.model.Api;
@@ -33,11 +41,24 @@ import java.util.Set;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  */
 public class ApisResourceNotAuthenticatedTest extends AbstractResourceTest {
+
+    @Autowired
+    private CategoryQueryServiceInMemory categoryQueryServiceInMemory;
+
+    @Autowired
+    private ApiCategoryOrderQueryServiceInMemory apiCategoryOrderQueryServiceInMemory;
+
+    @Autowired
+    private ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService;
+
+    @Autowired
+    private ApiQueryServiceInMemory apiQueryServiceInMemory;
 
     @Override
     protected String contextPath() {
@@ -52,32 +73,42 @@ public class ApisResourceNotAuthenticatedTest extends AbstractResourceTest {
     @Before
     public void init() {
         resetAllMocks();
+        categoryQueryServiceInMemory.reset();
+        apiCategoryOrderQueryServiceInMemory.reset();
+        apiAuthorizationDomainService.reset();
 
-        ApiEntity publishedApi = new ApiEntity();
-        publishedApi.setLifecycleState(ApiLifecycleState.PUBLISHED);
-        publishedApi.setName("A");
-        publishedApi.setId("A");
-
-        ApiEntity unpublishedApi = new ApiEntity();
-        unpublishedApi.setLifecycleState(ApiLifecycleState.UNPUBLISHED);
-        unpublishedApi.setName("B");
-        unpublishedApi.setId("B");
-
-        ApiEntity anotherPublishedApi = new ApiEntity();
-        anotherPublishedApi.setLifecycleState(ApiLifecycleState.PUBLISHED);
-        anotherPublishedApi.setName("C");
-        anotherPublishedApi.setId("C");
+        ApiEntity publishedApi = createApiEntity("A", "A", Visibility.PUBLIC, ApiLifecycleState.PUBLISHED);
+        ApiEntity unpublishedApi = createApiEntity("B", "B", Visibility.PUBLIC, ApiLifecycleState.UNPUBLISHED);
+        ApiEntity anotherPublishedApi = createApiEntity("C", "C", Visibility.PUBLIC, ApiLifecycleState.PUBLISHED);
+        ApiEntity privateApi = createApiEntity("D", "D", Visibility.PRIVATE, ApiLifecycleState.PUBLISHED);
 
         doReturn(Arrays.asList("A", "C")).when(filteringService).filterApis(any(), any(), any(), any(), any());
         doReturn(List.of(publishedApi, anotherPublishedApi))
             .when(apiSearchService)
             .search(eq(GraviteeContext.getExecutionContext()), any());
 
+        categoryQueryServiceInMemory.initWith(List.of(Category.builder().id("Category1").build()));
+
+        apiCategoryOrderQueryServiceInMemory.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("1").categoryId("myCat").build(),
+                ApiCategoryOrder.builder().apiId("A").categoryId("Category1").build(),
+                ApiCategoryOrder.builder().apiId("B").categoryId("Category1").build(),
+                ApiCategoryOrder.builder().apiId("C").categoryId("Category1").build(),
+                ApiCategoryOrder.builder().apiId("D").categoryId("Category1").build()
+            )
+        );
+
+        apiAuthorizationDomainService.initWith(List.of(createApi("A"), createApi("C")));
+
+        apiQueryServiceInMemory.initWith(List.of(createApi("A"), createApi("C")));
+
         doReturn(false).when(ratingService).isEnabled(GraviteeContext.getExecutionContext());
 
         doReturn(new Api().name("A").id("A")).when(apiMapper).convert(GraviteeContext.getExecutionContext(), publishedApi);
         doReturn(new Api().name("B").id("B")).when(apiMapper).convert(GraviteeContext.getExecutionContext(), unpublishedApi);
         doReturn(new Api().name("C").id("C")).when(apiMapper).convert(GraviteeContext.getExecutionContext(), anotherPublishedApi);
+        doReturn(new Api().name("D").id("D")).when(apiMapper).convert(GraviteeContext.getExecutionContext(), privateApi);
     }
 
     @Test
@@ -86,8 +117,43 @@ public class ApisResourceNotAuthenticatedTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+
+        assertNotNull(apiResponse.getData());
         assertEquals(2, apiResponse.getData().size());
-        assertEquals("A", ((Api) apiResponse.getData().get(0)).getName());
-        assertEquals("C", ((Api) apiResponse.getData().get(1)).getName());
+        assertEquals("A", apiResponse.getData().get(0).getName());
+        assertEquals("C", apiResponse.getData().get(1).getName());
+    }
+
+    @Test
+    public void shouldReturnPublishedPublicApiWhenQueryByCategory() {
+        final Response response = target().queryParam("category", "Category1").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+
+        assertNotNull(apiResponse.getData());
+        assertEquals(2, apiResponse.getData().size());
+        assertEquals("A", apiResponse.getData().get(0).getName());
+        assertEquals("C", apiResponse.getData().get(1).getName());
+    }
+
+    private static ApiEntity createApiEntity(String id, String name, Visibility visibility, ApiLifecycleState apiLifecycleState) {
+        ApiEntity anotherPublishedApi = new ApiEntity();
+        anotherPublishedApi.setLifecycleState(apiLifecycleState);
+        anotherPublishedApi.setVisibility(visibility);
+        anotherPublishedApi.setName(name);
+        anotherPublishedApi.setId(id);
+        return anotherPublishedApi;
+    }
+
+    private static io.gravitee.apim.core.api.model.Api createApi(String A) {
+        return io.gravitee.apim.core.api.model.Api
+            .builder()
+            .id(A)
+            .name(A)
+            .apiLifecycleState(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.PUBLISHED)
+            .categories(Set.of("Category1"))
+            .visibility(io.gravitee.apim.core.api.model.Api.Visibility.PUBLIC)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCase.java
@@ -130,6 +130,11 @@ public class GetCategoryApisUseCase {
             }
             var apiIdsInUserScope =
                 this.apiAuthorizationDomainService.findIdsByUser(executionContext, userId, apiQueryCriteria.build(), null, false);
+
+            if (apiIdsInUserScope == null || apiIdsInUserScope.isEmpty()) {
+                return Stream.empty();
+            }
+
             apiSearchCriteria.ids(new ArrayList<>(apiIdsInUserScope));
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8384

## Description

Allow access to public APIs listed in a category when user logged out.

## Additional context

This is the second PR raised to fix the same bug because of following reasons:

1. First one failed to pass some tests on earlier versions i.e. 4.4.x, 4.5.x. It passed the checks on 4.6.x and master.
2. After the discussion, it came to light that the `GetCategoryApisUseCase` already handled the scenario to display public APIs in a category when the user id is null. We were just not passing the null id as the input to the use case.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aodoxjyiup.chromatic.com)
<!-- Storybook placeholder end -->
