### PR TITLE
fix: text overflow in API documentation containers

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
@@ -228,6 +228,7 @@
 .toastui-editor-contents p {
   margin: 10px 0;
   color: #555;
+  word-wrap: break-word;
 }
 
 .toastui-editor-contents h1 {
@@ -383,6 +384,9 @@
 
 .toastui-editor-contents table td {
   border: 1px solid #eaeaea;
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .toastui-editor-contents table th {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
@@ -31,7 +31,7 @@
     [disableMiniMap]="true"
     [disabled]="disabled"
   ></gio-monaco-editor>
-  <markdown *ngIf="preview && pageType === 'MARKDOWN'" [data]="_value"> </markdown>
+  <markdown class="markdown-content" *ngIf="preview && pageType === 'MARKDOWN'" [data]="_value"> </markdown>
   <gio-swagger-ui *ngIf="preview && pageType === 'SWAGGER'" [spec]="_value"></gio-swagger-ui>
   <gio-async-api *ngIf="preview && pageType === 'ASYNCAPI'" [schema]="_value"></gio-async-api>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.scss
@@ -15,5 +15,16 @@
   &__editor {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 10px;
   }
+}
+
+:host ::ng-deep .markdown-content table td {
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: normal;
+}
+
+:host ::ng-deep .markdown-content p {
+  word-wrap: break-word;
 }

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -99,3 +99,8 @@ app-gv-markdown-toc {
   color: var(--gv-theme-font-color-light, #ffffff);
   padding-top: 6px;
 }
+:host ::ng-deep table td {
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7688

## Description

Fixed text wrap in both API specific documentation and common documentation

## Additional context

### Before
https://github.com/user-attachments/assets/004ef226-a7a1-493d-a886-700ce7474812

### After
https://github.com/user-attachments/assets/c9b94eef-fa43-4ec8-9f04-22ea8a6281fc

https://github.com/user-attachments/assets/d7f4c87a-dd55-4dc3-a08a-062bcdabc347
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ikvtxehulc.chromatic.com)
<!-- Storybook placeholder end -->
