### PR TITLE
APIM 8631-revert old commit and add null check for security config

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
@@ -62,10 +62,9 @@ public class PlanUpdates {
 
         var definition = result.getPlanDefinitionV4();
         definition.setSelectionRule(selectionRule);
-        if (securityConfiguration != null) {
+        if (definition.getSecurity() != null) {
             definition.getSecurity().setConfiguration(securityConfiguration);
         }
-
         return result;
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8631

## Description

Reverted the old commit, added null check for security config and junit


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/10656/console](https://pr.team-apim.gravitee.dev/10656/console)
      Portal: [https://pr.team-apim.gravitee.dev/10656/portal](https://pr.team-apim.gravitee.dev/10656/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/10656/api/management](https://pr.team-apim.gravitee.dev/10656/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/10656](https://pr.team-apim.gravitee.dev/10656)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/10656](https://pr.gateway-v3.team-apim.gravitee.dev/10656)

<!-- Environment placeholder end -->
