### PR TITLE
chore: bump version of jwt policy to 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <gravitee-policy-json-validation.version>2.0.2</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.6.1</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>6.0.0</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>6.1.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8921

## Description

Bump the version of the JWT to bring support for following redirects when fetching JWKS to avoid errors.



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kzwwyuiwln.chromatic.com)
<!-- Storybook placeholder end -->
