### PR TITLE
Allow users to define which portal should be used by default

### DIFF
--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       - management_api
     environment:
       - MGMT_API_URL=http://localhost:8083/management/
+      #- DEFAULT_PORTAL=next # Uncomment to set the portal-next as the default portal for management UI environment redirection.
     volumes:
       - ./.logs/apim-management-ui:/var/log/nginx
     networks:
@@ -148,7 +149,7 @@ services:
       - management_api
     environment:
       - PORTAL_API_URL=http://localhost:8083/portal
-      #- DEFAULT_PORTAL=next # Uncomment this line to use the next portal as default portal
+      #- DEFAULT_PORTAL=next # Uncomment to set the portal-next as default portal
     volumes:
       - ./.logs/apim-portal-ui:/var/log/nginx
     networks:

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -148,6 +148,7 @@ services:
       - management_api
     environment:
       - PORTAL_API_URL=http://localhost:8083/portal
+      #- DEFAULT_PORTAL=next # Uncomment this line to use the next portal as default portal
     volumes:
       - ./.logs/apim-portal-ui:/var/log/nginx
     networks:

--- a/gravitee-apim-console-webui/constants.json
+++ b/gravitee-apim-console-webui/constants.json
@@ -1,4 +1,5 @@
 {
   "baseURL": "/management",
+  "defaultPortal": "classic",
   "production": false
 }

--- a/gravitee-apim-console-webui/constants.prod.json
+++ b/gravitee-apim-console-webui/constants.prod.json
@@ -1,4 +1,5 @@
 {
   "baseURL": "http://localhost:8083/management",
+  "defaultPortal": "classic",
   "production": true
 }

--- a/gravitee-apim-console-webui/constants.tpl.json
+++ b/gravitee-apim-console-webui/constants.tpl.json
@@ -1,3 +1,4 @@
 {
-  "baseURL": "/management"
+  "baseURL": "/management",
+  "defaultPortal": "classic"
 }

--- a/gravitee-apim-console-webui/docker/config/constants.json
+++ b/gravitee-apim-console-webui/docker/config/constants.json
@@ -1,3 +1,4 @@
 {
-  "baseURL": "$MGMT_API_URL"
+  "baseURL": "$MGMT_API_URL",
+  "defaultPortal": "$DEFAULT_PORTAL"
 }

--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -43,6 +43,7 @@ export interface Constants {
   v2BaseURL?: string;
   isOEM: boolean;
   customization?: ConsoleCustomization;
+  defaultPortal: DefaultPortal;
 }
 
 // eslint-disable-next-line no-redeclare
@@ -210,3 +211,5 @@ export interface EnvSettings {
     notifications: number;
   };
 }
+
+export type DefaultPortal = 'classic' | 'next' | null;

--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -23,7 +23,7 @@ import { computeStyles, LicenseConfiguration } from '@gravitee/ui-particles-angu
 import { toLower, toUpper } from 'lodash';
 
 import { AppModule } from './app.module';
-import { Constants } from './entities/Constants';
+import { Constants, DefaultPortal } from './entities/Constants';
 import { getFeatureInfoData } from './shared/components/gio-license/gio-license-data';
 import { ConsoleCustomization } from './entities/management-api-v2/consoleCustomization';
 import { environment } from './environments/environment';
@@ -70,10 +70,11 @@ function fetchData(): Promise<{ constants: Constants; build: any }> {
           bootstrapResponse,
           build: buildResponse,
           production: environment.production,
+          defaultPortal: constantsResponse.defaultPortal,
         }));
     })
-    .then(({ bootstrapResponse, build, production }) => {
-      const constants = prepareConstants(bootstrapResponse);
+    .then(({ bootstrapResponse, build, production, defaultPortal }) => {
+      const constants = prepareConstants(bootstrapResponse, defaultPortal);
 
       constants.production = production ?? true;
 
@@ -117,7 +118,7 @@ function sanitizeBaseURLs(baseURLToSanitize: string): string {
   return baseURL;
 }
 
-function prepareConstants(bootstrap: { baseURL: string; organizationId: string }): Constants {
+function prepareConstants(bootstrap: { baseURL: string; organizationId: string }, defaultPortal: DefaultPortal): Constants {
   if (bootstrap.baseURL.endsWith('/')) {
     bootstrap.baseURL = bootstrap.baseURL.slice(0, -1);
   }
@@ -138,6 +139,7 @@ function prepareConstants(bootstrap: { baseURL: string; organizationId: string }
       v2BaseURL: `${bootstrap.baseURL}/v2/environments/{:envId}`,
     },
     isOEM: false,
+    defaultPortal,
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -207,7 +207,9 @@ export class PortalSettingsComponent implements OnInit {
             ? undefined
             : this.constants.env.baseURL.replace('{:envId}', this.constants.org.currentEnv.id) +
               '/portal/redirect' +
-              (this.isPortalNextEnabled ? '?version=next' : '');
+              (this.isPortalNextEnabled && (!this.constants.defaultPortal || this.constants.defaultPortal === 'classic')
+                ? '?version=next'
+                : '');
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -22,12 +22,14 @@ EXPOSE 8080
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"
 ENV PORTAL_BASE_HREF "/"
 ENV PORTAL_API_URL "http://localhost:8083/portal"
+ENV DEFAULT_PORTAL "classic"
 
 COPY ./dist /usr/share/nginx/html/
 
 COPY docker/config/config.json /usr/share/nginx/html/assets/config.json
 COPY docker/config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
 COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default-next.conf /etc/nginx/conf.d/default-next.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 

--- a/gravitee-apim-portal-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-from-download
@@ -25,6 +25,7 @@ ENV WWW_TARGET /usr/share/nginx/html
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"
 ENV PORTAL_BASE_HREF "/"
 ENV PORTAL_API_URL "http://localhost:8083/portal"
+ENV DEFAULT_PORTAL "classic"
 
 RUN apk update \
   && apk add --update --no-cache zip unzip netcat-openbsd wget \
@@ -38,6 +39,7 @@ RUN apk update \
 COPY config/config.json /usr/share/nginx/html/assets/config.json
 COPY config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
 COPY config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default-next.conf /etc/nginx/conf.d/default-next.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 

--- a/gravitee-apim-portal-webui/docker/config/default-next.conf
+++ b/gravitee-apim-portal-webui/docker/config/default-next.conf
@@ -1,0 +1,49 @@
+server {
+    listen $HTTP_PORT;
+    listen $HTTPS_PORT;
+    listen [::]:$HTTP_PORT;
+    listen [::]:$HTTPS_PORT;
+    server_name $SERVER_NAME;
+
+    add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Permitted-Cross-Domain-Policies none;
+
+    index index.html index.htm;
+    charset utf-8;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+    location /classic {
+        rewrite ^ /classic/ last;
+    }
+
+    location /classic/ {
+        alias /rw.mount/www/;
+        try_files $uri $uri/ /index.html;
+        sub_filter '<base href="/"' '<base href="${PORTAL_BASE_HREF}classic/"';
+        sub_filter_once on;
+    }
+
+    location / {
+        root /rw.mount/www/next/browser;
+        try_files $uri $uri/ /index.html;
+        sub_filter '<base href="/"' '<base href="$PORTAL_BASE_HREF"';
+        sub_filter_once on;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /rw.mount/www;
+    }
+}

--- a/gravitee-apim-portal-webui/docker/config/portal-next-run.sh
+++ b/gravitee-apim-portal-webui/docker/config/portal-next-run.sh
@@ -20,3 +20,7 @@ if [ -f "/usr/share/nginx/html/next/browser/assets/config.json" ]; then
     envsubst < /usr/share/nginx/html/next/browser/assets/config.json > /usr/share/nginx/html/next/browser/assets/config.json.tmp
     mv /usr/share/nginx/html/next/browser/assets/config.json.tmp /usr/share/nginx/html/next/browser/assets/config.json
 fi
+
+if [ "$DEFAULT_PORTAL" = "next" ]; then
+    cp /etc/nginx/conf.d/default-next.conf /etc/nginx/conf.d/default.conf
+fi

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -11,6 +11,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - Kafka Gateway: add fields to configure bootstrap and broker domain patterns
 - fix typo and indentation about mapping of user.anonymize-on-delete.enabled (APIM-8628)
 - remove nginx `configuration-snippet` by default (APIM-8630)
+- allow users to define which portal should be used by default
 
 ### 4.6.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -43,4 +43,5 @@ annotations:
       description: 'fix typo and indentation about mapping of user.anonymize-on-delete.enabled (APIM-8628)'
     - kind: fixed
       description: 'remove nginx `configuration-snippet` by default (APIM-8630)'
-
+    - kind: added
+      description: 'Allow users to define which portal should be used by default'

--- a/helm/templates/portal/portal-deployment.yaml
+++ b/helm/templates/portal/portal-deployment.yaml
@@ -121,6 +121,8 @@ spec:
             - name: PORTAL_BASE_HREF
               value: {{ print (regexFind "/[a-zA-Z0-9-\\/_.~]+" .Values.portal.ingress.path) "/" }}
             {{- end }}
+            - name: DEFAULT_PORTAL
+              value: {{ .Values.portal.defaultPortal }}
 {{- if .Values.portal.env | default .Values.portal.deployment.extraEnvs }}
 {{ toYaml ( .Values.portal.env | default .Values.portal.deployment.extraEnvs ) | indent 12 }}
 {{- end }}

--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -116,6 +116,8 @@ spec:
             - name: CONSOLE_BASE_HREF
               value: {{ print (regexFind "/[a-zA-Z0-9-\\/_.~]+" .Values.ui.ingress.path) "/" }}
             {{- end }}
+            - name: DEFAULT_PORTAL
+              value: {{ .Values.portal.defaultPortal }}
 {{- if .Values.ui.env | default .Values.ui.deployment.extraEnvs }}
 {{ toYaml ( .Values.ui.env | default .Values.ui.deployment.extraEnvs ) | indent 12 }}
 {{- end }}

--- a/helm/tests/portal/deployment_test.yaml
+++ b/helm/tests/portal/deployment_test.yaml
@@ -47,7 +47,7 @@ tests:
           path: spec.template.spec.containers[0].env[1].value
           value: "/test/"
 
-  - it: Should override generated CONSOLE_BASE_HREF environment variable
+  - it: Should override generated PORTAL_BASE_HREF environment variable
     template: portal/portal-deployment.yaml
     set:
       portal:
@@ -58,10 +58,10 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
+          path: spec.template.spec.containers[0].env[2].name
           value: "PORTAL_BASE_HREF"
       - equal:
-          path: spec.template.spec.containers[0].env[1].value
+          path: spec.template.spec.containers[0].env[2].value
           value: "/test/"
 
   - it: Check DB Less mode
@@ -228,3 +228,30 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "apim-portal"
+
+  - it: Should set DEFAULT_PORTAL environment variable with classic value by default
+    template: portal/portal-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "DEFAULT_PORTAL"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "classic"
+
+  - it: Should override DEFAULT_PORTAL environment variable value with next
+    template: portal/portal-deployment.yaml
+    set:
+      portal:
+        defaultPortal: "next"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "DEFAULT_PORTAL"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "next"

--- a/helm/tests/ui/deployment_test.yaml
+++ b/helm/tests/ui/deployment_test.yaml
@@ -74,10 +74,10 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.template.spec.containers[0].env[1].name
+          path: spec.template.spec.containers[0].env[2].name
           value: "CONSOLE_BASE_HREF"
       - equal:
-          path: spec.template.spec.containers[0].env[1].value
+          path: spec.template.spec.containers[0].env[2].value
           value: "/test/"
 
   - it: Should have default resources
@@ -253,3 +253,30 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "apim-ui"
+
+  - it: Should set DEFAULT_PORTAL environment variable with classic value by default
+    template: ui/ui-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "DEFAULT_PORTAL"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "classic"
+
+  - it: Should override DEFAULT_PORTAL environment variable value with next
+    template: ui/ui-deployment.yaml
+    set:
+      portal:
+        defaultPortal: "next"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "DEFAULT_PORTAL"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "next"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1735,6 +1735,8 @@ portal:
     # - name: extra-volume
     #   mountPath: /mnt/volume
     #   readOnly: true
+  defaultPortal: "classic" # set value to "next" to use the new portal by default
+
   # If you want to use your own config.json you have to provide your configmap or secret in extraVolume part.
   # the name of the volume MUST be "config".
   # In this case, values configuration related to config.json defined in this file will be ignored


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7518

## Description

In this PR we allow users to define which portal should be used by default ( `classic` or `next`)
As Nginx does not allow us to do configuration hot reload it will have to be defined before the deployment of the platform using an environment variable, the helm chart or the frontend configuration json files.

### See video below for classic value

https://github.com/user-attachments/assets/0b752987-30ed-43e4-bf28-5af1b84e1819


### See video below for next value

https://github.com/user-attachments/assets/aeae49f5-fa25-46d2-9ccc-812e532953ad


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fkplpwuvnu.chromatic.com)
<!-- Storybook placeholder end -->
