### PR TITLE
ci: fix package bundle after zx upgrade [skip-ci]

### DIFF
--- a/release/ci-steps/generate-changelog.mjs
+++ b/release/ci-steps/generate-changelog.mjs
@@ -1,6 +1,9 @@
+import { syncProcessCwd } from 'zx';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
 import { getJiraIssuesOfVersion, getJiraVersion } from '../helpers/jira-helper.mjs';
 import { ChangelogSections, ComponentTypes, getTicketsFor } from '../helpers/changelog-helper.mjs';
+
+syncProcessCwd(); // restores legacy v7 behavior
 
 console.log(chalk.magenta(`#############################################`));
 console.log(chalk.magenta(`# 📰 Open APIM docs PR for new Release Note #`));

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env zx
 
 import xml2json from 'xml2json';
+import { syncProcessCwd } from 'zx';
 
+syncProcessCwd(); // restores legacy v7 behavior
 console.log(chalk.magenta(`######################################`));
 console.log(chalk.magenta(`# 📦 Prepare APIM package bundles 📦 #`));
 console.log(chalk.magenta(`######################################`));


### PR DESCRIPTION
## Description

ZX 8 has disabled by default the process cwd synchronization between $
invocations.
This commit restores the zx v7 behavior
(see https://google.github.io/zx/migration-from-v7)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

