### PR TITLE
fix(portal-next): text overflow in API documentation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.scss
@@ -30,6 +30,8 @@
 
   &__page-content {
     width: 100%;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 
     &__container {
       min-width: 0;

--- a/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,4 +21,15 @@ pre {
   white-space: pre-wrap;
   white-space: -moz-pre-wrap;
   word-wrap: break-word;
+}
+
+table td {
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-all;
+}
+
+p {
+  word-break: break-word;
+  word-break: break-all;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7688

## Description

Fixed text wrap in both API specific documentation and common documentation

## Additional context

### Before
https://github.com/user-attachments/assets/afdd2fab-1b59-4330-9f48-b4b09ee2dc5d

### After
https://github.com/user-attachments/assets/eec380b1-8979-4153-afdc-0f2836e8b4a6

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xokhppqujv.chromatic.com)
<!-- Storybook placeholder end -->
