### PR TITLE
chore(deps): bump Regex Threat Protection to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <!--    <gravitee-policy-quota.version>2.1.1</gravitee-policy-quota.version>    -->
         <!--    <gravitee-policy-spikearrest.version>2.1.1</gravitee-policy-spikearrest.version>    -->
         <gravitee-policy-ratelimit.version>2.1.3</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.5.0</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-regex-threat-protection.version>1.6.0</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.1</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.15.1</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.10.0</gravitee-policy-resource-filtering.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8219

## Description

Upgrade Regex Threat Protection version to 1.6.0.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wvahuzbkte.chromatic.com)
<!-- Storybook placeholder end -->
