### PR TITLE
fix: do not index User custom fields containing base64 image

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
@@ -144,7 +144,7 @@ public class UserDocumentTransformer implements DocumentTransformer<UserEntity> 
                 .stream()
                 .filter(Objects::nonNull)
                 .map(Object::toString)
-                .filter(Predicate.not(String::isEmpty))
+                .filter(Predicate.not(String::isEmpty).and(value -> !value.startsWith("data:")))
                 .forEach(customValue -> {
                     doc.add(new StringField(FIELD_CUSTOM, toLowerCaseAndStripAccents(customValue), Field.Store.NO));
                     doc.add(new TextField(FIELD_CUSTOM_SPLIT, toLowerCaseAndStripAccents(customValue), Field.Store.NO));


### PR DESCRIPTION
## Description

To prevent an error during indexation because the value is too big

```
java.lang.IllegalArgumentException: Document contains at least one immense term in field="custom" (whose length is longer than the max length 32766), all of which were skipped. The prefix of the first immense term is: '[100, 97, 116, 97, 58, 105, 109, 97, 103, 101, 47, 106, 112, 101, 103, 59, 98, 97, 115, 101, 54, 52, 44, 47, 57, 106, 47, 52, 97, 97]...'
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

