### PR TITLE
fix: handling null aggregation for v4 Response Time analytics widget

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
@@ -17,17 +17,26 @@ package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.gravitee.elasticsearch.version.Version;
+import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SearchResponseStatusOverTimeAdapterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private SearchResponseStatusOverTimeAdapter cut = new SearchResponseStatusOverTimeAdapter();
 
@@ -132,6 +141,19 @@ class SearchResponseStatusOverTimeAdapterTest {
                                    "size": 0
                                  }"""
                 );
+        }
+    }
+
+    @Nested
+    class AdaptResponse {
+
+        @Test
+        @SneakyThrows
+        public void handle_null_aggregation_response() {
+            var searchResponse = new SearchResponse();
+            var result = cut.adaptResponse(searchResponse);
+
+            assertThatJson(result).isEqualTo(new ResponseStatusOverTimeAggregate(new HashMap<>()));
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8697

## Description

With empty es data, the v4 response time analysis returned some errors.  

Errors: 
![image](https://github.com/user-attachments/assets/bcd6b6fb-306f-4ec0-b9e3-cd1393542a8b)

After fix: 
<img width="1137" alt="Zrzut ekranu 2025-02-21 o 11 54 07" src="https://github.com/user-attachments/assets/b95d3efd-d648-4d3f-8379-2eb680a9fa5b" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

