### PR TITLE
APIM 8647: Show user is being deleted in Organization Settings

### DIFF
--- a/gravitee-apim-console-webui/src/entities/user/userHelper.ts
+++ b/gravitee-apim-console-webui/src/entities/user/userHelper.ts
@@ -21,6 +21,7 @@ export abstract class UserHelper {
       case 'ACTIVE':
         return 'gio-badge-success';
       case 'PENDING':
+      case 'ARCHIVED':
         return 'gio-badge-warning';
       case 'REJECTED':
         return 'gio-badge-error';

--- a/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.spec.ts
@@ -116,6 +116,28 @@ describe('OrgSettingsUsersComponent', () => {
       ]);
     }));
 
+    it('should display user in the process of being deleted', fakeAsync(async () => {
+      const archivedUser = fakeAdminUser();
+      archivedUser.status = 'ARCHIVED';
+      expectUsersListRequest([archivedUser]);
+
+      const table = await loader.getHarness(MatTableHarness.with({ selector: '#usersTable' }));
+
+      const rows = await table.getRows();
+      const rowCells = await parallel(() => rows.map((row) => row.getCellTextByColumnName()));
+
+      expect(rowCells).toEqual([
+        {
+          actions: '',
+          displayName: 'adminPrimary Owner Active Token',
+          email: '',
+          source: 'memory',
+          status: 'Deletion In Progress',
+          userPicture: '',
+        },
+      ]);
+    }));
+
     it('should confirm and delete user', fakeAsync(async () => {
       expectUsersListRequest([
         {

--- a/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.ts
@@ -122,7 +122,7 @@ export class OrgSettingsUsersComponent implements OnInit, OnDestroy {
       .pipe(
         filter((confirm) => confirm === true),
         switchMap(() => this.usersService.remove(userId)),
-        tap(() => this.snackBarService.success(`User ${displayName} successfully deleted!`)),
+        tap(() => this.snackBarService.success(`User ${displayName} is being deleted!`)),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => this.filtersStream.next({ ...this.filtersStream.value }));
@@ -138,7 +138,7 @@ export class OrgSettingsUsersComponent implements OnInit, OnDestroy {
       displayName: u.displayName,
       email: u.email,
       source: u.source,
-      status: u.status,
+      status: u.status === 'ARCHIVED' ? 'Deletion In Progress' : u.status,
       userPicture: this.usersService.getUserAvatar(u.id),
       primary_owner: u.primary_owner,
       number_of_active_tokens: u.number_of_active_tokens,

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-users.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-users.spec.ts
@@ -54,6 +54,13 @@ describe('Users', () => {
       cy.contains('Delete').click();
     });
 
+    cy.contains(firstName);
+    cy.contains(lastName);
+    cy.contains(email);
+    cy.contains('Deletion In Progress');
+
+    cy.reload();
+
     cy.contains(email).should('not.exist');
   });
 
@@ -84,6 +91,11 @@ describe('Users', () => {
     cy.get('mat-dialog-actions').within(() => {
       cy.contains('Delete').click();
     });
+
+    cy.contains(email);
+    cy.contains('Deletion In Progress');
+
+    cy.reload();
 
     cy.contains(email).should('not.exist');
   });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8647

## Description

When a user in Console clicks "Delete User", the back-end takes it into account and de-indexes the user from Lucene. However, this is an asynchronous process and we don't know when the user will be successfully de-indexed from Lucene.

This fix creates a new state in the UI for users that are archived --> Deletion In Progress.


https://github.com/user-attachments/assets/8fa2e731-1515-4dc9-a691-f45ebbc44bc7

The tests Cypress broke after this PR was merged: https://github.com/gravitee-io/gravitee-api-management/pull/10575. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wbeqapqvdz.chromatic.com)
<!-- Storybook placeholder end -->
