### PR TITLE
PoC: allow wild card host and sub-path api resolution

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/HttpAcceptorResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/HttpAcceptorResolverTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactor.handler;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
@@ -103,9 +104,7 @@ public class HttpAcceptorResolverTest {
         HttpAcceptor acceptor1 = new DefaultHttpAcceptor("/teams");
         HttpAcceptor acceptor2 = new DefaultHttpAcceptor("/teams2");
 
-        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>();
-
-        httpAcceptorHandlers.addAll(Arrays.asList(acceptor1, acceptor2));
+        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>(Arrays.asList(acceptor1, acceptor2));
 
         when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
         when(request.path()).thenReturn("/teams");
@@ -119,9 +118,7 @@ public class HttpAcceptorResolverTest {
         HttpAcceptor acceptor1 = new DefaultHttpAcceptor("/teams");
         HttpAcceptor acceptor2 = new DefaultHttpAcceptor("/teams2");
 
-        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>();
-
-        httpAcceptorHandlers.addAll(Arrays.asList(acceptor1, acceptor2));
+        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>(Arrays.asList(acceptor1, acceptor2));
 
         when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
 
@@ -136,9 +133,7 @@ public class HttpAcceptorResolverTest {
         HttpAcceptor acceptor1 = new DefaultHttpAcceptor("/teams");
         HttpAcceptor acceptor2 = new DefaultHttpAcceptor("/teams2");
 
-        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>();
-
-        httpAcceptorHandlers.addAll(Arrays.asList(acceptor1, acceptor2));
+        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>(Arrays.asList(acceptor1, acceptor2));
 
         when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
 
@@ -153,9 +148,7 @@ public class HttpAcceptorResolverTest {
         HttpAcceptor acceptor1 = new DefaultHttpAcceptor("/teams");
         HttpAcceptor acceptor2 = new DefaultHttpAcceptor("/teams2");
 
-        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>();
-
-        httpAcceptorHandlers.addAll(Arrays.asList(acceptor1, acceptor2));
+        final ConcurrentSkipListSet<HttpAcceptor> httpAcceptorHandlers = new ConcurrentSkipListSet<>(Arrays.asList(acceptor1, acceptor2));
 
         when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
 
@@ -180,6 +173,88 @@ public class HttpAcceptorResolverTest {
 
         assertNull(handlerResolver.resolve(context, SERVER_ID));
         verify(context, never()).setAttribute(eq(DefaultAcceptorResolver.ATTR_ENTRYPOINT), any());
+    }
+
+    @Test
+    public void should_resolve_with_sub_path_first() {
+        final List<HttpAcceptor> httpAcceptorHandlers = new ArrayList<>();
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor(null, "/c/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor(null, "/b/a/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor(null, "/b/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor(null, "/"));
+
+        List<HttpAcceptor> copy = List.copyOf(httpAcceptorHandlers);
+        Collections.sort(httpAcceptorHandlers);
+
+        assertThat(httpAcceptorHandlers).containsExactlyElementsOf(copy);
+
+        when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
+
+        record RequestData(String path, int acceptorIndex) {}
+
+        List<RequestData> pathAcceptors = new ArrayList<>();
+        pathAcceptors.add(new RequestData("/", 3));
+        pathAcceptors.add(new RequestData("/b", 2));
+        pathAcceptors.add(new RequestData("/b/a", 1));
+        pathAcceptors.add(new RequestData("/c", 0));
+        pathAcceptors.add(new RequestData("/foo", 3));
+        pathAcceptors.add(new RequestData("/b/foo", 2));
+        pathAcceptors.add(new RequestData("/b/a/foo", 1));
+        pathAcceptors.add(new RequestData("/c/foo", 0));
+        for (RequestData pathAcceptor : pathAcceptors) {
+            reset(request);
+            when(request.host()).thenReturn(null);
+            when(request.path()).thenReturn(pathAcceptor.path);
+            assertEquals(httpAcceptorHandlers.get(pathAcceptor.acceptorIndex), handlerResolver.resolve(context, SERVER_ID));
+        }
+    }
+
+    @Test
+    public void should_resolve_with_wildcard_host() {
+        final List<HttpAcceptor> httpAcceptorHandlers = new ArrayList<>();
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("root.test.acme.com", "/a/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("root.test.acme.com", "/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("*.test.acme.com", "/a/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("*.test.acme.com", "/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("test.acme.com", "/a/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("test.acme.com", "/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("*.acme.com", "/a/"));
+        httpAcceptorHandlers.add(new DefaultHttpAcceptor("*.acme.com", "/"));
+
+        List<HttpAcceptor> copy = List.copyOf(httpAcceptorHandlers);
+        Collections.sort(httpAcceptorHandlers);
+
+        assertThat(httpAcceptorHandlers).containsExactlyElementsOf(copy);
+
+        when(reactorHandlerRegistry.getAcceptors(HttpAcceptor.class)).thenReturn(httpAcceptorHandlers);
+
+        record RequestData(String host, String path, Integer acceptorIndex) {}
+
+        List<RequestData> requestDatas = new ArrayList<>();
+        requestDatas.add(new RequestData("root.test.acme.com", "/a", 0));
+        requestDatas.add(new RequestData("root.test.acme.com", "/", 1));
+        requestDatas.add(new RequestData("foo.test.acme.com", "/a", 2));
+        requestDatas.add(new RequestData("foo.test.acme.com", "/", 3));
+        requestDatas.add(new RequestData("test.acme.com", "/a", 4));
+        requestDatas.add(new RequestData("test.acme.com", "/", 5));
+        requestDatas.add(new RequestData("foo.acme.com", "/a", 6));
+        requestDatas.add(new RequestData("foo.bar.acme.com", "/a", 6));
+        requestDatas.add(new RequestData("foo.acme.com", "/", 7));
+        requestDatas.add(new RequestData("foo.bar.acme.com", "/", 7));
+        requestDatas.add(new RequestData("acme.com", "/", null));
+        requestDatas.add(new RequestData("api.acme.net", "/", null));
+
+        for (RequestData requestData : requestDatas) {
+            reset(request);
+            when(request.host()).thenReturn(requestData.host);
+            when(request.path()).thenReturn(requestData.path);
+            String message = "host=" + requestData.host + " path=" + requestData.path;
+            if (requestData.acceptorIndex != null) {
+                assertEquals(message, httpAcceptorHandlers.get(requestData.acceptorIndex), handlerResolver.resolve(context, SERVER_ID));
+            } else {
+                assertNull(message, handlerResolver.resolve(context, SERVER_ID));
+            }
+        }
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,8 +80,8 @@ public class ReactorHandlerRegistryTest {
         final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(2, httpAcceptorHandlers.size());
-        assertEntryPoint(null, "/products/v1/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/products/v2/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/products/v1/", httpAcceptorHandlerIterator.next());
     }
 
     @Test
@@ -141,8 +142,8 @@ public class ReactorHandlerRegistryTest {
         final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(2, httpAcceptorHandlers.size());
-        assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/products/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
     }
 
     @Test
@@ -224,22 +225,22 @@ public class ReactorHandlerRegistryTest {
         final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(17, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("apiX.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("apiX.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
     }
 
@@ -282,22 +283,96 @@ public class ReactorHandlerRegistryTest {
         final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(17, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/a/b/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a/b/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a/b/c1/sub/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a/b/c1/sub/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a/b/d/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a/b/e/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a/b/f/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("apiX.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/a/b/c1/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("apiX.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a/b/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a/b/f/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a/b/e/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a/b/d/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a/b/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a/b/c1/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a/b/c1/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
+    }
+
+    @Test
+    public void shouldHaveMultipleHttpAcceptors_multipleVhostsWithSubPathsAndWildcards() {
+        DummyReactable reactable = createReactable("reactable1");
+        ReactorHandler handler = createReactorHandler(
+            new DefaultHttpAcceptor(null, "/"),
+            new DefaultHttpAcceptor("*.gravitee.io", "/"),
+            new DefaultHttpAcceptor("test.gravitee.io", "/")
+        );
+        when(reactorHandlerFactoryManager.create(reactable)).thenReturn(List.of(handler));
+        reactorHandlerRegistry.create(reactable);
+
+        DummyReactable reactable2 = createReactable("reactable2");
+        ReactorHandler handler2 = createReactorHandler(
+            new DefaultHttpAcceptor("test.gravitee.io", "/a"),
+            new DefaultHttpAcceptor("test.gravitee.io", "/a/b"),
+            new DefaultHttpAcceptor("test.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("1.test.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("2.test.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("3.test.gravitee.io", "/a/b/c")
+        );
+        when(reactorHandlerFactoryManager.create(reactable2)).thenReturn(List.of(handler2));
+        reactorHandlerRegistry.create(reactable2);
+
+        DummyReactable reactable3 = createReactable("reactable3");
+        ReactorHandler handler3 = createReactorHandler(
+            new DefaultHttpAcceptor("*.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("*.gravitee.io", "/a/b/c/sub"),
+            new DefaultHttpAcceptor("*.foo.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("*.foo.gravitee.io", "/a/b/c/sub"),
+            new DefaultHttpAcceptor("*.test.gravitee.io", "/a/b/c"),
+            new DefaultHttpAcceptor("*.test.gravitee.io", "/a/b/c/sub")
+        );
+        when(reactorHandlerFactoryManager.create(reactable3)).thenReturn(List.of(handler3));
+        reactorHandlerRegistry.create(reactable3);
+
+        DummyReactable reactable4 = createReactable("reactable4");
+        ReactorHandler handler4 = createReactorHandler(
+            new DefaultHttpAcceptor(null, "/a/b/a"),
+            new DefaultHttpAcceptor(null, "/a/b/b"),
+            new DefaultHttpAcceptor(null, "/a/b/c"),
+            new DefaultHttpAcceptor(null, "/a/b/a/sub"),
+            new DefaultHttpAcceptor(null, "/a/b/b/sub"),
+            new DefaultHttpAcceptor(null, "/a/b/c/sub")
+        );
+
+        when(reactorHandlerFactoryManager.create(reactable4)).thenReturn(List.of(handler4));
+        reactorHandlerRegistry.create(reactable4);
+
+        final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
+        final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
+        Assert.assertEquals(21, httpAcceptorHandlers.size());
+        assertEntryPoint("3.test.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("2.test.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("1.test.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".test.gravitee.io", "/a/b/c/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".test.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("test.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("test.gravitee.io", "/a/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("test.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("test.gravitee.io", "/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".foo.gravitee.io", "/a/b/c/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".foo.gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".gravitee.io", "/a/b/c/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".gravitee.io", "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(".gravitee.io", "/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/c/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/c/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/b/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/a/sub/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint(null, "/a/b/a/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
     }
 
@@ -354,22 +429,22 @@ public class ReactorHandlerRegistryTest {
         final Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         final Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(17, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("apiX.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("apiX.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a-v1/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
     }
 
@@ -538,57 +613,57 @@ public class ReactorHandlerRegistryTest {
         Collection<HttpAcceptor> httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         Iterator<HttpAcceptor> httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(17, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("apiX.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("apiX.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
         assertEntryPoint(null, "/", httpAcceptorHandlerIterator.next());
 
         reactorHandlerRegistry.remove(reactable);
         httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(16, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("apiX.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("apiX.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/a/", httpAcceptorHandlerIterator.next());
 
         reactorHandlerRegistry.remove(reactable2);
         httpAcceptorHandlers = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
         httpAcceptorHandlerIterator = httpAcceptorHandlers.iterator();
         Assert.assertEquals(8, httpAcceptorHandlers.size());
-        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
-        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
         assertEntryPoint("apiX.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api4.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api3.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api2.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api1.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api11.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
+        assertEntryPoint("api10.gravitee.io", "/b/", httpAcceptorHandlerIterator.next());
 
         reactorHandlerRegistry.remove(reactable3);
         Assert.assertEquals(0, reactorHandlerRegistry.getAcceptors(HttpAcceptor.class).size());
@@ -644,7 +719,7 @@ public class ReactorHandlerRegistryTest {
         return createReactorHandler(new DefaultHttpAcceptor(virtualHost, contextPath));
     }
 
-    private ReactorHandler createReactorHandler(Acceptor<? extends Acceptor<?>>... httpAcceptors) {
+    private ReactorHandler createReactorHandler(Acceptor<?>... httpAcceptors) {
         ReactorHandler handler = mock(ReactorHandler.class);
 
         List<Acceptor<?>> acceptors = Arrays
@@ -692,7 +767,7 @@ public class ReactorHandlerRegistryTest {
         }
 
         @Override
-        public int compareTo(DummyAcceptor o) {
+        public int compareTo(@Nonnull DummyAcceptor o) {
             return 0;
         }
     }
@@ -701,7 +776,7 @@ public class ReactorHandlerRegistryTest {
         String apiId();
     }
 
-    private class DummyReactable implements Reactable {
+    private static class DummyReactable implements Reactable {
 
         private final String id;
 


### PR DESCRIPTION
## Issue

Gateway is not yet compatible for KGW API because it works with context paths.
Gateway cannot access '/' api and sub paths as well as wild host matches.

## Description

* Order path from the more specific to the least specific
** `/v1/api`
** `/v1`
** `/`

* if virtual host starts with `*.` match that host ends the host without `*`
eg. *.example.com

## Remaining work
* explore exact path vs. prefix  explore header matching
* explore header matching

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pxcdtnhvhs.chromatic.com)
<!-- Storybook placeholder end -->
