### PR TITLE
fix(portal): wrap long strings in Table of Contents to prevent floating

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -53,6 +53,12 @@
   overflow-wrap: break-word;
   white-space: pre-wrap;
 }
+:host ::ng-deep .toc-link {
+  display: block !important;
+  max-width: 100% !important;
+  white-space: normal !important;
+  word-break: break-word !important;
+}
 
 app-gv-markdown-toc {
   position: fixed;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8433

## Description

fixed long strings in Table of Contents to wrao

## Additional context
### Before
<img width="1716" alt="Screenshot 2025-03-04 at 8 53 26 PM" src="https://github.com/user-attachments/assets/a9914e4e-2e82-4c96-bb7b-cc1c8537374c" />

### After
<img width="1716" alt="Screenshot 2025-03-04 at 8 53 04 PM" src="https://github.com/user-attachments/assets/3f232106-29fa-438a-b99a-a8515be25422" />
