### PR TITLE
update supported version of mongo in APIM

### DIFF
--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -74,7 +74,7 @@ export class RepositoriesTestsWorkflow {
         context: ['cicd-orchestrator'],
         requires: [buildJobName],
         matrix: {
-          mongoVersion: ['4.4', '5.0', '6.0', '7.0'],
+          mongoVersion: ['4.4', '5.0', '6.0', '7.0', '8.0'],
         },
       }),
       new workflow.WorkflowJob(elasticTestContainerJob, {


### PR DESCRIPTION
## Description

Test repositories with mongo latest

👀 👉🏼 It looks like I can not trigger the repository pipeline on this branch. But everything looks ok when I run the repository tests with mongo 8.0 locally.
 
<img width="1792" alt="Capture d’écran 2025-02-17 à 09 28 58" src="https://github.com/user-attachments/assets/a32b81d6-8ae1-4082-a5aa-aa0216fc5341" />


I'll trigger the CI on master when it's merged

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

