### PR TITLE
fix: add quotes for kafka config

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.6.5
+
+- Kafka Gateway: use quotes in kafka configuration to avoid parsing issues
+
 ### 4.6.4
 
 - Kafka Gateway: fix configuration

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -18,9 +18,18 @@ kubeVersion: ">=1.14.0-0"
 annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
+  # example:
+  #     - kind: added
+  #      description: 'Allow to customize Kafka Gateway bootstrap and brokers domain patterns'
+  #      links:
+  #        - name: Github Issue
+  #          url: https://github.com/gravitee-io/issues/issues/xxx
   ###########
   # WARNING #
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: 'Use quotes in kafka configuration to avoid parsing issues'
+    

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -172,22 +172,22 @@ data:
       {{- if hasKey .Values.gateway.kafka "routingHostMode" }}
       routingHostMode:
         {{- if hasKey .Values.gateway.kafka.routingHostMode "brokerPrefix" }}
-        brokerPrefix: {{ .Values.gateway.kafka.routingHostMode.brokerPrefix }}
+        brokerPrefix: {{ .Values.gateway.kafka.routingHostMode.brokerPrefix | quote }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "domainSeparator" }}
-        domainSeparator: {{ .Values.gateway.kafka.routingHostMode.domainSeparator }}
+        domainSeparator: {{ .Values.gateway.kafka.routingHostMode.domainSeparator | quote }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "defaultDomain" }}
-        defaultDomain: {{ .Values.gateway.kafka.routingHostMode.defaultDomain }}
+        defaultDomain: {{ .Values.gateway.kafka.routingHostMode.defaultDomain | quote }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "defaultPort" }}
         defaultPort: {{ .Values.gateway.kafka.routingHostMode.defaultPort }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "bootstrapDomainPattern" }}
-        bootstrapDomainPattern: {{ .Values.gateway.kafka.routingHostMode.bootstrapDomainPattern }}
+        bootstrapDomainPattern: {{ .Values.gateway.kafka.routingHostMode.bootstrapDomainPattern | quote }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "brokerDomainPattern" }}
-        brokerDomainPattern: {{ .Values.gateway.kafka.routingHostMode.brokerDomainPattern }}
+        brokerDomainPattern: {{ .Values.gateway.kafka.routingHostMode.brokerDomainPattern | quote }}
         {{- end}}
       {{- end}}
       {{- if hasKey .Values.gateway.kafka "apiKey" }}

--- a/helm/tests/gateway/configmap_kafka_test.yaml
+++ b/helm/tests/gateway/configmap_kafka_test.yaml
@@ -43,9 +43,53 @@ tests:
               routingMode: host
               routingHostMode:
                 brokerPrefix: fox-
-                domainSeparator: |
-                defaultDomain: gravitee.io
+                domainSeparator: "|"
+                defaultDomain: "gravitee.io"
                 defaultPort: 42
+              api-key:
+                securityMechanisms: SCRAM-SHA-512
+              port: 9042
+              host: 42.42.42.42
+              idleTimeout: 42
+              tcpKeepAlive: 42
+              instances: 42
+              requestTimeout: 42
+  - it: Enable Kafka and set pattern values
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        kafka:
+          enabled: true
+          routingMode: host
+          routingHostMode:
+            brokerPrefix: "fox-"
+            domainSeparator: "|"
+            defaultDomain: "gravitee.io"
+            defaultPort: 42
+            bootstrapDomainPattern: "{apiHost}.mycompany.org"
+            brokerDomainPattern: "broker-{brokerId}-{apiHost}.mycompany.org"
+          apiKey:
+            securityMechanisms: SCRAM-SHA-512
+          port: 9042
+          host: 42.42.42.42
+          idleTimeout: 42
+          tcpKeepAlive: 42
+          instances: 42
+          requestTimeout: 42
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            kafka:
+              enabled: true
+              routingMode: host
+              routingHostMode:
+                brokerPrefix: "fox-"
+                domainSeparator: "|"
+                defaultDomain: "gravitee.io"
+                defaultPort: 42
+                bootstrapDomainPattern: "{apiHost}.mycompany.org"
+                brokerDomainPattern: "broker-{brokerId}-{apiHost}.mycompany.org"
               api-key:
                 securityMechanisms: SCRAM-SHA-512
               port: 9042


### PR DESCRIPTION
## Issue

N/A

## Description

Add quotes to kafka routing configuration to avoid parsing issues when APIM starts