### PR TITLE
fix(gateway): prevent gateway from switching thread when API stops

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -66,6 +66,7 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -434,6 +435,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
 
     protected Observable<Long> stopUntil(long timeout) {
         return interval(100, TimeUnit.MILLISECONDS)
+            .observeOn(Schedulers.io())
             .timeout(timeout, TimeUnit.MILLISECONDS)
             .takeWhile(t -> pendingRequests.get() > 0)
             .doFinally(this::stopNow);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
@@ -33,6 +33,7 @@ import io.gravitee.gateway.reactor.handler.Acceptor;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.node.api.configuration.Configuration;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -120,6 +121,7 @@ public abstract class AbstractApiReactor extends AbstractLifecycleComponent<Reac
     protected Completable stopUntil() {
         return interval(STOP_UNTIL_INTERVAL_PERIOD_MS, TimeUnit.MILLISECONDS)
             .timestamp()
+            .observeOn(Schedulers.io())
             .takeWhile(t -> pendingRequests.get() > 0 && (t.value() + 1) * STOP_UNTIL_INTERVAL_PERIOD_MS < pendingRequestsTimeout)
             .ignoreElements()
             .onErrorComplete()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -375,6 +375,7 @@ class SyncApiReactorTest {
 
     @Test
     void shouldStopUntil() throws Exception {
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
         ReflectionTestUtils.setField(cut, "pendingRequests", new AtomicInteger(1));
         Observable<Long> stopUntil = cut.stopUntil(10000L);
         TestObserver<Long> testObserver = stopUntil.test();
@@ -392,6 +393,7 @@ class SyncApiReactorTest {
         verify(resourceLifecycleManager).stop();
         verify(policyManager).stop();
         verify(groupLifecycleManager).stop();
+        RxJavaPlugins.reset();
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -873,6 +873,7 @@ class DefaultApiReactorTest {
 
     @Test
     void shouldWaitForPendingRequestBeforeStopping() throws Exception {
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
         when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
         final AtomicLong pendingRequests = new AtomicLong(1);
         ReflectionTestUtils.setField(cut, "pendingRequests", pendingRequests);
@@ -902,10 +903,12 @@ class DefaultApiReactorTest {
         verify(resourceLifecycleManager).stop();
         verify(policyManager).stop();
         verify(apiService).stop();
+        RxJavaPlugins.reset();
     }
 
     @Test
     void shouldWaitForPendingRequestAndForceStopAfter10sWhenRequestDoesNotFinish() throws Exception {
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
         when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
         final AtomicLong pendingRequests = new AtomicLong(1);
         ReflectionTestUtils.setField(cut, "pendingRequests", pendingRequests);
@@ -936,6 +939,7 @@ class DefaultApiReactorTest {
         verify(apiService).stop();
 
         assertEquals(STOPPED, cut.lifecycleState());
+        RxJavaPlugins.reset();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>3.1.5</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.1.6</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>4.0.1</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.3</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.1</gravitee-policy-assign-content.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8624

## Description

On API stop the thread is switched from gio.sync-deployer to vert.x-eventloop which can block the gateway if there are pending requests. To prevent it we should switch to the worker thread 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mkqbxsexep.chromatic.com)
<!-- Storybook placeholder end -->
