### PR TITLE
fix: add script to configure IPv4-only Nginx setup and update Dockerfile

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
-COPY config/check_ip_config.sh /check_ip_config.sh
+COPY docker/config/check_ip_config.sh /check_ip_config.sh
 
 CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
 

--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -24,9 +24,12 @@ COPY ./dist /usr/share/nginx/html/
 
 ADD docker/config/constants.json /usr/share/nginx/html/constants.json
 ADD docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
-CMD ["sh", "/run.sh"]
+COPY config/check_ip_config.sh /check_ip_config.sh
+
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx

--- a/gravitee-apim-console-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-console-webui/docker/Dockerfile-from-download
@@ -36,9 +36,12 @@ RUN apk update \
 
 COPY config/constants.json /usr/share/nginx/html/constants.json
 COPY config/default.conf /etc/nginx/conf.d/default.conf
+COPY config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
-CMD ["sh", "/run.sh"]
+COPY config/check_ip_config.sh /check_ip_config.sh
+
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx

--- a/gravitee-apim-console-webui/docker/config/check_ip_config.sh
+++ b/gravitee-apim-console-webui/docker/config/check_ip_config.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+IPV4_ONLY=${IPV4_ONLY:-false}
+
+if [ "$IPV4_ONLY" = "true" ]; then
+    mv /etc/nginx/conf.d/default.no-ipv6.conf /etc/nginx/conf.d/default.conf
+fi
+

--- a/gravitee-apim-console-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-apim-console-webui/docker/config/default.no-ipv6.conf
@@ -1,0 +1,38 @@
+server {
+    listen $HTTP_PORT;
+    listen $HTTPS_PORT;
+    server_name $SERVER_NAME;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Permitted-Cross-Domain-Policies none;
+
+    index index.html index.htm;
+    charset utf-8;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+    location / {
+        try_files $uri $uri/ =404;
+        error_page 404 /;
+        root /rw.mount/www;
+        sub_filter '<base href="/"' '<base href="$CONSOLE_BASE_HREF"';
+        sub_filter_once on;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /rw.mount/www;
+    }
+}

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -28,11 +28,13 @@ COPY ./dist /usr/share/nginx/html/
 COPY docker/config/config.json /usr/share/nginx/html/assets/config.json
 COPY docker/config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
 COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
 COPY docker/config/portal-next-run.sh /portal-next-run.sh
+COPY docker/config/check_ip_config.sh /check_ip_config.sh
 
-CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /run.sh"]
+CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx

--- a/gravitee-apim-portal-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-from-download
@@ -38,11 +38,13 @@ RUN apk update \
 COPY config/config.json /usr/share/nginx/html/assets/config.json
 COPY config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
 COPY config/default.conf /etc/nginx/conf.d/default.conf
+COPY config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
 
 COPY config/portal-next-run.sh /portal-next-run.sh
+COPY config/check_ip_config.sh /check_ip_config.sh
 
-CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /run.sh"]
+CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /check_ip_config.sh; sh /run.sh"]
 
 USER nginx

--- a/gravitee-apim-portal-webui/docker/config/check_ip_config.sh
+++ b/gravitee-apim-portal-webui/docker/config/check_ip_config.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+IPV4_ONLY=${IPV4_ONLY:-false}
+
+if [ "$IPV4_ONLY" = "true" ]; then
+    mv /etc/nginx/conf.d/default.no-ipv6.conf /etc/nginx/conf.d/default.conf
+fi
+

--- a/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
@@ -1,0 +1,38 @@
+server {
+    listen $HTTP_PORT;
+    listen $HTTPS_PORT;
+    server_name $SERVER_NAME;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Permitted-Cross-Domain-Policies none;
+
+    index index.html index.htm;
+    charset utf-8;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+    location / {
+        try_files $uri $uri/ =404;
+        error_page 404 /;
+        root /rw.mount/www;
+        sub_filter '<base href="/"' '<base href="$CONSOLE_BASE_HREF"';
+        sub_filter_once on;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /rw.mount/www;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8908

## Description

Made use of IPv6 optional, so that Docker image can be run in IPv4-only environment.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tihcchxplf.chromatic.com)
<!-- Storybook placeholder end -->
