### PR TITLE
fix(console): log all API calls including unauthorized (401) requests

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -88,11 +88,7 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         ResponseStatusRangesQuery query
     ) {
         var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
-        return this.client.getFieldTypes(index, ENTRYPOINT_ID_FIELD)
-            .map(types -> types.stream().allMatch(KEYWORD::equals))
-            .flatMap(isEntrypointIdKeyword ->
-                this.client.search(index, null, SearchResponseStatusRangesQueryAdapter.adapt(query, isEntrypointIdKeyword))
-            )
+        return this.client.search(index, null, SearchResponseStatusRangesQueryAdapter.adapt(query))
             .map(SearchResponseStatusRangesResponseAdapter::adapt)
             .blockingGet();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
@@ -26,42 +26,33 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SearchResponseStatusRangesQueryAdapter {
 
-    public static final String ENTRYPOINT_ID_AGG = "entrypoint_id_agg";
     public static final String FIELD = "field";
     public static final String STATUS_RANGES = "status_ranges";
 
-    public static String adapt(ResponseStatusRangesQuery query, boolean isEntrypointIdKeyword) {
+    public static String adapt(ResponseStatusRangesQuery query) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(ResponseStatusRangesQuery.builder().build()));
         jsonContent.put("size", 0);
         jsonContent.put("query", esQuery);
-        jsonContent.put("aggs", buildResponseCountPerStatusCodeRangePerEntrypointAggregation(isEntrypointIdKeyword));
+        jsonContent.put("aggs", buildResponseCountPerStatusCodeRangePerEntrypointAggregation());
         return new JsonObject(jsonContent).encode();
     }
 
-    private static JsonObject buildResponseCountPerStatusCodeRangePerEntrypointAggregation(boolean isEntrypointIdKeyword) {
+    private static JsonObject buildResponseCountPerStatusCodeRangePerEntrypointAggregation() {
         return JsonObject.of(
-            ENTRYPOINT_ID_AGG,
+            STATUS_RANGES,
             JsonObject.of(
-                "terms",
-                JsonObject.of(FIELD, isEntrypointIdKeyword ? "entrypoint-id" : "entrypoint-id.keyword"),
-                "aggs",
+                "range",
                 JsonObject.of(
-                    STATUS_RANGES,
-                    JsonObject.of(
-                        "range",
-                        JsonObject.of(
-                            FIELD,
-                            "status",
-                            "ranges",
-                            JsonArray.of(
-                                JsonObject.of("from", 100.0, "to", 200.0),
-                                JsonObject.of("from", 200.0, "to", 300.0),
-                                JsonObject.of("from", 300.0, "to", 400.0),
-                                JsonObject.of("from", 400.0, "to", 500.0),
-                                JsonObject.of("from", 500.0, "to", 600.0)
-                            )
-                        )
+                    FIELD,
+                    "status",
+                    "ranges",
+                    JsonArray.of(
+                        JsonObject.of("from", 100.0, "to", 200.0),
+                        JsonObject.of("from", 200.0, "to", 300.0),
+                        JsonObject.of("from", 300.0, "to", 400.0),
+                        JsonObject.of("from", 400.0, "to", 500.0),
+                        JsonObject.of("from", 500.0, "to", 600.0)
                     )
                 )
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
@@ -27,55 +27,48 @@ class SearchResponseStatusRangesQueryAdapterTest {
 
     @Test
     void should_build_query() {
-        var result = SearchResponseStatusRangesQueryAdapter.adapt(ResponseStatusRangesQuery.builder().apiId("api-id").build(), true);
+        var result = SearchResponseStatusRangesQueryAdapter.adapt(ResponseStatusRangesQuery.builder().apiId("api-id").build());
 
         assertThatJson(result)
             .isEqualTo(
                 """
-                            {
-                              "size": 0,
-                              "query": {
-                                "term": {
-                                  "api-id": "api-id"
-                                }
-                              },
-                              "aggs": {
-                                "entrypoint_id_agg": {
-                                  "terms": {
-                                    "field": "entrypoint-id"
-                                  },
-                                  "aggs": {
-                                    "status_ranges": {
-                                      "range": {
-                                        "field": "status",
-                                        "ranges": [
-                                          {
-                                            "from": 100.0,
-                                            "to": 200.0
-                                          },
-                                          {
-                                            "from": 200.0,
-                                            "to": 300.0
-                                          },
-                                          {
-                                            "from": 300.0,
-                                            "to": 400.0
-                                          },
-                                          {
-                                            "from": 400.0,
-                                            "to": 500.0
-                                          },
-                                          {
-                                            "from": 500.0,
-                                            "to": 600.0
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
+                           {
+                                 "size": 0,
+                                 "query": {
+                                     "term": {
+                                         "api-id": "api-id"
+                                     }
+                                 },
+                                 "aggs": {
+                                     "status_ranges": {
+                                         "range": {
+                                             "field": "status",
+                                             "ranges": [
+                                                 {
+                                                     "from": 100.0,
+                                                     "to": 200.0
+                                                 },
+                                                 {
+                                                     "from": 200.0,
+                                                     "to": 300.0
+                                                 },
+                                                 {
+                                                     "from": 300.0,
+                                                     "to": 400.0
+                                                 },
+                                                 {
+                                                     "from": 400.0,
+                                                     "to": 500.0
+                                                 },
+                                                 {
+                                                     "from": 500.0,
+                                                     "to": 600.0
+                                                 }
+                                             ]
+                                         }
+                                     }
+                                 }
+                             }
                         """
             );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesResponseAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
 
-import static io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchResponseStatusRangesQueryAdapter.ENTRYPOINT_ID_AGG;
+import static io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchResponseStatusRangesQueryAdapter.STATUS_RANGES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,17 +54,19 @@ class SearchResponseStatusRangesResponseAdapterTest {
 
     @ParameterizedTest
     @MethodSource("provideSearchData")
-    void should_build_search_requests_count_response(String[] entrypoints) {
+    void should_build_search_requests_count_response(String[] statusRanges) {
         final SearchResponse searchResponse = new SearchResponse();
         final Aggregation aggregation = new Aggregation();
-        searchResponse.setAggregations(Map.of(ENTRYPOINT_ID_AGG, aggregation));
+        searchResponse.setAggregations(Map.of(STATUS_RANGES, aggregation));
 
-        aggregation.setBuckets(Arrays.stream(entrypoints).map(this::provideBucket).toList());
+        aggregation.setBuckets(Arrays.stream(statusRanges).map(this::provideBucket).toList());
 
         assertThat(SearchResponseStatusRangesResponseAdapter.adapt(searchResponse))
-            .hasValueSatisfying(topHits ->
-                assertThat(topHits.getStatusRangesCountByEntrypoint().keySet()).containsExactlyInAnyOrder(entrypoints)
-            );
+            .hasValueSatisfying(response -> {
+                assertThat(response.getStatusRangesCountByEntrypoint().keySet()).containsExactly("all");
+
+                assertThat(response.getStatusRangesCountByEntrypoint().get("all").keySet()).containsExactlyInAnyOrder(statusRanges);
+            });
     }
 
     private JsonNode provideBucket(String entrypoint) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7232

## Description

I have updated the query to remove aggregation based on entrypoint-id since response codes that fail at the gateway (e.g., unauthorized requests due to an incorrect API key) do not have an entrypoint-id. Previously, the query grouped results by entrypoint-id, which excluded these failures. Now, the aggregation is directly based on status_ranges, ensuring all response codes are logged, including those that fail at the gateway.

## Additional context

### Before
https://github.com/user-attachments/assets/919baec1-d657-4929-86f9-7fff04ae6bde

### After
https://github.com/user-attachments/assets/9f347f27-3449-4d70-8b30-bcf1615dc351

