### PR TITLE
feat: force redoc medium breakpoint to an extremely high value in the portal next

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
@@ -36,8 +36,8 @@ export class PageRedocComponent implements AfterViewInit {
   ngAfterViewInit() {
     const redocElement = this.element.nativeElement.querySelector('#redoc');
 
-    // Force the right-side panel to join into the middle panel
-    const options = { theme: { breakpoints: { medium: '120rem' } } };
+    // Force the right-side panel to join into the middle panel with an extremely high value for the medium breakpoint
+    const options = { theme: { breakpoints: { medium: '599rem', large: '600rem' } } };
 
     this.redocService.init(this.page.content, options, redocElement);
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4338

## Description

Here we force the redoc medium breakpoint to an extremely high value in the portal next. We do this to avoid any overflow problem. By default we want to always keep this view where the right panel join the middle one ( see screenshot )

### Before
<img width="1237" alt="Capture d’écran 2025-02-19 à 17 32 45" src="https://github.com/user-attachments/assets/8fc4d3cc-048b-455f-b431-446ae8f70c3a" />

### After
<img width="1146" alt="Capture d’écran 2025-02-19 à 17 31 53" src="https://github.com/user-attachments/assets/e0f96d38-3d2c-4d53-855a-2b1958f10865" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

