### PR TITLE
ci: update bridge compatibility tests

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -331,7 +331,7 @@ workflows:
                 - 4.5.x-latest
                 - graviteeio@4.5.0
                 - 4.4.x-latest
-                - graviteeio@4.4.0
+                - graviteeio@4.4.2
                 - 4.3.x-latest
                 - graviteeio@4.3.0
 orbs:

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -67,7 +67,7 @@ export class BridgeCompatibilityTestsWorkflow {
             '4.5.x-latest',
             'graviteeio@4.5.0',
             '4.4.x-latest',
-            'graviteeio@4.4.0',
+            'graviteeio@4.4.2',
             '4.3.x-latest',
             'graviteeio@4.3.0',
           ],


### PR DESCRIPTION
use 4.4.2 as 4.4.0 & 4.4.1 were not stable and sync process was not working correctly
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zupoufpnpk.chromatic.com)
<!-- Storybook placeholder end -->
