### PR TITLE
fix(portal): persist HTTP status criteria after search validation

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-analytics-filters/gv-analytics-filters.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-analytics-filters/gv-analytics-filters.component.ts
@@ -121,6 +121,7 @@ export class GvAnalyticsFiltersComponent implements OnInit, AfterViewInit, OnDes
         responseTimes: queryParams['response-time'],
         api: queryParams.api,
         payloads: queryParams.body,
+        status: queryParams.status,
       };
 
       this.analyticsForm.reset(formValues);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8521

## Description

Ensure HTTP status criteria persists after search validation in portal logs.

## Additional context

### Before
Selecting the status
<img width="1728" alt="Screenshot 2025-02-14 at 12 59 23 PM" src="https://github.com/user-attachments/assets/a7dfeb48-2bc9-40b8-98c9-99c3cc67a945" />
 
***

status appears as query param
<img width="1728" alt="Screenshot 2025-02-14 at 1 00 34 PM" src="https://github.com/user-attachments/assets/716d0de8-f065-4293-9fee-278c0fb38986" />

---

### after
Status appears as query param
![image](https://github.com/user-attachments/assets/9bc159bc-2a91-407e-af5c-6ab0ff1360bb)

***
With multiple status selected
<img width="1728" alt="Screenshot 2025-02-14 at 1 06 01 PM" src="https://github.com/user-attachments/assets/a7f0e504-c53e-42f5-9a72-21445a3f4b83" />

<img width="1728" alt="Screenshot 2025-02-14 at 1 06 16 PM" src="https://github.com/user-attachments/assets/7b5efa40-54a5-4958-bf13-05559048f9e0" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-luitliasgb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/10658/console](https://pr.team-apim.gravitee.dev/10658/console)
      Portal: [https://pr.team-apim.gravitee.dev/10658/portal](https://pr.team-apim.gravitee.dev/10658/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/10658/api/management](https://pr.team-apim.gravitee.dev/10658/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/10658](https://pr.team-apim.gravitee.dev/10658)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/10658](https://pr.gateway-v3.team-apim.gravitee.dev/10658)

<!-- Environment placeholder end -->
