### PR TITLE
APIM 7360 fix:  put api owner in metadata

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
@@ -38,7 +38,6 @@ import {
   Api,
   ConnectorPlugin,
   fakeApiFederated,
-  fakeApiV2,
   fakeApiV4,
   fakePlanFederated,
   fakePlanV2,
@@ -139,7 +138,6 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
     tick(800);
     expectApplicationGetRequest(app);
     expectSubscriptionsGetRequest([API_KEY_SUBSCRIPTION]);
-    expectApiGetRequest(fakeApiV2({ id: ANOTHER_API_ID }));
 
     // open subscription's creation dialog
     await harness.createSubscription();
@@ -417,15 +415,6 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
       })
       .flush(fakePagedResult(subscriptions));
     fixture.detectChanges();
-  };
-
-  const expectApiGetRequest = (api: Api) => {
-    httpTestingController
-      .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
-        method: 'GET',
-      })
-      .flush(api);
   };
 
   const expectApplicationGetRequest = (application: Application) => {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.html
@@ -118,7 +118,7 @@
       <ng-container matColumnDef="api">
         <th mat-header-cell *matHeaderCellDef id="api">API</th>
         <td mat-cell *matCellDef="let element">
-          <span [matTooltip]="element.apiPo$ | async">{{ element.apiName }}</span>
+          <span [matTooltip]="element.apiPo">{{ element.apiName }}</span>
         </td>
       </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
@@ -40,7 +40,7 @@ type SubscriptionsTableDS = {
   securityType: string;
   isSharedApiKey: boolean;
   apiName: string;
-  apiPo$: Observable<string>;
+  apiPo: string;
   createdAt: Date;
   processedAt: Date;
   startingAt: Date;
@@ -191,10 +191,7 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
           return {
             id: subscription.id,
             apiName: apiMetadata['name'] ? `${apiMetadata['name']} - ${apiMetadata['apiVersion']}` : subscription.api,
-            apiPo$: this.apiService.get(subscription.api).pipe(
-              map((api) => api.primaryOwner?.displayName),
-              catchError(() => of("Unknown API's owner")),
-            ),
+            apiPo: apiMetadata['apiPrimaryOwner'] ?? 'Unknown API owner',
             createdAt: subscription.created_at,
             endAt: subscription.ending_at,
             planName: planMetadata['name'] ?? subscription.plan,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1609,6 +1609,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             metadata.put(api.getId(), "name", api.getName());
             metadata.put(api.getId(), "definitionVersion", api.getDefinitionVersion());
             metadata.put(api.getId(), "apiVersion", api.getApiVersion());
+            metadata.put(api.getId(), "apiPrimaryOwner", api.getPrimaryOwner().getDisplayName());
             if (query.hasDetails()) {
                 metadata.put(api.getId(), "state", api.getLifecycleState());
                 metadata.put(api.getId(), "version", api.getApiVersion());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -205,6 +205,9 @@ public class SubscriptionServiceTest {
     private ApiModel apiModelEntity;
 
     @Mock
+    PrimaryOwnerEntity primaryOwnerEntity;
+
+    @Mock
     private AuditService auditService;
 
     @Mock
@@ -1547,6 +1550,8 @@ public class SubscriptionServiceTest {
         when(apiEntity.getId()).thenReturn(API_ID);
         when(apiSearchService.findGenericByEnvironmentAndIdIn(GraviteeContext.getExecutionContext(), Set.of(API_ID)))
             .thenReturn(Set.of(apiEntity));
+        when(apiEntity.getPrimaryOwner()).thenReturn(primaryOwnerEntity);
+        when(primaryOwnerEntity.getDisplayName()).thenReturn("Primary Owner Display Name");
         final SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
         subscriptionEntity.setId(SUBSCRIPTION_ID);
         subscriptionEntity.setApplication(APPLICATION_ID);
@@ -1609,6 +1614,8 @@ public class SubscriptionServiceTest {
         when(apiEntity.getId()).thenReturn(API_ID);
         when(apiSearchService.findGenericByEnvironmentAndIdIn(GraviteeContext.getExecutionContext(), Set.of(API_ID)))
             .thenReturn(Set.of(apiEntity));
+        when(apiEntity.getPrimaryOwner()).thenReturn(primaryOwnerEntity);
+        when(primaryOwnerEntity.getDisplayName()).thenReturn("Primary Owner Display Name");
         final SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
         subscriptionEntity.setId(SUBSCRIPTION_ID);
         subscriptionEntity.setApplication(APPLICATION_ID);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7360

## Description

Added api primary owner in metadata instead of calling apiService. 
In Subscription Creation Dialog, after creation of subscription, we were expecting the same apiService get request, hence removed it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-brnzmhogpq.chromatic.com)
<!-- Storybook placeholder end -->
