### PR TITLE
fix: Issue with Webhook notifications - Lifecycle status changing

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -48,7 +48,9 @@ import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.*;
 import org.springframework.core.env.Environment;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -146,5 +148,20 @@ public class ServiceConfiguration {
         executor.setDaemon(true);
         executor.setCorePoolSize(2);
         return executor;
+    }
+
+    @Bean(name = "asyncNotificationThreadPoolTaskExecutor")
+    public TaskExecutor asyncExecutorService() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("gio-async-notification");
+        executor.setDaemon(true);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return new DelegatingSecurityContextAsyncTaskExecutor(executor);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiNotificationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiNotificationServiceImpl.java
@@ -51,38 +51,38 @@ public class ApiNotificationServiceImpl extends AbstractService implements ApiNo
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerUpdateNotification(final ExecutionContext executionContext, final Api api) {
         GenericApiEntity indexableApi = indexableApiMapper.toGenericApi(api, null);
         triggerUpdateNotification(executionContext, indexableApi);
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerUpdateNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_UPDATED, indexableApi);
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerDeprecatedNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_DEPRECATED, indexableApi);
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerDeployNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_DEPLOYED, indexableApi);
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerStartNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_STARTED, indexableApi);
     }
 
     @Override
-    @Async
+    @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerStopNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_STOPPED, indexableApi);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8449

## Description

Webhook notifications were failing when triggered asynchronously after a lifecycle status change. The issue occurred because Spring Security’s SecurityContext was lost when executing @Async methods.

## Additional context

By default, SecurityContextHolder stores authentication details in a thread-local scope, which means that when an @Async method is executed in a separate thread, it does not inherit the SecurityContext from the main request thread. As a result:

- SecurityContextHolder.getContext().getAuthentication() was returning null.

- Webhook notifications were never triggered because the user was not recognized.

To ensure SecurityContext is propagated to @Async methods, I implemented a dedicated thread pool executor wrapped with DelegatingSecurityContextAsyncTaskExecutor. This allows the authentication context to persist across threads when executing asynchronous tasks.

This is a sample of the received webhook:
![7FAEB698-204A-428F-AC32-16A6216BE14E_1_201_a](https://github.com/user-attachments/assets/898e95c3-4838-4aeb-9c1f-78b3863478df)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-njxvxjsawj.chromatic.com)
<!-- Storybook placeholder end -->
