### PR TITLE
fix: hide associations from groups for unauthorized users

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
@@ -112,71 +112,72 @@
         </div>
       </div>
     </div>
+    <div permission permission-only="'environment-group-u'">
+      <h2>Associations</h2>
+      <div class="gv-form-content" layout="column">
+        <div layout="column" style="margin-bottom: 10px">
+          <md-checkbox
+            ng-model="$ctrl.apiByDefault"
+            ng-click="$event.stopPropagation()"
+            aria-label="Associate to every new API"
+            class="md-primary md-align-top-left"
+            flex
+          >
+            Associate automatically to every new API
+          </md-checkbox>
+          <md-checkbox
+            ng-model="$ctrl.applicationByDefault"
+            aria-label="Associate to every new application"
+            class="md-primary md-align-top-left"
+            flex
+          >
+            Associate automatically to every new application
+          </md-checkbox>
+        </div>
+        <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.updateMode">
+          <md-button aria-label="Associate to existing APIs" ng-click="$ctrl.associateToApis()" class="md-actions md-raised md-primary">
+            Associate to existing APIs
+          </md-button>
 
-    <h2>Associations</h2>
-    <div class="gv-form-content" layout="column">
-      <div layout="column" style="margin-bottom: 10px">
-        <md-checkbox
-          ng-model="$ctrl.apiByDefault"
-          ng-click="$event.stopPropagation()"
-          aria-label="Associate to every new API"
-          class="md-primary md-align-top-left"
-          flex
-        >
-          Associate automatically to every new API
-        </md-checkbox>
-        <md-checkbox
-          ng-model="$ctrl.applicationByDefault"
-          aria-label="Associate to every new application"
-          class="md-primary md-align-top-left"
-          flex
-        >
-          Associate automatically to every new application
-        </md-checkbox>
+          <md-button
+            aria-label="Associate to existing applications"
+            ng-click="$ctrl.associateToApplications()"
+            class="md-actions md-raised md-primary"
+          >
+            Associate to existing applications
+          </md-button>
+        </div>
       </div>
-      <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.updateMode">
-        <md-button aria-label="Associate to existing APIs" ng-click="$ctrl.associateToApis()" class="md-actions md-raised md-primary">
-          Associate to existing APIs
-        </md-button>
 
-        <md-button
-          aria-label="Associate to existing applications"
-          ng-click="$ctrl.associateToApplications()"
-          class="md-actions md-raised md-primary"
-        >
-          Associate to existing applications
-        </md-button>
-      </div>
-    </div>
+      <h2>Actions</h2>
+      <div class="gv-form-content" layout="column">
+        <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.canSave()">
+          <md-button
+            ng-if="$ctrl.updateMode"
+            class="md-raised md-primary"
+            type="submit"
+            ng-disabled="formGroup.$invalid || formGroup.$pristine"
+            permission
+            permission-only="['environment-group-u']"
+          >
+            Update
+          </md-button>
 
-    <h2>Actions</h2>
-    <div class="gv-form-content" layout="column">
-      <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.canSave()">
-        <md-button
-          ng-if="$ctrl.updateMode"
-          class="md-raised md-primary"
-          type="submit"
-          ng-disabled="formGroup.$invalid || formGroup.$pristine"
-          permission
-          permission-only="['environment-group-u']"
-        >
-          Update
-        </md-button>
+          <md-button
+            ng-if="!$ctrl.updateMode"
+            class="md-raised md-primary"
+            type="submit"
+            ng-disabled="formGroup.$invalid || formGroup.$pristine"
+            permission
+            permission-only="['environment-group-c']"
+          >
+            Create
+          </md-button>
 
-        <md-button
-          ng-if="!$ctrl.updateMode"
-          class="md-raised md-primary"
-          type="submit"
-          ng-disabled="formGroup.$invalid || formGroup.$pristine"
-          permission
-          permission-only="['environment-group-c']"
-        >
-          Create
-        </md-button>
-
-        <md-button class="md-raised" type="button" ng-click="$ctrl.reset()" ng-disabled="formGroup.$invalid || formGroup.$pristine">
-          Reset
-        </md-button>
+          <md-button class="md-raised" type="button" ng-click="$ctrl.reset()" ng-disabled="formGroup.$invalid || formGroup.$pristine">
+            Reset
+          </md-button>
+        </div>
       </div>
     </div>
   </form>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5628

## Description

currently, the group associations box is visible in the group maintenance screen for users who are group admins but do not have the proper authorization to modify associations.


with all rights -
<img width="844" alt="with_superadmin_rights" src="https://github.com/user-attachments/assets/e52095ae-f27e-4220-8b6c-d9bfecb256ae" />

with group admin rights only -
<img width="797" alt="with_groupAdmin_rightsOnly" src="https://github.com/user-attachments/assets/cbcf756e-7d9c-4d44-94e6-f53e733fe887" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oxareypnti.chromatic.com)
<!-- Storybook placeholder end -->
