### PR TITLE
feat: update portal message for documentation page not found 

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -158,6 +158,7 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
     },
     documentation: {
       url: 'https://docs.gravitee.ios',
+      pageNotFoundMessage: null,
     },
     openAPIDocViewer: {
       openAPIDocType: {

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -192,6 +192,7 @@ export interface PortalSettingsScheduler {
 
 export interface PortalSettingsDocumentation {
   url: string;
+  pageNotFoundMessage: string;
 }
 
 export interface PortalSettingsEmail {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -413,6 +413,15 @@
           <mat-label>Documentation URL</mat-label>
           <input formControlName="url" matInput type="text" />
         </mat-form-field>
+        <mat-form-field
+          matTooltip="Message to be displayed when a Documentation Page is not found"
+          [matTooltipDisabled]="!isReadonly('documentation.pageNotFoundMessage')"
+          class="portal__form__card__form-field"
+          formGroupName="documentation"
+        >
+          <mat-label>Page Not Found Message</mat-label>
+          <textarea formControlName="pageNotFoundMessage" matInput></textarea>
+        </mat-form-field>
       </mat-card-content>
     </mat-card>
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -253,6 +253,30 @@ describe('PortalSettingsComponent', () => {
         },
       });
     });
+
+    it('display settings form and edit Documentation field', async () => {
+      const message = 'Page not found';
+
+      portalSettingsMock = fakePortalSettings();
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const pageNotFoundMessageInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=pageNotFoundMessage' }));
+      await pageNotFoundMessageInput.setValue(message);
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({
+        ...portalSettingsMock,
+        documentation: {
+          ...portalSettingsMock.documentation,
+          pageNotFoundMessage: message,
+        },
+      });
+    });
   });
   describe('Portal next setting form', () => {
     beforeEach(() => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -114,6 +114,7 @@ interface PortalForm {
   }>;
   documentation: FormGroup<{
     url: FormControl<string>;
+    pageNotFoundMessage: FormControl<string>;
   }>;
   openAPIDocViewer: FormGroup<{
     openAPIDocType: FormGroup<{
@@ -398,6 +399,10 @@ export class PortalSettingsComponent implements OnInit {
         url: new FormControl({
           value: this.settings.documentation.url,
           disabled: this.isReadonly('documentation.url'),
+        }),
+        pageNotFoundMessage: new FormControl({
+          value: this.settings.documentation.pageNotFoundMessage,
+          disabled: this.isReadonly('documentation.pageNotFoundMessage'),
         }),
       }),
       openAPIDocViewer: new FormGroup({

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
@@ -47,9 +47,12 @@
   <section>
     <gv-message class="message-empty">
       <gv-icon shape="home:library"></gv-icon>
-      <div class="title">
-        {{ 'gv-documentation.empty' | translate }}
+      <div *ngIf="!!pageNotFoundMessage; else defaultMessage">
+        <div class="title" [innerHTML]="pageNotFoundMessage | safe : 'html'"></div>
       </div>
+      <ng-template #defaultMessage>
+        <div class="title">{{ 'gv-documentation.empty' | translate }}</div>
+      </ng-template>
     </gv-message>
   </section>
 </div>

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.spec.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { Page } from '../../../../projects/portal-webclient-sdk/src/lib';
+import { ConfigurationService } from '../../services/configuration.service';
 
 import { GvDocumentationComponent } from './gv-documentation.component';
 
@@ -26,6 +28,7 @@ describe('GvDocumentationComponent', () => {
     component: GvDocumentationComponent,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [RouterTestingModule],
+    providers: [mockProvider(ConfigurationService), { provide: DomSanitizer, useValue: { sanitize: jest.fn() } }],
   });
 
   let spectator: Spectator<GvDocumentationComponent>;

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -15,13 +15,14 @@
  */
 import '@gravitee/ui-components/wc/gv-tree';
 import { animate, style, transition, trigger } from '@angular/animations';
-import { AfterViewInit, Component, HostListener, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, HostListener, Input, OnInit, SecurityContext, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { DomSanitizer } from '@angular/platform-browser';
 
 import { Page } from '../../../../projects/portal-webclient-sdk/src/lib';
 import { TreeItem } from '../../model/tree-item';
-import { NotificationService } from '../../services/notification.service';
 import { ScrollService } from '../../services/scroll.service';
+import { ConfigurationService } from '../../services/configuration.service';
 
 @Component({
   selector: 'app-gv-documentation',
@@ -72,7 +73,17 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
     return this._pages;
   }
 
-  constructor(private notificationService: NotificationService, private route: ActivatedRoute, private router: Router) {}
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly configurationService: ConfigurationService,
+    private readonly sanitizer: DomSanitizer,
+  ) {
+    this.pageNotFoundMessage = this.sanitizer.sanitize(
+      SecurityContext.HTML,
+      this.configurationService.get('documentation.pageNotFoundMessage'),
+    );
+  }
 
   static PAGE_PADDING_TOP_BOTTOM = 44;
   static PAGE_COMPONENT = 'app-gv-page';
@@ -83,6 +94,7 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
   isLoaded = false;
   hasTreeClosed = true;
   hasOneOrLessPages = true;
+  pageNotFoundMessage: string;
 
   @Input() rootDir: string;
   private _pages: Page[];

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -151,6 +151,8 @@ public enum Key {
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
 
+    DOCUMENTATION_PAGE_NOT_FOUND_MESSAGE("documentation.pageNotFoundMessage", "", new HashSet<>(Arrays.asList(ENVIRONMENT))),
+
     PLAN_SECURITY_MTLS_ENABLED("plan.security.mtls.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_JWT_ENABLED("plan.security.jwt.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_OAUTH2_ENABLED("plan.security.oauth2.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Documentation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Documentation.java
@@ -18,22 +18,21 @@ package io.gravitee.rest.api.model.settings;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.gravitee.rest.api.model.annotations.ParameterKey;
 import io.gravitee.rest.api.model.parameters.Key;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
 public class Documentation {
 
     @ParameterKey(Key.DOCUMENTATION_URL)
     String url;
 
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
+    @ParameterKey(Key.DOCUMENTATION_PAGE_NOT_FOUND_MESSAGE)
+    String pageNotFoundMessage;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -207,6 +207,7 @@ public class ConfigurationMapper {
     private ConfigurationDocumentation convert(Documentation documentation) {
         ConfigurationDocumentation configuration = new ConfigurationDocumentation();
         configuration.setUrl(documentation.getUrl());
+        configuration.setPageNotFoundMessage(documentation.getPageNotFoundMessage());
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4892,6 +4892,9 @@ components:
                 url:
                     description: URL of the main documentation.
                     type: string
+                pageNotFoundMessage:
+                  description: Message to display when a page is not found.
+                  type: string
         ConfigurationPlan:
             properties:
                 security:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8821

## Description

In this PR we add an option in the environment settings to allow customers to display a different message in the portal when a documentation page is not found without having to update the en.json. It's intended that this message won't be translated.


https://github.com/user-attachments/assets/562b620b-693a-47e9-bd84-666cc05c6967
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bfptlmvdch.chromatic.com)
<!-- Storybook placeholder end -->
