### PR TITLE
chore: update docker base image to 17-alpine-3.20

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -15,13 +15,12 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17-alpine-3.18 AS base
+FROM graviteeio/java:17-alpine-3.20 AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 RUN apk update  \
     && apk add --no-cache libc6-compat  \
-    && apkArch="$(apk --print-arch)" \
-    && ln -s /lib/libc.musl-${apkArch}.so.1 /lib/ld-linux-${apkArch/_/-}.so.2
+    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
 
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio

--- a/gravitee-apim-gateway/docker/Dockerfile-from-download
+++ b/gravitee-apim-gateway/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17-alpine-3.18
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0
@@ -34,8 +34,7 @@ RUN apk update \
     && rm -rf /tmp/* \
     && chgrp -R graviteeio ${GRAVITEEIO_HOME} \
     && chmod -R g=u ${GRAVITEEIO_HOME} \
-    && apkArch="$(apk --print-arch)" \
-    && ln -s /lib/libc.musl-${apkArch}.so.1 /lib/ld-linux-${apkArch/_/-}.so.2
+    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
 
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17-alpine-3.18 AS base
+FROM graviteeio/java:17-alpine-3.20 AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 RUN addgroup -g 1000 graviteeio \

--- a/gravitee-apim-rest-api/docker/Dockerfile-from-download
+++ b/gravitee-apim-rest-api/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17-alpine-3.18
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
## Description

Update MAPI & Gateway Docker base image for `java:17-alpine-3.20`

As the new alpine contains change related to libc, with @ThibaudAV we ran some tests using Kafka Compression to ensure everything was working. The original fixed we add related to Kafka compression & libc can be found [here](https://github.com/gravitee-io/gravitee-api-management/pull/3422)

Co-authored-by: Lars Næsbye Christensen <lars@naesbye.dk> (https://github.com/gravitee-io/gravitee-api-management/pull/9857)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

