### PR TITLE
fix: use config map to define default portal in the console

### DIFF
--- a/helm/templates/ui/ui-configmap.yaml
+++ b/helm/templates/ui/ui-configmap.yaml
@@ -74,5 +74,8 @@ data:
       {{- if .Values.ui.scheduler }},
       "scheduler": {{ toJson .Values.ui.scheduler }}
       {{- end }}
+      {{- if .Values.portal.defaultPortal }},
+      "defaultPortal": "{{ .Values.portal.defaultPortal }}"
+      {{- end }}
     }
 {{- end -}}

--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -116,8 +116,6 @@ spec:
             - name: CONSOLE_BASE_HREF
               value: {{ print (regexFind "/[a-zA-Z0-9-\\/_.~]+" .Values.ui.ingress.path) "/" }}
             {{- end }}
-            - name: DEFAULT_PORTAL
-              value: {{ .Values.portal.defaultPortal }}
 {{- if .Values.ui.env | default .Values.ui.deployment.extraEnvs }}
 {{ toYaml ( .Values.ui.env | default .Values.ui.deployment.extraEnvs ) | indent 12 }}
 {{- end }}

--- a/helm/tests/ui/configmap_test.yaml
+++ b/helm/tests/ui/configmap_test.yaml
@@ -1,0 +1,76 @@
+suite: Test UI configmap
+templates:
+  - "ui/ui-configmap.yaml"
+tests:
+  - it: should set classic portal as default
+    template: ui/ui-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["constants.json"]
+          value: |-
+            {
+              "baseURL": "https://apim.example.com/management",
+              "management": {
+                "title": "API Management"
+              },
+              "company": {
+                "name": "Gravitee.io"
+              },
+              "documentation": {
+                "url": "https://documentation.gravitee.io/"
+              },
+              "portal": {
+                "entrypoint": "https://apim.example.com/",
+                "title": "Management UI",
+                "analytics": {"enabled":false,"trackingId":""},
+                "apikeyHeader": "X-Gravitee-Api-Key",
+                "rating": {"enabled":false},
+                "support": {"enabled":true},
+                "userCreation": {"enabled":false}
+              },
+              "theme": {"loader":"assets/gravitee_logo_anim.gif","logo":"themes/assets/GRAVITEE_LOGO1-01.png","name":"default"},
+              "scheduler": {"tasks":10},
+              "defaultPortal": "classic"
+            }
+
+  - it: should set next as default portal value
+    template: ui/ui-configmap.yaml
+    set:
+      portal:
+        defaultPortal: "next"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["constants.json"]
+          value: |-
+            {
+              "baseURL": "https://apim.example.com/management",
+              "management": {
+                "title": "API Management"
+              },
+              "company": {
+                "name": "Gravitee.io"
+              },
+              "documentation": {
+                "url": "https://documentation.gravitee.io/"
+              },
+              "portal": {
+                "entrypoint": "https://apim.example.com/",
+                "title": "Management UI",
+                "analytics": {"enabled":false,"trackingId":""},
+                "apikeyHeader": "X-Gravitee-Api-Key",
+                "rating": {"enabled":false},
+                "support": {"enabled":true},
+                "userCreation": {"enabled":false}
+              },
+              "theme": {"loader":"assets/gravitee_logo_anim.gif","logo":"themes/assets/GRAVITEE_LOGO1-01.png","name":"default"},
+              "scheduler": {"tasks":10},
+              "defaultPortal": "next"
+            }

--- a/helm/tests/ui/deployment_test.yaml
+++ b/helm/tests/ui/deployment_test.yaml
@@ -68,16 +68,16 @@ tests:
     set:
       ui:
         env:
-        - name: CONSOLE_BASE_HREF
-          value: /test/
+          - name: CONSOLE_BASE_HREF
+            value: /test/
     asserts:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[1].name
           value: "CONSOLE_BASE_HREF"
       - equal:
-          path: spec.template.spec.containers[0].env[2].value
+          path: spec.template.spec.containers[0].env[1].value
           value: "/test/"
 
   - it: Should have default resources
@@ -253,30 +253,3 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "apim-ui"
-
-  - it: Should set DEFAULT_PORTAL environment variable with classic value by default
-    template: ui/ui-deployment.yaml
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: spec.template.spec.containers[0].env[2].name
-          value: "DEFAULT_PORTAL"
-      - equal:
-          path: spec.template.spec.containers[0].env[2].value
-          value: "classic"
-
-  - it: Should override DEFAULT_PORTAL environment variable value with next
-    template: ui/ui-deployment.yaml
-    set:
-      portal:
-        defaultPortal: "next"
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: spec.template.spec.containers[0].env[2].name
-          value: "DEFAULT_PORTAL"
-      - equal:
-          path: spec.template.spec.containers[0].env[2].value
-          value: "next"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7518

## Description

Following my previous PR about the default portal here is a PR to use the configmap instead of the deployment environment variables for the console

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

