### PR TITLE
fix: instance of policies not properly released

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactory.java
@@ -24,9 +24,6 @@ import io.gravitee.gateway.reactive.api.policy.Policy;
 import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
 import io.gravitee.gateway.reactive.policy.adapter.policy.PolicyAdapter;
 import io.gravitee.policy.api.PolicyConfiguration;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Guillaume Lamirand (guillaume.lamirand at graviteesource.com)
@@ -34,7 +31,6 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class DefaultPolicyFactory implements PolicyFactory {
 
-    private final ConcurrentMap<String, Policy> policies = new ConcurrentHashMap<>();
     private final PolicyPluginFactory policyPluginFactory;
     private final io.gravitee.gateway.policy.PolicyFactory v3PolicyFactory;
     protected final ExpressionLanguageConditionFilter<ConditionalPolicy> filter;
@@ -56,16 +52,7 @@ public class DefaultPolicyFactory implements PolicyFactory {
         final PolicyConfiguration policyConfiguration,
         final PolicyMetadata policyMetadata
     ) {
-        return policies.computeIfAbsent(
-            generateKey(
-                executionPhase,
-                policyManifest,
-                policyConfiguration,
-                policyMetadata.getCondition(),
-                policyMetadata.getMessageCondition()
-            ),
-            k -> createPolicy(executionPhase, policyManifest, policyConfiguration, policyMetadata)
-        );
+        return createPolicy(executionPhase, policyManifest, policyConfiguration, policyMetadata);
     }
 
     private Policy createPolicy(
@@ -115,26 +102,6 @@ public class DefaultPolicyFactory implements PolicyFactory {
     @Override
     public void cleanup(PolicyManifest policyManifest) {
         policyPluginFactory.cleanup(policyManifest);
-    }
-
-    private String generateKey(
-        final ExecutionPhase executionPhase,
-        final PolicyManifest policyManifest,
-        final PolicyConfiguration policyConfiguration,
-        final String condition,
-        final String messageCondition
-    ) {
-        return (
-            Objects.hashCode(executionPhase) +
-            "-" +
-            Objects.hashCode(policyManifest) +
-            "-" +
-            Objects.hashCode(policyConfiguration) +
-            "-" +
-            Objects.hashCode(condition) +
-            "-" +
-            Objects.hashCode(messageCondition)
-        );
     }
 
     protected boolean isNotBlank(String s) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactoryTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.gateway.reactive.policy;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.policy.PolicyManifest;
@@ -40,7 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -118,7 +120,7 @@ class DefaultPolicyFactoryTest {
     }
 
     @Test
-    void shouldCreateOnceReactivePolicy() {
+    void shouldCreateEverytimeReactivePolicy() {
         PolicyManifest policyManifest = policyManifestBuilder
             .setPolicy(DummyReactivePolicyWithConfig.class)
             .setConfiguration(DummyPolicyConfiguration.class)
@@ -129,7 +131,8 @@ class DefaultPolicyFactoryTest {
         Policy policy2 = cut.create(ExecutionPhase.REQUEST, policyManifest, policyConfiguration, policyMetadata);
         assertInstanceOf(DummyReactivePolicyWithConfig.class, policy);
 
-        assertSame(policy, policy2);
+        // V4 HttpPolicyFactory is a global factory, there is no more cache at this level and is replaced by a cache at HttpPolicyChainFactory level.
+        assertNotSame(policy, policy2);
     }
 
     @ParameterizedTest
@@ -176,7 +179,7 @@ class DefaultPolicyFactoryTest {
     }
 
     @Test
-    void shouldCreateOncePolicyAdapter() {
+    void shouldCreateEverytimePolicyAdapter() {
         PolicyManifest policyManifest = policyManifestBuilder
             .setPolicy(DummyPolicyWithConfig.class)
             .setConfiguration(DummyPolicyConfiguration.class)
@@ -188,7 +191,7 @@ class DefaultPolicyFactoryTest {
         Policy policy2 = cut.create(ExecutionPhase.REQUEST, policyManifest, policyConfiguration, policyMetadata);
         assertInstanceOf(PolicyAdapter.class, policy);
 
-        assertSame(policy, policy2);
+        assertNotSame(policy, policy2);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8830

## Description

Remove the cache of policies on the V4 `HttpPolicyFactory` which is now global and wasn't properly cleaned up. This cache is not useful anymore as it has been replaced by a cache of policy chains.