### PR TITLE
feat(helm): remove nginx configuration-snippet by default

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 4.3.23
 
 - fix typo and indentation about mapping of user.anonymize-on-delete.enabled (APIM-8628)
+- remove nginx `configuration-snippet` by default (APIM-8630)
 
 ### 4.3.21
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -25,3 +25,4 @@ annotations:
   ###########
   artifacthub.io/changes: |
     - 'fix typo and indentation about mapping of user.anonymize-on-delete.enabled (APIM-8628)'
+    - 'remove nginx `configuration-snippet` by default (APIM-8630)'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -715,7 +715,7 @@ api:
         - apim.example.com
       annotations:
         kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_pass_header if-match;\n"
+        #nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_pass_header if-match;\n"
         # kubernetes.io/tls-acme: "true"
       # tls:
         # Secrets must be manually created in the namespace.
@@ -733,7 +733,6 @@ api:
         - apim.example.com
       annotations: 
         kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
         # kubernetes.io/tls-acme: "true"
       # tls:
         # Secrets must be manually created in the namespace.
@@ -1375,7 +1374,6 @@ portal:
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/rewrite-target: /
-      nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\n"
     #tls:
       # Secrets must be manually created in the namespace.
     #  - hosts:
@@ -1572,7 +1570,6 @@ ui:
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/rewrite-target: /$1
-      nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\n"
     # tls:
       # Secrets must be manually created in the namespace.
     #  - hosts:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8630
https://gravitee.atlassian.net/browse/TT-6449

## Description

By default, the console, portal and the management ingress
define this nginx configuration:

```yaml
nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\n"
```

However this configuration implies security issue
as mentioned in official documentation (CVE-2021-25742).
https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#configuration-snippet

Also, this Etag configuration is not needed
for Console and Portal as the Etag are already
covered by the nginx in their respective container
to serve static files.

Finally, for the management-api it may not be needed.
So we keep it in comment to mention that it is still an option.

So the goal here is to remove the
`nginx.ingress.kubernetes.io/configuration-snippet` in `helm/values.yaml`.

For testing, deploy you APIM and then curl console and portal:

With Etag provided by nginx ingress:

```bash
curl -I -u 'admin:admin' 'https://your.management-api.url.gravitee.dev/management/v2/environments/DEFAULT/apis/f415bb33-9282-4f7f-95bb-3392821f7f97'
HTTP/2 200
etag: "1739439486097"

curl -I 'https://your.console.url.gravitee.dev/webcomponents/webcomponents-loader.js'
HTTP/2 200
etag: "67adbfd2-1e5d"

curl -I 'https://your.portal.url.gravitee.dev/webcomponents/webcomponents-loader.js'
HTTP/2 200
etag: "67adbfd0-1911"
```

Without Etag from nginx but Etag from management, console or portal
itself:

```bash
curl -I -u 'admin:admin' 'https://your.management-api.url.gravitee.dev/management/v2/environments/DEFAULT/apis/f415bb33-9282-4f7f-95bb-3392821f7f97'
HTTP/2 200
etag: "1739439486097"

curl -I 'https://your.console.url.gravitee.dev/webcomponents/webcomponents-loader.js'
HTTP/2 200
etag: "67ad234b-1911"

curl -I 'https://your.portal.url.gravitee.dev/webcomponents/webcomponents-loader.js'
HTTP/2 200
etag: "67ad2357-1e5d"
```

With both kind of nginx configuration to see ETag headers.
