### PR TITLE
fix(console): log all API calls including unauthorized (401) requests

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
@@ -29,6 +29,7 @@ public class SearchResponseStatusRangesQueryAdapter {
     public static final String ENTRYPOINT_ID_AGG = "entrypoint_id_agg";
     public static final String FIELD = "field";
     public static final String STATUS_RANGES = "status_ranges";
+    public static final String ALL_APIS_STATUS_RANGES = "all_apis_status_ranges";
 
     public static String adapt(ResponseStatusRangesQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
@@ -62,6 +63,22 @@ public class SearchResponseStatusRangesQueryAdapter {
                                 JsonObject.of("from", 500.0, "to", 600.0)
                             )
                         )
+                    )
+                )
+            ),
+            ALL_APIS_STATUS_RANGES,
+            JsonObject.of(
+                "range",
+                JsonObject.of(
+                    FIELD,
+                    "status",
+                    "ranges",
+                    JsonArray.of(
+                        JsonObject.of("from", 100.0, "to", 200.0),
+                        JsonObject.of("from", 200.0, "to", 300.0),
+                        JsonObject.of("from", 300.0, "to", 400.0),
+                        JsonObject.of("from", 400.0, "to", 500.0),
+                        JsonObject.of("from", 500.0, "to", 600.0)
                     )
                 )
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
@@ -73,10 +73,37 @@ class SearchResponseStatusRangesQueryAdapterTest {
                                       }
                                     }
                                   }
+                                },
+                                 "all_apis_status_ranges": {
+                                    "range": {
+                                        "field": "status",
+                                        "ranges": [
+                                        {
+                                            "from": 100.0,
+                                            "to": 200.0
+                                        },
+                                        {
+                                            "from": 200.0,
+                                            "to": 300.0
+                                        },
+                                        {
+                                            "from": 300.0,
+                                            "to": 400.0
+                                        },
+                                        {
+                                            "from": 400.0,
+                                            "to": 500.0
+                                        },
+                                        {
+                                            "from": 500.0,
+                                            "to": 600.0
+                                        }
+                                    ]
                                 }
-                              }
                             }
-                        """
+                           }
+                         }
+                    """
             );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7232

## Description

I have updated the query to remove aggregation based on entrypoint-id since response codes that fail at the gateway (e.g., unauthorized requests due to an incorrect API key) do not have an entrypoint-id. Previously, the query grouped results by entrypoint-id, which excluded these failures. Now, the aggregation is directly based on status_ranges, ensuring all response codes are logged, including those that fail at the gateway.

## Additional context

### Before
https://github.com/user-attachments/assets/919baec1-d657-4929-86f9-7fff04ae6bde

### After
https://github.com/user-attachments/assets/9f347f27-3449-4d70-8b30-bcf1615dc351

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sathgvoqow.chromatic.com)
<!-- Storybook placeholder end -->
