### PR TITLE
feat: enable Api Score from environment settings

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -35,6 +35,7 @@ import { License } from '../../entities/license/License';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { Constants } from '../../entities/Constants';
+import { EnvironmentSettingsService } from '../../services-ngx/environment-settings.service';
 
 describe('GioSideNavComponent', () => {
   let fixture: ComponentFixture<GioSideNavComponent>;
@@ -71,7 +72,6 @@ describe('GioSideNavComponent', () => {
             constants.org.settings = {
               ...constants.org.settings,
               licenseExpirationNotification: { enabled: licenseNotificationEnabled },
-              scoring: { enabled: scoringEnabled },
             };
             constants.org.environments = [
               {
@@ -83,6 +83,14 @@ describe('GioSideNavComponent', () => {
             ];
 
             return constants;
+          },
+        },
+        {
+          provide: EnvironmentSettingsService,
+          useValue: {
+            get: () => {
+              return of({ apiScore: { enabled: scoringEnabled } });
+            },
           },
         },
         { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -20,7 +20,7 @@ import { Observable, Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
-import { Constants } from '../../entities/Constants';
+import { Constants, EnvSettings } from '../../entities/Constants';
 import { ApimFeature, UTMTags } from '../../shared/components/gio-license/gio-license-data';
 import { Environment } from '../../entities/environment/environment';
 import { cleanRouterLink } from '../../util/router-link.util';
@@ -91,8 +91,8 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
 
     this.licenseExpirationDate$ = this.gioLicenseService.getExpiresAt$().pipe(distinctUntilChanged(), takeUntil(this.unsubscribe$));
 
-    this.environmentSettingsService.get().subscribe((_) => {
-      this.mainMenuItems = this.buildMainMenuItems();
+    this.environmentSettingsService.get().subscribe((envSettings) => {
+      this.mainMenuItems = this.buildMainMenuItems(envSettings);
     });
   }
 
@@ -109,7 +109,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
     this.router.navigate([selectedItem.routerLink]);
   }
 
-  private buildMainMenuItems(): MenuItem[] {
+  private buildMainMenuItems(envSettings?: EnvSettings): MenuItem[] {
     const auditLicenseOptions: LicenseOptions = {
       feature: ApimFeature.APIM_AUDIT_TRAIL,
       context: UTMTags.CONTEXT_ENVIRONMENT,
@@ -157,7 +157,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       });
     }
 
-    if (this.constants.org.settings?.scoring?.enabled) {
+    if (envSettings?.apiScore.enabled) {
       mainMenuItems.push({
         icon: 'gio:shield-check',
         routerLink: './api-score',

--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -56,6 +56,9 @@ export interface EnvSettings {
     labelsDictionary: string[];
     primaryOwnerMode: string;
   };
+  apiScore: {
+    enabled: boolean;
+  };
   apiQualityMetrics: {
     enabled: boolean;
     functionalDocumentationWeight: number;

--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -32,7 +32,6 @@ export interface ConsoleSettings {
   licenseExpirationNotification?: ConsoleSettingsLicenseExpirationNotification;
   trialInstance?: ConsoleSettingsTrialInstance;
   federation?: ConsoleSettingsFederation;
-  scoring?: ConsoleSettingsScoring;
   cloudHosted?: ConsoleSettingsCloudHosted;
 }
 
@@ -182,10 +181,6 @@ export interface ConsoleSettingsTrialInstance {
 }
 
 export interface ConsoleSettingsFederation {
-  enabled?: boolean;
-}
-
-export interface ConsoleSettingsScoring {
   enabled?: boolean;
 }
 

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -24,6 +24,7 @@ export interface PortalConfiguration {
   portal?: PortalSettingsPortal;
   metadata?: PortalSettingsMetadata;
   application?: PortalSettingsApplication;
+  apiScore?: PortalSettingsApiScore;
   apiQualityMetrics?: PortalSettingsApiQualityMetrics;
   apiReview?: PortalSettingsApiReview;
   authentication?: PortalSettingsAuthentication;
@@ -126,6 +127,10 @@ export interface PortalSettingsApiQualityMetrics {
   categoriesWeight: number;
   labelsWeight: number;
   healthcheckWeight: number;
+}
+
+export interface PortalSettingsApiScore {
+  enabled: boolean;
 }
 
 export interface PortalSettingsApiReview {

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.spec.ts
@@ -19,27 +19,27 @@ import { LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
 
 import { ApiFederatedMenuService } from './api-federated-menu.service';
 
-import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { GioTestingModule } from '../../../shared/testing';
 import { GioTestingPermission, GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
-import { ConsoleSettings } from '../../../entities/consoleSettings';
-import { Constants } from '../../../entities/Constants';
+import { EnvSettings } from '../../../entities/Constants';
 import { fakeApiFederated } from '../../../entities/management-api-v2';
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 
 const DEFAULT_PERMISSIONS: GioTestingPermission = ['api-member-r', 'api-audit-r', 'api-documentation-r', 'api-metadata-r', 'api-plan-r'];
-const DEFAULT_SETTINGS: ConsoleSettings = { scoring: { enabled: true } };
+const DEFAULT_ENV_SETTINGS: Partial<EnvSettings> = { apiScore: { enabled: true } };
 
 describe('ApiFederatedMenuService', () => {
   const init = async (
-    { permissions, settings } = {
+    { permissions, envSettings } = {
       permissions: DEFAULT_PERMISSIONS,
-      settings: DEFAULT_SETTINGS,
+      envSettings: DEFAULT_ENV_SETTINGS,
     },
   ) => {
     await TestBed.configureTestingModule({
       imports: [GioTestingModule],
       providers: [
         { provide: ApiFederatedMenuService },
-        { provide: Constants, useValue: { ...CONSTANTS_TESTING, org: { settings } } },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => envSettings } },
         {
           provide: GioTestingPermissionProvider,
           useValue: permissions,
@@ -152,7 +152,7 @@ describe('ApiFederatedMenuService', () => {
     });
 
     it('should hide elements for published API when not enough permissions', async () => {
-      await init({ permissions: [], settings: DEFAULT_SETTINGS });
+      await init({ permissions: [], envSettings: DEFAULT_ENV_SETTINGS });
       const service = TestBed.inject(ApiFederatedMenuService);
 
       expect(service.getMenu(fakeApiFederated({ lifecycleState: 'PUBLISHED' }))).toEqual({
@@ -220,7 +220,10 @@ describe('ApiFederatedMenuService', () => {
     });
 
     it('should hide scoring elements when feature is disabled', async () => {
-      await init({ permissions: DEFAULT_PERMISSIONS, settings: { scoring: { enabled: false } } });
+      await init({
+        permissions: DEFAULT_PERMISSIONS,
+        envSettings: { apiScore: { enabled: false } },
+      });
       const service = TestBed.inject(ApiFederatedMenuService);
 
       const menu = service.getMenu(fakeApiFederated());

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.ts
@@ -25,6 +25,7 @@ import { GioPermissionService } from '../../../shared/components/gio-permission/
 import { Constants } from '../../../entities/Constants';
 import { ApiFederated } from '../../../entities/management-api-v2';
 import { ApiDocumentationV2Service } from '../../../services-ngx/api-documentation-v2.service';
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 
 @Injectable()
 export class ApiFederatedMenuService implements ApiMenuService {
@@ -32,6 +33,7 @@ export class ApiFederatedMenuService implements ApiMenuService {
     private readonly permissionService: GioPermissionService,
     private readonly gioLicenseService: GioLicenseService,
     private readonly apiDocumentationV2Service: ApiDocumentationV2Service,
+    private readonly environmentSettingsService: EnvironmentSettingsService,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
@@ -41,7 +43,7 @@ export class ApiFederatedMenuService implements ApiMenuService {
   } {
     const subMenuItems: MenuItem[] = [
       this.addConfigurationMenuEntry(),
-      ...(this.constants.org.settings?.scoring?.enabled ? [this.addApiScoreMenuEntry()] : []),
+      ...(this.environmentSettingsService.getSnapshot().apiScore.enabled ? [this.addApiScoreMenuEntry()] : []),
       this.addConsumersMenuEntry(),
       this.addDocumentationMenuEntry(api),
     ];

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
@@ -27,8 +27,9 @@ import { ApiNavigationComponent } from './api-navigation.component';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { Api, fakeApiV1, fakeApiV2, fakeApiV4 } from '../../../entities/management-api-v2';
 import { GioPermissionService, GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
-import { Constants } from '../../../entities/Constants';
+import { Constants, EnvSettings } from '../../../entities/Constants';
 import { IntegrationsService } from '../../../services-ngx/integrations.service';
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 
 describe('ApiNavigationComponent', () => {
   const API_ID = 'apiId';
@@ -165,6 +166,7 @@ describe('ApiNavigationComponent', () => {
   describe('side nave search items', () => {
     let addSearchItemByGroupIds: jest.SpyInstance;
     const menuSearchService = new GioMenuSearchService();
+    const DEFAULT_ENV_SETTINGS: Partial<EnvSettings> = { apiScore: { enabled: true } };
 
     beforeEach(async () => {
       addSearchItemByGroupIds = jest.spyOn(menuSearchService, 'addMenuSearchItems');
@@ -188,6 +190,12 @@ describe('ApiNavigationComponent', () => {
           { provide: Constants, useValue: { ...CONSTANTS_TESTING, org: { settings: { scoring: { enabled: true } } } } },
           { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },
           { provide: GioMenuSearchService, useValue: menuSearchService },
+          {
+            provide: EnvironmentSettingsService,
+            useValue: {
+              getSnapshot: () => DEFAULT_ENV_SETTINGS,
+            },
+          },
         ],
       }).compileComponents();
 

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v1-v2-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v1-v2-menu.service.ts
@@ -25,12 +25,14 @@ import { Constants } from '../../../entities/Constants';
 import { ApiV1, ApiV2, DefinitionVersion } from '../../../entities/management-api-v2';
 import { ApimFeature, UTMTags } from '../../../shared/components/gio-license/gio-license-data';
 import { GioRoleService } from '../../../shared/components/gio-role/gio-role.service';
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 
 @Injectable()
 export class ApiV1V2MenuService implements ApiMenuService {
   constructor(
     private readonly permissionService: GioPermissionService,
     private readonly roleService: GioRoleService,
+    private readonly environmentSettingsService: EnvironmentSettingsService,
     @Inject(Constants) private readonly constants: Constants,
     private readonly gioLicenseService: GioLicenseService,
   ) {}
@@ -137,7 +139,7 @@ export class ApiV1V2MenuService implements ApiMenuService {
     }
 
     // Api Score
-    if (this.constants.org.settings?.scoring?.enabled && definitionVersion === 'V2') {
+    if (this.environmentSettingsService.getSnapshot().apiScore.enabled && definitionVersion === 'V2') {
       portalGroup.items.push({
         displayName: 'API Score',
         routerLink: 'api-score',

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -25,6 +25,7 @@ import { GioPermissionService } from '../../../shared/components/gio-permission/
 import { Constants } from '../../../entities/Constants';
 import { ApiV4 } from '../../../entities/management-api-v2';
 import { ApiDocumentationV2Service } from '../../../services-ngx/api-documentation-v2.service';
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 
 @Injectable()
 export class ApiV4MenuService implements ApiMenuService {
@@ -32,6 +33,7 @@ export class ApiV4MenuService implements ApiMenuService {
     private readonly permissionService: GioPermissionService,
     private readonly gioLicenseService: GioLicenseService,
     private readonly apiDocumentationV2Service: ApiDocumentationV2Service,
+    private readonly environmentSettingsService: EnvironmentSettingsService,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
   public getMenu(api: ApiV4): {
@@ -42,7 +44,7 @@ export class ApiV4MenuService implements ApiMenuService {
 
     const subMenuItems: MenuItem[] = [
       this.addConfigurationMenuEntry(),
-      ...(this.constants.org.settings?.scoring?.enabled ? [this.addApiScoreMenuEntry()] : []),
+      ...(this.environmentSettingsService.getSnapshot().apiScore.enabled ? [this.addApiScoreMenuEntry()] : []),
       this.addEntrypointsMenuEntry(hasTcpListeners, api),
       this.addEndpointsMenuEntry(api, hasTcpListeners),
       this.addPoliciesMenuEntry(hasTcpListeners),

--- a/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.html
@@ -22,6 +22,11 @@
 <form *ngIf="apiQualityRulesForm" [formGroup]="apiQualityRulesForm" autocomplete="off">
   <mat-card class="api-quality-rules__form__card">
     <mat-card-content>
+      <gio-form-slide-toggle formGroupName="apiScore" class="api-quality-rules__form__card__form-field">
+        <mat-icon *ngIf="isReadonly('api.score.enabled')" gioFormPrefix>lock</mat-icon>
+        <gio-form-label>Enable API Score</gio-form-label>
+        <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Enable API Score"></mat-slide-toggle>
+      </gio-form-slide-toggle>
       <gio-form-slide-toggle
         [matTooltip]="'Configuration provided by the system'"
         [matTooltipDisabled]="!isReadonly('api.review.enabled')"
@@ -30,7 +35,12 @@
       >
         <mat-icon *ngIf="isReadonly('api.review.enabled')" gioFormPrefix>lock</mat-icon>
         <gio-form-label>Enable API review</gio-form-label>
-        <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Enable API review"></mat-slide-toggle>
+        <mat-slide-toggle
+          formControlName="enabled"
+          gioFormSlideToggle
+          aria-label="Enable API review"
+          data-testid="api-review-enabled-toggle"
+        ></mat-slide-toggle>
       </gio-form-slide-toggle>
       <gio-form-slide-toggle
         [matTooltip]="'Configuration provided by the system'"

--- a/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.spec.ts
@@ -56,6 +56,9 @@ describe('ApiQualityRulesComponent', () => {
     apiReview: {
       enabled: false,
     },
+    apiScore: {
+      enabled: false,
+    },
   };
 
   beforeEach(() => {
@@ -105,7 +108,9 @@ describe('ApiQualityRulesComponent', () => {
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await saveBar.isVisible()).toBe(false);
 
-      const enableApiReviewToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName=enabled]' }));
+      const enableApiReviewToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '[data-testid=api-review-enabled-toggle]' }),
+      );
       expect(await enableApiReviewToggle.isChecked()).toBe(false);
       await enableApiReviewToggle.toggle();
 
@@ -131,6 +136,9 @@ describe('ApiQualityRulesComponent', () => {
           technicalDocumentationWeight: 500,
         },
         apiReview: {
+          enabled: false,
+        },
+        apiScore: {
           enabled: false,
         },
       });

--- a/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/api-quality-rules/api-quality-rules.component.ts
@@ -36,6 +36,9 @@ import { PortalSettings } from '../../../entities/portal/portalSettings';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 interface ApiQualityRulesForm {
+  apiScore: FormGroup<{
+    enabled: FormControl<boolean>;
+  }>;
   apiReview: FormGroup<{
     enabled: FormControl<boolean>;
   }>;
@@ -111,6 +114,12 @@ export class ApiQualityRulesComponent implements OnInit {
           ]);
 
           this.apiQualityRulesForm = new FormGroup<ApiQualityRulesForm>({
+            apiScore: new FormGroup({
+              enabled: new FormControl({
+                value: this.settings.apiScore.enabled,
+                disabled: this.isReadonly('api.score.enabled') || settingsPermission,
+              }),
+            }),
             apiReview: new FormGroup({
               enabled: new FormControl({
                 value: this.settings.apiReview.enabled,
@@ -177,6 +186,10 @@ export class ApiQualityRulesComponent implements OnInit {
     this.portalSettingsService
       .save({
         ...this.settings,
+        apiScore: {
+          ...this.settings.apiScore,
+          enabled: this.apiQualityRulesForm.get('apiScore.enabled').value,
+        },
         apiReview: {
           ...this.settings.apiReview,
           enabled: this.apiQualityRulesForm.get('apiReview.enabled').value,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -182,6 +182,7 @@ public enum Key {
     ),
     OPEN_API_DOC_TYPE_DEFAULT("open.api.doc.type.default", "Swagger", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
+    API_SCORE_ENABLED("api.score.enabled", "false", new HashSet<>(singletonList(ENVIRONMENT))),
     API_QUALITY_METRICS_ENABLED("api.quality.metrics.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     API_QUALITY_METRICS_FUNCTIONAL_DOCUMENTATION_WEIGHT(
         "api.quality.metrics.functional.documentation.weight",
@@ -412,8 +413,6 @@ public enum Key {
 
     ALERT_ENGINE_ENABLED("alerts.alert-engine.enabled", "false", Set.of(SYSTEM)),
     FEDERATION_ENABLED("integration.enabled", "false", Set.of(SYSTEM)),
-
-    SCORING_ENABLED("scoring.enabled", "false", Set.of(SYSTEM)),
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
     TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiScore.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiScore.java
@@ -22,8 +22,8 @@ import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Scoring {
+public class ApiScore {
 
-    @ParameterKey(Key.SCORING_ENABLED)
+    @ParameterKey(Key.API_SCORE_ENABLED)
     private Boolean enabled;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
@@ -37,7 +37,6 @@ public class ConsoleConfigEntity {
     private LicenseExpirationNotification licenseExpirationNotification;
     private TrialInstance trialInstance;
     private Federation federation;
-    private Scoring scoring;
     private CloudHosted cloudHosted;
 
     public ConsoleConfigEntity() {
@@ -56,7 +55,6 @@ public class ConsoleConfigEntity {
         licenseExpirationNotification = new LicenseExpirationNotification();
         trialInstance = new TrialInstance();
         federation = new Federation();
-        scoring = new Scoring();
         cloudHosted = new CloudHosted();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
@@ -21,11 +21,13 @@ import io.gravitee.rest.api.model.parameters.Key;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author GraviteeSource Team
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
 
     private Alert alert;
@@ -47,7 +49,6 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
     private LicenseExpirationNotification licenseExpirationNotification;
     private TrialInstance trialInstance;
     private Federation federation;
-    private Scoring scoring;
     private CloudHosted cloudHosted;
 
     public ConsoleSettingsEntity() {
@@ -67,7 +68,6 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
         licenseExpirationNotification = new LicenseExpirationNotification();
         trialInstance = new TrialInstance();
         federation = new Federation();
-        scoring = new Scoring();
         cloudHosted = new CloudHosted();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
@@ -28,6 +28,7 @@ public class PortalConfigEntity {
 
     private Analytics analytics;
     private Api api;
+    private ApiScore apiScore;
     private ApiQualityMetrics apiQualityMetrics;
     private ApiReview apiReview;
     private PortalApplicationSettings application;
@@ -46,6 +47,7 @@ public class PortalConfigEntity {
         super();
         analytics = new Analytics();
         api = new Api();
+        apiScore = new ApiScore();
         apiQualityMetrics = new ApiQualityMetrics();
         apiReview = new ApiReview();
         application = new PortalApplicationSettings();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
@@ -33,6 +33,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
 
     private Analytics analytics;
     private Api api;
+    private ApiScore apiScore;
     private ApiQualityMetrics apiQualityMetrics;
     private ApiReview apiReview;
     private PortalApplicationSettings application;
@@ -57,6 +58,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
         super();
         analytics = new Analytics();
         api = new Api();
+        apiScore = new ApiScore();
         apiQualityMetrics = new ApiQualityMetrics();
         apiReview = new ApiReview();
         application = new PortalApplicationSettings();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -422,6 +422,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             // Portal Config
             portalConfigEntity.getAnalytics(),
             portalConfigEntity.getApi(),
+            portalConfigEntity.getApiScore(),
             portalConfigEntity.getApiQualityMetrics(),
             portalConfigEntity.getApiReview(),
             portalConfigEntity.getApplication(),
@@ -489,7 +490,6 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getLicenseExpirationNotification(),
             consoleConfigEntity.getTrialInstance(),
             consoleConfigEntity.getFederation(),
-            consoleConfigEntity.getScoring(),
             consoleConfigEntity.getCloudHosted(),
         };
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7932

## Description

Enable API Score feature from Environment Settings instead of using a flag in `gravitee.yaml`
A simple FrontEnd work has been done with the PR, just to be able to enable the feature. A proper front-end implementation will be done in another PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zlfbhqtrro.chromatic.com)
<!-- Storybook placeholder end -->
