### PR TITLE
fix: jdbc - ignore category delete if categoriesIds is empty

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiCategoryOrderRepository.java
@@ -113,13 +113,19 @@ public class JdbcApiCategoryOrderRepository extends JdbcAbstractFindAllRepositor
     public void delete(String apiId, Collection<String> categoriesIds) throws TechnicalException {
         LOGGER.debug("JdbcApiCategoryRepository.delete({}, {})", apiId, categoriesIds);
         try {
-            jdbcTemplate.update(
-                "delete from " + this.tableName + " where api_id = ? and category_id in ( " + getOrm().buildInClause(categoriesIds) + " ) ",
-                (PreparedStatement ps) -> {
-                    ps.setString(1, apiId);
-                    getOrm().setArguments(ps, categoriesIds, 2);
-                }
-            );
+            if (!categoriesIds.isEmpty()) {
+                jdbcTemplate.update(
+                    "delete from " +
+                    this.tableName +
+                    " where api_id = ? and category_id in ( " +
+                    getOrm().buildInClause(categoriesIds) +
+                    " ) ",
+                    (PreparedStatement ps) -> {
+                        ps.setString(1, apiId);
+                        getOrm().setArguments(ps, categoriesIds, 2);
+                    }
+                );
+            }
         } catch (Exception e) {
             LOGGER.error("Failed to delete api category order", e);
             throw new TechnicalException("Failed to delete api category order", e);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
@@ -122,6 +122,13 @@ public class ApiCategoryOrderRepositoryTest extends AbstractManagementRepository
     }
 
     @Test
+    public void shouldDeleteWithEmptyCategoryList() throws Exception {
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId("api-4").categoryId("category-4").order(0).build();
+        apiCategoryOrderRepository.create(apiCategoryOrder);
+        apiCategoryOrderRepository.delete("api-4", List.of());
+    }
+
+    @Test
     public void shouldNotUpdateUnknownApiCategoryOrder() {
         var unknownCategory = ApiCategoryOrder.builder().categoryId("unknown").apiId("unknown").order(0).build();
         Exception exception = catchException(() -> apiCategoryOrderRepository.update(unknownCategory));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8912

## Description

With JDBC ignore category delete if categoriesIds is empty

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

