### PR TITLE
Bump some java dependencies to major version

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
@@ -35,7 +35,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -33,8 +33,8 @@
     <properties>
         <!-- Dependencies version -->
         <HikariCP.version>5.1.0</HikariCP.version>
-        <liquibase.version>4.21.1</liquibase.version>
-        <liquibase-slf4j.version>4.1.0</liquibase-slf4j.version>
+        <liquibase.version>4.27.0</liquibase.version>
+        <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
         <mariaDB.version>2.7.12</mariaDB.version>
         <mssql-jdbc.version>9.4.1.jre16</mssql-jdbc.version>
         <mysql-connector-j.version>8.4.0</mysql-connector-j.version>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <!-- Dependencies version -->
-        <HikariCP.version>5.1.0</HikariCP.version>
+        <HikariCP.version>6.2.1</HikariCP.version>
         <liquibase.version>4.27.0</liquibase.version>
         <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
         <mariaDB.version>3.5.2</mariaDB.version>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -35,9 +35,9 @@
         <HikariCP.version>5.1.0</HikariCP.version>
         <liquibase.version>4.27.0</liquibase.version>
         <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
-        <mariaDB.version>2.7.12</mariaDB.version>
-        <mssql-jdbc.version>9.4.1.jre16</mssql-jdbc.version>
-        <mysql-connector-j.version>8.4.0</mysql-connector-j.version>
+        <mariaDB.version>3.5.2</mariaDB.version>
+        <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
+        <mysql-connector-j.version>9.2.0</mysql-connector-j.version>
         <postgresql.version>42.7.5</postgresql.version>
 
         <!-- Plugin configuration -->

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -53,6 +53,7 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
     private static final long DEFAULT_MAX_LIFETIME = 1800000;
     private static final int DEFAULT_MIN_IDLE = 10;
     private static final int DEFAULT_MAX_POOL_SIZE = 10;
+    private static final int DEFAULT_KEEPALIVE_TIME = 0;
     private static final boolean DEFAULT_REGISTER_MBEANS = true;
     private static final boolean LIQUIBASE_ENABLED = true;
 
@@ -149,6 +150,7 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
         dsConfig.setMaxLifetime(readPropertyValue("jdbc.pool.maxLifetime", Long.class, DEFAULT_MAX_LIFETIME));
         dsConfig.setMinimumIdle(readPropertyValue("jdbc.pool.minIdle", Integer.class, DEFAULT_MIN_IDLE));
         dsConfig.setMaximumPoolSize(readPropertyValue("jdbc.pool.maxPoolSize", Integer.class, DEFAULT_MAX_POOL_SIZE));
+        dsConfig.setKeepaliveTime(readPropertyValue("jdbc.pool.keepaliveTime", Integer.class, DEFAULT_KEEPALIVE_TIME));
         dsConfig.setRegisterMbeans(readPropertyValue("jdbc.pool.registerMbeans", Boolean.class, DEFAULT_REGISTER_MBEANS));
 
         final DataSource dataSource = new HikariDataSource(dsConfig);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
@@ -309,6 +309,13 @@ public class JdbcObjectMapper<T> {
         } else if (column.javaType == InputStream.class) {
             byte[] data = (byte[]) value;
             return new ByteArrayInputStream(data);
+        } else if (column.javaType == boolean.class) {
+            return switch (value) {
+                case String sValue -> Boolean.parseBoolean(sValue);
+                case Integer iValue -> iValue.equals(1);
+                case Boolean bValue -> bValue;
+                default -> false;
+            };
         }
         return value;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
@@ -81,7 +81,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -33,7 +33,7 @@
 	<name>Gravitee.io APIM - Management API - Management - v2 - Rest API</name>
 
 	<properties>
-		<openapi-generator.version>6.6.0</openapi-generator.version>
+		<openapi-generator.version>7.2.0</openapi-generator.version>
 		<openapi.modelPackage>io.gravitee.rest.api.management.v2.rest.model</openapi.modelPackage>
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		<jaxb-runtime.version>4.0.5</jaxb-runtime.version>
@@ -223,12 +223,12 @@
 					<generateModelTests>false</generateModelTests>
 					<generateModelDocumentation>false</generateModelDocumentation>
 					<generateSupportingFiles>true</generateSupportingFiles>
+                    <generateBuilders>true</generateBuilders>
 					<supportingFilesToGenerate>JSON.java,RFC3339DateFormat.java,AbstractOpenApiSchema.java,ApiException.java</supportingFilesToGenerate>
 					<reservedWordsMappings>configuration=configuration</reservedWordsMappings>
 					<configOptions>
 						<dateLibrary>java8</dateLibrary>
 						<useBeanValidation>true</useBeanValidation>
-						<additionalModelTypeAnnotations>@lombok.experimental.SuperBuilder(toBuilder = true)</additionalModelTypeAnnotations>
 					</configOptions>
 					<typeMappings>
 						<typeMapping>BigDecimal=Number</typeMapping>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -36,6 +36,7 @@
 		<openapi-generator.version>6.6.0</openapi-generator.version>
 		<openapi.modelPackage>io.gravitee.rest.api.management.v2.rest.model</openapi.modelPackage>
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+		<jaxb-runtime.version>4.0.5</jaxb-runtime.version>
 	</properties>
 
 	<dependencies>
@@ -152,7 +153,7 @@
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>2.3.9</version>
+			<version>${jaxb-runtime.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/AbstractExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/AbstractExceptionMapper.java
@@ -31,6 +31,6 @@ public abstract class AbstractExceptionMapper<T extends Throwable> implements Ex
     }
 
     protected Error convert(final Throwable t, final int status, final String technicalCode, final Map<String, String> parameters) {
-        return Error.builder().httpStatus(status).message(t.getMessage()).parameters(parameters).technicalCode(technicalCode).build();
+        return new Error().httpStatus(status).message(t.getMessage()).parameters(parameters).technicalCode(technicalCode);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapper.java
@@ -38,12 +38,7 @@ public class ConstraintValidationExceptionMapper extends AbstractExceptionMapper
     }
 
     private Object validationError(ConstraintViolationException cve) {
-        return Error
-            .builder()
-            .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
-            .message("Validation error")
-            .details(buildDetails(cve))
-            .build();
+        return new Error().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).message("Validation error").details(buildDetails(cve));
     }
 
     private List<ErrorDetailsInner> buildDetails(ConstraintViolationException exception) {
@@ -52,13 +47,11 @@ public class ConstraintValidationExceptionMapper extends AbstractExceptionMapper
             .stream()
             .map(constraintViolation -> {
                 String errorLocation = constraintViolation.getPropertyPath().toString();
-                return ErrorDetailsInner
-                    .builder()
+                return new ErrorDetailsInner()
                     .message(constraintViolation.getMessage())
                     // getPropertyPath returns a location in the form of "methodName.methodParameter.fieldNameOfTheParameter.[...]". We are not interested by the method name and parameter, so we remove them.
                     .location(errorLocation.substring(StringUtils.ordinalIndexOf(errorLocation, ".", 2) + 1))
-                    .invalidValue(JsonNullable.of(constraintViolation.getInvalidValue()))
-                    .build();
+                    .invalidValue(JsonNullable.of(constraintViolation.getInvalidValue()));
             })
             .collect(Collectors.toList());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapper.java
@@ -34,7 +34,7 @@ public class JsonMappingExceptionMapper extends AbstractExceptionMapper<JsonMapp
         return Response
             .status(Response.Status.BAD_REQUEST)
             .type(MediaType.APPLICATION_JSON_TYPE)
-            .entity(Error.builder().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).message(exception.getOriginalMessage()).build())
+            .entity(new Error().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).message(exception.getOriginalMessage()))
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/UnrecognizedPropertyExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/UnrecognizedPropertyExceptionMapper.java
@@ -35,11 +35,9 @@ public class UnrecognizedPropertyExceptionMapper extends AbstractExceptionMapper
             .type(MediaType.APPLICATION_JSON_TYPE)
             .entity(
                 Entity.json(
-                    Error
-                        .builder()
+                    new Error()
                         .message(String.format("Property [%s] is not recognized as a valid property", e.getPropertyName()))
                         .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
-                        .build()
                 )
             )
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
@@ -40,7 +40,7 @@ public class ValidationExceptionMapper extends AbstractExceptionMapper<AbstractV
     }
 
     private Error validationError(AbstractValidationException ve) {
-        return Error.builder().httpStatus(ve.getHttpStatusCode()).message(ve.getMessage()).details(buildDetails(ve)).build();
+        return new Error().httpStatus(ve.getHttpStatusCode()).message(ve.getMessage()).details(buildDetails(ve));
     }
 
     private List<ErrorDetailsInner> buildDetails(AbstractValidationException exception) {
@@ -49,12 +49,10 @@ public class ValidationExceptionMapper extends AbstractExceptionMapper<AbstractV
             .entrySet()
             .stream()
             .map(entry ->
-                ErrorDetailsInner
-                    .builder()
+                new ErrorDetailsInner()
                     .message(exception.getDetailMessage())
                     .invalidValue(JsonNullable.of(entry.getKey()))
                     .location(entry.getValue())
-                    .build()
             )
             .collect(Collectors.toList());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/AbstractDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/AbstractDomainExceptionMapper.java
@@ -26,6 +26,6 @@ public abstract class AbstractDomainExceptionMapper<T extends Throwable> impleme
     }
 
     protected Error convert(final Throwable t, final int status, final String technicalCode, final Map<String, String> parameters) {
-        return Error.builder().httpStatus(status).message(t.getMessage()).parameters(parameters).technicalCode(technicalCode).build();
+        return new Error().httpStatus(status).message(t.getMessage()).parameters(parameters).technicalCode(technicalCode);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/NotAllowedDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/NotAllowedDomainExceptionMapper.java
@@ -32,6 +32,6 @@ public class NotAllowedDomainExceptionMapper extends AbstractDomainExceptionMapp
     }
 
     private Error toError(NotAllowedDomainException notAllowedException) {
-        return Error.builder().httpStatus(Response.Status.FORBIDDEN.getStatusCode()).message(notAllowedException.getMessage()).build();
+        return new Error().httpStatus(Response.Status.FORBIDDEN.getStatusCode()).message(notAllowedException.getMessage());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/NotFoundDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/NotFoundDomainExceptionMapper.java
@@ -30,11 +30,9 @@ public class NotFoundDomainExceptionMapper extends AbstractDomainExceptionMapper
     }
 
     private Error notFoundDomainError(NotFoundDomainException nfe) {
-        return Error
-            .builder()
+        return new Error()
             .httpStatus(Response.Status.NOT_FOUND.getStatusCode())
             .message(nfe.getMessage())
-            .parameters(Map.of("id", nfe.getId()))
-            .build();
+            .parameters(Map.of("id", nfe.getId()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/TechnicalDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/TechnicalDomainExceptionMapper.java
@@ -32,6 +32,6 @@ public class TechnicalDomainExceptionMapper extends AbstractDomainExceptionMappe
     }
 
     private Error technicalDomainError(TechnicalDomainException tde) {
-        return Error.builder().httpStatus(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).message(tde.getMessage()).build();
+        return new Error().httpStatus(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()).message(tde.getMessage());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapper.java
@@ -28,11 +28,9 @@ public class ValidationDomainExceptionMapper extends AbstractDomainExceptionMapp
     }
 
     private Error validationDomainError(ValidationDomainException vde) {
-        return Error
-            .builder()
+        return new Error()
             .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
             .message(vde.getMessage())
-            .parameters(vde.getParameters())
-            .build();
+            .parameters(vde.getParameters());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EntrypointMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EntrypointMapper.java
@@ -33,6 +33,7 @@ public interface EntrypointMapper {
     @Mapping(target = "configuration", qualifiedByName = "serializeConfiguration")
     io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint mapToNativeV4(Entrypoint entrypoint);
 
+    @Mapping(target = "qos", expression = "java(null)")
     @Mapping(target = "configuration", qualifiedByName = "deserializeConfiguration")
     Entrypoint mapFromNativeV4(io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint entrypoint);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
@@ -58,8 +58,7 @@ public interface IntegrationMapper {
     AsyncJobStatus map(AsyncJob.Status source);
 
     static IngestionPreviewResponse mapper(DiscoveryUseCase.Output preview) {
-        return IngestionPreviewResponse
-            .builder()
+        return new IngestionPreviewResponse()
             .totalCount(preview.apis().size())
             .newCount(preview.apis().stream().filter(api -> api.state() == NEW).count())
             .updateCount(preview.apis().stream().filter(api -> api.state() == UPDATE).count())
@@ -79,7 +78,6 @@ public interface IntegrationMapper {
                             )
                     )
                     .toList()
-            )
-            .build();
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMetadataResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMetadataResource.java
@@ -59,11 +59,9 @@ public class ApiMetadataResource extends AbstractResource {
         return Response
             .ok()
             .entity(
-                MetadataResponse
-                    .builder()
+                new MetadataResponse()
                     .data(MetadataMapper.INSTANCE.mapFromCore(paginationData))
                     .pagination(PaginationInfo.computePaginationInfo(output.metadata().size(), paginationData.size(), paginationParam))
-                    .build()
             )
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -463,9 +463,9 @@ public class ApiResource extends AbstractResource {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         try {
             apiLicenseService.checkLicense(executionContext, apiId);
-            return Response.ok(VerifyApiDeploymentResponse.builder().ok(true).build()).build();
+            return Response.ok(new VerifyApiDeploymentResponse().ok(true)).build();
         } catch (ForbiddenFeatureException | InvalidLicenseException | TechnicalManagementException e) {
-            return Response.ok(VerifyApiDeploymentResponse.builder().ok(false).reason(e.getMessage()).build()).build();
+            return Response.ok(new VerifyApiDeploymentResponse().ok(false).reason(e.getMessage())).build();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -294,7 +294,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             apiId,
             verifySubscriptionSubscription.getApplicationId()
         );
-        return Response.ok(VerifySubscriptionResponse.builder().ok(canCreate).build()).build();
+        return Response.ok(new VerifySubscriptionResponse().ok(canCreate)).build();
     }
 
     private Page<SubscriptionEntity> getSubscriptionEntityPage(
@@ -314,14 +314,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .apiKey(apiKey)
             .build();
 
-        final Page<SubscriptionEntity> subscriptionPage = subscriptionService.search(
-            executionContext,
-            subscriptionQuery,
-            paginationParam.toPageable(),
-            false,
-            false
-        );
-        return subscriptionPage;
+        return subscriptionService.search(executionContext, subscriptionQuery, paginationParam.toPageable(), false, false);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -423,9 +423,9 @@ public class ApisResource extends AbstractResource {
                 )
             );
 
-            return Response.accepted(VerifyApiPathsResponse.builder().ok(true).build()).build();
+            return Response.accepted(new VerifyApiPathsResponse().ok(true)).build();
         } catch (InvalidPathsException e) {
-            return Response.accepted(VerifyApiPathsResponse.builder().ok(false).reason(e.getMessage()).build()).build();
+            return Response.accepted(new VerifyApiPathsResponse().ok(false).reason(e.getMessage())).build();
         }
     }
 
@@ -445,9 +445,9 @@ public class ApisResource extends AbstractResource {
                     verifyPayload.getHosts()
                 )
             );
-            return Response.accepted(VerifyApiHostsResponse.builder().ok(true).build()).build();
+            return Response.accepted(new VerifyApiHostsResponse().ok(true)).build();
         } catch (Exception e) {
-            return Response.accepted(VerifyApiHostsResponse.builder().ok(false).reason(e.getMessage()).build()).build();
+            return Response.accepted(new VerifyApiHostsResponse().ok(false).reason(e.getMessage())).build();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/audit/ApiAuditsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/audit/ApiAuditsResource.java
@@ -62,12 +62,10 @@ public class ApiAuditsResource extends AbstractResource {
 
         var output = searchApiAuditUseCase.execute(input);
 
-        return AuditsResponse
-            .builder()
+        return new AuditsResponse()
             .data(ApiAuditMapper.INSTANCE.map(output.data(), output.metadata()))
             .pagination(computePaginationInfo(output.total(), output.data().size(), paginationParam))
-            .links(computePaginationLinks(output.total(), paginationParam))
-            .build();
+            .links(computePaginationLinks(output.total(), paginationParam));
     }
 
     @GET
@@ -75,7 +73,7 @@ public class ApiAuditsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_AUDIT, acls = { RolePermissionAction.READ }) })
     public AuditEventsResponse listAllApiAuditEvent() {
-        return AuditEventsResponse.builder().data(auditEventQueryService.listAllApiAuditEvents()).build();
+        return new AuditEventsResponse().data(auditEventQueryService.listAllApiAuditEvents());
     }
 
     @NotNull

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResource.java
@@ -62,12 +62,10 @@ public class ApiEventsResource extends AbstractResource {
 
         var output = searchEventsUseCase.execute(input);
 
-        return EventsResponse
-            .builder()
+        return new EventsResponse()
             .data(ApiEventMapper.INSTANCE.map(output.data()))
             .pagination(computePaginationInfo(output.total(), output.data().size(), paginationParam))
-            .links(computePaginationLinks(output.total(), paginationParam))
-            .build();
+            .links(computePaginationLinks(output.total(), paginationParam));
     }
 
     @NotNull

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
@@ -70,12 +70,10 @@ public class ApiLogsResource extends AbstractResource {
 
         var response = searchConnectionLogsUsecase.execute(GraviteeContext.getExecutionContext(), request);
 
-        return ApiLogsResponse
-            .builder()
+        return new ApiLogsResponse()
             .data(ApiLogsMapper.INSTANCE.mapToList(response.data()))
             .pagination(computePaginationInfo(response.total(), response.data().size(), paginationParam))
-            .links(computePaginationLinks(response.total(), paginationParam))
-            .build();
+            .links(computePaginationLinks(response.total(), paginationParam));
     }
 
     @Path("/{requestId}/messages")
@@ -94,12 +92,10 @@ public class ApiLogsResource extends AbstractResource {
 
         var response = searchMessageLogsUsecase.execute(GraviteeContext.getExecutionContext(), request);
 
-        return ApiMessageLogsResponse
-            .builder()
+        return new ApiMessageLogsResponse()
             .data(ApiMessageLogsMapper.INSTANCE.mapToList(response.data()))
             .pagination(computePaginationInfo(response.total(), response.data().size(), paginationParam))
-            .links(computePaginationLinks(response.total(), paginationParam))
-            .build();
+            .links(computePaginationLinks(response.total(), paginationParam));
     }
 
     @Path("/{requestId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
@@ -50,7 +50,7 @@ public class ApiScoringResource extends AbstractResource {
         scoreApiRequestUseCase
             .execute(new ScoreApiRequestUseCase.Input(apiId, getAuditInfo()))
             .subscribe(
-                () -> response.resume(Response.accepted(ApiScoringTriggerResponse.builder().status(ScoringStatus.PENDING).build()).build()),
+                () -> response.resume(Response.accepted(new ApiScoringTriggerResponse().status(ScoringStatus.PENDING)).build()),
                 response::resume
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApisResource.java
@@ -70,11 +70,9 @@ public class CategoryApisResource extends AbstractResource {
         return Response
             .ok()
             .entity(
-                CategoryApisResponse
-                    .builder()
+                new CategoryApisResponse()
                     .data(paginationData)
                     .pagination(PaginationInfo.computePaginationInfo(output.results().size(), paginationData.size(), paginationParam))
-                    .build()
             )
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResource.java
@@ -93,11 +93,11 @@ public class ApiPagesResource extends AbstractResource {
     public Response getApiPages(@PathParam("apiId") String apiId, @QueryParam("parentId") String parentId) {
         final var mapper = Mappers.getMapper(PageMapper.class);
         var result = apiGetDocumentationPagesUsecase.execute(new ApiGetDocumentationPagesUseCase.Input(apiId, parentId));
-        var response = ApiDocumentationPagesResponse.builder().pages(mapper.mapPageList(result.pages()));
+        var response = new ApiDocumentationPagesResponse().pages(mapper.mapPageList(result.pages()));
         if (!StringUtils.isEmpty(parentId)) {
             response.breadcrumb(mapper.map(result.breadcrumbList()));
         }
-        return Response.ok(response.build()).build();
+        return Response.ok(response).build();
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
@@ -84,7 +84,7 @@ public class EnvironmentAnalyticsResource {
             .execute(input)
             .responseStatusRanges()
             .map(EnvironmentAnalyticsMapper.INSTANCE::map)
-            .orElse(EnvironmentAnalyticsResponseStatusRangesResponse.builder().ranges(Map.of()).build());
+            .orElse(new EnvironmentAnalyticsResponseStatusRangesResponse().ranges(Map.of()));
     }
 
     @Path("/top-hits")
@@ -97,7 +97,7 @@ public class EnvironmentAnalyticsResource {
         var topHitsApis = searchEnvironmentTopHitsApisCountUseCase.execute(input).topHitsApis();
 
         if (topHitsApis == null) {
-            return EnvironmentAnalyticsTopHitsApisResponse.builder().build();
+            return new EnvironmentAnalyticsTopHitsApisResponse();
         }
 
         return EnvironmentAnalyticsMapper.INSTANCE.map(topHitsApis);
@@ -114,7 +114,7 @@ public class EnvironmentAnalyticsResource {
             .execute(input)
             .requestResponseTime()
             .map(EnvironmentAnalyticsMapper.INSTANCE::map)
-            .orElse(EnvironmentAnalyticsRequestResponseTimeResponse.builder().build());
+            .orElse(new EnvironmentAnalyticsRequestResponseTimeResponse());
     }
 
     @Path("/response-time-over-time")
@@ -175,7 +175,7 @@ public class EnvironmentAnalyticsResource {
         var topHitsApps = searchEnvironmentTopAppsByRequestCountUseCase.execute(input).topHitsApps();
 
         if (topHitsApps == null) {
-            return EnvironmentAnalyticsTopAppsByRequestCountResponse.builder().build();
+            return new EnvironmentAnalyticsTopAppsByRequestCountResponse();
         }
 
         return EnvironmentAnalyticsMapper.INSTANCE.map(topHitsApps);
@@ -192,7 +192,7 @@ public class EnvironmentAnalyticsResource {
         var topFailedApis = searchEnvironmentTopFailedApisUseCase.execute(input).topFailedApis();
 
         if (topFailedApis == null) {
-            return EnvironmentAnalyticsTopFailedApisResponse.builder().build();
+            return new EnvironmentAnalyticsTopFailedApisResponse();
         }
 
         return EnvironmentAnalyticsMapper.INSTANCE.map(topFailedApis);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringFunctionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringFunctionsResource.java
@@ -70,7 +70,7 @@ public class EnvironmentScoringFunctionsResource extends AbstractResource {
     public ScoringFunctionsResponse listFunctions() {
         var executionContext = GraviteeContext.getExecutionContext();
         var result = getEnvironmentFunctionsUseCase.execute(new GetEnvironmentFunctionsUseCase.Input(executionContext.getEnvironmentId()));
-        return ScoringFunctionsResponse.builder().data(result.reports().stream().map(ScoringFunctionMapper.INSTANCE::map).toList()).build();
+        return new ScoringFunctionsResponse().data(result.reports().stream().map(ScoringFunctionMapper.INSTANCE::map).toList());
     }
 
     @Path("{functionName}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
@@ -70,12 +70,10 @@ public class EnvironmentScoringResource extends AbstractResource {
 
         var page = result.reports();
         var totalElements = page.getTotalElements();
-        return EnvironmentApisScoringResponse
-            .builder()
+        return new EnvironmentApisScoringResponse()
             .data(page.getContent().stream().map(r -> ScoringReportMapper.INSTANCE.map(r, uriInfo)).toList())
             .pagination(PaginationInfo.computePaginationInfo(totalElements, Math.toIntExact(page.getPageElements()), paginationParam))
-            .links(computePaginationLinks(totalElements, paginationParam))
-            .build();
+            .links(computePaginationLinks(totalElements, paginationParam));
     }
 
     @Path("overview")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
@@ -75,7 +75,7 @@ public class EnvironmentScoringRulesetsResource extends AbstractResource {
     public ScoringRulesetsResponse listRulesets() {
         var executionContext = GraviteeContext.getExecutionContext();
         var result = getEnvironmentRulesetsUseCase.execute(new GetEnvironmentRulesetsUseCase.Input(executionContext.getEnvironmentId()));
-        return ScoringRulesetsResponse.builder().data(result.reports().stream().map(ScoringRulesetMapper.INSTANCE::map).toList()).build();
+        return new ScoringRulesetsResponse().data(result.reports().stream().map(ScoringRulesetMapper.INSTANCE::map).toList());
     }
 
     @Path("{rulesetId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
@@ -150,10 +150,7 @@ public class IntegrationResource extends AbstractResource {
 
         startIngestIntegrationApisUseCase
             .execute(new StartIngestIntegrationApisUseCase.Input(integrationId, apisIngest.getApiIds(), audit))
-            .subscribe(
-                status -> response.resume(IntegrationIngestionResponse.builder().status(AsyncJobStatus.PENDING).build()),
-                response::resume
-            );
+            .subscribe(status -> response.resume(new IntegrationIngestionResponse().status(AsyncJobStatus.PENDING)), response::resume);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinksResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinksResource.java
@@ -71,12 +71,10 @@ public class PortalMenuLinksResource extends AbstractResource {
 
         return Response
             .ok(
-                PortalMenuLinksResponse
-                    .builder()
+                new PortalMenuLinksResponse()
                     .data(mapper.map(portalMenuLinksSubset))
                     .pagination(PaginationInfo.computePaginationInfo(portalMenuLinks.size(), portalMenuLinksSubset.size(), paginationParam))
                     .links(computePaginationLinks(portalMenuLinks.size(), paginationParam))
-                    .build()
             )
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
@@ -80,14 +80,12 @@ public class ThemesResource extends AbstractResource {
             .result();
         return Response
             .ok(
-                ThemesResponse
-                    .builder()
+                new ThemesResponse()
                     .data(ThemeMapper.INSTANCE.map(result.getContent()))
                     .pagination(
                         PaginationInfo.computePaginationInfo(result.getTotalElements(), (int) result.getPageElements(), paginationParam)
                     )
                     .links(computePaginationLinks(result.getTotalElements(), paginationParam))
-                    .build()
             )
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ApiFixtures.java
@@ -41,135 +41,134 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class ApiFixtures {
 
     private ApiFixtures() {}
 
-    private static final DefinitionContext.DefinitionContextBuilder BASE_DEFINITION_CONTEXT = DefinitionContext
-        .builder()
-        .origin(DefinitionContext.OriginEnum.MANAGEMENT)
-        .mode(DefinitionContext.ModeEnum.FULLY_MANAGED);
+    private static final Supplier<DefinitionContext> BASE_DEFINITION_CONTEXT = () ->
+        new DefinitionContext().origin(DefinitionContext.OriginEnum.MANAGEMENT).mode(DefinitionContext.ModeEnum.FULLY_MANAGED);
 
-    private static final ApiV4.ApiV4Builder BASE_API_V4 = ApiV4
-        .builder()
-        // BaseApi fields
-        .id("my-api")
-        .crossId("my-cross-id")
-        .name("my-name")
-        .description("my-description")
-        .apiVersion("v1.0")
-        .definitionVersion(DefinitionVersion.V4)
-        .deployedAt(OffsetDateTime.now())
-        .createdAt(OffsetDateTime.now())
-        .updatedAt(OffsetDateTime.now())
-        .disableMembershipNotifications(true)
-        .groups(List.of("my-group1", "my-group2"))
-        .state(GenericApi.StateEnum.STARTED)
-        .visibility(Visibility.PUBLIC)
-        .labels(List.of("my-label1", "my-label2"))
-        .lifecycleState(ApiLifecycleState.CREATED)
-        .tags(List.of("my-tag1", "my-tag2"))
-        .primaryOwner(PrimaryOwnerFixtures.aPrimaryOwner())
-        .categories(List.of("my-category1", "my-category2"))
-        .definitionContext(BASE_DEFINITION_CONTEXT.build())
-        .workflowState(ApiWorkflowState.REVIEW_OK)
-        .responseTemplates(Map.of("key", new HashMap<>()))
-        .resources(List.of(ResourceFixtures.aResource()))
-        .properties(List.of(PropertyFixtures.aProperty()))
-        // ApiV4 specific
-        .type(ApiType.PROXY)
-        .listeners(
-            List.of(
-                new Listener(ListenerFixtures.aHttpListener()),
-                new Listener(ListenerFixtures.aSubscriptionListener()),
-                new Listener(ListenerFixtures.aTcpListener())
+    private static final Supplier<ApiV4> BASE_API_V4 = () ->
+        (ApiV4) new ApiV4()
+            // ApiV4 specific
+            .type(ApiType.PROXY)
+            .listeners(
+                List.of(
+                    new Listener(ListenerFixtures.aHttpListener()),
+                    new Listener(ListenerFixtures.aSubscriptionListener()),
+                    new Listener(ListenerFixtures.aTcpListener())
+                )
             )
-        )
-        .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()))
-        .services(new ApiServices())
-        .analytics(new Analytics())
-        .flows(List.of(FlowFixtures.aFlowHttpV4()));
+            .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()))
+            .services(new ApiServices())
+            .analytics(new Analytics())
+            .flows(List.of(FlowFixtures.aFlowHttpV4()))
+            // BaseApi fields
+            .id("my-api")
+            .crossId("my-cross-id")
+            .name("my-name")
+            .description("my-description")
+            .apiVersion("v1.0")
+            .definitionVersion(DefinitionVersion.V4)
+            .deployedAt(OffsetDateTime.now())
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .disableMembershipNotifications(true)
+            .groups(List.of("my-group1", "my-group2"))
+            .state(GenericApi.StateEnum.STARTED)
+            .visibility(Visibility.PUBLIC)
+            .labels(List.of("my-label1", "my-label2"))
+            .lifecycleState(ApiLifecycleState.CREATED)
+            .tags(List.of("my-tag1", "my-tag2"))
+            .primaryOwner(PrimaryOwnerFixtures.aPrimaryOwner())
+            .categories(List.of("my-category1", "my-category2"))
+            .definitionContext(BASE_DEFINITION_CONTEXT.get())
+            .workflowState(ApiWorkflowState.REVIEW_OK)
+            .responseTemplates(Map.of("key", new HashMap<>()))
+            .resources(List.of(ResourceFixtures.aResource()))
+            .properties(List.of(PropertyFixtures.aProperty()));
 
-    private static final UpdateApiV2.UpdateApiV2Builder BASE_UPDATE_API_V2 = UpdateApiV2
-        .builder()
-        .apiVersion("v1")
-        .definitionVersion(DefinitionVersion.V2)
-        .name("api-name")
-        .description("api-description")
-        .visibility(Visibility.PUBLIC)
-        .executionMode(ExecutionMode.V4_EMULATION_ENGINE)
-        .proxy(new Proxy())
-        .flowMode(FlowMode.DEFAULT)
-        .flows(List.of(FlowFixtures.aFlowV2()))
-        .pathMappings(List.of("path-mapping1", "path-mapping2"))
-        .tags(List.of("my-tag1", "my-tag2"))
-        .resources(List.of(ResourceFixtures.aResource()))
-        .responseTemplates(Map.of("key", new HashMap<>()))
-        .services(new ApiServicesV2())
-        .groups(List.of("my-group1", "my-group2"))
-        .categories(List.of("my-category1", "my-category2"))
-        .lifecycleState(ApiLifecycleState.CREATED)
-        .disableMembershipNotifications(true)
-        .executionMode(ExecutionMode.V4_EMULATION_ENGINE);
+    private static final Supplier<UpdateApiV2> BASE_UPDATE_API_V2 = () ->
+        (UpdateApiV2) new UpdateApiV2()
+            .executionMode(ExecutionMode.V4_EMULATION_ENGINE)
+            .proxy(new Proxy())
+            .flowMode(FlowMode.DEFAULT)
+            .flows(List.of(FlowFixtures.aFlowV2()))
+            .pathMappings(List.of("path-mapping1", "path-mapping2"))
+            .services(new ApiServicesV2())
+            .executionMode(ExecutionMode.V4_EMULATION_ENGINE)
+            .apiVersion("v1")
+            .definitionVersion(DefinitionVersion.V2)
+            .name("api-name")
+            .description("api-description")
+            .visibility(Visibility.PUBLIC)
+            .tags(List.of("my-tag1", "my-tag2"))
+            .resources(List.of(ResourceFixtures.aResource()))
+            .responseTemplates(Map.of("key", new HashMap<>()))
+            .groups(List.of("my-group1", "my-group2"))
+            .categories(List.of("my-category1", "my-category2"))
+            .lifecycleState(ApiLifecycleState.CREATED)
+            .disableMembershipNotifications(true);
 
-    private static final UpdateApiV4.UpdateApiV4Builder BASE_UPDATE_API_V4 = UpdateApiV4
-        .builder()
-        .apiVersion("v1")
-        .definitionVersion(DefinitionVersion.V4)
-        .type(ApiType.MESSAGE)
-        .name("api-name")
-        .description("api-description")
-        .visibility(Visibility.PUBLIC)
-        .tags(List.of("tag1", "tag2"))
-        .groups(List.of("group1", "group2"))
-        .labels(List.of("label1", "label2"))
-        .categories(List.of("category1", "category2"))
-        .analytics(new Analytics())
-        .listeners(List.of(new Listener(ListenerFixtures.aHttpListener())))
-        .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()))
-        .resources(List.of(ResourceFixtures.aResource()))
-        .properties(List.of(PropertyFixtures.aProperty()))
-        .flows(List.of(FlowFixtures.aFlowHttpV4()))
-        .services(new ApiServices())
-        .lifecycleState(ApiLifecycleState.ARCHIVED)
-        .disableMembershipNotifications(true)
-        .responseTemplates(Map.of("template-id", Map.of("application/json", new ResponseTemplate())));
+    private static final Supplier<UpdateApiV4> BASE_UPDATE_API_V4 = () ->
+        (UpdateApiV4) new UpdateApiV4()
+            .type(ApiType.MESSAGE)
+            .analytics(new Analytics())
+            .listeners(List.of(new Listener(ListenerFixtures.aHttpListener())))
+            .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()))
+            .services(new ApiServices())
+            .flows(List.of(FlowFixtures.aFlowHttpV4()))
+            .apiVersion("v1")
+            .definitionVersion(DefinitionVersion.V4)
+            .name("api-name")
+            .description("api-description")
+            .visibility(Visibility.PUBLIC)
+            .tags(List.of("tag1", "tag2"))
+            .groups(List.of("group1", "group2"))
+            .labels(List.of("label1", "label2"))
+            .categories(List.of("category1", "category2"))
+            .resources(List.of(ResourceFixtures.aResource()))
+            .properties(List.of(PropertyFixtures.aProperty()))
+            .lifecycleState(ApiLifecycleState.ARCHIVED)
+            .disableMembershipNotifications(true)
+            .responseTemplates(Map.of("template-id", Map.of("application/json", new ResponseTemplate())));
 
-    private static final UpdateApiFederated.UpdateApiFederatedBuilder BASE_UPDATE_API_FEDERATED = UpdateApiFederated
-        .builder()
-        .apiVersion("1.0.0")
-        .definitionVersion(DefinitionVersion.FEDERATED)
-        .name("api-name")
-        .description("api-description")
-        .visibility(Visibility.PRIVATE)
-        .tags(List.of("tag1", "tag2"))
-        .groups(List.of("group1", "group2"))
-        .labels(List.of("label1", "label2"))
-        .categories(List.of("category1", "category2"))
-        .resources(List.of(ResourceFixtures.aResource()))
-        .properties(List.of(PropertyFixtures.aProperty()))
-        .lifecycleState(ApiLifecycleState.CREATED);
+    private static final Supplier<UpdateApiFederated> BASE_UPDATE_API_FEDERATED = () ->
+        (UpdateApiFederated) new UpdateApiFederated()
+            .apiVersion("1.0.0")
+            .definitionVersion(DefinitionVersion.FEDERATED)
+            .name("api-name")
+            .description("api-description")
+            .visibility(Visibility.PRIVATE)
+            .tags(List.of("tag1", "tag2"))
+            .groups(List.of("group1", "group2"))
+            .labels(List.of("label1", "label2"))
+            .categories(List.of("category1", "category2"))
+            .resources(List.of(ResourceFixtures.aResource()))
+            .properties(List.of(PropertyFixtures.aProperty()))
+            .lifecycleState(ApiLifecycleState.CREATED);
 
     public static ApiV4 anApiV4() {
-        return BASE_API_V4.build();
+        return BASE_API_V4.get();
     }
 
     public static BaseApi aBaseApi() {
         final ApiV4 apiV4 = anApiV4();
-        return BaseApi.builder().id(apiV4.getId()).description(apiV4.getDescription()).name(apiV4.getName()).build();
+        return new BaseApi().id(apiV4.getId()).description(apiV4.getDescription()).name(apiV4.getName());
     }
 
     public static UpdateApiV4 anUpdateApiV4() {
-        return BASE_UPDATE_API_V4.build();
+        return BASE_UPDATE_API_V4.get();
     }
 
     public static UpdateApiV2 anUpdateApiV2() {
-        return BASE_UPDATE_API_V2.build();
+        return BASE_UPDATE_API_V2.get();
     }
 
     public static UpdateApiFederated anUpdateApiFederated() {
-        return BASE_UPDATE_API_FEDERATED.build();
+        return BASE_UPDATE_API_FEDERATED.get();
     }
 
     public static io.gravitee.rest.api.model.api.ApiEntity aModelApiV1() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/CorsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/CorsFixtures.java
@@ -17,29 +17,29 @@ package fixtures;
 
 import io.gravitee.rest.api.management.v2.rest.model.Cors;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@SuppressWarnings("ALL")
 public class CorsFixtures {
 
     private CorsFixtures() {}
 
-    private static final Cors.CorsBuilder BASE_CORS = Cors
-        .builder()
-        .allowCredentials(true)
-        .allowHeaders(Set.of("header1", "header2"))
-        .allowMethods(Set.of("method1", "method2"))
-        .allowOrigin(Set.of("origin1", "origin2"))
-        .enabled(true)
-        .exposeHeaders(Set.of("exposeHeader1", "exposeHeader2"))
-        .maxAge(10)
-        .runPolicies(true);
+    private static final Supplier<Cors> BASE_CORS = () ->
+        new Cors()
+            .allowCredentials(true)
+            .allowHeaders(Set.of("header1", "header2"))
+            .allowMethods(Set.of("method1", "method2"))
+            .allowOrigin(Set.of("origin1", "origin2"))
+            .enabled(true)
+            .exposeHeaders(Set.of("exposeHeader1", "exposeHeader2"))
+            .maxAge(10)
+            .runPolicies(true);
 
     public static Cors aCors() {
-        return BASE_CORS.build();
+        return BASE_CORS.get();
     }
 
     public static io.gravitee.definition.model.Cors aModelCors() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EndpointFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EndpointFixtures.java
@@ -34,74 +34,67 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class EndpointFixtures {
 
     private EndpointFixtures() {}
 
-    private static final HttpEndpointV2.HttpEndpointV2Builder BASE_HTTP_ENDPOINT_V2 = HttpEndpointV2
-        .builder()
-        .name("Endpoint name")
-        .target("http://gravitee.io")
-        .weight(1)
-        .backup(false)
-        .status(EndpointStatus.UP)
-        .tenants(List.of("tenant1", "tenant2"))
-        .type("http")
-        .inherit(true)
-        .healthCheck(EndpointHealthCheckService.builder().build())
-        .headers(Collections.emptyList())
-        .httpProxy(null)
-        .httpClientOptions(null)
-        .httpClientSslOptions(null);
-    private static final EndpointGroupServicesV2.EndpointGroupServicesV2Builder BASE_SERVICES_V2 = EndpointGroupServicesV2
-        .builder()
-        .discovery(null);
+    private static final Supplier<HttpEndpointV2> BASE_HTTP_ENDPOINT_V2 = () ->
+        new HttpEndpointV2()
+            .name("Endpoint name")
+            .target("http://gravitee.io")
+            .weight(1)
+            .backup(false)
+            .status(EndpointStatus.UP)
+            .tenants(List.of("tenant1", "tenant2"))
+            .type("http")
+            .inherit(true)
+            .healthCheck(new EndpointHealthCheckService())
+            .headers(Collections.emptyList())
+            .httpProxy(null)
+            .httpClientOptions(null)
+            .httpClientSslOptions(null);
+    private static final Supplier<EndpointGroupServicesV2> BASE_SERVICES_V2 = EndpointGroupServicesV2::new;
 
-    private static final EndpointGroupV2.EndpointGroupV2Builder BASE_ENDPOINTGROUP_V2 = EndpointGroupV2
-        .builder()
-        .name("Endpoint group name")
-        .endpoints(List.of(new EndpointV2(BASE_HTTP_ENDPOINT_V2.build())))
-        .loadBalancer(LoadBalancer.builder().type(LoadBalancer.TypeEnum.ROUND_ROBIN).build())
-        .services(BASE_SERVICES_V2.build())
-        .httpProxy(null)
-        .httpClientOptions(null)
-        .httpClientSslOptions(null);
+    private static final Supplier<EndpointGroupV2> BASE_ENDPOINTGROUP_V2 = () ->
+        new EndpointGroupV2()
+            .name("Endpoint group name")
+            .endpoints(List.of(new EndpointV2(BASE_HTTP_ENDPOINT_V2.get())))
+            .loadBalancer(new LoadBalancer().type(LoadBalancer.TypeEnum.ROUND_ROBIN))
+            .services(BASE_SERVICES_V2.get())
+            .httpProxy(null)
+            .httpClientOptions(null)
+            .httpClientSslOptions(null);
 
-    private static final EndpointGroupServices.EndpointGroupServicesBuilder BASE_ENDPOINTGROUP_SERVICES_V4 = EndpointGroupServices
-        .builder()
-        .discovery(null)
-        .healthCheck(null);
+    private static final Supplier<EndpointGroupServices> BASE_ENDPOINTGROUP_SERVICES_V4 = EndpointGroupServices::new;
 
-    private static final EndpointV4.EndpointV4Builder BASE_ENDPOINT_V4 = EndpointV4
-        .builder()
-        .name("Endpoint name")
-        .type("http-get")
-        .weight(1)
-        .inheritConfiguration(false)
-        .secondary(false)
-        .tenants(List.of("tenant1", "tenant2"))
-        .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")))
-        .sharedConfigurationOverride(new LinkedHashMap<>(Map.of("nice", "configuration")))
-        .services(EndpointServices.builder().healthCheck(null).build());
+    private static final Supplier<EndpointV4> BASE_ENDPOINT_V4 = () ->
+        new EndpointV4()
+            .name("Endpoint name")
+            .type("http-get")
+            .weight(1)
+            .inheritConfiguration(false)
+            .secondary(false)
+            .tenants(List.of("tenant1", "tenant2"))
+            .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")))
+            .sharedConfigurationOverride(new LinkedHashMap<>(Map.of("nice", "configuration")))
+            .services(new EndpointServices());
 
-    private static final EndpointGroupV4.EndpointGroupV4Builder BASE_ENDPOINTGROUP_V4 = EndpointGroupV4
-        .builder()
-        .name("Endpoint group name")
-        .type("http-get")
-        .loadBalancer(LoadBalancer.builder().type(LoadBalancer.TypeEnum.ROUND_ROBIN).build())
-        .sharedConfiguration(new LinkedHashMap<>(Map.of("nice", "configuration")))
-        .endpoints(List.of(BASE_ENDPOINT_V4.build()))
-        .services(BASE_ENDPOINTGROUP_SERVICES_V4.build());
+    private static final Supplier<EndpointGroupV4> BASE_ENDPOINTGROUP_V4 = () ->
+        new EndpointGroupV4()
+            .name("Endpoint group name")
+            .type("http-get")
+            .loadBalancer(new LoadBalancer().type(LoadBalancer.TypeEnum.ROUND_ROBIN))
+            .sharedConfiguration(new LinkedHashMap<>(Map.of("nice", "configuration")))
+            .endpoints(List.of(BASE_ENDPOINT_V4.get()))
+            .services(BASE_ENDPOINTGROUP_SERVICES_V4.get());
 
-    private static final EndpointHealthCheckService.EndpointHealthCheckServiceBuilder BASE_HEALTH_CHECK_SERVICE = EndpointHealthCheckService
-        .builder()
-        .enabled(true)
-        .schedule("0 */5 * * * *");
+    private static final Supplier<EndpointHealthCheckService> BASE_HEALTH_CHECK_SERVICE = () ->
+        new EndpointHealthCheckService().enabled(true).schedule("0 */5 * * * *");
 
     public static HttpEndpointV2 anHttpEndpointV2() {
-        return BASE_HTTP_ENDPOINT_V2.build();
+        return BASE_HTTP_ENDPOINT_V2.get();
     }
 
     public static EndpointV2 anEndpointV2() {
@@ -109,15 +102,15 @@ public class EndpointFixtures {
     }
 
     public static EndpointGroupV2 anEndpointGroupV2() {
-        return BASE_ENDPOINTGROUP_V2.build();
+        return BASE_ENDPOINTGROUP_V2.get();
     }
 
     public static EndpointV4 anEndpointV4() {
-        return BASE_ENDPOINT_V4.build();
+        return BASE_ENDPOINT_V4.get();
     }
 
     public static EndpointGroupV4 anEndpointGroupV4() {
-        return BASE_ENDPOINTGROUP_V4.build();
+        return BASE_ENDPOINTGROUP_V4.get();
     }
 
     public static io.gravitee.definition.model.Endpoint aModelEndpointV2() {
@@ -145,6 +138,6 @@ public class EndpointFixtures {
     }
 
     public static EndpointHealthCheckService anEndpointHealthCheckService() {
-        return BASE_HEALTH_CHECK_SERVICE.build();
+        return BASE_HEALTH_CHECK_SERVICE.get();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EntrypointFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EntrypointFixtures.java
@@ -20,30 +20,28 @@ import io.gravitee.rest.api.management.v2.rest.model.Entrypoint;
 import io.gravitee.rest.api.management.v2.rest.model.Qos;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class EntrypointFixtures {
 
     private EntrypointFixtures() {}
 
-    private static final Entrypoint.EntrypointBuilder BASE_ENTRYPOINT_HTTP_V4 = Entrypoint
-        .builder()
-        .type("Entrypoint type")
-        .qos(Qos.AT_LEAST_ONCE)
-        .dlq(new Dlq().endpoint("my-endpoint"))
-        .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
+    private static final Supplier<Entrypoint> BASE_ENTRYPOINT_HTTP_V4 = () ->
+        new Entrypoint()
+            .type("Entrypoint type")
+            .qos(Qos.AT_LEAST_ONCE)
+            .dlq(new Dlq().endpoint("my-endpoint"))
+            .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
 
-    private static final Entrypoint.EntrypointBuilder BASE_ENTRYPOINT_NATIVE_V4 = Entrypoint
-        .builder()
-        .type("Entrypoint type")
-        .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
+    private static final Supplier<Entrypoint> BASE_ENTRYPOINT_NATIVE_V4 = () ->
+        new Entrypoint().type("Entrypoint type").configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
 
     public static Entrypoint anEntrypointHttpV4() {
-        return BASE_ENTRYPOINT_HTTP_V4.build();
+        return BASE_ENTRYPOINT_HTTP_V4.get();
     }
 
     public static Entrypoint anEntrypointNativeV4() {
-        return BASE_ENTRYPOINT_NATIVE_V4.build();
+        return BASE_ENTRYPOINT_NATIVE_V4.get();
     }
 
     public static io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint aModelEntrypointHttpV4() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/FlowFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/FlowFixtures.java
@@ -18,6 +18,7 @@ package fixtures;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.rest.api.management.v2.rest.model.BaseSelector;
+import io.gravitee.rest.api.management.v2.rest.model.ChannelSelector;
 import io.gravitee.rest.api.management.v2.rest.model.FlowV2;
 import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.model.Operator;
@@ -29,21 +30,18 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@SuppressWarnings("ALL")
 public class FlowFixtures {
 
     private FlowFixtures() {}
 
-    private static final io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.ChannelSelectorBuilder BASE_CHANNEL_SELECTOR_V4 =
-        io.gravitee.rest.api.management.v2.rest.model.ChannelSelector
-            .builder()
-            .channel("channel")
-            .type(BaseSelector.TypeEnum.CHANNEL)
+    private static final Supplier<ChannelSelector> BASE_CHANNEL_SELECTOR_V4 = () ->
+        (io.gravitee.rest.api.management.v2.rest.model.ChannelSelector) new io.gravitee.rest.api.management.v2.rest.model.ChannelSelector()
             .entrypoints(Set.of("entrypoint1", "entrypoint2"))
             .operations(
                 Set.of(
@@ -51,67 +49,69 @@ public class FlowFixtures {
                     io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.PUBLISH
                 )
             )
-            .channelOperator(io.gravitee.rest.api.management.v2.rest.model.Operator.EQUALS);
+            .channelOperator(io.gravitee.rest.api.management.v2.rest.model.Operator.EQUALS)
+            .channel("channel")
+            .type(BaseSelector.TypeEnum.CHANNEL);
 
-    private static final StepV4.StepV4Builder BASE_STEP_V4 = StepV4
-        .builder()
-        .name("step")
-        .description("description")
-        .enabled(true)
-        .policy("policy")
-        .condition("{#context.attribute['condition'] == true}")
-        .messageCondition("{#context.attribute['messageCondition'] == true}")
-        .configuration(new LinkedHashMap<>(Map.of("nice", "config")));
+    private static final Supplier<StepV4> BASE_STEP_V4 = () ->
+        new StepV4()
+            .name("step")
+            .description("description")
+            .enabled(true)
+            .policy("policy")
+            .condition("{#context.attribute['condition'] == true}")
+            .messageCondition("{#context.attribute['messageCondition'] == true}")
+            .configuration(new LinkedHashMap<>(Map.of("nice", "config")));
 
-    private static final FlowV4.FlowV4Builder BASE_FLOW_HTTP_V4 = FlowV4
-        .builder()
-        .name("Flow")
-        .enabled(true)
-        .selectors(List.of(new Selector(BASE_CHANNEL_SELECTOR_V4.build())))
-        .request(List.of(BASE_STEP_V4.name("step_request").build()))
-        .publish(List.of(BASE_STEP_V4.name("step_publish").build()))
-        .response(List.of(BASE_STEP_V4.name("step_response").build()))
-        .subscribe(List.of(BASE_STEP_V4.name("step_subscribe").build()))
-        .tags(Set.of("tag1", "tag2"));
+    private static final Supplier<FlowV4> BASE_FLOW_HTTP_V4 = () ->
+        new FlowV4()
+            .name("Flow")
+            .enabled(true)
+            .selectors(List.of(new Selector(BASE_CHANNEL_SELECTOR_V4.get())))
+            .request(List.of(BASE_STEP_V4.get().name("step_request")))
+            .publish(List.of(BASE_STEP_V4.get().name("step_publish")))
+            .response(List.of(BASE_STEP_V4.get().name("step_response")))
+            .subscribe(List.of(BASE_STEP_V4.get().name("step_subscribe")))
+            .tags(Set.of("tag1", "tag2"));
 
-    private static final FlowV4.FlowV4Builder BASE_FLOW_NATIVE_V4 = FlowV4
-        .builder()
-        .name("Flow")
-        .enabled(true)
-        .connect(List.of(BASE_STEP_V4.name("step_connect").build()))
-        .publish(List.of(BASE_STEP_V4.name("step_publish").build()))
-        .interact(List.of(BASE_STEP_V4.name("step_interact").build()))
-        .subscribe(List.of(BASE_STEP_V4.name("step_subscribe").build()))
-        .tags(Set.of("tag1", "tag2"));
+    private static final Supplier<FlowV4> BASE_FLOW_NATIVE_V4 = () ->
+        new FlowV4()
+            .name("Flow")
+            .enabled(true)
+            .connect(List.of(BASE_STEP_V4.get().name("step_connect")))
+            .publish(List.of(BASE_STEP_V4.get().name("step_publish")))
+            .interact(List.of(BASE_STEP_V4.get().name("step_interact")))
+            .subscribe(List.of(BASE_STEP_V4.get().name("step_subscribe")))
+            .tags(Set.of("tag1", "tag2"));
 
-    private static final StepV2.StepV2Builder BASE_STEP_V2 = StepV2
-        .builder()
-        .name("step")
-        .description("description")
-        .enabled(true)
-        .policy("policy")
-        .condition("{#context.attribute['condition'] == true}")
-        .configuration(new LinkedHashMap<>(Map.of("nice", "config")));
+    private static final Supplier<StepV2> BASE_STEP_V2 = () ->
+        new StepV2()
+            .name("step")
+            .description("description")
+            .enabled(true)
+            .policy("policy")
+            .condition("{#context.attribute['condition'] == true}")
+            .configuration(new LinkedHashMap<>(Map.of("nice", "config")));
 
-    private static final FlowV2.FlowV2Builder BASE_FLOW_V2 = FlowV2
-        .builder()
-        .name("Flow")
-        .enabled(true)
-        .pathOperator(PathOperator.builder().operator(Operator.EQUALS).path("/path").build())
-        .condition("{#context.attribute['condition'] == true}")
-        .pre(List.of(BASE_STEP_V2.name("step_pre").build()))
-        .post(List.of(BASE_STEP_V2.name("step_pot").build()));
+    private static final Supplier<FlowV2> BASE_FLOW_V2 = () ->
+        new FlowV2()
+            .name("Flow")
+            .enabled(true)
+            .pathOperator(new PathOperator().operator(Operator.EQUALS).path("/path"))
+            .condition("{#context.attribute['condition'] == true}")
+            .pre(List.of(BASE_STEP_V2.get().name("step_pre")))
+            .post(List.of(BASE_STEP_V2.get().name("step_pot")));
 
     public static FlowV4 aFlowHttpV4() {
-        return BASE_FLOW_HTTP_V4.build();
+        return BASE_FLOW_HTTP_V4.get();
     }
 
     public static FlowV4 aFlowNativeV4() {
-        return BASE_FLOW_NATIVE_V4.build();
+        return BASE_FLOW_NATIVE_V4.get();
     }
 
     public static FlowV2 aFlowV2() {
-        return BASE_FLOW_V2.build();
+        return BASE_FLOW_V2.get();
     }
 
     public static Flow aModelFlowHttpV4() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/GraviteeLicenseFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/GraviteeLicenseFixtures.java
@@ -16,27 +16,23 @@
 package fixtures;
 
 import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
-import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense.GraviteeLicenseBuilder;
 import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@SuppressWarnings("rawtypes")
 public class GraviteeLicenseFixtures {
 
     private GraviteeLicenseFixtures() {}
 
-    private static final GraviteeLicenseBuilder BASE_GRAVITEE_LICENSE = GraviteeLicense
-        .builder()
-        .tier("tier-galaxy")
-        .features(List.of("feature-datadog-reporter"))
-        .packs(List.of("pack-observability"));
+    private static final Supplier<GraviteeLicense> BASE_GRAVITEE_LICENSE = () ->
+        new GraviteeLicense().tier("tier-galaxy").features(List.of("feature-datadog-reporter")).packs(List.of("pack-observability"));
 
     public static GraviteeLicense aGraviteeLicense() {
-        return BASE_GRAVITEE_LICENSE.build();
+        return BASE_GRAVITEE_LICENSE.get();
     }
 
     public static GraviteeLicenseEntity aGraviteeLicenseEntity() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ListenerFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ListenerFixtures.java
@@ -22,60 +22,60 @@ import io.gravitee.rest.api.management.v2.rest.model.PathV4;
 import io.gravitee.rest.api.management.v2.rest.model.SubscriptionListener;
 import io.gravitee.rest.api.management.v2.rest.model.TcpListener;
 import java.util.List;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class ListenerFixtures {
 
     private ListenerFixtures() {}
 
-    private static final PathV4.PathV4Builder BASE_PATH_V4 = PathV4.builder().host("my.fake.host").path("/test").overrideAccess(true);
+    private static final Supplier<PathV4> BASE_PATH_V4 = () -> new PathV4().host("my.fake.host").path("/test").overrideAccess(true);
 
-    private static final HttpListener.HttpListenerBuilder BASE_HTTP_LISTENER = HttpListener
-        .builder()
-        // BaseListener
-        .type(ListenerType.HTTP)
-        .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
-        .servers(List.of("my-server1", "my-server2"))
-        // HttpListener specific
-        .paths(List.of(BASE_PATH_V4.build()))
-        .pathMappings(List.of("/test"))
-        .cors(CorsFixtures.aCors());
+    private static final Supplier<HttpListener> BASE_HTTP_LISTENER = () ->
+        (HttpListener) new HttpListener()
+            // HttpListener specific
+            .paths(List.of(BASE_PATH_V4.get()))
+            .pathMappings(List.of("/test"))
+            .cors(CorsFixtures.aCors())
+            // BaseListener
+            .type(ListenerType.HTTP)
+            .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
-    private static final SubscriptionListener.SubscriptionListenerBuilder BASE_SUBSCRIPTION_LISTENER = SubscriptionListener
-        .builder()
-        // BaseListener
-        .type(ListenerType.SUBSCRIPTION)
-        .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
-        .servers(List.of("my-server1", "my-server2"));
+    private static final Supplier<SubscriptionListener> BASE_SUBSCRIPTION_LISTENER = () ->
+        (SubscriptionListener) new SubscriptionListener()
+            // BaseListener
+            .type(ListenerType.SUBSCRIPTION)
+            .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
-    private static final TcpListener.TcpListenerBuilder BASE_TCP_LISTENER = TcpListener
-        .builder()
-        // BaseListener
-        .type(ListenerType.TCP)
-        .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
-        .servers(List.of("my-server1", "my-server2"));
+    private static final Supplier<TcpListener> BASE_TCP_LISTENER = () ->
+        (TcpListener) new TcpListener()
+            // BaseListener
+            .type(ListenerType.TCP)
+            .entrypoints(List.of(EntrypointFixtures.anEntrypointHttpV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
-    private static final KafkaListener.KafkaListenerBuilder BASE_KAFKA_LISTENER = KafkaListener
-        .builder()
-        // BaseListener
-        .type(ListenerType.KAFKA)
-        .entrypoints(List.of(EntrypointFixtures.anEntrypointNativeV4()))
-        .servers(List.of("my-server1", "my-server2"));
+    private static final Supplier<KafkaListener> BASE_KAFKA_LISTENER = () ->
+        (KafkaListener) new KafkaListener()
+            // BaseListener
+            .type(ListenerType.KAFKA)
+            .entrypoints(List.of(EntrypointFixtures.anEntrypointNativeV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
     public static HttpListener aHttpListener() {
-        return BASE_HTTP_LISTENER.build();
+        return BASE_HTTP_LISTENER.get();
     }
 
     public static SubscriptionListener aSubscriptionListener() {
-        return BASE_SUBSCRIPTION_LISTENER.build();
+        return BASE_SUBSCRIPTION_LISTENER.get();
     }
 
     public static TcpListener aTcpListener() {
-        return BASE_TCP_LISTENER.build();
+        return BASE_TCP_LISTENER.get();
     }
 
     public static KafkaListener aKafkaListener() {
-        return BASE_KAFKA_LISTENER.build();
+        return BASE_KAFKA_LISTENER.get();
     }
 
     public static io.gravitee.definition.model.v4.listener.http.HttpListener aModelHttpListener() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/MetadataFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/MetadataFixtures.java
@@ -17,7 +17,6 @@ package fixtures;
 
 import io.gravitee.apim.core.metadata.model.Metadata;
 
-@SuppressWarnings("rawtypes")
 public class MetadataFixtures {
 
     private MetadataFixtures() {}
@@ -58,13 +57,11 @@ public class MetadataFixtures {
         Object defaultValue,
         io.gravitee.rest.api.management.v2.rest.model.MetadataFormat format
     ) {
-        return io.gravitee.rest.api.management.v2.rest.model.Metadata
-            .builder()
+        return new io.gravitee.rest.api.management.v2.rest.model.Metadata()
             .key(key)
             .name(name)
             .value(value != null ? value.toString() : null)
             .defaultValue(defaultValue != null ? defaultValue.toString() : null)
-            .format(format)
-            .build();
+            .format(format);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -42,126 +43,125 @@ public class PlanFixtures {
 
     private PlanFixtures() {}
 
-    private static final UpdateGenericPlanSecurity.UpdateGenericPlanSecurityBuilder<?, ?> BASE_UPDATE_PLAN_SECURITY =
-        UpdateGenericPlanSecurity.builder().configuration("{\"nice\": \"config\"}");
+    private static final Supplier<UpdateGenericPlanSecurity> BASE_UPDATE_PLAN_SECURITY = () ->
+        new UpdateGenericPlanSecurity().configuration("{\"nice\": \"config\"}");
 
-    private static final io.gravitee.rest.api.management.v2.rest.model.PlanSecurity.PlanSecurityBuilder<?, ?> BASE_PLAN_SECURITY =
-        io.gravitee.rest.api.management.v2.rest.model.PlanSecurity
-            .builder()
+    private static final Supplier<io.gravitee.rest.api.management.v2.rest.model.PlanSecurity> BASE_PLAN_SECURITY = () ->
+        new io.gravitee.rest.api.management.v2.rest.model.PlanSecurity()
             .type(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.API_KEY)
             .configuration("{\"nice\": \"config\"}");
 
-    private static final CreatePlanV4.CreatePlanV4Builder BASE_CREATE_PLAN_HTTP_V4 = CreatePlanV4
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentRequired(true)
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowHttpV4()));
+    private static final Supplier<CreatePlanV4> BASE_CREATE_PLAN_HTTP_V4 = () ->
+        (CreatePlanV4) new CreatePlanV4()
+            .flows(List.of(FlowFixtures.aFlowHttpV4()))
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentRequired(true)
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .tags(List.of("tag1", "tag2"))
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .security(BASE_PLAN_SECURITY.get());
 
-    private static final CreatePlanV4.CreatePlanV4Builder BASE_CREATE_PLAN_NATIVE_V4 = CreatePlanV4
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentRequired(true)
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowNativeV4()));
+    private static final Supplier<CreatePlanV4> BASE_CREATE_PLAN_NATIVE_V4 = () ->
+        (CreatePlanV4) new CreatePlanV4()
+            .flows(List.of(FlowFixtures.aFlowNativeV4()))
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentRequired(true)
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .tags(List.of("tag1", "tag2"))
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .security(BASE_PLAN_SECURITY.get());
 
-    private static final CreatePlanV2.CreatePlanV2Builder BASE_CREATE_PLAN_V2 = CreatePlanV2
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowV2()));
+    private static final Supplier<CreatePlanV2> BASE_CREATE_PLAN_V2 = () ->
+        (CreatePlanV2) new CreatePlanV2()
+            .flows(List.of(FlowFixtures.aFlowV2()))
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .tags(List.of("tag1", "tag2"))
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .security(BASE_PLAN_SECURITY.get());
 
-    private static final UpdatePlanV4.UpdatePlanV4Builder BASE_UPDATE_PLAN_V4 = UpdatePlanV4
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_UPDATE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowHttpV4()));
+    private static final Supplier<UpdatePlanV4> BASE_UPDATE_PLAN_V4 = () ->
+        (UpdatePlanV4) new UpdatePlanV4()
+            .flows(List.of(FlowFixtures.aFlowHttpV4()))
+            .tags(List.of("tag1", "tag2"))
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .security(BASE_UPDATE_PLAN_SECURITY.get());
 
-    private static final UpdatePlanV4.UpdatePlanV4Builder BASE_UPDATE_NATIVE_PLAN_V4 = UpdatePlanV4
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_UPDATE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowNativeV4()));
+    private static final Supplier<UpdatePlanV4> BASE_UPDATE_NATIVE_PLAN_V4 = () ->
+        (UpdatePlanV4) new UpdatePlanV4()
+            .flows(List.of(FlowFixtures.aFlowNativeV4()))
+            .tags(List.of("tag1", "tag2"))
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .security(BASE_UPDATE_PLAN_SECURITY.get());
 
-    private static final UpdatePlanFederated.UpdatePlanFederatedBuilder BASE_UPDATE_PLAN_FEDERATED = UpdatePlanFederated
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .commentRequired(false)
-        .security(BASE_UPDATE_PLAN_SECURITY.build());
+    private static final Supplier<UpdatePlanFederated> BASE_UPDATE_PLAN_FEDERATED = () ->
+        (UpdatePlanFederated) new UpdatePlanFederated()
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .commentRequired(false)
+            .security(BASE_UPDATE_PLAN_SECURITY.get());
 
-    private static final UpdatePlanV2.UpdatePlanV2Builder BASE_UPDATE_PLAN_V2 = UpdatePlanV2
-        .builder()
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(List.of("tag1", "tag2"))
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(PlanValidation.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .security(BASE_UPDATE_PLAN_SECURITY.build())
-        .flows(List.of(FlowFixtures.aFlowV2()));
+    private static final Supplier<UpdatePlanV2> BASE_UPDATE_PLAN_V2 = () ->
+        (UpdatePlanV2) new UpdatePlanV2()
+            .flows(List.of(FlowFixtures.aFlowV2()))
+            .tags(List.of("tag1", "tag2"))
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(PlanValidation.AUTO)
+            .security(BASE_UPDATE_PLAN_SECURITY.get());
 
     private static final io.gravitee.rest.api.model.PlanEntity.PlanEntityBuilder BASE_PLAN_ENTITY_V2 = io.gravitee.rest.api.model.PlanEntity
         .builder()
@@ -186,31 +186,31 @@ public class PlanFixtures {
         .flows(List.of(FlowFixtures.aModelFlowV2()));
 
     public static CreatePlanV4 aCreatePlanHttpV4() {
-        return BASE_CREATE_PLAN_HTTP_V4.build();
+        return BASE_CREATE_PLAN_HTTP_V4.get();
     }
 
     public static CreatePlanV4 aCreatePlanNativeV4() {
-        return BASE_CREATE_PLAN_NATIVE_V4.build();
+        return BASE_CREATE_PLAN_NATIVE_V4.get();
     }
 
     public static CreatePlanV2 aCreatePlanV2() {
-        return BASE_CREATE_PLAN_V2.build();
+        return BASE_CREATE_PLAN_V2.get();
     }
 
     public static UpdatePlanV4 anUpdatePlanV4() {
-        return BASE_UPDATE_PLAN_V4.build();
+        return BASE_UPDATE_PLAN_V4.get();
     }
 
     public static UpdatePlanV4 anUpdatePlanNativeV4() {
-        return BASE_UPDATE_NATIVE_PLAN_V4.build();
+        return BASE_UPDATE_NATIVE_PLAN_V4.get();
     }
 
     public static UpdatePlanV2 anUpdatePlanV2() {
-        return BASE_UPDATE_PLAN_V2.build();
+        return BASE_UPDATE_PLAN_V2.get();
     }
 
     public static UpdatePlanFederated anUpdatePlanFederated() {
-        return BASE_UPDATE_PLAN_FEDERATED.build();
+        return BASE_UPDATE_PLAN_FEDERATED.get();
     }
 
     public static PlanEntity aPlanEntityV4() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PrimaryOwnerFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PrimaryOwnerFixtures.java
@@ -18,21 +18,21 @@ package fixtures;
 import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
 import io.gravitee.rest.api.management.v2.rest.model.PrimaryOwner;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class PrimaryOwnerFixtures {
 
     private PrimaryOwnerFixtures() {}
 
-    private static final PrimaryOwner.PrimaryOwnerBuilder BASE_PRIMARY_OWNER = PrimaryOwner
-        .builder()
-        .id("primary-owner-id")
-        .displayName("primary-owner-displayName")
-        .email("primary-owner@email.com")
-        .type(MembershipMemberType.USER);
+    private static final Supplier<PrimaryOwner> BASE_PRIMARY_OWNER = () ->
+        new PrimaryOwner()
+            .id("primary-owner-id")
+            .displayName("primary-owner-displayName")
+            .email("primary-owner@email.com")
+            .type(MembershipMemberType.USER);
 
     public static PrimaryOwner aPrimaryOwner() {
-        return BASE_PRIMARY_OWNER.build();
+        return BASE_PRIMARY_OWNER.get();
     }
 
     public static PrimaryOwnerEntity aPrimaryOwnerEntity() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PropertyFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PropertyFixtures.java
@@ -17,21 +17,17 @@ package fixtures;
 
 import io.gravitee.definition.model.Properties;
 import io.gravitee.rest.api.management.v2.rest.model.Property;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class PropertyFixtures {
 
     private PropertyFixtures() {}
 
-    private static final Property.PropertyBuilder BASE_PROPERTY = Property
-        .builder()
-        .dynamic(false)
-        .encrypted(false)
-        .key("prop-key")
-        .value("prop-value");
+    private static final Supplier<Property> BASE_PROPERTY = () ->
+        new Property().dynamic(false).encrypted(false).key("prop-key").value("prop-value");
 
     public static Property aProperty() {
-        return BASE_PROPERTY.build();
+        return BASE_PROPERTY.get();
     }
 
     public static Properties aModelPropertiesV2() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ResourceFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ResourceFixtures.java
@@ -18,21 +18,17 @@ package fixtures;
 import io.gravitee.rest.api.management.v2.rest.model.Resource;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class ResourceFixtures {
 
     private ResourceFixtures() {}
 
-    private static final Resource.ResourceBuilder BASE_RESOURCE = Resource
-        .builder()
-        .name("role-name")
-        .type("resource-type")
-        .enabled(true)
-        .configuration(new LinkedHashMap<>(Map.of("key", "value")));
+    private static final Supplier<Resource> BASE_RESOURCE = () ->
+        new Resource().name("role-name").type("resource-type").enabled(true).configuration(new LinkedHashMap<>(Map.of("key", "value")));
 
     public static Resource aResource() {
-        return BASE_RESOURCE.build();
+        return BASE_RESOURCE.get();
     }
 
     public static io.gravitee.definition.model.plugins.resources.Resource aResourceEntityV2() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/RuleFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/RuleFixtures.java
@@ -19,22 +19,22 @@ import io.gravitee.rest.api.management.v2.rest.model.HttpMethod;
 import io.gravitee.rest.api.management.v2.rest.model.Rule;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class RuleFixtures {
 
     private RuleFixtures() {}
 
-    private static final Rule.RuleBuilder BASE_RULE = Rule
-        .builder()
-        .description("description")
-        .enabled(true)
-        .methods(List.of(HttpMethod.GET, HttpMethod.POST))
-        .operation("policy-name")
-        .configuration(new LinkedHashMap<>());
+    private static final Supplier<Rule> BASE_RULE = () ->
+        new Rule()
+            .description("description")
+            .enabled(true)
+            .methods(List.of(HttpMethod.GET, HttpMethod.POST))
+            .operation("policy-name")
+            .configuration(new LinkedHashMap<>());
 
     public static Rule oneRule() {
-        return BASE_RULE.build();
+        return BASE_RULE.get();
     }
 
     public static io.gravitee.definition.model.Rule oneModelRule() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
@@ -15,65 +15,64 @@
  */
 package fixtures;
 
-import io.gravitee.rest.api.management.v2.rest.model.*;
+import io.gravitee.rest.api.management.v2.rest.model.ApiServicesV2;
+import io.gravitee.rest.api.management.v2.rest.model.DynamicPropertyProvider;
+import io.gravitee.rest.api.management.v2.rest.model.DynamicPropertyService;
+import io.gravitee.rest.api.management.v2.rest.model.DynamicPropertyServiceConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.EndpointDiscoveryService;
+import io.gravitee.rest.api.management.v2.rest.model.EndpointGroupServicesV2;
+import io.gravitee.rest.api.management.v2.rest.model.HealthCheckService;
+import io.gravitee.rest.api.management.v2.rest.model.HttpDynamicPropertyProviderConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.HttpMethod;
+import io.gravitee.rest.api.management.v2.rest.model.ServiceV4;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class ServiceFixture {
 
     private ServiceFixture() {}
 
-    private static final EndpointDiscoveryService.EndpointDiscoveryServiceBuilder BASE_ENDPOINT_DISCOVERY_SERVICE = EndpointDiscoveryService
-        .builder()
-        .enabled(true)
-        .provider("consul")
-        .configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
-    private static final DynamicPropertyService.DynamicPropertyServiceBuilder BASE_DYNAMIC_PROPERTY_SERVICE = DynamicPropertyService
-        .builder()
-        .enabled(true)
-        .schedule("0 */5 * * * *")
-        .provider(DynamicPropertyProvider.HTTP)
-        .configuration(
-            new DynamicPropertyServiceConfiguration(
-                HttpDynamicPropertyProviderConfiguration
-                    .builder()
-                    .url("http://localhost")
-                    .method(HttpMethod.GET)
-                    .specification(String.valueOf(new LinkedHashMap<>(Map.of("nice", "configuration"))))
-                    .body("body")
-                    .build()
-            )
-        );
-    private static final HealthCheckService.HealthCheckServiceBuilder BASE_HEALTH_CHECK_SERVICE = HealthCheckService.builder();
+    private static final Supplier<EndpointDiscoveryService> BASE_ENDPOINT_DISCOVERY_SERVICE = () ->
+        new EndpointDiscoveryService().enabled(true).provider("consul").configuration(new LinkedHashMap<>(Map.of("nice", "configuration")));
+    private static final Supplier<DynamicPropertyService> BASE_DYNAMIC_PROPERTY_SERVICE = () ->
+        new DynamicPropertyService()
+            .enabled(true)
+            .schedule("0 */5 * * * *")
+            .provider(DynamicPropertyProvider.HTTP)
+            .configuration(
+                new DynamicPropertyServiceConfiguration(
+                    new HttpDynamicPropertyProviderConfiguration()
+                        .url("http://localhost")
+                        .method(HttpMethod.GET)
+                        .specification(String.valueOf(new LinkedHashMap<>(Map.of("nice", "configuration"))))
+                        .body("body")
+                )
+            );
+    private static final Supplier<HealthCheckService> BASE_HEALTH_CHECK_SERVICE = HealthCheckService::new;
 
-    private static final ApiServicesV2.ApiServicesV2Builder BASE_API_SERVICES_V2 = ApiServicesV2
-        .builder()
-        .dynamicProperty(BASE_DYNAMIC_PROPERTY_SERVICE.build())
-        .healthCheck(BASE_HEALTH_CHECK_SERVICE.build());
+    private static final Supplier<ApiServicesV2> BASE_API_SERVICES_V2 = () ->
+        new ApiServicesV2().dynamicProperty(BASE_DYNAMIC_PROPERTY_SERVICE.get()).healthCheck(BASE_HEALTH_CHECK_SERVICE.get());
 
-    private static final EndpointGroupServicesV2.EndpointGroupServicesV2Builder BASE_ENDPOINT_GROUP_SERVICES_V2 = EndpointGroupServicesV2
-        .builder()
-        .discovery(BASE_ENDPOINT_DISCOVERY_SERVICE.build());
+    private static final Supplier<EndpointGroupServicesV2> BASE_ENDPOINT_GROUP_SERVICES_V2 = () ->
+        new EndpointGroupServicesV2().discovery(BASE_ENDPOINT_DISCOVERY_SERVICE.get());
 
-    private static final ServiceV4.ServiceV4Builder BASE_API_V4_SERVICE = ServiceV4
-        .builder()
-        .type("dynamicProperty")
-        .configuration(new LinkedHashMap<>(Map.of("url", "http://localhost")))
-        .enabled(true);
+    private static final Supplier<ServiceV4> BASE_API_V4_SERVICE = () ->
+        new ServiceV4().type("dynamicProperty").configuration(new LinkedHashMap<>(Map.of("url", "http://localhost"))).enabled(true);
 
     public static ApiServicesV2 anApiServicesV2() {
-        return BASE_API_SERVICES_V2.build();
+        return BASE_API_SERVICES_V2.get();
     }
 
     public static EndpointGroupServicesV2 anEndpointGroupServicesV2() {
-        return BASE_ENDPOINT_GROUP_SERVICES_V2.build();
+        return BASE_ENDPOINT_GROUP_SERVICES_V2.get();
     }
 
     public static ServiceV4 aServiceV4() {
-        return BASE_API_V4_SERVICE.build();
+        return BASE_API_V4_SERVICE.get();
     }
 
     public static HealthCheckService aHealthCheckService() {
-        return BASE_HEALTH_CHECK_SERVICE.build();
+        return BASE_HEALTH_CHECK_SERVICE.get();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SharedPolicyGroupFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SharedPolicyGroupFixtures.java
@@ -21,29 +21,24 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.CreateSharedPolicyGroup;
 import io.gravitee.rest.api.management.v2.rest.model.FlowPhase;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateSharedPolicyGroup;
+import java.util.function.Supplier;
 
-@SuppressWarnings("ALL")
 public class SharedPolicyGroupFixtures {
 
     private SharedPolicyGroupFixtures() {}
 
-    private static final CreateSharedPolicyGroup.CreateSharedPolicyGroupBuilder CREATE_BASE = CreateSharedPolicyGroup
-        .builder()
-        .name("My Shared Policy Group")
-        .apiType(ApiType.PROXY)
-        .phase(FlowPhase.REQUEST);
+    private static final Supplier<CreateSharedPolicyGroup> CREATE_BASE = () ->
+        new CreateSharedPolicyGroup().name("My Shared Policy Group").apiType(ApiType.PROXY).phase(FlowPhase.REQUEST);
 
     public static CreateSharedPolicyGroup aCreateSharedPolicyGroup() {
-        return CREATE_BASE.build();
+        return CREATE_BASE.get();
     }
 
-    private static final UpdateSharedPolicyGroup.UpdateSharedPolicyGroupBuilder UPDATE_BASE = UpdateSharedPolicyGroup
-        .builder()
-        .name("My Shared Policy Group updated")
-        .description("My Shared Policy Group description updated");
+    private static final Supplier<UpdateSharedPolicyGroup> UPDATE_BASE = () ->
+        new UpdateSharedPolicyGroup().name("My Shared Policy Group updated").description("My Shared Policy Group description updated");
 
     public static UpdateSharedPolicyGroup aUpdateSharedPolicyGroup() {
-        return UPDATE_BASE.build();
+        return UPDATE_BASE.get();
     }
 
     private static final SharedPolicyGroupCRD.SharedPolicyGroupCRDBuilder CRD_BASE = SharedPolicyGroupCRD

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -37,71 +38,65 @@ public class SubscriptionFixtures {
 
     private SubscriptionFixtures() {}
 
-    private static final CreateSubscription.CreateSubscriptionBuilder BASE_CREATE_SUBSCRIPTION = CreateSubscription
-        .builder()
-        .planId("my-plan")
-        .applicationId("my-application")
-        .customApiKey("custom")
-        .consumerConfiguration(
-            SubscriptionConsumerConfiguration
-                .builder()
-                .entrypointConfiguration("{\"nice\": \"config\"}")
-                .entrypointId("entrypoint-id")
-                .channel("channel")
-                .build()
-        )
-        .metadata(Map.of("meta1", "value1", "meta2", "value2"));
+    private static final Supplier<CreateSubscription> BASE_CREATE_SUBSCRIPTION = () ->
+        new CreateSubscription()
+            .planId("my-plan")
+            .applicationId("my-application")
+            .customApiKey("custom")
+            .consumerConfiguration(
+                new SubscriptionConsumerConfiguration()
+                    .entrypointConfiguration("{\"nice\": \"config\"}")
+                    .entrypointId("entrypoint-id")
+                    .channel("channel")
+            )
+            .metadata(Map.of("meta1", "value1", "meta2", "value2"));
 
-    private static final UpdateSubscription.UpdateSubscriptionBuilder BASE_UPDATE_SUBSCRIPTION = UpdateSubscription
-        .builder()
-        .startingAt(OffsetDateTime.now())
-        .endingAt(OffsetDateTime.now())
-        .consumerConfiguration(
-            SubscriptionConsumerConfiguration
-                .builder()
-                .entrypointConfiguration("{\"nice\": \"config\"}")
-                .entrypointId("entrypoint-id")
-                .channel("channel")
-                .build()
-        )
-        .metadata(Map.of("meta1", "value1", "meta2", "value2"));
+    private static final Supplier<UpdateSubscription> BASE_UPDATE_SUBSCRIPTION = () ->
+        new UpdateSubscription()
+            .startingAt(OffsetDateTime.now())
+            .endingAt(OffsetDateTime.now())
+            .consumerConfiguration(
+                new SubscriptionConsumerConfiguration()
+                    .entrypointConfiguration("{\"nice\": \"config\"}")
+                    .entrypointId("entrypoint-id")
+                    .channel("channel")
+            )
+            .metadata(Map.of("meta1", "value1", "meta2", "value2"));
 
     public static CreateSubscription aCreateSubscription() {
-        return BASE_CREATE_SUBSCRIPTION.build();
+        return BASE_CREATE_SUBSCRIPTION.get();
     }
 
     public static UpdateSubscription anUpdateSubscription() {
-        return BASE_UPDATE_SUBSCRIPTION.build();
+        return BASE_UPDATE_SUBSCRIPTION.get();
     }
 
     public static VerifySubscription aVerifySubscription() {
-        return VerifySubscription.builder().applicationId("my-application").apiKey("custom").build();
+        return new VerifySubscription().applicationId("my-application").apiKey("custom");
     }
 
     public static AcceptSubscription anAcceptSubscription() {
-        return AcceptSubscription
-            .builder()
+        return new AcceptSubscription()
             .customApiKey("custom")
             .reason("reason")
             .startingAt(OffsetDateTime.now())
-            .endingAt(OffsetDateTime.now())
-            .build();
+            .endingAt(OffsetDateTime.now());
     }
 
     public static RejectSubscription aRejectSubscription() {
-        return RejectSubscription.builder().reason("reason").build();
+        return new RejectSubscription().reason("reason");
     }
 
     public static TransferSubscription aTransferSubscription() {
-        return TransferSubscription.builder().planId("other-plan").build();
+        return new TransferSubscription().planId("other-plan");
     }
 
     public static UpdateApiKey anUpdateApiKey() {
-        return UpdateApiKey.builder().expireAt(OffsetDateTime.now()).build();
+        return new UpdateApiKey().expireAt(OffsetDateTime.now());
     }
 
     public static RenewApiKey aRenewApiKey() {
-        return RenewApiKey.builder().customApiKey("custom").build();
+        return new RenewApiKey().customApiKey("custom");
     }
 
     public static SubscriptionEntity aSubscriptionEntity() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapperTest.java
@@ -29,6 +29,7 @@ import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -96,7 +97,7 @@ class ConstraintValidationExceptionMapperTest {
                                 .filter(detail -> "path1".equals(detail.getLocation()))
                                 .findFirst()
                                 .get();
-                            assertThat(firstDetail.getInvalidValue()).isEqualTo(List.of());
+                            assertThat(firstDetail.getInvalidValue()).isEqualTo(JsonNullable.of(List.of()));
                             assertThat(firstDetail.getMessage()).isEqualTo("Size must be between 1 and 2147483647");
                             assertThat(firstDetail.getLocation()).isEqualTo("path1");
 
@@ -105,7 +106,7 @@ class ConstraintValidationExceptionMapperTest {
                                 .filter(detail -> "path2".equals(detail.getLocation()))
                                 .findFirst()
                                 .get();
-                            assertThat(secondDetail.getInvalidValue()).isEqualTo("InvalidValue");
+                            assertThat(secondDetail.getInvalidValue()).isEqualTo(JsonNullable.of("InvalidValue"));
                             assertThat(secondDetail.getMessage()).isEqualTo("This value is not allowed");
                             assertThat(secondDetail.getLocation()).isEqualTo("path2");
                         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapperTest.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -56,19 +57,17 @@ class ValidationExceptionMapperTest {
                         .satisfies(listErrorDetails -> {
                             final ErrorDetailsInner firstDetail = listErrorDetails
                                 .stream()
-                                .filter(detail -> "key1".equals(detail.getInvalidValue()))
+                                .filter(detail -> JsonNullable.of("key1").equals(detail.getInvalidValue()))
                                 .findFirst()
                                 .get();
-                            assertThat(firstDetail.getInvalidValue()).isEqualTo("key1");
                             assertThat(firstDetail.getMessage()).isEqualTo("fake detail message");
                             assertThat(firstDetail.getLocation()).isEqualTo("value1");
 
                             final ErrorDetailsInner secondDetail = listErrorDetails
                                 .stream()
-                                .filter(detail -> "key2".equals(detail.getInvalidValue()))
+                                .filter(detail -> JsonNullable.of("key2").equals(detail.getInvalidValue()))
                                 .findFirst()
                                 .get();
-                            assertThat(secondDetail.getInvalidValue()).isEqualTo("key2");
                             assertThat(secondDetail.getMessage()).isEqualTo("fake detail message");
                             assertThat(secondDetail.getLocation()).isEqualTo("value2");
                         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -46,14 +46,7 @@ public class ApiMapperTest {
     void shouldMapToUpdateApiEntityV4() {
         var updateApi = ApiFixtures.anUpdateApiV4();
         updateApi.failover(
-            FailoverV4
-                .builder()
-                .enabled(true)
-                .perSubscription(false)
-                .maxFailures(3)
-                .openStateDuration(11000L)
-                .slowCallDuration(500L)
-                .build()
+            new FailoverV4().enabled(true).perSubscription(false).maxFailures(3).openStateDuration(11000L).slowCallDuration(500L)
         );
 
         var updateApiEntity = apiMapper.map(updateApi, "api-id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
@@ -19,7 +19,6 @@ import static assertions.MAPIAssertions.assertThat;
 
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.category.model.ApiCategoryOrder;
-import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
@@ -71,16 +70,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV2);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V2)
             .order(11)
-            .accessPaths(List.of("host-1/path-2", "/great-path"))
-            .build();
+            .accessPaths(List.of("host-1/path-2", "/great-path"));
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }
@@ -107,16 +104,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV2);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V2)
             .order(11)
-            .accessPaths(List.of())
-            .build();
+            .accessPaths(List.of());
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }
@@ -146,16 +141,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV4);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
             .order(11)
-            .accessPaths(List.of("one-host", "two-host"))
-            .build();
+            .accessPaths(List.of("one-host", "two-host"));
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }
@@ -188,16 +181,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV4);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
             .order(11)
-            .accessPaths(List.of("host-1/path-2", "/great-path"))
-            .build();
+            .accessPaths(List.of("host-1/path-2", "/great-path"));
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }
@@ -232,16 +223,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV4);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
             .order(11)
-            .accessPaths(List.of("one-host", "two-host", "host-1/path-2", "/great-path"))
-            .build();
+            .accessPaths(List.of("one-host", "two-host", "host-1/path-2", "/great-path"));
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }
@@ -269,16 +258,14 @@ public class CategoryApiMapperTest {
 
         var mappedResult = mapper.map(apiCategoryOrder, apiV4);
 
-        var expectedResult = CategoryApi
-            .builder()
+        var expectedResult = new CategoryApi()
             .id(API_ID)
             .name(API_NAME)
             .apiVersion(API_VERSION)
             .description(API_DESCRIPTION)
             .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
             .order(11)
-            .accessPaths(List.of())
-            .build();
+            .accessPaths(List.of());
 
         assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/DuplicateApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/DuplicateApiMapperTest.java
@@ -30,8 +30,7 @@ public class DuplicateApiMapperTest {
 
     @Test
     void should_map_to_DuplicateApiEntity() {
-        var duplicateApi = DuplicateApiOptions
-            .builder()
+        var duplicateApi = new DuplicateApiOptions()
             .contextPath("/context-path")
             .version("1.0")
             .filteredFields(
@@ -41,8 +40,7 @@ public class DuplicateApiMapperTest {
                     DuplicateApiOptions.FilteredFieldsEnum.PLANS,
                     DuplicateApiOptions.FilteredFieldsEnum.MEMBERS
                 )
-            )
-            .build();
+            );
 
         DuplicateApiEntity result = mapper.mapToV2(duplicateApi);
 
@@ -53,8 +51,7 @@ public class DuplicateApiMapperTest {
 
     @Test
     void should_map_to_DuplicateOptions() {
-        var duplicateApi = DuplicateApiOptions
-            .builder()
+        var duplicateApi = new DuplicateApiOptions()
             .contextPath("/context-path")
             .version("1.0")
             .filteredFields(
@@ -64,8 +61,7 @@ public class DuplicateApiMapperTest {
                     DuplicateApiOptions.FilteredFieldsEnum.PLANS,
                     DuplicateApiOptions.FilteredFieldsEnum.MEMBERS
                 )
-            )
-            .build();
+            );
 
         DuplicateOptions result = mapper.map(duplicateApi);
 
@@ -83,8 +79,7 @@ public class DuplicateApiMapperTest {
 
     @Test
     void should_map_to_DuplicateOptions_with_host() {
-        var duplicateApi = DuplicateApiOptions
-            .builder()
+        var duplicateApi = new DuplicateApiOptions()
             .host("host.gravitee.io")
             .version("1.0")
             .filteredFields(
@@ -94,8 +89,7 @@ public class DuplicateApiMapperTest {
                     DuplicateApiOptions.FilteredFieldsEnum.PLANS,
                     DuplicateApiOptions.FilteredFieldsEnum.MEMBERS
                 )
-            )
-            .build();
+            );
 
         DuplicateOptions result = mapper.map(duplicateApi);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/KeyStoreMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/KeyStoreMapperTest.java
@@ -61,7 +61,7 @@ public class KeyStoreMapperTest {
 
     @Test
     void shouldMapToJKSKeyStoreV2() {
-        var jksKeyStore = JKSKeyStore.builder().type(KeyStoreType.JKS).path("path").content("content").password("password").build();
+        var jksKeyStore = (JKSKeyStore) new JKSKeyStore().path("path").content("content").password("password").type(KeyStoreType.JKS);
 
         var jksKeyStoreEntityV2 = keyStoreMapper.mapToV2(new KeyStore(jksKeyStore));
         assertThat(jksKeyStoreEntityV2).isNotNull();
@@ -77,13 +77,11 @@ public class KeyStoreMapperTest {
 
     @Test
     void shouldMapToPKCS12KeyStoreV2() {
-        var pkcs12KeyStore = PKCS12KeyStore
-            .builder()
-            .type(KeyStoreType.PKCS12)
+        var pkcs12KeyStore = (PKCS12KeyStore) new PKCS12KeyStore()
             .path("path")
             .content("content")
             .password("password")
-            .build();
+            .type(KeyStoreType.PKCS12);
 
         var pkcs12KeyStoreEntityV2 = keyStoreMapper.mapToV2(new KeyStore(pkcs12KeyStore));
         assertThat(pkcs12KeyStoreEntityV2).isNotNull();
@@ -100,14 +98,12 @@ public class KeyStoreMapperTest {
 
     @Test
     void shouldMapToPEMKeyStoreV2() {
-        var pemKeyStore = PEMKeyStore
-            .builder()
-            .type(KeyStoreType.PEM)
+        var pemKeyStore = (PEMKeyStore) new PEMKeyStore()
             .keyPath("path")
             .keyContent("content")
             .certPath("cert-path")
             .certContent("cert-content")
-            .build();
+            .type(KeyStoreType.PEM);
 
         var pemKeyStoreEntityV2 = keyStoreMapper.mapToV2(new KeyStore(pemKeyStore));
         assertThat(pemKeyStoreEntityV2).isNotNull();
@@ -126,7 +122,7 @@ public class KeyStoreMapperTest {
 
     @Test
     void shouldMapToNoneKeyStoreV2() {
-        var noneKeyStore = NoneKeyStore.builder().type(KeyStoreType.NONE).build();
+        var noneKeyStore = (NoneKeyStore) new NoneKeyStore().type(KeyStoreType.NONE);
 
         var noneKeyStoreEntityV2 = keyStoreMapper.mapToV2(new KeyStore(noneKeyStore));
         assertThat(noneKeyStoreEntityV2).isNotNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
@@ -29,6 +29,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePlanV4;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
 import java.util.HashSet;
@@ -148,7 +149,7 @@ public class PlanMapperTest {
 
     @Test
     void should_map_CreatePlanV4_to_core_Plan_with_default_values() {
-        final var createPlanV4 = PlanFixtures.aCreatePlanHttpV4().toBuilder().validation(null).mode(null).flows(null).build();
+        final var createPlanV4 = (CreatePlanV4) PlanFixtures.aCreatePlanHttpV4().mode(null).flows(null).validation(null);
         final var plan = planMapper.map(createPlanV4, Api.builder().type(ApiType.PROXY).build());
 
         Assertions.assertNull(plan.getId());
@@ -209,10 +210,8 @@ public class PlanMapperTest {
         final var createPlanV2 = PlanFixtures.aCreatePlanV2();
         // PlanSecurityType is a common enum containing MTLS plan. Such security type is not supported by V2, so it is ignored during mapping
         createPlanV2.security(
-            io.gravitee.rest.api.management.v2.rest.model.PlanSecurity
-                .builder()
+            new io.gravitee.rest.api.management.v2.rest.model.PlanSecurity()
                 .type(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.MTLS)
-                .build()
         );
         final var createPlanEntity = planMapper.map(createPlanV2);
 
@@ -345,7 +344,7 @@ public class PlanMapperTest {
 
     @Test
     void should_map_CreatePlanV4_to_core_native_Plan_with_default_values() {
-        final var createPlanV4 = PlanFixtures.aCreatePlanNativeV4().toBuilder().validation(null).mode(null).flows(null).build();
+        final var createPlanV4 = (CreatePlanV4) PlanFixtures.aCreatePlanNativeV4().mode(null).flows(null).validation(null);
         final var plan = planMapper.map(createPlanV4, Api.builder().type(ApiType.NATIVE).build());
 
         Assertions.assertNull(plan.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapperTest.java
@@ -60,7 +60,7 @@ public class ServiceMapperTest {
 
     @Test
     void shouldMapEmptyApiServicesV2ToNull() {
-        var apiServicesV2 = ServiceFixture.anApiServicesV2().toBuilder().dynamicProperty(null).healthCheck(null).build();
+        var apiServicesV2 = ServiceFixture.anApiServicesV2().dynamicProperty(null).healthCheck(null);
 
         var services = serviceMapper.map(apiServicesV2);
         assertThat(services).isNotNull();
@@ -83,7 +83,7 @@ public class ServiceMapperTest {
 
     @Test
     void shouldMapEmptyEndpointGroupServicesV2ToNull() {
-        var endpointGroupServicesV2ServicesV2 = ServiceFixture.anEndpointGroupServicesV2().toBuilder().discovery(null).build();
+        var endpointGroupServicesV2ServicesV2 = ServiceFixture.anEndpointGroupServicesV2().discovery(null);
 
         var services = serviceMapper.map(endpointGroupServicesV2ServicesV2);
         assertThat(services).isNotNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/TrustStoreMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/TrustStoreMapperTest.java
@@ -67,7 +67,11 @@ public class TrustStoreMapperTest {
 
     @Test
     void shouldMapToJKSTrustStoreV2() {
-        var jksTrustStore = JKSTrustStore.builder().type(TrustStoreType.JKS).path("path").content("content").password("password").build();
+        var jksTrustStore = (JKSTrustStore) new JKSTrustStore()
+            .path("path")
+            .content("content")
+            .password("password")
+            .type(TrustStoreType.JKS);
 
         var jksTrustStoreEntityV2 = trustStoreMapper.mapToV2(new TrustStore(jksTrustStore));
         assertThat(jksTrustStoreEntityV2).isNotNull();
@@ -84,13 +88,11 @@ public class TrustStoreMapperTest {
 
     @Test
     void shouldMapToPKCS12TrustStoreV2() {
-        var pkcs12TrustStore = PKCS12TrustStore
-            .builder()
-            .type(TrustStoreType.PKCS12)
+        var pkcs12TrustStore = (PKCS12TrustStore) new PKCS12TrustStore()
             .path("path")
             .content("content")
             .password("password")
-            .build();
+            .type(TrustStoreType.PKCS12);
 
         var pkcs12TrustStoreEntityV2 = trustStoreMapper.mapToV2(new TrustStore(pkcs12TrustStore));
         assertThat(pkcs12TrustStoreEntityV2).isNotNull();
@@ -107,7 +109,7 @@ public class TrustStoreMapperTest {
 
     @Test
     void shouldMapToPEMTrustStoreV2() {
-        var pemTrustStore = PEMTrustStore.builder().type(TrustStoreType.PEM).path("path").content("content").build();
+        var pemTrustStore = (PEMTrustStore) new PEMTrustStore().path("path").content("content").type(TrustStoreType.PEM);
 
         var pemTrustStoreEntityV2 = trustStoreMapper.mapToV2(new TrustStore(pemTrustStore));
         assertThat(pemTrustStoreEntityV2).isNotNull();
@@ -122,7 +124,7 @@ public class TrustStoreMapperTest {
 
     @Test
     void shouldMapToNoneTrustStoreV2() {
-        var noneTrustStore = NoneTrustStore.builder().type(TrustStoreType.NONE).build();
+        var noneTrustStore = (NoneTrustStore) new NoneTrustStore().type(TrustStoreType.NONE);
 
         var noneTrustStoreEntityV2 = trustStoreMapper.mapToV2(new TrustStore(noneTrustStore));
         assertThat(noneTrustStoreEntityV2).isNotNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
@@ -37,9 +37,7 @@ public class PaginationInfoTest {
 
         Assertions
             .assertThat(pagination)
-            .isEqualTo(
-                Pagination.builder().page(page).perPage(perPage).totalCount(total).pageItemsCount(pageItemsCount).pageCount(4).build()
-            );
+            .isEqualTo(new Pagination().page(page).perPage(perPage).totalCount(total).pageItemsCount(pageItemsCount).pageCount(4));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
@@ -40,7 +40,7 @@ public class PaginationLinksTest {
 
         var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
 
-        assertThat(result).isEqualTo(Links.builder().self(REQUEST_URI.toString()).build());
+        assertThat(result).isEqualTo(new Links().self(REQUEST_URI.toString()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class PaginationLinksTest {
 
         var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
 
-        assertThat(result).isEqualTo(Links.builder().self(REQUEST_URI.toString()).build());
+        assertThat(result).isEqualTo(new Links().self(REQUEST_URI.toString()));
     }
 
     @Test
@@ -62,13 +62,11 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI.toString())
                     .first(REQUEST_URI + "?page=1")
                     .next(REQUEST_URI + "?page=2")
                     .last(REQUEST_URI + "?page=4")
-                    .build()
             );
     }
 
@@ -86,13 +84,11 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI + "?perPage=10")
                     .first(REQUEST_URI + "?perPage=10&page=1")
                     .next(REQUEST_URI + "?perPage=10&page=2")
                     .last(REQUEST_URI + "?perPage=10&page=4")
-                    .build()
             );
     }
 
@@ -111,13 +107,11 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI + "?page=1")
                     .first(REQUEST_URI + "?page=1")
                     .next(REQUEST_URI + "?page=2")
                     .last(REQUEST_URI + "?page=4")
-                    .build()
             );
     }
 
@@ -136,14 +130,12 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI + "?page=2")
                     .first(REQUEST_URI + "?page=1")
                     .next(REQUEST_URI + "?page=3")
                     .previous(REQUEST_URI + "?page=1")
                     .last(REQUEST_URI + "?page=4")
-                    .build()
             );
     }
 
@@ -162,13 +154,11 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI + "?page=4")
                     .first(REQUEST_URI + "?page=1")
                     .previous(REQUEST_URI + "?page=3")
                     .last(REQUEST_URI + "?page=4")
-                    .build()
             );
     }
 
@@ -192,14 +182,12 @@ public class PaginationLinksTest {
 
         assertThat(result)
             .isEqualTo(
-                Links
-                    .builder()
+                new Links()
                     .self(REQUEST_URI + "?page=2&perPage=10")
                     .first(REQUEST_URI + "?page=1&perPage=10")
                     .next(REQUEST_URI + "?page=3&perPage=10")
                     .previous(REQUEST_URI + "?page=1&perPage=10")
                     .last(REQUEST_URI + "?page=4&perPage=10")
-                    .build()
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -64,6 +64,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -159,23 +160,19 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
+                    new ApiLogsResponse()
                         .data(
                             List.of(
-                                ApiLog
-                                    .builder()
-                                    .application(BaseApplication.builder().id(APPLICATION.getId()).name(APPLICATION.getName()).build())
+                                new ApiLog()
+                                    .application(new BaseApplication().id(APPLICATION.getId()).name(APPLICATION.getName()))
                                     .plan(
-                                        BasePlan
-                                            .builder()
+                                        new BasePlan()
                                             .id(PLAN_1.getId())
                                             .name(PLAN_1.getName())
                                             .apiId(API)
                                             .description(PLAN_1.getDescription())
-                                            .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
+                                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
                                             .mode(PlanMode.STANDARD)
-                                            .build()
                                     )
                                     .method(HttpMethod.GET)
                                     .status(200)
@@ -184,12 +181,10 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                                     .requestId("req1")
                                     .transactionId("transaction-id")
                                     .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
-                                    .build()
                             )
                         )
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
 
@@ -211,7 +206,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .extracting(ApiLogsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total).build());
+                .isEqualTo(new Pagination().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total));
         }
 
         @Test
@@ -234,14 +229,12 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .asEntity(ApiLogsResponse.class)
                 .extracting(ApiLogsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(connectionLogsTarget.queryParam("page", page).queryParam("perPage", pageSize).getUri().toString())
                         .first(connectionLogsTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .last(connectionLogsTarget.queryParam("page", 4).queryParam("perPage", pageSize).getUri().toString())
                         .previous(connectionLogsTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .next(connectionLogsTarget.queryParam("page", 3).queryParam("perPage", pageSize).getUri().toString())
-                        .build()
                 );
         }
 
@@ -303,47 +296,43 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                     .queryParam(SearchLogsParam.TO_QUERY_PARAM_NAME, Instant.parse("2020-02-03T23:59:59.00Z").toEpochMilli());
             final Response response = connectionLogsTarget.request().get();
 
-            var expectedApiLog = ApiLog
-                .builder()
-                .application(BaseApplication.builder().id(APPLICATION.getId()).name(APPLICATION.getName()).build())
-                .plan(
-                    BasePlan
-                        .builder()
-                        .id(PLAN_1.getId())
-                        .name(PLAN_1.getName())
-                        .apiId(API)
-                        .description(PLAN_1.getDescription())
-                        .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
-                        .mode(PlanMode.STANDARD)
-                        .build()
-                )
-                .method(HttpMethod.GET)
-                .status(200)
-                .clientIdentifier("client-identifier")
-                .requestEnded(true)
-                .transactionId("transaction-id");
+            Supplier<ApiLog> expectedApiLog = () ->
+                new ApiLog()
+                    .application(new BaseApplication().id(APPLICATION.getId()).name(APPLICATION.getName()))
+                    .plan(
+                        new BasePlan()
+                            .id(PLAN_1.getId())
+                            .name(PLAN_1.getName())
+                            .apiId(API)
+                            .description(PLAN_1.getDescription())
+                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
+                            .mode(PlanMode.STANDARD)
+                    )
+                    .method(HttpMethod.GET)
+                    .status(200)
+                    .clientIdentifier("client-identifier")
+                    .requestEnded(true)
+                    .transactionId("transaction-id");
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
+                    new ApiLogsResponse()
                         .data(
                             List.of(
                                 expectedApiLog
+                                    .get()
                                     .requestId("req2")
-                                    .timestamp(Instant.parse("2020-02-02T20:00:00.00Z").atOffset(ZoneOffset.UTC))
-                                    .build(),
+                                    .timestamp(Instant.parse("2020-02-02T20:00:00.00Z").atOffset(ZoneOffset.UTC)),
                                 expectedApiLog
+                                    .get()
                                     .requestId("req1")
                                     .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
-                                    .build()
                             )
                         )
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
 
@@ -360,37 +349,33 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             connectionLogsTarget = connectionLogsTarget.queryParam(SearchLogsParam.APPLICATION_IDS_QUERY_PARAM_NAME, "app1");
             final Response response = connectionLogsTarget.request().get();
 
-            var expectedApiLog = ApiLog
-                .builder()
-                .application(BaseApplication.builder().id("app1").name(APPLICATION.getName()).build())
-                .plan(
-                    BasePlan
-                        .builder()
-                        .id(PLAN_1.getId())
-                        .name(PLAN_1.getName())
-                        .apiId(API)
-                        .description(PLAN_1.getDescription())
-                        .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
-                        .mode(PlanMode.STANDARD)
-                        .build()
-                )
-                .method(HttpMethod.GET)
-                .status(200)
-                .clientIdentifier("client-identifier")
-                .requestEnded(true)
-                .transactionId("transaction-id")
-                .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC));
+            Supplier<ApiLog> expectedApiLog = () ->
+                new ApiLog()
+                    .application(new BaseApplication().id("app1").name(APPLICATION.getName()))
+                    .plan(
+                        new BasePlan()
+                            .id(PLAN_1.getId())
+                            .name(PLAN_1.getName())
+                            .apiId(API)
+                            .description(PLAN_1.getDescription())
+                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
+                            .mode(PlanMode.STANDARD)
+                    )
+                    .method(HttpMethod.GET)
+                    .status(200)
+                    .clientIdentifier("client-identifier")
+                    .requestEnded(true)
+                    .transactionId("transaction-id")
+                    .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC));
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
-                        .data(List.of(expectedApiLog.requestId("req1").build(), expectedApiLog.requestId("req2").build()))
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                    new ApiLogsResponse()
+                        .data(List.of(expectedApiLog.get().requestId("req1"), expectedApiLog.get().requestId("req2")))
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
 
@@ -407,37 +392,33 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             connectionLogsTarget = connectionLogsTarget.queryParam(SearchLogsParam.PLAN_IDS_QUERY_PARAM_NAME, PLAN_1.getId());
             final Response response = connectionLogsTarget.request().get();
 
-            var expectedApiLog = ApiLog
-                .builder()
-                .application(BaseApplication.builder().id("app1").name(APPLICATION.getName()).build())
-                .plan(
-                    BasePlan
-                        .builder()
-                        .id(PLAN_1.getId())
-                        .name(PLAN_1.getName())
-                        .apiId(API)
-                        .description(PLAN_1.getDescription())
-                        .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
-                        .mode(PlanMode.STANDARD)
-                        .build()
-                )
-                .method(HttpMethod.GET)
-                .status(200)
-                .clientIdentifier("client-identifier")
-                .requestEnded(true)
-                .transactionId("transaction-id")
-                .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC));
+            Supplier<ApiLog> expectedApiLog = () ->
+                new ApiLog()
+                    .application(new BaseApplication().id("app1").name(APPLICATION.getName()))
+                    .plan(
+                        new BasePlan()
+                            .id(PLAN_1.getId())
+                            .name(PLAN_1.getName())
+                            .apiId(API)
+                            .description(PLAN_1.getDescription())
+                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
+                            .mode(PlanMode.STANDARD)
+                    )
+                    .method(HttpMethod.GET)
+                    .status(200)
+                    .clientIdentifier("client-identifier")
+                    .requestEnded(true)
+                    .transactionId("transaction-id")
+                    .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC));
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
-                        .data(List.of(expectedApiLog.requestId("req1").build(), expectedApiLog.requestId("req2").build()))
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                    new ApiLogsResponse()
+                        .data(List.of(expectedApiLog.get().requestId("req1"), expectedApiLog.get().requestId("req2")))
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
 
@@ -458,23 +439,19 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
+                    new ApiLogsResponse()
                         .data(
                             List.of(
-                                ApiLog
-                                    .builder()
-                                    .application(BaseApplication.builder().id("app1").name(APPLICATION.getName()).build())
+                                new ApiLog()
+                                    .application(new BaseApplication().id("app1").name(APPLICATION.getName()))
                                     .plan(
-                                        BasePlan
-                                            .builder()
+                                        new BasePlan()
                                             .id(PLAN_1.getId())
                                             .name(PLAN_1.getName())
                                             .apiId(API)
                                             .description(PLAN_1.getDescription())
-                                            .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
+                                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
                                             .mode(PlanMode.STANDARD)
-                                            .build()
                                     )
                                     .method(HttpMethod.GET)
                                     .status(200)
@@ -483,12 +460,10 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                                     .transactionId("transaction-id")
                                     .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
                                     .requestId("req2")
-                                    .build()
                             )
                         )
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
 
@@ -509,23 +484,19 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .isEqualTo(
-                    ApiLogsResponse
-                        .builder()
+                    new ApiLogsResponse()
                         .data(
                             List.of(
-                                ApiLog
-                                    .builder()
-                                    .application(BaseApplication.builder().id("app1").name(APPLICATION.getName()).build())
+                                new ApiLog()
+                                    .application(new BaseApplication().id("app1").name(APPLICATION.getName()))
                                     .plan(
-                                        BasePlan
-                                            .builder()
+                                        new BasePlan()
                                             .id(PLAN_1.getId())
                                             .name(PLAN_1.getName())
                                             .apiId(API)
                                             .description(PLAN_1.getDescription())
-                                            .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).build())
+                                            .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS))
                                             .mode(PlanMode.STANDARD)
-                                            .build()
                                     )
                                     .method(HttpMethod.GET)
                                     .status(202)
@@ -534,12 +505,10 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                                     .transactionId("transaction-id")
                                     .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
                                     .requestId("req2")
-                                    .build()
                             )
                         )
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
-                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L))
+                        .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
     }
@@ -578,12 +547,10 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiMessageLogsResponse.class)
                 .isEqualTo(
-                    ApiMessageLogsResponse
-                        .builder()
+                    new ApiMessageLogsResponse()
                         .data(
                             List.of(
-                                ApiMessageLog
-                                    .builder()
+                                new ApiMessageLog()
                                     .requestId(REQUEST_ID)
                                     .clientIdentifier("client-identifier")
                                     .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
@@ -591,31 +558,25 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                                     .parentCorrelationId("parent-correlation-id")
                                     .operation(MessageOperation.SUBSCRIBE.name())
                                     .entrypoint(
-                                        ApiMessageLogContent
-                                            .builder()
+                                        new ApiMessageLogContent()
                                             .connectorId("http-get")
                                             .id("message-id")
                                             .payload("message-payload")
                                             .headers(Map.of("X-Header", List.of("header-value")))
                                             .metadata(Map.of("X-Metdata", "metadata-value"))
-                                            .build()
                                     )
                                     .endpoint(
-                                        ApiMessageLogContent
-                                            .builder()
+                                        new ApiMessageLogContent()
                                             .connectorId("kafka")
                                             .id("message-id")
                                             .payload("message-payload")
                                             .headers(Map.of("X-Header", List.of("header-value")))
                                             .metadata(Map.of("X-Metdata", "metadata-value"))
-                                            .build()
                                     )
-                                    .build()
                             )
                         )
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
-                        .links(Links.builder().self(messageLogsTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L))
+                        .links(new Links().self(messageLogsTarget.getUri().toString()))
                 );
         }
 
@@ -640,7 +601,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogsResponse.class)
                 .extracting(ApiLogsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total).build());
+                .isEqualTo(new Pagination().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total));
         }
 
         @Test
@@ -666,14 +627,12 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .asEntity(ApiLogsResponse.class)
                 .extracting(ApiLogsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(messageLogsTarget.queryParam("page", page).queryParam("perPage", pageSize).getUri().toString())
                         .first(messageLogsTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .last(messageLogsTarget.queryParam("page", 4).queryParam("perPage", pageSize).getUri().toString())
                         .previous(messageLogsTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .next(messageLogsTarget.queryParam("page", 3).queryParam("perPage", pageSize).getUri().toString())
-                        .build()
                 );
         }
     }
@@ -713,44 +672,34 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiLogResponse.class)
                 .isEqualTo(
-                    ApiLogResponse
-                        .builder()
+                    new ApiLogResponse()
                         .requestId(connectionLogDetail.getRequestId())
                         .apiId(connectionLogDetail.getApiId())
                         .timestamp(Instant.parse(connectionLogDetail.getTimestamp()).atOffset(ZoneOffset.UTC))
                         .requestEnded(connectionLogDetail.isRequestEnded())
                         .clientIdentifier(connectionLogDetail.getClientIdentifier())
                         .entrypointRequest(
-                            ApiLogRequestContent
-                                .builder()
+                            new ApiLogRequestContent()
                                 .uri(connectionLogDetail.getEntrypointRequest().getUri())
                                 .method(HttpMethod.valueOf(connectionLogDetail.getEntrypointRequest().getMethod()))
                                 .headers(connectionLogDetail.getEntrypointRequest().getHeaders())
-                                .build()
                         )
                         .endpointRequest(
-                            ApiLogRequestContent
-                                .builder()
+                            new ApiLogRequestContent()
                                 .uri(connectionLogDetail.getEndpointRequest().getUri())
                                 .method(HttpMethod.valueOf(connectionLogDetail.getEndpointRequest().getMethod()))
                                 .headers(connectionLogDetail.getEndpointRequest().getHeaders())
-                                .build()
                         )
                         .endpointResponse(
-                            ApiLogResponseContent
-                                .builder()
+                            new ApiLogResponseContent()
                                 .status(connectionLogDetail.getEndpointResponse().getStatus())
                                 .headers(connectionLogDetail.getEndpointResponse().getHeaders())
-                                .build()
                         )
                         .entrypointResponse(
-                            ApiLogResponseContent
-                                .builder()
+                            new ApiLogResponseContent()
                                 .status(connectionLogDetail.getEntrypointResponse().getStatus())
                                 .headers(connectionLogDetail.getEntrypointResponse().getHeaders())
-                                .build()
                         )
-                        .build()
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResourceTest.java
@@ -121,21 +121,19 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_role_is_primary_owner() {
-            var newMembership = AddMember.builder().roleName("PRIMARY_OWNER").build();
+            var newMembership = new AddMember().roleName("PRIMARY_OWNER");
             final Response response = target.request().post(Entity.json(newMembership));
             assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessage("An API must always have only one PRIMARY_OWNER !");
         }
 
         @Test
         public void should_create_an_api_member() {
-            var newMembership = AddMember.builder().roleName("OWNER").userId("userId").build();
+            var newMembership = new AddMember().roleName("OWNER").userId("userId");
             final Response response = target.request().post(Entity.json(newMembership));
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(Member.class)
-                .isEqualTo(
-                    Member.builder().id("userId").displayName("John Doe").roles(List.of(Role.builder().name("OWNER").build())).build()
-                );
+                .isEqualTo(new Member().id("userId").displayName("John Doe").roles(List.of(new Role().name("OWNER"))));
         }
     }
 
@@ -177,12 +175,10 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1))
                         .data(Stream.of(member).map(MemberMapper.INSTANCE::map).toList())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -244,20 +240,16 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(2).perPage(2).totalCount(4L).pageItemsCount(2).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(2).perPage(2).totalCount(4L).pageItemsCount(2))
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .links(
-                            Links
-                                .builder()
+                            new Links()
                                 .self(paginatedTarget.getUri().toString())
                                 .first(paginatedTarget.getUri().toString())
                                 .last(target.queryParam("page", 2).queryParam("perPage", 2).getUri().toString())
                                 .next(target.queryParam("page", 2).queryParam("perPage", 2).getUri().toString())
-                                .build()
                         )
-                        .build()
                 );
         }
     }
@@ -336,7 +328,7 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_editing_with_role_primary_owner() {
-            var newMembership = UpdateMember.builder().roleName("PRIMARY_OWNER").build();
+            var newMembership = new UpdateMember().roleName("PRIMARY_OWNER");
 
             final Response response = target.request().put(Entity.json(newMembership));
 
@@ -345,16 +337,14 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_edit_a_membership() {
-            var newMembership = UpdateMember.builder().roleName("OWNER").build();
+            var newMembership = new UpdateMember().roleName("OWNER");
 
             final Response response = target.request().put(Entity.json(newMembership));
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(Member.class)
-                .isEqualTo(
-                    Member.builder().id(MEMBER_ID).displayName("John Doe").roles(List.of(Role.builder().name("OWNER").build())).build()
-                );
+                .isEqualTo(new Member().id(MEMBER_ID).displayName("John Doe").roles(List.of(new Role().name("OWNER"))));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -178,12 +178,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().build())
-                        .data(List.of())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                    new PlansResponse().pagination(new Pagination()).data(List.of()).links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -202,9 +197,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
+                    new PlansResponse()
+                        .pagination(new Pagination().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1))
                         .data(
                             Stream
                                 .of(plan3, plan1)
@@ -216,8 +210,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                                 })
                                 .toList()
                         )
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -236,9 +229,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
+                    new PlansResponse()
+                        .pagination(new Pagination().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1))
                         .data(
                             Stream
                                 .of(plan2, plan1)
@@ -250,8 +242,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                                 })
                                 .toList()
                         )
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -300,9 +291,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).perPage(1).pageItemsCount(1).totalCount(2L).pageCount(2).build())
+                    new PlansResponse()
+                        .pagination(new Pagination().page(1).perPage(1).pageItemsCount(1).totalCount(2L).pageCount(2))
                         .data(
                             Stream
                                 .of(plan1)
@@ -315,15 +305,12 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                                 .toList()
                         )
                         .links(
-                            Links
-                                .builder()
+                            new Links()
                                 .self(target.getUri().toString())
                                 .first(target.queryParam("page", 1).getUri().toString())
                                 .last(target.queryParam("page", 2).getUri().toString())
                                 .next(target.queryParam("page", 2).getUri().toString())
-                                .build()
                         )
-                        .build()
                 );
         }
 
@@ -367,9 +354,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
+                    new PlansResponse()
+                        .pagination(new Pagination().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1))
                         .data(
                             Stream
                                 .of(plan1, plan3)
@@ -381,8 +367,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                                 })
                                 .toList()
                         )
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -478,9 +463,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
                 .isEqualTo(
-                    PlansResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
+                    new PlansResponse()
+                        .pagination(new Pagination().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1))
                         .data(
                             Stream
                                 .of(plan3, plan4)
@@ -492,8 +476,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                                 })
                                 .toList()
                         )
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
     }
@@ -545,8 +528,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(CREATED_201)
                 .asEntity(PlanV4.class)
                 .isEqualTo(
-                    PlanV4
-                        .builder()
+                    new PlanV4()
+                        .flows(createPlanV4.getFlows())
                         .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
                         .id(planId)
                         .crossId(createPlanV4.getCrossId())
@@ -560,14 +543,12 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .validation(createPlanV4.getValidation())
                         .mode(PlanMode.STANDARD)
                         .status(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.STAGING)
-                        .security(PlanSecurity.builder().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")))
                         .selectionRule(createPlanV4.getSelectionRule())
                         .characteristics(createPlanV4.getCharacteristics())
                         .excludedGroups(createPlanV4.getExcludedGroups())
                         .tags(List.of("tag1", "tag2"))
                         .type(io.gravitee.rest.api.management.v2.rest.model.PlanType.API)
-                        .flows(createPlanV4.getFlows())
-                        .build()
                 );
         }
 
@@ -589,8 +570,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(CREATED_201)
                 .asEntity(PlanV4.class)
                 .isEqualTo(
-                    PlanV4
-                        .builder()
+                    new PlanV4()
+                        .flows(createPlanV4.getFlows())
                         .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
                         .id(planId)
                         .crossId(createPlanV4.getCrossId())
@@ -604,14 +585,12 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .validation(createPlanV4.getValidation())
                         .mode(PlanMode.STANDARD)
                         .status(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.STAGING)
-                        .security(PlanSecurity.builder().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")))
                         .selectionRule(createPlanV4.getSelectionRule())
                         .characteristics(createPlanV4.getCharacteristics())
                         .excludedGroups(createPlanV4.getExcludedGroups())
                         .tags(List.of("tag1", "tag2"))
                         .type(io.gravitee.rest.api.management.v2.rest.model.PlanType.API)
-                        .flows(createPlanV4.getFlows())
-                        .build()
                 );
         }
 
@@ -624,15 +603,15 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                     return new PlanWithFlows(plan.setPlanId(planId), invocation.getArgument(1));
                 });
 
-            final CreatePlanV4 createPlanV4 = PlanFixtures.aCreatePlanHttpV4().toBuilder().flows(null).build();
+            final CreatePlanV4 createPlanV4 = PlanFixtures.aCreatePlanHttpV4().flows(null);
             final Response response = target.request().post(Entity.json(createPlanV4));
 
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(PlanV4.class)
                 .isEqualTo(
-                    PlanV4
-                        .builder()
+                    new PlanV4()
+                        .flows(Collections.emptyList())
                         .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
                         .id(planId)
                         .crossId(createPlanV4.getCrossId())
@@ -646,14 +625,12 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .validation(createPlanV4.getValidation())
                         .mode(PlanMode.STANDARD)
                         .status(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.STAGING)
-                        .security(PlanSecurity.builder().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.API_KEY).configuration(Map.of("nice", "config")))
                         .selectionRule(createPlanV4.getSelectionRule())
                         .characteristics(createPlanV4.getCharacteristics())
                         .excludedGroups(createPlanV4.getExcludedGroups())
                         .tags(List.of("tag1", "tag2"))
                         .type(io.gravitee.rest.api.management.v2.rest.model.PlanType.API)
-                        .flows(Collections.emptyList())
-                        .build()
                 );
         }
 
@@ -680,19 +657,17 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(CREATED_201)
                 .asEntity(PlanV2.class)
                 .isEqualTo(
-                    PlanV2
-                        .builder()
+                    new PlanV2()
+                        .paths(Map.of())
+                        .flows(createPlanV2.getFlows())
                         .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V2)
                         .id("new-id")
                         .apiId(API)
                         .name(createPlanV2.getName())
                         .type(io.gravitee.rest.api.management.v2.rest.model.PlanType.API)
-                        .security(PlanSecurity.builder().type(PlanSecurityType.API_KEY).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.API_KEY))
                         .order(0)
                         .commentRequired(false)
-                        .flows(createPlanV2.getFlows())
-                        .paths(Map.of())
-                        .build()
                 );
         }
     }
@@ -773,10 +748,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
             final Response response = target.request().get();
 
-            assertThat(response)
-                .hasStatus(OK_200)
-                .asEntity(PlanV2.class)
-                .isEqualTo(PlanMapper.INSTANCE.map(planEntity).toBuilder().paths(Map.of()).build());
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity).paths(Map.of()));
         }
     }
 
@@ -866,8 +838,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlanV4.class)
                 .isEqualTo(
-                    PlanV4
-                        .builder()
+                    new PlanV4()
+                        .flows(updatePlanV4.getFlows())
                         .id(PLAN)
                         .apiId(API)
                         .status(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.PUBLISHED)
@@ -883,13 +855,11 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .characteristics(updatePlanV4.getCharacteristics())
                         .order(updatePlanV4.getOrder())
                         .excludedGroups(updatePlanV4.getExcludedGroups())
-                        .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).configuration(Map.of("nice", "config")).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS).configuration(Map.of("nice", "config")))
                         .commentRequired(false)
                         .commentMessage(updatePlanV4.getCommentMessage())
                         .tags(updatePlanV4.getTags())
                         .selectionRule(updatePlanV4.getSelectionRule())
-                        .flows(updatePlanV4.getFlows())
-                        .build()
                 );
         }
 
@@ -917,8 +887,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlanV4.class)
                 .isEqualTo(
-                    PlanV4
-                        .builder()
+                    new PlanV4()
+                        .flows(updatePlanV4.getFlows())
                         .id(PLAN)
                         .apiId(API)
                         .status(io.gravitee.rest.api.management.v2.rest.model.PlanStatus.PUBLISHED)
@@ -934,13 +904,11 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .characteristics(updatePlanV4.getCharacteristics())
                         .order(updatePlanV4.getOrder())
                         .excludedGroups(updatePlanV4.getExcludedGroups())
-                        .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS).configuration(Map.of("nice", "config")).build())
+                        .security(new PlanSecurity().type(PlanSecurityType.KEY_LESS).configuration(Map.of("nice", "config")))
                         .commentRequired(false)
                         .commentMessage(updatePlanV4.getCommentMessage())
                         .tags(updatePlanV4.getTags())
                         .selectionRule(updatePlanV4.getSelectionRule())
-                        .flows(updatePlanV4.getFlows())
-                        .build()
                 );
         }
 
@@ -991,8 +959,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(PlanV2.class)
                 .isEqualTo(
-                    PlanV2
-                        .builder()
+                    new PlanV2()
+                        .flows(updatePlanV2.getFlows())
+                        .paths(Map.of())
                         .id(PLAN)
                         .definitionVersion(DefinitionVersion.V2)
                         .name(updatePlanV2.getName())
@@ -1003,14 +972,11 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                         .characteristics(updatePlanV2.getCharacteristics())
                         .order(updatePlanV2.getOrder())
                         .excludedGroups(updatePlanV2.getExcludedGroups())
-                        .security(PlanSecurity.builder().build())
+                        .security(new PlanSecurity())
                         .commentRequired(false)
                         .commentMessage(updatePlanV2.getCommentMessage())
                         .tags(updatePlanV2.getTags())
                         .selectionRule(updatePlanV2.getSelectionRule())
-                        .flows(updatePlanV2.getFlows())
-                        .paths(Map.of())
-                        .build()
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DuplicateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DuplicateApiTest.java
@@ -185,10 +185,6 @@ class ApiResource_DuplicateApiTest extends ApiResourceTest {
     }
 
     private DuplicateApiOptions aDuplicateApiOptions() {
-        return DuplicateApiOptions
-            .builder()
-            .contextPath("/duplicate")
-            .filteredFields(Set.of(DuplicateApiOptions.FilteredFieldsEnum.GROUPS))
-            .build();
+        return new DuplicateApiOptions().contextPath("/duplicate").filteredFields(Set.of(DuplicateApiOptions.FilteredFieldsEnum.GROUPS));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_RollbackTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_RollbackTest.java
@@ -111,6 +111,6 @@ class ApiResource_RollbackTest extends ApiResourceTest {
     }
 
     private ApiRollback aRollbackPayload(String eventId) {
-        return ApiRollback.builder().eventId(eventId).build();
+        return new ApiRollback().eventId(eventId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -246,12 +246,10 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
 
         var updateApiFederated = ApiFixtures
             .anUpdateApiFederated()
-            .toBuilder()
             .name(updatedName)
             .description(updatedDescription)
             .apiVersion(updatedVersion)
-            .lifecycleState(updatedLifecycle)
-            .build();
+            .lifecycleState(updatedLifecycle);
 
         final Response response = rootTarget(API).request().put(Entity.json(updateApiFederated));
 
@@ -303,13 +301,11 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
 
         var updateApiV4 = ApiFixtures
             .anUpdateApiV4()
-            .toBuilder()
             .type(ApiType.NATIVE)
             .name(updatedName)
             .description(updatedDescription)
             .apiVersion(updatedVersion)
-            .lifecycleState(updatedLifecycle)
-            .build();
+            .lifecycleState(updatedLifecycle);
 
         final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
@@ -49,7 +49,6 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
-import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.ws.rs.client.Entity;
@@ -85,9 +84,6 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Autowired
     protected ApiKeyService apiKeyService;
-
-    @Autowired
-    protected UserService userService;
 
     @Autowired
     AcceptSubscriptionUseCase acceptSubscriptionUseCase;
@@ -132,12 +128,10 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
         public void should_create_subscription() {
             final CreateSubscription createSubscription = SubscriptionFixtures
                 .aCreateSubscription()
-                .toBuilder()
                 .applicationId(APPLICATION)
                 .planId(PLAN)
                 .customApiKey(null)
-                .apiKeyMode(ApiKeyMode.EXCLUSIVE)
-                .build();
+                .apiKeyMode(ApiKeyMode.EXCLUSIVE);
 
             when(subscriptionService.create(eq(GraviteeContext.getExecutionContext()), any(NewSubscriptionEntity.class), any()))
                 .thenReturn(
@@ -148,13 +142,13 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(Subscription.class)
-                .satisfies(subscription -> {
+                .satisfies(subscription ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(subscription.getId()).isEqualTo(SUBSCRIPTION);
                         soft.assertThat(subscription.getPlan()).extracting(BasePlan::getId).isEqualTo(PLAN);
                         soft.assertThat(subscription.getApplication()).extracting(BaseApplication::getId).isEqualTo(APPLICATION);
-                    });
-                });
+                    })
+                );
 
             verify(subscriptionService)
                 .create(
@@ -193,11 +187,9 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
         public void should_return_400_if_custom_api_key_not_enabled() {
             final CreateSubscription createSubscription = SubscriptionFixtures
                 .aCreateSubscription()
-                .toBuilder()
                 .applicationId(APPLICATION)
                 .planId(PLAN)
-                .customApiKey("custom")
-                .build();
+                .customApiKey("custom");
 
             when(
                 parameterService.findAsBoolean(
@@ -221,11 +213,9 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
         public void should_create_subscription_with_custom_api_key() {
             final CreateSubscription createSubscription = SubscriptionFixtures
                 .aCreateSubscription()
-                .toBuilder()
                 .applicationId(APPLICATION)
                 .planId(PLAN)
-                .customApiKey("custom")
-                .build();
+                .customApiKey("custom");
 
             when(
                 parameterService.findAsBoolean(
@@ -258,11 +248,9 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
         public void should_create_subscription_with_custom_api_key_and_auto_process_it_if_pending() {
             final CreateSubscription createSubscription = SubscriptionFixtures
                 .aCreateSubscription()
-                .toBuilder()
                 .applicationId(APPLICATION)
                 .planId(PLAN)
-                .customApiKey(null)
-                .build();
+                .customApiKey(null);
 
             doReturn(
                 SubscriptionFixtures
@@ -294,13 +282,13 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(Subscription.class)
-                .satisfies(subscription -> {
+                .satisfies(subscription ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(subscription.getId()).isEqualTo(SUBSCRIPTION);
                         soft.assertThat(subscription.getPlan()).extracting(BasePlan::getId).isEqualTo(PLAN);
                         soft.assertThat(subscription.getApplication()).extracting(BaseApplication::getId).isEqualTo(APPLICATION);
-                    });
-                });
+                    })
+                );
         }
     }
 
@@ -334,13 +322,13 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(Subscription.class)
-                .satisfies(subscription -> {
+                .satisfies(subscription ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(subscription.getId()).isEqualTo(SUBSCRIPTION);
                         soft.assertThat(subscription.getPlan()).extracting(BasePlan::getId).isEqualTo(PLAN);
                         soft.assertThat(subscription.getApplication()).extracting(BaseApplication::getId).isEqualTo(APPLICATION);
-                    });
-                });
+                    })
+                );
 
             var captor = ArgumentCaptor.forClass(AcceptSubscriptionUseCase.Input.class);
             verify(acceptSubscriptionUseCase).execute(captor.capture());
@@ -407,14 +395,14 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(Subscription.class)
-                .satisfies(subscription -> {
+                .satisfies(subscription ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(subscription.getId()).isEqualTo(SUBSCRIPTION);
                         soft
                             .assertThat(subscription.getStatus())
                             .isEqualTo(io.gravitee.rest.api.management.v2.rest.model.SubscriptionStatus.REJECTED);
-                    });
-                });
+                    })
+                );
 
             var captor = ArgumentCaptor.forClass(RejectSubscriptionUseCase.Input.class);
             verify(rejectSubscriptionUseCase).execute(captor.capture());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListApiKeysTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListApiKeysTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
+import static assertions.MAPIAssertions.assertThat;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import assertions.MAPIAssertions;
 import fixtures.SubscriptionFixtures;
-import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
 import io.gravitee.rest.api.management.v2.rest.model.Pagination;
 import io.gravitee.rest.api.management.v2.rest.model.SubscriptionApiKeysResponse;
@@ -50,11 +51,11 @@ public class ApiSubscriptionsResource_ListApiKeysTest extends AbstractApiSubscri
         when(subscriptionService.findById(SUBSCRIPTION)).thenThrow(new SubscriptionNotFoundException(SUBSCRIPTION));
 
         final Response response = rootTarget().request().get();
-        assertEquals(NOT_FOUND_404, response.getStatus());
-
-        var error = response.readEntity(Error.class);
-        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
-        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+        assertThat(response)
+            .hasStatus(HttpStatusCode.NOT_FOUND_404)
+            .asError()
+            .hasHttpStatus(NOT_FOUND_404)
+            .hasMessage("Subscription [" + SUBSCRIPTION + "] cannot be found.");
     }
 
     @Test
@@ -81,7 +82,7 @@ public class ApiSubscriptionsResource_ListApiKeysTest extends AbstractApiSubscri
 
         // Check links
         Links links = subscriptionApiKeysResponse.getLinks();
-        MAPIAssertions.assertThat(links).isEqualTo(Links.builder().self(rootTarget().getUri().toString()).build());
+        MAPIAssertions.assertThat(links).isEqualTo(new Links().self(rootTarget().getUri().toString()));
     }
 
     @Test
@@ -97,11 +98,7 @@ public class ApiSubscriptionsResource_ListApiKeysTest extends AbstractApiSubscri
             .thenReturn(false);
 
         final Response response = rootTarget().request().get();
-        assertEquals(FORBIDDEN_403, response.getStatus());
-
-        var error = response.readEntity(Error.class);
-        assertEquals(FORBIDDEN_403, (int) error.getHttpStatus());
-        assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
+        MAPIAssertions.assertThat(response).hasStatus(FORBIDDEN_403);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListTest.java
@@ -18,8 +18,6 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -83,7 +81,7 @@ public class ApiSubscriptionsResource_ListTest extends AbstractApiSubscriptionsR
 
         // Check links
         Links links = subscriptionsResponse.getLinks();
-        MAPIAssertions.assertThat(links).isEqualTo(Links.builder().self(rootTarget().getUri().toString()).build());
+        MAPIAssertions.assertThat(links).isEqualTo(new Links().self(rootTarget().getUri().toString()));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_RenewApiKeysTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_RenewApiKeysTest.java
@@ -173,9 +173,7 @@ public class ApiSubscriptionsResource_RenewApiKeysTest extends AbstractApiSubscr
             .thenReturn(ApplicationFixtures.anApplicationEntity());
         when(apiKeyService.renew(GraviteeContext.getExecutionContext(), subscriptionEntity, customApiKey)).thenReturn(apiKeyEntity);
 
-        final Response response = rootTarget()
-            .request()
-            .post(Entity.json(SubscriptionFixtures.aRenewApiKey().toBuilder().customApiKey(customApiKey).build()));
+        final Response response = rootTarget().request().post(Entity.json(SubscriptionFixtures.aRenewApiKey().customApiKey(customApiKey)));
         assertEquals(OK_200, response.getStatus());
 
         var apiKey = response.readEntity(ApiKey.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_UpdateApiKeyTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_UpdateApiKeyTest.java
@@ -201,7 +201,7 @@ public class ApiSubscriptionsResource_UpdateApiKeyTest extends AbstractApiSubscr
         when(apiKeyService.findById(GraviteeContext.getExecutionContext(), API_KEY_ID)).thenReturn(apiKeyEntity);
         when(apiKeyService.update(any(), any())).thenAnswer(i -> i.getArgument(1));
 
-        final UpdateApiKey updateApiKey = UpdateApiKey.builder().expireAt(null).build();
+        final UpdateApiKey updateApiKey = new UpdateApiKey().expireAt(null);
         final Response response = rootTarget().request().put(Entity.json(updateApiKey));
 
         assertEquals(OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest.java
@@ -76,9 +76,7 @@ public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends Ab
 
     @Test
     public void should_return_400_when_invalid_api_key_pattern() {
-        final Response response = rootTarget()
-            .request()
-            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().apiKey("###").build()));
+        final Response response = rootTarget().request().post(Entity.json(SubscriptionFixtures.aVerifySubscription().apiKey("###")));
         assertEquals(BAD_REQUEST_400, response.getStatus());
 
         var error = response.readEntity(Error.class);
@@ -88,9 +86,7 @@ public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends Ab
 
     @Test
     public void should_return_400_when_missing_api_key() {
-        final Response response = rootTarget()
-            .request()
-            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().apiKey(null).build()));
+        final Response response = rootTarget().request().post(Entity.json(SubscriptionFixtures.aVerifySubscription().apiKey(null)));
         assertEquals(BAD_REQUEST_400, response.getStatus());
 
         var error = response.readEntity(Error.class);
@@ -100,9 +96,7 @@ public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends Ab
 
     @Test
     public void should_return_400_when_missing_application() {
-        final Response response = rootTarget()
-            .request()
-            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().applicationId(null).build()));
+        final Response response = rootTarget().request().post(Entity.json(SubscriptionFixtures.aVerifySubscription().applicationId(null)));
         assertEquals(BAD_REQUEST_400, response.getStatus());
 
         var error = response.readEntity(Error.class);
@@ -116,10 +110,8 @@ public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends Ab
 
         final VerifySubscription verifySubscription = SubscriptionFixtures
             .aVerifySubscription()
-            .toBuilder()
             .applicationId(APPLICATION)
-            .apiKey("apiKey")
-            .build();
+            .apiKey("apiKey");
         final Response response = rootTarget().request().post(Entity.json(verifySubscription));
         assertEquals(OK_200, response.getStatus());
 
@@ -133,10 +125,8 @@ public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends Ab
 
         final VerifySubscription verifySubscription = SubscriptionFixtures
             .aVerifySubscription()
-            .toBuilder()
             .applicationId(APPLICATION)
-            .apiKey("apiKey")
-            .build();
+            .apiKey("apiKey");
         final Response response = rootTarget().request().post(Entity.json(verifySubscription));
         assertEquals(OK_200, response.getStatus());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -176,9 +176,7 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(ACCEPTED_202)
                 .asEntity(VerifyApiHostsResponse.class)
-                .isEqualTo(
-                    VerifyApiHostsResponse.builder().ok(false).reason("At least one host is required for the TCP listener.").build()
-                );
+                .isEqualTo(new VerifyApiHostsResponse().ok(false).reason("At least one host is required for the TCP listener."));
         }
 
         @Test
@@ -196,11 +194,9 @@ class ApisResourceTest extends AbstractResourceTest {
                 .hasStatus(ACCEPTED_202)
                 .asEntity(VerifyApiHostsResponse.class)
                 .isEqualTo(
-                    VerifyApiHostsResponse
-                        .builder()
+                    new VerifyApiHostsResponse()
                         .ok(false)
                         .reason("Duplicated hosts detected: 'tcp.example.com, tcp-2.example.com'. Please ensure each host is unique.")
-                        .build()
                 );
         }
 
@@ -218,9 +214,7 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(ACCEPTED_202)
                 .asEntity(VerifyApiHostsResponse.class)
-                .isEqualTo(
-                    VerifyApiHostsResponse.builder().ok(false).reason("Hosts [foo.example.com, bar.example.com] already exists").build()
-                );
+                .isEqualTo(new VerifyApiHostsResponse().ok(false).reason("Hosts [foo.example.com, bar.example.com] already exists"));
         }
 
         @Test
@@ -237,7 +231,7 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(ACCEPTED_202)
                 .asEntity(VerifyApiHostsResponse.class)
-                .isEqualTo(VerifyApiHostsResponse.builder().ok(true).build());
+                .isEqualTo(new VerifyApiHostsResponse().ok(true));
         }
     }
 
@@ -271,7 +265,7 @@ class ApisResourceTest extends AbstractResourceTest {
             )
                 .thenReturn(false);
 
-            final Response response = target.request().post(Entity.json(CreateApiV4.builder().build()));
+            final Response response = target.request().post(Entity.json(new CreateApiV4()));
 
             assertThat(response)
                 .hasStatus(FORBIDDEN_403)
@@ -293,23 +287,19 @@ class ApisResourceTest extends AbstractResourceTest {
                 .request()
                 .post(
                     Entity.json(
-                        CreateApiV4
-                            .builder()
-                            .name("")
-                            .apiVersion("v1")
+                        new CreateApiV4()
                             .type(ApiType.PROXY)
                             .listeners(
                                 List.of(
                                     new Listener(
-                                        HttpListener
-                                            .builder()
-                                            .paths(List.of(PathV4.builder().path("/path").build()))
-                                            .entrypoints(List.of(Entrypoint.builder().type("sse").build()))
-                                            .build()
+                                        (HttpListener) new HttpListener()
+                                            .paths(List.of(new PathV4().path("/path")))
+                                            .entrypoints(List.of(new Entrypoint().type("sse")))
                                     )
                                 )
                             )
-                            .build()
+                            .apiVersion("v1")
+                            .name("")
                     )
                 );
 
@@ -320,7 +310,7 @@ class ApisResourceTest extends AbstractResourceTest {
         public void should_return_400_when_an_api_without_listeners() {
             final Response response = target
                 .request()
-                .post(Entity.json(CreateApiV4.builder().name("no-listeners").apiVersion("v1").type(ApiType.PROXY).build()));
+                .post(Entity.json(new CreateApiV4().type(ApiType.PROXY).name("no-listeners").apiVersion("v1")));
 
             assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
         }
@@ -329,7 +319,7 @@ class ApisResourceTest extends AbstractResourceTest {
         public void should_return_400_when_native_api_has_multiple_flows() {
             doThrow(new NativeApiWithMultipleFlowsException()).when(createApiDomainService).create(any(), any(), any(), any(), any());
 
-            var newApi = aValidNativeV4Api().toBuilder().flows(List.of(FlowV4.builder().build(), FlowV4.builder().build())).build();
+            var newApi = aValidNativeV4Api().flows(List.of(new FlowV4(), new FlowV4()));
 
             final Response response = target.request().post(Entity.json(newApi));
 
@@ -342,23 +332,19 @@ class ApisResourceTest extends AbstractResourceTest {
                 .request()
                 .post(
                     Entity.json(
-                        CreateApiV4
-                            .builder()
-                            .name("no-endpoints")
-                            .apiVersion("v1")
-                            .type(ApiType.PROXY)
+                        new CreateApiV4()
                             .listeners(
                                 List.of(
                                     new Listener(
-                                        HttpListener
-                                            .builder()
-                                            .paths(List.of(PathV4.builder().path("/path").build()))
-                                            .entrypoints(List.of(Entrypoint.builder().type("sse").build()))
-                                            .build()
+                                        (HttpListener) new HttpListener()
+                                            .paths(List.of(new PathV4().path("/path")))
+                                            .entrypoints(List.of(new Entrypoint().type("sse")))
                                     )
                                 )
                             )
-                            .build()
+                            .type(ApiType.PROXY)
+                            .name("no-endpoints")
+                            .apiVersion("v1")
                     )
                 );
 
@@ -385,7 +371,7 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(ApiV4.class)
-                .satisfies(api -> {
+                .satisfies(api ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(api.getId()).isEqualTo("api-id");
                         soft.assertThat(api.getAnalytics()).isEqualTo(newApi.getAnalytics());
@@ -400,8 +386,8 @@ class ApisResourceTest extends AbstractResourceTest {
                         soft.assertThat(api.getName()).isEqualTo(newApi.getName());
                         soft.assertThat(api.getTags()).containsExactlyElementsOf(newApi.getTags());
                         soft.assertThat(api.getType()).isEqualTo(newApi.getType());
-                    });
-                });
+                    })
+                );
         }
 
         @Test
@@ -424,7 +410,7 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(ApiV4.class)
-                .satisfies(api -> {
+                .satisfies(api ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(api.getId()).isEqualTo("api-id");
                         soft.assertThat(api.getAnalytics()).isEqualTo(newApi.getAnalytics());
@@ -439,8 +425,8 @@ class ApisResourceTest extends AbstractResourceTest {
                         soft.assertThat(api.getName()).isEqualTo(newApi.getName());
                         soft.assertThat(api.getTags()).containsExactlyElementsOf(newApi.getTags());
                         soft.assertThat(api.getType()).isEqualTo(newApi.getType());
-                    });
-                });
+                    })
+                );
         }
 
         @Test
@@ -457,7 +443,7 @@ class ApisResourceTest extends AbstractResourceTest {
                 });
 
             var newApi = aValidNativeV4Api();
-            var kafkaListenerWithoutPort = (KafkaListener) newApi.getListeners().get(0).getKafkaListener().toBuilder().port(null).build();
+            var kafkaListenerWithoutPort = newApi.getListeners().getFirst().getKafkaListener().port(null);
             newApi.setListeners(List.of(new Listener(kafkaListenerWithoutPort)));
 
             final Response response = target.request().post(Entity.json(newApi));
@@ -465,47 +451,37 @@ class ApisResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(ApiV4.class)
-                .satisfies(api -> {
+                .satisfies(api ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(api.getId()).isEqualTo("api-id");
                         soft.assertThat(api.getListeners()).isEqualTo(newApi.getListeners());
-                    });
-                });
+                    })
+                );
         }
 
         private static CreateApiV4 aValidV4Api() {
-            return CreateApiV4
-                .builder()
-                .name("my api")
-                .description("api description")
-                .definitionVersion(DefinitionVersion.V4)
-                .groups(List.of("group1"))
-                .apiVersion("v1")
-                .analytics(Analytics.builder().enabled(true).build())
+            return (CreateApiV4) new CreateApiV4()
+                .analytics(new Analytics().enabled(true))
                 .type(ApiType.PROXY)
                 .tags(Set.of("tag1"))
                 .listeners(
                     List.of(
                         new Listener(
-                            HttpListener
-                                .builder()
+                            (HttpListener) new HttpListener()
+                                .paths(List.of(new PathV4().path("/path").overrideAccess(false)))
                                 .type(ListenerType.HTTP)
-                                .paths(List.of(PathV4.builder().path("/path").overrideAccess(false).build()))
-                                .entrypoints(List.of(Entrypoint.builder().type("sse").qos(Qos.AUTO).build()))
-                                .build()
+                                .entrypoints(List.of(new Entrypoint().type("sse").qos(Qos.AUTO)))
                         )
                     )
                 )
                 .endpointGroups(
                     List.of(
-                        EndpointGroupV4
-                            .builder()
+                        new EndpointGroupV4()
                             .name("default-group")
                             .type("http")
                             .endpoints(
                                 List.of(
-                                    EndpointV4
-                                        .builder()
+                                    new EndpointV4()
                                         .name("default")
                                         .type("kafka")
                                         .weight(1)
@@ -524,73 +500,61 @@ class ApisResourceTest extends AbstractResourceTest {
                                                 )
                                             )
                                         )
-                                        .build()
                                 )
                             )
-                            .build()
                     )
                 )
-                .flowExecution(FlowExecution.builder().mode(FlowMode.BEST_MATCH).matchRequired(true).build())
+                .flowExecution(new FlowExecution().mode(FlowMode.BEST_MATCH).matchRequired(true))
                 .flows(
                     List.of(
-                        FlowV4
-                            .builder()
+                        new FlowV4()
                             .name("flowName")
                             .enabled(true)
                             .tags(Set.of("tag1"))
-                            .request(List.of(StepV4.builder().enabled(true).policy("my-policy").condition("my-condition").build()))
+                            .request(List.of(new StepV4().enabled(true).policy("my-policy").condition("my-condition")))
                             .selectors(
                                 List.of(
                                     new Selector(
-                                        HttpSelector
-                                            .builder()
-                                            .type(BaseSelector.TypeEnum.HTTP)
+                                        (HttpSelector) new HttpSelector()
                                             .path("/test")
                                             .methods(Set.of(HttpMethod.GET, HttpMethod.POST))
                                             .pathOperator(Operator.STARTS_WITH)
-                                            .build()
+                                            .type(BaseSelector.TypeEnum.HTTP)
                                     )
                                 )
                             )
-                            .build()
                     )
                 )
-                .build();
-        }
-
-        private static CreateApiV4 aValidNativeV4Api() {
-            return CreateApiV4
-                .builder()
                 .name("my api")
                 .description("api description")
                 .definitionVersion(DefinitionVersion.V4)
                 .groups(List.of("group1"))
-                .apiVersion("v1")
+                .apiVersion("v1");
+        }
+
+        private static CreateApiV4 aValidNativeV4Api() {
+            return (CreateApiV4) new CreateApiV4()
                 .type(ApiType.NATIVE)
                 .tags(Set.of("tag1"))
                 .listeners(
                     List.of(
                         new Listener(
-                            KafkaListener
-                                .builder()
-                                .type(ListenerType.KAFKA)
+                            (KafkaListener) new KafkaListener()
                                 .host("host")
                                 .port(4000)
-                                .entrypoints(List.of(Entrypoint.builder().type("mock").qos(Qos.AUTO).build()))
-                                .build()
+                                .type(ListenerType.KAFKA)
+                                .entrypoints(List.of(new Entrypoint().type("mock").qos(Qos.AUTO)))
                         )
                     )
                 )
                 .endpointGroups(
                     List.of(
-                        EndpointGroupV4
-                            .builder()
+                        new EndpointGroupV4()
                             .name("default-group")
                             .type("http")
                             .endpoints(
                                 List.of(
-                                    EndpointV4
-                                        .builder()
+                                    new EndpointV4()
                                         .name("default")
                                         .type("kafka")
                                         .weight(1)
@@ -609,24 +573,24 @@ class ApisResourceTest extends AbstractResourceTest {
                                                 )
                                             )
                                         )
-                                        .build()
                                 )
                             )
-                            .build()
                     )
                 )
                 .flows(
                     List.of(
-                        FlowV4
-                            .builder()
+                        new FlowV4()
                             .name("flowName")
                             .enabled(true)
                             .tags(Set.of("tag1"))
-                            .connect(List.of(StepV4.builder().enabled(true).policy("my-policy").condition("my-condition").build()))
-                            .build()
+                            .connect(List.of(new StepV4().enabled(true).policy("my-policy").condition("my-condition")))
                     )
                 )
-                .build();
+                .name("my api")
+                .description("api description")
+                .definitionVersion(DefinitionVersion.V4)
+                .groups(List.of("group1"))
+                .apiVersion("v1");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
@@ -110,7 +110,7 @@ public class ApisResource_CreateApiFromSwagger extends AbstractResourceTest {
         var response = rootTarget().request().post(null);
 
         // Then
-        assertThat(FORBIDDEN_403).isEqualTo(response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
     }
 
     @Test
@@ -137,11 +137,11 @@ public class ApisResource_CreateApiFromSwagger extends AbstractResourceTest {
         // When
         var response = rootTarget()
             .request()
-            .post(Entity.json(ImportSwaggerDescriptor.builder().payload(Resources.toString(resource, Charsets.UTF_8)).build()));
+            .post(Entity.json(new ImportSwaggerDescriptor().payload(Resources.toString(resource, Charsets.UTF_8))));
 
         // Then
         var error = response.readEntity(Error.class);
-        assertThat(BAD_REQUEST_400).isEqualTo((int) error.getHttpStatus());
-        assertThat("Cannot import API with invalid paths (Invalid paths)").isEqualTo(error.getMessage());
+        assertThat(error.getHttpStatus()).isEqualTo(BAD_REQUEST_400);
+        assertThat(error.getMessage()).isEqualTo("Cannot import API with invalid paths (Invalid paths)");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
@@ -496,28 +496,24 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
             .hasStatus(OK_200)
             .asEntity(ApisResponse.class)
             .extracting(ApisResponse::getData)
-            .satisfies(list -> {
+            .satisfies(list ->
                 assertThat(list)
                     .extracting(Api::getApiFederated)
                     .isEqualTo(
                         List.of(
-                            ApiFederated
-                                .builder()
+                            new ApiFederated()
                                 .id("api-id")
                                 .name("api-name")
                                 .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.FEDERATED)
                                 .originContext(
-                                    IntegrationOriginContext
-                                        .builder()
-                                        .origin(BaseOriginContext.OriginEnum.INTEGRATION)
+                                    new IntegrationOriginContext()
                                         .integrationId("integration-id")
-                                        .build()
+                                        .origin(BaseOriginContext.OriginEnum.INTEGRATION)
                                 )
                                 .disableMembershipNotifications(false)
                                 .responseTemplates(Collections.emptyMap())
                                 .links(
-                                    ApiLinks
-                                        .builder()
+                                    new ApiLinks()
                                         .pictureUrl(
                                             rootTarget()
                                                 .getUriBuilder()
@@ -530,12 +526,10 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                                                 .replacePath("/environments/" + ENVIRONMENT + "/apis/api-id/background")
                                                 .toTemplate()
                                         )
-                                        .build()
                                 )
-                                .build()
                         )
-                    );
-            });
+                    )
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/audit/ApiAuditsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/audit/ApiAuditsResourceTest.java
@@ -128,8 +128,7 @@ class ApiAuditsResourceTest extends ApiResourceTest {
                 .extracting(AuditsResponse::getData)
                 .isEqualTo(
                     List.of(
-                        Audit
-                            .builder()
+                        new Audit()
                             .id("audit-id")
                             .reference(new AuditReference().id(API).type(AuditReference.TypeEnum.API).name("my-api-name"))
                             .organizationId(ORGANIZATION)
@@ -140,7 +139,6 @@ class ApiAuditsResourceTest extends ApiResourceTest {
                             .properties(List.of(new AuditPropertiesInner().key("API").value(API).name("my-api-name")))
                             .patch("""
                         [{ "op": "add", "path": "/hello", "value": ["world"] }]""")
-                            .build()
                     )
                 );
         }
@@ -264,7 +262,7 @@ class ApiAuditsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(AuditsResponse.class)
                 .extracting(AuditsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total).build());
+                .isEqualTo(new Pagination().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total));
         }
 
         @Test
@@ -298,14 +296,12 @@ class ApiAuditsResourceTest extends ApiResourceTest {
                 .asEntity(AuditsResponse.class)
                 .extracting(AuditsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(target.queryParam("page", page).queryParam("perPage", pageSize).getUri().toString())
                         .first(target.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .last(target.queryParam("page", 4).queryParam("perPage", pageSize).getUri().toString())
                         .previous(target.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .next(target.queryParam("page", 3).queryParam("perPage", pageSize).getUri().toString())
-                        .build()
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResourceTest.java
@@ -132,8 +132,7 @@ class ApiEventsResourceTest extends ApiResourceTest {
                 .extracting(EventsResponse::getData)
                 .isEqualTo(
                     List.of(
-                        Event
-                            .builder()
+                        new Event()
                             .id("event-id")
                             .environmentIds(List.of(ENVIRONMENT))
                             .initiator(new BaseUser().id("user-id").displayName("John Doe"))
@@ -141,7 +140,6 @@ class ApiEventsResourceTest extends ApiResourceTest {
                             .createdAt(OffsetDateTime.parse("2020-02-01T20:22:02.00Z"))
                             .payload("event-payload")
                             .properties(Map.of("API_ID", API, "USER", "user-id"))
-                            .build()
                     )
                 );
         }
@@ -230,7 +228,7 @@ class ApiEventsResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(EventsResponse.class)
                 .extracting(EventsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total).build());
+                .isEqualTo(new Pagination().page(2).perPage(pageSize).pageCount(4).pageItemsCount(pageSize).totalCount(total));
         }
 
         @Test
@@ -256,14 +254,12 @@ class ApiEventsResourceTest extends ApiResourceTest {
                 .asEntity(EventsResponse.class)
                 .extracting(EventsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(target.queryParam("page", page).queryParam("perPage", pageSize).getUri().toString())
                         .first(target.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .last(target.queryParam("page", 4).queryParam("perPage", pageSize).getUri().toString())
                         .previous(target.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .next(target.queryParam("page", 3).queryParam("perPage", pageSize).getUri().toString())
-                        .build()
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResource_getByEventIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/event/ApiEventsResource_getByEventIdTest.java
@@ -16,7 +16,10 @@
 package io.gravitee.rest.api.management.v2.rest.resource.api.event;
 
 import static assertions.MAPIAssertions.assertThat;
-import static io.gravitee.common.http.HttpStatusCode.*;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.EventFixtures;
@@ -118,8 +121,7 @@ class ApiEventsResource_getByEventIdTest extends ApiResourceTest {
             .hasStatus(OK_200)
             .asEntity(Event.class)
             .isEqualTo(
-                Event
-                    .builder()
+                new Event()
                     .id("2")
                     .environmentIds(List.of(ENVIRONMENT))
                     .initiator(new BaseUser().id("user-id").displayName("John Doe"))
@@ -127,7 +129,6 @@ class ApiEventsResource_getByEventIdTest extends ApiResourceTest {
                     .createdAt(OffsetDateTime.parse("2020-02-02T20:00:00.00Z"))
                     .payload("event-payload")
                     .properties(Map.of("API_ID", API, "USER", "user-id"))
-                    .build()
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/health/ApiHealthResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/health/ApiHealthResourceTest.java
@@ -35,9 +35,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiHealthAvailabilityRespon
 import io.gravitee.rest.api.management.v2.rest.model.ApiHealthAverageResponseTimeOvertimeResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiHealthAverageResponseTimeResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiHealthLogsResponse;
-import io.gravitee.rest.api.management.v2.rest.model.HealthCheckLogRequest;
 import io.gravitee.rest.api.management.v2.rest.model.HealthCheckLogStep;
-import io.gravitee.rest.api.management.v2.rest.model.IntegrationsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
 import io.gravitee.rest.api.management.v2.rest.model.Pagination;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApiResourceTest;
@@ -48,7 +46,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -203,14 +200,7 @@ class ApiHealthResourceTest extends ApiResourceTest {
                 .asEntity(ApiHealthAverageResponseTimeOvertimeResponse.class)
                 .satisfies(r -> {
                     assertThat(r.getTimeRange())
-                        .isEqualTo(
-                            AnalyticTimeRange
-                                .builder()
-                                .to(TO.toEpochMilli())
-                                .from(FROM.toEpochMilli())
-                                .interval(INTERVAL.toMillis())
-                                .build()
-                        );
+                        .isEqualTo(new AnalyticTimeRange().to(TO.toEpochMilli()).from(FROM.toEpochMilli()).interval(INTERVAL.toMillis()));
                     assertThat(r.getData()).isEqualTo(List.of(3L));
                 });
         }
@@ -448,7 +438,7 @@ class ApiHealthResourceTest extends ApiResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(ApiHealthLogsResponse.class)
                 .extracting(ApiHealthLogsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(1).perPage(10).pageItemsCount(1).pageCount(1).totalCount(1L).build());
+                .isEqualTo(new Pagination().page(1).perPage(10).pageItemsCount(1).pageCount(1).totalCount(1L));
         }
 
         @Test
@@ -506,14 +496,12 @@ class ApiHealthResourceTest extends ApiResourceTest {
                 .asEntity(ApiHealthLogsResponse.class)
                 .extracting(ApiHealthLogsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(target.queryParam("page", 2).queryParam("perPage", 5).getUri().toString())
                         .first(target.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .last(target.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
                         .previous(target.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .next(target.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
-                        .build()
                 );
         }
 
@@ -534,9 +522,8 @@ class ApiHealthResourceTest extends ApiResourceTest {
                 .extracting(ApiHealthLogsResponse::getData, ApiHealthLogsResponse::getPagination, ApiHealthLogsResponse::getLinks)
                 .contains(
                     List.of(),
-                    Pagination.builder().build(),
-                    Links
-                        .builder()
+                    new Pagination(),
+                    new Links()
                         .self(
                             healthCheckLogsTarget
                                 .queryParam("from", FROM.toEpochMilli())
@@ -544,7 +531,6 @@ class ApiHealthResourceTest extends ApiResourceTest {
                                 .getUri()
                                 .toString()
                         )
-                        .build()
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResourceTest.java
@@ -116,7 +116,7 @@ public class ApiScoringResourceTest extends ApiResourceTest {
                 .assertThat(response)
                 .hasStatus(ACCEPTED_202)
                 .asEntity(ApiScoringTriggerResponse.class)
-                .isEqualTo(ApiScoringTriggerResponse.builder().status(ScoringStatus.PENDING).build());
+                .isEqualTo(new ApiScoringTriggerResponse().status(ScoringStatus.PENDING));
         }
     }
 
@@ -143,45 +143,32 @@ public class ApiScoringResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiScoring.class)
                 .isEqualTo(
-                    ApiScoring
-                        .builder()
-                        .summary(ApiScoringSummary.builder().score(0.9).all(1).errors(0).hints(0).infos(0).warnings(1).build())
+                    new ApiScoring()
+                        .summary(new ApiScoringSummary().score(0.9).all(1).errors(0).hints(0).infos(0).warnings(1))
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
                         .assets(
                             List.of(
-                                ApiScoringAsset
-                                    .builder()
+                                new ApiScoringAsset()
                                     .name("parent")
                                     .type(ApiScoringAssetType.SWAGGER)
                                     .diagnostics(
                                         List.of(
-                                            ApiScoringDiagnostic
-                                                .builder()
+                                            new ApiScoringDiagnostic()
                                                 .severity(ApiScoringSeverity.WARN)
                                                 .range(
-                                                    ApiScoringDiagnosticRange
-                                                        .builder()
-                                                        .start(ApiScoringPosition.builder().line(17).character(12).build())
-                                                        .end(ApiScoringPosition.builder().line(38).character(25).build())
-                                                        .build()
+                                                    new ApiScoringDiagnosticRange()
+                                                        .start(new ApiScoringPosition().line(17).character(12))
+                                                        .end(new ApiScoringPosition().line(38).character(25))
                                                 )
                                                 .rule("operation-operationId")
                                                 .message("Operation must have \"operationId\".")
                                                 .path("paths./echo.options")
-                                                .build()
                                         )
                                     )
-                                    .errors(List.of())
-                                    .build(),
-                                ApiScoringAsset
-                                    .builder()
-                                    .type(ApiScoringAssetType.GRAVITEE_DEFINITION)
-                                    .diagnostics(List.of())
-                                    .errors(List.of())
-                                    .build()
+                                    .errors(List.of()),
+                                new ApiScoringAsset().type(ApiScoringAssetType.GRAVITEE_DEFINITION).diagnostics(List.of()).errors(List.of())
                             )
                         )
-                        .build()
                 );
         }
 
@@ -198,30 +185,22 @@ public class ApiScoringResourceTest extends ApiResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(ApiScoring.class)
                 .isEqualTo(
-                    ApiScoring
-                        .builder()
-                        .summary(ApiScoringSummary.builder().score(0.9).all(1).errors(0).hints(0).infos(0).warnings(1).build())
+                    new ApiScoring()
+                        .summary(new ApiScoringSummary().score(0.9).all(1).errors(0).hints(0).infos(0).warnings(1))
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
                         .assets(
                             List.of(
-                                ApiScoringAsset
-                                    .builder()
+                                new ApiScoringAsset()
                                     .name("parent")
                                     .type(ApiScoringAssetType.SWAGGER)
                                     .diagnostics(List.of())
                                     .errors(
                                         List.of(
-                                            ApiScoringError
-                                                .builder()
-                                                .code("some-error-code")
-                                                .path(List.of("path", "to", "the", "property"))
-                                                .build()
+                                            new ApiScoringError().code("some-error-code").path(List.of("path", "to", "the", "property"))
                                         )
                                     )
-                                    .build()
                             )
                         )
-                        .build()
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApiResourceTest.java
@@ -125,7 +125,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
             )
                 .thenReturn(false);
 
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi().order(99)));
 
             MAPIAssertions
                 .assertThat(response)
@@ -149,7 +149,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_if_order_not_specified() {
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi()));
 
             MAPIAssertions
                 .assertThat(response)
@@ -161,7 +161,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_404_if_category_not_found() {
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi().order(99)));
 
             MAPIAssertions
                 .assertThat(response)
@@ -175,7 +175,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
         public void should_return_404_if_api_not_found() {
             categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
 
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi().order(99)));
 
             MAPIAssertions
                 .assertThat(response)
@@ -190,7 +190,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
             categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
             apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).definitionVersion(DefinitionVersion.V4).build()));
 
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi().order(99)));
 
             MAPIAssertions
                 .assertThat(response)
@@ -209,7 +209,7 @@ public class CategoryApiResourceTest extends AbstractResourceTest {
             categoryApiCrudServiceInMemory.initWith(List.of(apiCategoryOrder));
             updateCategoryApiDomainServiceInMemory.initWith(categoryApiCrudServiceInMemory.storage());
 
-            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+            final Response response = rootTarget().request().post(Entity.json(new UpdateCategoryApi().order(99)));
 
             MAPIAssertions.assertThat(response).hasStatus(OK_200).asEntity(CategoryApi.class).isNotNull();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -25,7 +25,19 @@ import static org.mockito.Mockito.when;
 
 import assertions.MAPIAssertions;
 import fixtures.core.model.PlanFixtures;
-import inmemory.*;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.IndexerInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
+import inmemory.PageQueryServiceInMemory;
+import inmemory.PageRevisionCrudServiceInMemory;
+import inmemory.PageSourceDomainServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.group.model.Group;
@@ -33,7 +45,24 @@ import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.management.v2.rest.model.*;
+import io.gravitee.rest.api.management.v2.rest.model.AccessControl;
+import io.gravitee.rest.api.management.v2.rest.model.ApiDocumentationPagesResponse;
+import io.gravitee.rest.api.management.v2.rest.model.Breadcrumb;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentation;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationAsciiDoc;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationAsyncApi;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationFolder;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationMarkdown;
+import io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationSwagger;
+import io.gravitee.rest.api.management.v2.rest.model.PageSource;
+import io.gravitee.rest.api.management.v2.rest.model.PageType;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentation;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationAsciiDoc;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationAsyncApi;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationFolder;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationMarkdown;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationSwagger;
+import io.gravitee.rest.api.management.v2.rest.model.Visibility;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -100,8 +129,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
     );
 
     private static final List<AccessControl> MAPI_V2_ACCESS_ROLES = List.of(
-        AccessControl.builder().referenceId(ROLE_ID).referenceType("ROLE").build(),
-        AccessControl.builder().referenceId(GROUP_ID).referenceType("GROUP").build()
+        new AccessControl().referenceId(ROLE_ID).referenceType("ROLE"),
+        new AccessControl().referenceId(GROUP_ID).referenceType("GROUP")
     );
 
     @BeforeEach
@@ -243,8 +272,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .hasSize(4)
                 .containsAll(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger")
                             .type(PageType.SWAGGER)
                             .name("swagger")
@@ -254,10 +282,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("async-api")
                             .type(PageType.ASYNCAPI)
                             .name("async-api")
@@ -267,10 +293,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("folder")
                             .type(PageType.FOLDER)
                             .name("folder")
@@ -281,11 +305,10 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .hidden(true)
-                            .build()
                     )
                 )
                 .satisfies(list -> {
-                    assertThat(list.get(0))
+                    assertThat(list.getFirst())
                         .hasFieldOrPropertyWithValue("id", "page-1")
                         .hasFieldOrPropertyWithValue("type", PageType.MARKDOWN)
                         .hasFieldOrPropertyWithValue("name", "page-1")
@@ -299,8 +322,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                                 .hasSize(2)
                                 .containsAll(
                                     List.of(
-                                        AccessControl.builder().referenceId(ROLE_ID).referenceType("ROLE").build(),
-                                        AccessControl.builder().referenceId(GROUP_ID).referenceType("GROUP").build()
+                                        new AccessControl().referenceId(ROLE_ID).referenceType("ROLE"),
+                                        new AccessControl().referenceId(GROUP_ID).referenceType("GROUP")
                                     )
                                 );
                         });
@@ -350,8 +373,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             assertThat(body.getPages())
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("page-1")
                             .type(PageType.MARKDOWN)
                             .name("page-1")
@@ -361,10 +383,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger")
                             .type(PageType.SWAGGER)
                             .name("swagger")
@@ -374,10 +394,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("async-api")
                             .type(PageType.ASYNCAPI)
                             .name("async-api")
@@ -387,10 +405,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("folder")
                             .type(PageType.FOLDER)
                             .name("folder")
@@ -401,7 +417,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .hidden(true)
-                            .build()
                     )
                 );
         }
@@ -457,12 +472,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             assertThat(response.getStatus()).isEqualTo(200);
 
             var body = response.readEntity(ApiDocumentationPagesResponse.class);
-            assertThat(body.getBreadcrumb()).isNotNull().hasSize(0);
+            assertThat(body.getBreadcrumb()).isEmpty();
             assertThat(body.getPages())
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("page-1")
                             .type(PageType.MARKDOWN)
                             .name("page-1")
@@ -473,10 +487,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .parentId("")
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger")
                             .type(PageType.SWAGGER)
                             .name("swagger")
@@ -487,10 +499,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .parentId("")
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("async-api")
                             .type(PageType.ASYNCAPI)
                             .name("async-api")
@@ -501,10 +511,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .parentId("")
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("folder-1")
                             .type(PageType.FOLDER)
                             .name("folder 1")
@@ -515,7 +523,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .hidden(true)
-                            .build()
                     )
                 );
         }
@@ -563,15 +570,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
             var body = response.readEntity(ApiDocumentationPagesResponse.class);
             assertThat(body.getBreadcrumb())
-                .isNotNull()
                 .hasSize(1)
                 .usingRecursiveComparison()
-                .isEqualTo(List.of(Breadcrumb.builder().id("parent-id").name("folder 2").position(1).build()));
+                .isEqualTo(List.of(new Breadcrumb().id("parent-id").name("folder 2").position(1)));
             assertThat(body.getPages().get(0))
                 .usingRecursiveComparison()
                 .isEqualTo(
-                    io.gravitee.rest.api.management.v2.rest.model.Page
-                        .builder()
+                    new io.gravitee.rest.api.management.v2.rest.model.Page()
                         .id("page-1")
                         .type(PageType.MARKDOWN)
                         .name("page-1")
@@ -583,13 +588,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                         .excludedAccessControls(false)
                         .parentId("parent-id")
                         .generalConditions(false)
-                        .build()
                 );
             assertThat(body.getPages().get(1))
                 .usingRecursiveComparison()
                 .isEqualTo(
-                    io.gravitee.rest.api.management.v2.rest.model.Page
-                        .builder()
+                    new io.gravitee.rest.api.management.v2.rest.model.Page()
                         .id("swagger")
                         .type(PageType.SWAGGER)
                         .name("swagger")
@@ -601,7 +604,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                         .excludedAccessControls(false)
                         .parentId("parent-id")
                         .generalConditions(false)
-                        .build()
                 );
         }
 
@@ -645,8 +647,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .usingRecursiveComparison()
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("page-1")
                             .type(PageType.MARKDOWN)
                             .name("page-1")
@@ -658,10 +659,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId("parent-id")
                             .published(true)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger-1")
                             .type(PageType.SWAGGER)
                             .name("swagger-1")
@@ -673,10 +672,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId("parent-id")
                             .published(true)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id(page.getId())
                             .type(PageType.FOLDER)
                             .name(page.getName())
@@ -688,7 +685,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId(page.getParentId())
                             .hidden(false)
-                            .build()
                     )
                 );
         }
@@ -723,8 +719,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .usingRecursiveComparison()
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger")
                             .type(PageType.SWAGGER)
                             .name("swagger")
@@ -736,10 +731,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId("parent-id")
                             .published(true)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id(page.getId())
                             .type(PageType.FOLDER)
                             .name(page.getName())
@@ -751,7 +744,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId(page.getParentId())
                             .hidden(false)
-                            .build()
                     )
                 );
         }
@@ -786,8 +778,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .usingRecursiveComparison()
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("async-api")
                             .type(PageType.ASYNCAPI)
                             .name("async-api")
@@ -799,10 +790,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId("parent-id")
                             .published(true)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id(page.getId())
                             .type(PageType.FOLDER)
                             .name(page.getName())
@@ -814,7 +803,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .excludedAccessControls(false)
                             .parentId(page.getParentId())
                             .hidden(false)
-                            .build()
                     )
                 );
         }
@@ -875,8 +863,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             assertThat(body.getPages())
                 .isEqualTo(
                     List.of(
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("page-1")
                             .type(PageType.MARKDOWN)
                             .name("page-1")
@@ -886,10 +873,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(true)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(true),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger-1")
                             .type(PageType.SWAGGER)
                             .name("swagger-1")
@@ -899,10 +884,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("swagger-2")
                             .type(PageType.SWAGGER)
                             .name("swagger-2")
@@ -912,10 +895,8 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
-                            .generalConditions(false)
-                            .build(),
-                        io.gravitee.rest.api.management.v2.rest.model.Page
-                            .builder()
+                            .generalConditions(false),
+                        new io.gravitee.rest.api.management.v2.rest.model.Page()
                             .id("page-2")
                             .type(PageType.MARKDOWN)
                             .name("page-2")
@@ -926,7 +907,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .metadata(Map.of())
                             .excludedAccessControls(false)
                             .generalConditions(false)
-                            .build()
                     )
                 );
         }
@@ -992,7 +972,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             )
                 .thenReturn(false);
 
-            final Response response = rootTarget().request().post(Entity.json(CreateDocumentation.builder().build()));
+            final Response response = rootTarget().request().post(Entity.json(new CreateDocumentation()));
 
             MAPIAssertions
                 .assertThat(response)
@@ -1004,9 +984,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_create_markdown_page() {
-            var pageToCreate = CreateDocumentationMarkdown
-                .builder()
-                .name("created page")
+            var pageToCreate = (CreateDocumentationMarkdown) new CreateDocumentationMarkdown()
                 .homepage(true)
                 .content("nice content")
                 .type(CreateDocumentation.TypeEnum.MARKDOWN)
@@ -1014,7 +992,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .visibility(Visibility.PUBLIC)
                 .excludedAccessControls(true)
                 .accessControls(MAPI_V2_ACCESS_ROLES)
-                .build();
+                .name("created page");
 
             final Response response = rootTarget().request().post(Entity.json(pageToCreate));
             var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
@@ -1037,15 +1015,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_create_swagger_page() {
-            var pageToCreate = CreateDocumentationSwagger
-                .builder()
-                .name("created page")
+            var pageToCreate = (CreateDocumentationSwagger) new CreateDocumentationSwagger()
                 .homepage(true)
                 .content("openapi: 3.0.0")
                 .type(CreateDocumentation.TypeEnum.SWAGGER)
                 .parentId(null)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
 
             final Response response = rootTarget().request().post(Entity.json(pageToCreate));
             var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
@@ -1066,15 +1042,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_create_async_api_page() {
-            var pageToCreate = CreateDocumentationAsyncApi
-                .builder()
-                .name("created page")
+            var pageToCreate = (CreateDocumentationAsyncApi) new CreateDocumentationAsyncApi()
                 .homepage(true)
                 .content("nice content")
                 .type(CreateDocumentation.TypeEnum.ASYNCAPI)
                 .parentId(null)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
 
             final Response response = rootTarget().request().post(Entity.json(pageToCreate));
             var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
@@ -1095,15 +1069,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_create_asciidoc_page() {
-            var pageToCreate = CreateDocumentationAsciiDoc
-                .builder()
-                .name("created page")
+            var pageToCreate = (CreateDocumentationAsciiDoc) new CreateDocumentationAsciiDoc()
                 .homepage(true)
                 .content("= AsciiDoc content")
                 .type(CreateDocumentation.TypeEnum.ASCIIDOC)
                 .parentId(null)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
 
             final Response response = rootTarget().request().post(Entity.json(pageToCreate));
             var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
@@ -1124,13 +1096,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_create_folder() {
-            var folderToCreate = CreateDocumentationFolder
-                .builder()
+            var folderToCreate = new CreateDocumentationFolder()
                 .name("created page")
                 .type(CreateDocumentation.TypeEnum.FOLDER)
                 .parentId(null)
-                .visibility(Visibility.PUBLIC)
-                .build();
+                .visibility(Visibility.PUBLIC);
 
             final Response response = rootTarget().request().post(Entity.json(folderToCreate));
             var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
@@ -1149,13 +1119,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_null_name() {
-            var request = CreateDocumentationMarkdown
-                .builder()
+            var request = new CreateDocumentationMarkdown()
                 .type(CreateDocumentation.TypeEnum.MARKDOWN)
                 .parentId("parent")
                 .visibility(Visibility.PRIVATE)
-                .name(null)
-                .build();
+                .name(null);
 
             final Response response = rootTarget().request().post(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1170,13 +1138,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_empty_name() {
-            var request = CreateDocumentationMarkdown
-                .builder()
+            var request = new CreateDocumentationMarkdown()
                 .type(CreateDocumentation.TypeEnum.MARKDOWN)
                 .parentId("parent")
                 .visibility(Visibility.PRIVATE)
-                .name("")
-                .build();
+                .name("");
 
             final Response response = rootTarget().request().post(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1262,8 +1228,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
             assertThat(body)
                 .isEqualTo(
-                    io.gravitee.rest.api.management.v2.rest.model.Page
-                        .builder()
+                    new io.gravitee.rest.api.management.v2.rest.model.Page()
                         .id(PAGE_ID)
                         .type(PageType.MARKDOWN)
                         .name("page-1")
@@ -1274,7 +1239,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                         .metadata(Map.of())
                         .excludedAccessControls(false)
                         .generalConditions(false)
-                        .build()
                 );
         }
     }
@@ -1328,7 +1292,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             )
                 .thenReturn(false);
 
-            final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(UpdateDocumentation.builder().build()));
+            final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(new UpdateDocumentation()));
 
             MAPIAssertions
                 .assertThat(response)
@@ -1340,9 +1304,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_markdown_page() {
-            var request = UpdateDocumentationMarkdown
-                .builder()
-                .name("created page")
+            var request = (UpdateDocumentationMarkdown) new UpdateDocumentationMarkdown()
                 .homepage(true)
                 .content("nice content")
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
@@ -1350,7 +1312,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .visibility(Visibility.PUBLIC)
                 .excludedAccessControls(true)
                 .accessControls(MAPI_V2_ACCESS_ROLES)
-                .build();
+                .name("created page");
             var oldMarkdown = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1400,15 +1362,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_swagger_page() {
-            var request = UpdateDocumentationSwagger
-                .builder()
-                .name("created page")
+            var request = (UpdateDocumentationSwagger) new UpdateDocumentationSwagger()
                 .homepage(true)
                 .content("openapi: 3.0.0")
                 .type(UpdateDocumentation.TypeEnum.SWAGGER)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
             var oldPage = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1444,15 +1404,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_async_api_page() {
-            var request = UpdateDocumentationAsyncApi
-                .builder()
-                .name("created page")
+            var request = (UpdateDocumentationAsyncApi) new UpdateDocumentationAsyncApi()
                 .homepage(true)
                 .content("nice content")
                 .type(UpdateDocumentation.TypeEnum.ASYNCAPI)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
             var oldPage = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1488,15 +1446,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_asciidoc_page() {
-            var request = UpdateDocumentationAsciiDoc
-                .builder()
-                .name("updated page")
+            var request = (UpdateDocumentationAsciiDoc) new UpdateDocumentationAsciiDoc()
                 .homepage(true)
                 .content("= Updated AsciiDoc content")
                 .type(UpdateDocumentation.TypeEnum.ASCIIDOC)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("updated page");
             var oldPage = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1532,13 +1488,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_folder() {
-            var folderToCreate = UpdateDocumentationFolder
-                .builder()
+            var folderToCreate = new UpdateDocumentationFolder()
                 .name("new name")
                 .type(UpdateDocumentation.TypeEnum.FOLDER)
                 .order(24)
-                .visibility(Visibility.PUBLIC)
-                .build();
+                .visibility(Visibility.PUBLIC);
             var oldFolder = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1571,15 +1525,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_change_markdown_page_order_to_0() {
-            var request = UpdateDocumentationMarkdown
-                .builder()
-                .name("created page")
+            var request = new UpdateDocumentationMarkdown()
                 .homepage(true)
                 .content("nice content")
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(0)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
 
             var oldMarkdown = Page
                 .builder()
@@ -1604,15 +1556,13 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_change_swagger_page_order_to_0() {
-            var request = UpdateDocumentationSwagger
-                .builder()
-                .name("created page")
+            var request = (UpdateDocumentationSwagger) new UpdateDocumentationSwagger()
                 .homepage(true)
                 .content("openapi: 3.0.0")
                 .type(UpdateDocumentation.TypeEnum.SWAGGER)
                 .order(0)
                 .visibility(Visibility.PUBLIC)
-                .build();
+                .name("created page");
 
             var oldMarkdown = Page
                 .builder()
@@ -1638,16 +1588,14 @@ class ApiPagesResourceTest extends AbstractResourceTest {
         @Test
         public void should_update_configuration() {
             var configuration = Map.of("key", "value");
-            var request = UpdateDocumentationMarkdown
-                .builder()
-                .name("created page")
+            var request = new UpdateDocumentationMarkdown()
                 .homepage(true)
                 .content("nice content")
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
                 .configuration(configuration)
-                .build();
+                .name("created page");
             var oldMarkdown = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1674,17 +1622,15 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_update_page_source() {
-            var pageSource = PageSource.builder().type("http-fetcher").configuration("{ \"some\": \"config\"}").build();
-            var request = UpdateDocumentationMarkdown
-                .builder()
-                .name("created page")
+            var pageSource = new PageSource().type("http-fetcher").configuration("{ \"some\": \"config\"}");
+            var request = new UpdateDocumentationMarkdown()
                 .homepage(true)
                 .content("nice content")
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
                 .source(pageSource)
-                .build();
+                .name("created page");
             var oldMarkdown = Page
                 .builder()
                 .id(PAGE_ID)
@@ -1714,13 +1660,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_null_name() {
-            var request = UpdateDocumentationMarkdown
-                .builder()
+            var request = new UpdateDocumentationMarkdown()
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .visibility(Visibility.PRIVATE)
-                .name(null)
-                .build();
+                .name(null);
 
             final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1735,13 +1679,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_empty_name() {
-            var request = UpdateDocumentationMarkdown
-                .builder()
+            var request = new UpdateDocumentationMarkdown()
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .visibility(Visibility.PRIVATE)
-                .name("")
-                .build();
+                .name("");
 
             final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1756,13 +1698,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_empty_name_swagger_page() {
-            var request = UpdateDocumentationSwagger
-                .builder()
+            var request = new UpdateDocumentationSwagger()
                 .type(UpdateDocumentation.TypeEnum.SWAGGER)
                 .order(1)
                 .visibility(Visibility.PRIVATE)
-                .name("")
-                .build();
+                .name("");
 
             final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1777,13 +1717,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_empty_name_assync_api_page() {
-            var request = UpdateDocumentationSwagger
-                .builder()
+            var request = new UpdateDocumentationSwagger()
                 .type(UpdateDocumentation.TypeEnum.ASYNCAPI)
                 .order(1)
                 .visibility(Visibility.PRIVATE)
-                .name("")
-                .build();
+                .name("");
 
             final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
@@ -1798,13 +1736,11 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_allow_negative_order() {
-            var request = UpdateDocumentationMarkdown
-                .builder()
+            var request = new UpdateDocumentationMarkdown()
                 .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .visibility(Visibility.PRIVATE)
                 .name("name")
-                .order(-1)
-                .build();
+                .order(-1);
 
             final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
@@ -131,10 +131,8 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsResponseStatusRangesResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsResponseStatusRangesResponse
-                        .builder()
+                    new EnvironmentAnalyticsResponseStatusRangesResponse()
                         .ranges(Map.of("100.0-200.0", 1, "200.0-300.0", 17, "300.0-400.0", 0, "400.0-500.0", 0, "500.0-600.0", 0))
-                        .build()
                 );
         }
     }
@@ -178,16 +176,14 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopHitsApisResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsTopHitsApisResponse
-                        .builder()
+                    new EnvironmentAnalyticsTopHitsApisResponse()
                         .data(
                             List.of(
-                                TopHitApi.builder().id(topHitApi2Id).name("Top Hit API 2").count(13L).definitionVersion("V4").build(),
-                                TopHitApi.builder().id(topHitApi1Id).name("Top Hit API 1").count(7L).definitionVersion("V4").build(),
-                                TopHitApi.builder().id(topHitApi3Id).name("Top Hit API legacy v2").count(6L).definitionVersion("V2").build()
+                                new TopHitApi().id(topHitApi2Id).name("Top Hit API 2").count(13L).definitionVersion("V4"),
+                                new TopHitApi().id(topHitApi1Id).name("Top Hit API 1").count(7L).definitionVersion("V4"),
+                                new TopHitApi().id(topHitApi3Id).name("Top Hit API legacy v2").count(6L).definitionVersion("V2")
                             )
                         )
-                        .build()
                 );
         }
 
@@ -203,7 +199,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopHitsApisResponse.class)
-                .isEqualTo(EnvironmentAnalyticsTopHitsApisResponse.builder().data(List.of()).build());
+                .isEqualTo(new EnvironmentAnalyticsTopHitsApisResponse().data(List.of()));
         }
     }
 
@@ -240,14 +236,12 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsRequestResponseTimeResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsRequestResponseTimeResponse
-                        .builder()
+                    new EnvironmentAnalyticsRequestResponseTimeResponse()
                         .requestsPerSecond(3.7)
                         .requestsTotal(25600)
                         .responseMinTime(32.5)
                         .responseMaxTime(1220.87)
                         .responseAvgTime(159.2)
-                        .build()
                 );
         }
     }
@@ -285,8 +279,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_200_with_valid_request_response_time_analytics() {
-            //Given
-            var topHitApi1Id = "my-api";
+            // Given
             var api1 = ApiFixtures.aProxyApiV4().toBuilder().id("api-1").build();
             var api2 = ApiFixtures.aProxyApiV4().toBuilder().id("api-2").build();
 
@@ -295,19 +288,17 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
             analyticsQueryService.averageAggregate.put("1970-01-01T00:00:00", 1.2D);
             analyticsQueryService.averageAggregate.put("1970-01-01T00:30:00", 1.6D);
 
-            //When
-
+            // When
             Response response = target.queryParam("from", FROM).queryParam("to", TO).request().get();
 
+            // Then
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsOverPeriodResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsOverPeriodResponse
-                        .builder()
-                        .timeRange(AnalyticTimeRange.builder().from(FROM).to(TO).interval(1000L).build())
+                    new EnvironmentAnalyticsOverPeriodResponse()
+                        .timeRange(new AnalyticTimeRange().from(FROM).to(TO).interval(1000L))
                         .data(List.of(1L, 2L))
-                        .build()
                 );
         }
     }
@@ -322,7 +313,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_200_with_valid_request_response_time_analytics() {
-            //Given
+            // Given
             var api1 = ApiFixtures.aProxyApiV4().toBuilder().id("api-1").build();
             var api2 = ApiFixtures.aProxyApiV4().toBuilder().id("api-2").build();
 
@@ -336,19 +327,17 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                     .data(Map.of("200", List.of(0L, 0L, 0L, 1L, 4L, 0L, 0L)))
                     .build();
 
-            //When
-
+            // When
             Response response = target.queryParam("from", FROM).queryParam("to", TO).request().get();
 
+            // Then
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsResponseStatusOvertimeResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsResponseStatusOvertimeResponse
-                        .builder()
-                        .timeRange(AnalyticTimeRange.builder().from(FROM).to(TO).interval(1000L).build())
+                    new EnvironmentAnalyticsResponseStatusOvertimeResponse()
+                        .timeRange(new AnalyticTimeRange().from(FROM).to(TO).interval(1000L))
                         .data(Map.of("200", List.of(0L, 0L, 0L, 1L, 4L, 0L, 0L)))
-                        .build()
                 );
         }
     }
@@ -363,7 +352,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_200_with_valid_top_apps_by_request_count() {
-            //Given
+            // Given
             var topHitApp1 = BaseApplicationEntity
                 .builder()
                 .id("top-hit-app-id-1")
@@ -393,22 +382,21 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                     )
                     .build();
 
-            //When
+            // When
             Response response = target.queryParam("from", FROM).queryParam("to", TO).request().get();
 
+            // Then
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopAppsByRequestCountResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsTopAppsByRequestCountResponse
-                        .builder()
+                    new EnvironmentAnalyticsTopAppsByRequestCountResponse()
                         .data(
                             List.of(
-                                TopApp.builder().id("top-hit-app-id-2").name("Top Hit App 2").count(13L).build(),
-                                TopApp.builder().id("top-hit-app-id-1").name("Top Hit App 1").count(7L).build()
+                                new TopApp().id("top-hit-app-id-2").name("Top Hit App 2").count(13L),
+                                new TopApp().id("top-hit-app-id-1").name("Top Hit App 1").count(7L)
                             )
                         )
-                        .build()
                 );
         }
 
@@ -423,7 +411,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopAppsByRequestCountResponse.class)
-                .isEqualTo(EnvironmentAnalyticsTopAppsByRequestCountResponse.builder().data(List.of()).build());
+                .isEqualTo(new EnvironmentAnalyticsTopAppsByRequestCountResponse().data(List.of()));
         }
     }
 
@@ -466,52 +454,46 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopFailedApisResponse.class)
                 .isEqualTo(
-                    EnvironmentAnalyticsTopFailedApisResponse
-                        .builder()
+                    new EnvironmentAnalyticsTopFailedApisResponse()
                         .data(
                             List.of(
-                                io.gravitee.rest.api.management.v2.rest.model.TopFailedApis
-                                    .builder()
+                                new io.gravitee.rest.api.management.v2.rest.model.TopFailedApis()
                                     .id(apiId2)
                                     .name("API 2")
                                     .definitionVersion("V4")
                                     .failedCalls(13L)
-                                    .failedCallsRatio(0.2)
-                                    .build(),
-                                io.gravitee.rest.api.management.v2.rest.model.TopFailedApis
-                                    .builder()
+                                    .failedCallsRatio(0.2),
+                                new io.gravitee.rest.api.management.v2.rest.model.TopFailedApis()
                                     .id(apiId1)
                                     .name("API 1")
                                     .definitionVersion("V4")
                                     .failedCalls(7L)
-                                    .failedCallsRatio(0.1)
-                                    .build(),
-                                io.gravitee.rest.api.management.v2.rest.model.TopFailedApis
-                                    .builder()
+                                    .failedCallsRatio(0.1),
+                                new io.gravitee.rest.api.management.v2.rest.model.TopFailedApis()
                                     .id(apiId3)
                                     .name("API 3")
                                     .definitionVersion("V2")
                                     .failedCalls(3L)
                                     .failedCallsRatio(0.3)
-                                    .build()
                             )
                         )
-                        .build()
                 );
         }
 
         @Test
         void should_return_200_with_empty_list_if_no_apis_found() {
+            // Given
             apiQueryService.initWith(List.of());
             analyticsQueryService.topFailedApis = TopFailedApis.builder().data(List.of()).build();
 
-            //When
+            // When
             Response response = target.queryParam("from", FROM).queryParam("to", TO).request().get();
 
+            // Then
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(EnvironmentAnalyticsTopFailedApisResponse.class)
-                .isEqualTo(EnvironmentAnalyticsTopFailedApisResponse.builder().data(List.of()).build());
+                .isEqualTo(new EnvironmentAnalyticsTopFailedApisResponse().data(List.of()));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringFunctionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringFunctionsResourceTest.java
@@ -86,7 +86,7 @@ class EnvironmentScoringFunctionsResourceTest extends AbstractResourceTest {
         @Test
         void should_create_function() {
             // Given
-            var request = ImportScoringFunction.builder().name("function-name.js").payload("function-payload").build();
+            var request = new ImportScoringFunction().name("function-name.js").payload("function-payload");
 
             // When
             target.request().post(json(request));
@@ -101,7 +101,7 @@ class EnvironmentScoringFunctionsResourceTest extends AbstractResourceTest {
         void should_set_location_header_with_created_function_url() {
             // Given
             UuidString.overrideGenerator(() -> "generated-id");
-            var request = ImportScoringFunction.builder().name("function-name.js").payload("function-payload").build();
+            var request = new ImportScoringFunction().name("function-name.js").payload("function-payload");
 
             // When
             Response response = target.request().post(json(request));
@@ -120,7 +120,7 @@ class EnvironmentScoringFunctionsResourceTest extends AbstractResourceTest {
                     ScoringFunctionFixture.aFunction().toBuilder().id("function1").name("function-name.js").referenceId(ENVIRONMENT).build()
                 )
             );
-            var request2 = ImportScoringFunction.builder().name("function-name.js").payload("function-payload2").build();
+            var request2 = new ImportScoringFunction().name("function-name.js").payload("function-payload2");
 
             // When
             Response response = target.request().post(json(request2));
@@ -157,22 +157,18 @@ class EnvironmentScoringFunctionsResourceTest extends AbstractResourceTest {
                 .extracting(ScoringFunctionsResponse::getData)
                 .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsExactly(
-                    io.gravitee.rest.api.management.v2.rest.model.ScoringFunction
-                        .builder()
+                    new io.gravitee.rest.api.management.v2.rest.model.ScoringFunction()
+                        .name("function-name")
+                        .payload("function-payload")
+                        .referenceId(ENVIRONMENT)
+                        .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringFunctionReferenceType.ENVIRONMENT)
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC)),
+                    new io.gravitee.rest.api.management.v2.rest.model.ScoringFunction()
                         .name("function-name")
                         .payload("function-payload")
                         .referenceId(ENVIRONMENT)
                         .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringFunctionReferenceType.ENVIRONMENT)
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
-                        .build(),
-                    io.gravitee.rest.api.management.v2.rest.model.ScoringFunction
-                        .builder()
-                        .name("function-name")
-                        .payload("function-payload")
-                        .referenceId(ENVIRONMENT)
-                        .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringFunctionReferenceType.ENVIRONMENT)
-                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
-                        .build()
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResourceTest.java
@@ -114,8 +114,7 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
                     assertThat(result.getData())
                         .hasSize(1)
                         .containsOnly(
-                            EnvironmentApiScore
-                                .builder()
+                            new EnvironmentApiScore()
                                 .id("api1")
                                 .name("api-name")
                                 .pictureUrl(apisTarget.path("api1").path("picture").queryParam("hash", "1697969730000").getUri().toString())
@@ -124,10 +123,9 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
                                 .warnings(1)
                                 .infos(1)
                                 .hints(1)
-                                .build()
                         );
                     assertThat(result.getPagination())
-                        .isEqualTo(Pagination.builder().page(1).perPage(10).pageItemsCount(1).pageCount(1).totalCount(1L).build());
+                        .isEqualTo(new Pagination().page(1).perPage(10).pageItemsCount(1).pageCount(1).totalCount(1L));
                 });
         }
 
@@ -151,14 +149,12 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
                 .asEntity(EnvironmentApisScoringResponse.class)
                 .extracting(EnvironmentApisScoringResponse::getPagination)
                 .isEqualTo(
-                    Pagination
-                        .builder()
+                    new Pagination()
                         .page(pageNumber)
                         .perPage(pageSize)
                         .pageItemsCount(pageSize)
                         .pageCount(3)
                         .totalCount((long) expectedTotal)
-                        .build()
                 );
         }
 
@@ -182,14 +178,12 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
                 .asEntity(EnvironmentApisScoringResponse.class)
                 .extracting(EnvironmentApisScoringResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(scoringApisTarget.queryParam("page", page).queryParam("perPage", pageSize).getUri().toString())
                         .first(scoringApisTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .last(scoringApisTarget.queryParam("page", 4).queryParam("perPage", pageSize).getUri().toString())
                         .previous(scoringApisTarget.queryParam("page", 1).queryParam("perPage", pageSize).getUri().toString())
                         .next(scoringApisTarget.queryParam("page", 3).queryParam("perPage", pageSize).getUri().toString())
-                        .build()
                 );
         }
     }
@@ -215,9 +209,7 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(EnvironmentScoringOverview.class)
-                .isEqualTo(
-                    EnvironmentScoringOverview.builder().id(ENVIRONMENT).score(0.84).errors(3).warnings(3).infos(3).hints(3).build()
-                );
+                .isEqualTo(new EnvironmentScoringOverview().id(ENVIRONMENT).score(0.84).errors(3).warnings(3).infos(3).hints(3));
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResourceTest.java
@@ -115,8 +115,7 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(ScoringRuleset.class)
                 .isEqualTo(
-                    ScoringRuleset
-                        .builder()
+                    new ScoringRuleset()
                         .id("ruleset-id")
                         .name("ruleset-name")
                         .description("ruleset-description")
@@ -125,7 +124,6 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
                         .referenceType(ScoringRulesetReferenceType.ENVIRONMENT)
                         .payload("payload-ruleset-id")
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
-                        .build()
                 );
         }
 
@@ -147,11 +145,7 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
         void should_update_a_ruleset() {
             // Given
             scoringRulesetCrudService.initWith(List.of(ScoringRulesetFixture.aRuleset().withReferenceId(ENVIRONMENT)));
-            UpdateScoringRuleset updateScoringPayload = UpdateScoringRuleset
-                .builder()
-                .name("updated-name")
-                .description("updated-description")
-                .build();
+            UpdateScoringRuleset updateScoringPayload = new UpdateScoringRuleset().name("updated-name").description("updated-description");
             TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
             //When
             var response = rootTarget.path("ruleset-id").request().put(Entity.json(updateScoringPayload));
@@ -161,8 +155,7 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(ScoringRuleset.class)
                 .isEqualTo(
-                    ScoringRuleset
-                        .builder()
+                    new ScoringRuleset()
                         .id("ruleset-id")
                         .name("updated-name")
                         .description("updated-description")
@@ -172,7 +165,6 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
                         .referenceType(ScoringRulesetReferenceType.ENVIRONMENT)
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
                         .updatedAt(INSTANT_NOW.atOffset(ZoneOffset.UTC))
-                        .build()
                 );
         }
 
@@ -180,8 +172,9 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
         void should_return_400_when_missing_name_to_update() {
             // Given
             scoringRulesetCrudService.initWith(List.of(ScoringRulesetFixture.aRuleset().withReferenceId(ENVIRONMENT)));
-            UpdateScoringRuleset updateScoringPayload = UpdateScoringRuleset.builder().description("updated-description").build();
-            //When
+            UpdateScoringRuleset updateScoringPayload = new UpdateScoringRuleset().description("updated-description");
+
+            // When
             var response = rootTarget.path("ruleset-id").request().put(Entity.json(updateScoringPayload));
 
             //Then
@@ -192,8 +185,9 @@ class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
         void should_return_400_when_missing_body() {
             // Given
             scoringRulesetCrudService.initWith(List.of(ScoringRulesetFixture.aRuleset("ruleset-id").withReferenceId(ENVIRONMENT)));
-            UpdateScoringRuleset updateScoringPayload = UpdateScoringRuleset.builder().build();
-            //When
+            UpdateScoringRuleset updateScoringPayload = new UpdateScoringRuleset();
+
+            // When
             var response = rootTarget.path("ruleset-id").request().put(Entity.json(updateScoringPayload));
 
             //Then

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
@@ -87,13 +87,11 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
         @Test
         void should_create_ruleset() {
             // Given
-            var request = ImportScoringRuleset
-                .builder()
+            var request = new ImportScoringRuleset()
                 .name("ruleset-name")
                 .description("ruleset-description")
                 .payload("ruleset-payload")
-                .format(ScoringAssetFormat.GRAVITEE_PROXY)
-                .build();
+                .format(ScoringAssetFormat.GRAVITEE_PROXY);
 
             // When
             try (var ignored = target.request().post(json(request))) {
@@ -107,12 +105,10 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
         @Test
         void should_create_ruleset_without_description() {
             // Given
-            var request = ImportScoringRuleset
-                .builder()
+            var request = new ImportScoringRuleset()
                 .name("ruleset-name")
                 .payload("ruleset-payload")
-                .format(ScoringAssetFormat.GRAVITEE_PROXY)
-                .build();
+                .format(ScoringAssetFormat.GRAVITEE_PROXY);
 
             // When
             try (var ignored = target.request().post(json(request))) {
@@ -127,13 +123,11 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
         void should_set_location_header_with_created_ruleset_url() {
             // Given
             UuidString.overrideGenerator(() -> "generated-id");
-            var request = ImportScoringRuleset
-                .builder()
+            var request = new ImportScoringRuleset()
                 .name("ruleset-name")
                 .description("ruleset-description")
                 .payload("ruleset-payload")
-                .format(ScoringAssetFormat.GRAVITEE_PROXY)
-                .build();
+                .format(ScoringAssetFormat.GRAVITEE_PROXY);
 
             // When
             Response response = target.request().post(json(request));
@@ -168,8 +162,7 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
                 .extracting(ScoringRulesetsResponse::getData)
                 .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsExactly(
-                    io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset
-                        .builder()
+                    new io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset()
                         .id("ruleset1")
                         .name("ruleset-name")
                         .description("ruleset-description")
@@ -177,10 +170,8 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
                         .format(ScoringAssetFormat.GRAVITEE_PROXY)
                         .referenceId(ENVIRONMENT)
                         .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetReferenceType.ENVIRONMENT)
-                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
-                        .build(),
-                    io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset
-                        .builder()
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC)),
+                    new io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset()
                         .id("ruleset2")
                         .name("ruleset-name")
                         .description("ruleset-description")
@@ -189,7 +180,6 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
                         .referenceId(ENVIRONMENT)
                         .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetReferenceType.ENVIRONMENT)
                         .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
-                        .build()
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SharedPolicyGroupResource_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SharedPolicyGroupResource_UpdateTest.java
@@ -117,13 +117,11 @@ public class SharedPolicyGroupResource_UpdateTest extends AbstractResourceTest {
                     .hasSize(1)
                     .containsAll(
                         List.of(
-                            StepV4
-                                .builder()
+                            new StepV4()
                                 .policy("policyId")
                                 .name("Step name")
                                 .enabled(true)
                                 .configuration(Map.ofEntries(Map.entry("key", "value")))
-                                .build()
                         )
                     );
             })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SharedPolicyGroupsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SharedPolicyGroupsResource_CreateTest.java
@@ -117,13 +117,11 @@ public class SharedPolicyGroupsResource_CreateTest extends AbstractResourceTest 
                     .hasSize(1)
                     .containsAll(
                         List.of(
-                            StepV4
-                                .builder()
+                            new StepV4()
                                 .policy("policyId")
                                 .name("Step name")
                                 .enabled(true)
                                 .configuration(Map.ofEntries(Map.entry("key", "value")))
-                                .build()
                         )
                     );
             })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -130,12 +130,10 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
                 .isEqualTo(
-                    GroupsResponse
-                        .builder()
+                    new GroupsResponse()
                         .data(List.of())
-                        .pagination(Pagination.builder().build())
-                        .links(Links.builder().self(paginatedTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination())
+                        .links(new Links().self(paginatedTarget.getUri().toString()))
                 );
         }
 
@@ -188,12 +186,10 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
                 .isEqualTo(
-                    GroupsResponse
-                        .builder()
+                    new GroupsResponse()
                         .data(Stream.of(group1, group2).map(GroupMapper.INSTANCE::map).toList())
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L))
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
     }
@@ -267,13 +263,11 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().build())
+                    new MembersResponse()
+                        .pagination(new Pagination())
                         .data(List.of())
                         .metadata(Map.of("groupName", GROUP_NAME))
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -291,13 +285,11 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2L).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2L))
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .metadata(Map.of("groupName", GROUP_NAME))
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationMembersResourceTest.java
@@ -138,7 +138,7 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_role_is_primary_owner() {
-            var newMembership = AddMember.builder().roleName("PRIMARY_OWNER").build();
+            var newMembership = new AddMember().roleName("PRIMARY_OWNER");
             final Response response = target.request().post(Entity.json(newMembership));
             assertThat(response)
                 .hasStatus(BAD_REQUEST_400)
@@ -148,21 +148,19 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_user_id_and_external_reference_is_empty() {
-            var newMembership = AddMember.builder().roleName("OWNER").build();
+            var newMembership = new AddMember().roleName("OWNER");
             final Response response = target.request().post(Entity.json(newMembership));
             assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessage("Request must specify either userId or externalReference");
         }
 
         @Test
         public void should_create_an_integration_member() {
-            var newMembership = AddMember.builder().roleName("OWNER").userId("userId").build();
+            var newMembership = new AddMember().roleName("OWNER").userId("userId");
             final Response response = target.request().post(Entity.json(newMembership));
             assertThat(response)
                 .hasStatus(CREATED_201)
                 .asEntity(Member.class)
-                .isEqualTo(
-                    Member.builder().id("userId").displayName("John Doe").roles(List.of(Role.builder().name("OWNER").build())).build()
-                );
+                .isEqualTo(new Member().id("userId").displayName("John Doe").roles(List.of(new Role().name("OWNER"))));
         }
     }
 
@@ -209,12 +207,10 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1))
                         .data(Stream.of(member).map(MemberMapper.INSTANCE::map).toList())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -276,20 +272,16 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(2).perPage(2).totalCount(4L).pageItemsCount(2).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(2).perPage(2).totalCount(4L).pageItemsCount(2))
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .links(
-                            Links
-                                .builder()
+                            new Links()
                                 .self(paginatedTarget.getUri().toString())
                                 .first(paginatedTarget.getUri().toString())
                                 .last(target.queryParam("page", 2).queryParam("perPage", 2).getUri().toString())
                                 .next(target.queryParam("page", 2).queryParam("perPage", 2).getUri().toString())
-                                .build()
                         )
-                        .build()
                 );
         }
     }
@@ -369,7 +361,7 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_editing_with_role_primary_owner() {
-            var newMembership = UpdateMember.builder().roleName("PRIMARY_OWNER").build();
+            var newMembership = new UpdateMember().roleName("PRIMARY_OWNER");
 
             final Response response = target.request().put(Entity.json(newMembership));
 
@@ -381,16 +373,14 @@ public class IntegrationMembersResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_edit_a_membership() {
-            var newMembership = UpdateMember.builder().roleName("OWNER").build();
+            var newMembership = new UpdateMember().roleName("OWNER");
 
             final Response response = target.request().put(Entity.json(newMembership));
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(Member.class)
-                .isEqualTo(
-                    Member.builder().id(MEMBER_ID).displayName("John Doe").roles(List.of(Role.builder().name("OWNER").build())).build()
-                );
+                .isEqualTo(new Member().id(MEMBER_ID).displayName("John Doe").roles(List.of(new Role().name("OWNER"))));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResourceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AsyncJobFixture;
 import fixtures.core.model.IntegrationApiFixtures;
@@ -175,16 +174,14 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(Integration.class)
                 .isEqualTo(
-                    Integration
-                        .builder()
+                    new Integration()
                         .id(INTEGRATION_ID)
                         .name(integration.getName())
                         .description(integration.getDescription())
                         .provider(integration.getProvider())
                         .agentStatus(Integration.AgentStatusEnum.CONNECTED)
-                        .primaryOwner(PrimaryOwner.builder().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe").build())
+                        .primaryOwner(new PrimaryOwner().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe"))
                         .groups(List.of())
-                        .build()
                 );
         }
 
@@ -202,23 +199,17 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(Integration.class)
                 .isEqualTo(
-                    Integration
-                        .builder()
+                    new Integration()
                         .id(INTEGRATION_ID)
                         .name(integration.getName())
                         .description(integration.getDescription())
                         .provider(integration.getProvider())
                         .agentStatus(Integration.AgentStatusEnum.CONNECTED)
-                        .primaryOwner(PrimaryOwner.builder().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe").build())
+                        .primaryOwner(new PrimaryOwner().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe"))
                         .pendingJob(
-                            io.gravitee.rest.api.management.v2.rest.model.IngestionJob
-                                .builder()
-                                .id(job.getId())
-                                .status(AsyncJobStatus.PENDING)
-                                .build()
+                            new io.gravitee.rest.api.management.v2.rest.model.IngestionJob().id(job.getId()).status(AsyncJobStatus.PENDING)
                         )
                         .groups(List.of())
-                        .build()
                 );
         }
 
@@ -302,7 +293,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(IntegrationIngestionResponse.class)
-                .isEqualTo(IntegrationIngestionResponse.builder().status(AsyncJobStatus.PENDING).build());
+                .isEqualTo(new IntegrationIngestionResponse().status(AsyncJobStatus.PENDING));
         }
     }
 
@@ -317,11 +308,9 @@ public class IntegrationResourceTest extends AbstractResourceTest {
             var integration = List.of(IntegrationFixture.anIntegration());
             integrationCrudServiceInMemory.initWith(integration);
 
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration
-                .builder()
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration()
                 .name(updatedName)
-                .description(updatedDescription)
-                .build();
+                .description(updatedDescription);
 
             //When
             Response response = target.request().put(Entity.json(updateIntegration));
@@ -331,13 +320,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(Integration.class)
                 .isEqualTo(
-                    Integration
-                        .builder()
-                        .id(INTEGRATION_ID)
-                        .name(updatedName)
-                        .description(updatedDescription)
-                        .provider(INTEGRATION_PROVIDER)
-                        .build()
+                    new Integration().id(INTEGRATION_ID).name(updatedName).description(updatedDescription).provider(INTEGRATION_PROVIDER)
                 );
         }
 
@@ -351,12 +334,10 @@ public class IntegrationResourceTest extends AbstractResourceTest {
             integrationCrudServiceInMemory.initWith(integration);
             givenExistingGroup(List.of(Group.builder().id(groupId).name("group-name").build()));
 
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration
-                .builder()
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration()
                 .name(updatedName)
                 .description(updatedDescription)
-                .groups(List.of(groupId))
-                .build();
+                .groups(List.of(groupId));
 
             //When
             Response response = target.request().put(Entity.json(updateIntegration));
@@ -366,14 +347,12 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(Integration.class)
                 .isEqualTo(
-                    Integration
-                        .builder()
+                    new Integration()
                         .id(INTEGRATION_ID)
                         .name(updatedName)
                         .description(updatedDescription)
                         .provider(INTEGRATION_PROVIDER)
                         .groups(List.of(groupId))
-                        .build()
                 );
         }
 
@@ -383,11 +362,9 @@ public class IntegrationResourceTest extends AbstractResourceTest {
             var updatedName = "updated-name";
             var updatedDescription = "updated-description";
 
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration
-                .builder()
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration()
                 .name(updatedName)
-                .description(updatedDescription)
-                .build();
+                .description(updatedDescription);
 
             //When
             Response response = target.request().put(Entity.json(updateIntegration));
@@ -408,7 +385,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
             )
                 .thenReturn(false);
 
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration.builder().build();
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration();
 
             Response response = target.request().put(Entity.json(updateIntegration));
 
@@ -419,10 +396,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
         public void should_return_400_when_missing_name_to_update() {
             var updatedDescription = "updated-description";
 
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration
-                .builder()
-                .description(updatedDescription)
-                .build();
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration().description(updatedDescription);
 
             Response response = target.request().put(Entity.json(updateIntegration));
 
@@ -431,7 +405,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_400_when_missing_body() {
-            var updateIntegration = io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration.builder().build();
+            var updateIntegration = new io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration();
 
             Response response = target.request().put(Entity.json(updateIntegration));
 
@@ -451,7 +425,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
 
             //Then
             assertThat(response).hasStatus(HttpStatusCode.NO_CONTENT_204);
-            assertThat(integrationCrudServiceInMemory.storage().size()).isEqualTo(0);
+            assertThat(integrationCrudServiceInMemory.storage()).isEmpty();
         }
 
         @Test
@@ -505,7 +479,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(200)
                 .asEntity(IngestedApisResponse.class)
                 .extracting(IngestedApisResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(1).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L).build());
+                .isEqualTo(new Pagination().page(1).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L));
         }
 
         @Test
@@ -516,7 +490,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(200)
                 .asEntity(IngestedApisResponse.class)
                 .extracting(IngestedApisResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L).build());
+                .isEqualTo(new Pagination().page(2).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L));
         }
 
         @Test
@@ -535,7 +509,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(200)
                 .asEntity(IngestedApisResponse.class)
                 .extracting(IngestedApisResponse::getData)
-                .extracting(ingestedApis -> ingestedApis.get(0))
+                .extracting(List::getFirst)
                 .extracting(IngestedApi::getName)
                 .isEqualTo(recentlyUpdatedApi.getName());
         }
@@ -550,14 +524,12 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .asEntity(IngestedApisResponse.class)
                 .extracting(IngestedApisResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(webtarget.queryParam("page", 2).queryParam("perPage", 5).getUri().toString())
                         .first(webtarget.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .last(webtarget.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
                         .previous(webtarget.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .next(webtarget.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
-                        .build()
                 );
         }
 
@@ -699,21 +671,17 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(IngestionPreviewResponse.class)
                 .isEqualTo(
-                    IngestionPreviewResponse
-                        .builder()
+                    new IngestionPreviewResponse()
                         .totalCount(1)
                         .newCount(1)
                         .updateCount(0)
-                        .apis(List.of(IngestionPreviewResponseApisInner.builder().id("asset-id").name("An alien API").state(NEW).build()))
-                        .build()
+                        .apis(List.of(new IngestionPreviewResponseApisInner().id("asset-id").name("An alien API").state(NEW)))
                 );
         }
     }
 
     @Nested
     class GetPermissions {
-
-        private static final TypeReference<Map<String, char[]>> apiType = new TypeReference<>() {};
 
         @BeforeEach
         void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationsResourceTest.java
@@ -124,12 +124,10 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
         @Test
         public void should_create_integration() {
             //Given
-            var createIntegration = CreateIntegration
-                .builder()
+            var createIntegration = new CreateIntegration()
                 .name(INTEGRATION_NAME)
                 .description(INTEGRATION_DESCRIPTION)
-                .provider(INTEGRATION_PROVIDER)
-                .build();
+                .provider(INTEGRATION_PROVIDER);
 
             //When
             Response response = target.request().post(Entity.json(createIntegration));
@@ -140,24 +138,20 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.CREATED_201)
                 .asEntity(Integration.class)
                 .isEqualTo(
-                    Integration
-                        .builder()
+                    new Integration()
                         .id(INTEGRATION_ID)
                         .name(INTEGRATION_NAME)
                         .description(INTEGRATION_DESCRIPTION)
                         .provider(INTEGRATION_PROVIDER)
-                        .build()
                 );
         }
 
         @Test
         public void should_throw_bad_request_when_name_is_missing() {
             //Given
-            CreateIntegration createIntegration = CreateIntegration
-                .builder()
+            CreateIntegration createIntegration = new CreateIntegration()
                 .description(INTEGRATION_DESCRIPTION)
-                .provider(INTEGRATION_PROVIDER)
-                .build();
+                .provider(INTEGRATION_PROVIDER);
 
             //When
             Response response = target.request().post(Entity.json(createIntegration));
@@ -178,7 +172,7 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_403_when_incorrect_permission() {
             //Given
-            CreateIntegration createIntegration = new CreateIntegration().toBuilder().name("Barbicha").build();
+            CreateIntegration createIntegration = new CreateIntegration().name("Barbicha");
             when(
                 permissionService.hasPermission(
                     eq(GraviteeContext.getExecutionContext()),
@@ -231,7 +225,7 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(IntegrationsResponse.class)
                 .extracting(IntegrationsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(1).perPage(5).pageItemsCount(5).pageCount(3).totalCount(15L).build());
+                .isEqualTo(new Pagination().page(1).perPage(5).pageItemsCount(5).pageCount(3).totalCount(15L));
         }
 
         @Test
@@ -244,7 +238,7 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(IntegrationsResponse.class)
                 .extracting(IntegrationsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(2).perPage(2).pageItemsCount(2).pageCount(8).totalCount(15L).build());
+                .isEqualTo(new Pagination().page(2).perPage(2).pageItemsCount(2).pageCount(8).totalCount(15L));
         }
 
         @Test
@@ -257,7 +251,7 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .hasStatus(HttpStatusCode.OK_200)
                 .asEntity(IntegrationsResponse.class)
                 .extracting(IntegrationsResponse::getPagination)
-                .isEqualTo(Pagination.builder().page(1).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L).build());
+                .isEqualTo(new Pagination().page(1).perPage(10).pageItemsCount(10).pageCount(2).totalCount(15L));
         }
 
         @Test
@@ -288,16 +282,14 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .extracting(IntegrationsResponse::getData)
                 .extracting(integrations -> integrations.get(0))
                 .isEqualTo(
-                    Integration
-                        .builder()
+                    new Integration()
                         .id(INTEGRATION_ID)
                         .name(name)
                         .description(description)
                         .provider(provider)
                         .agentStatus(Integration.AgentStatusEnum.CONNECTED)
-                        .primaryOwner(PrimaryOwner.builder().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe").build())
+                        .primaryOwner(new PrimaryOwner().id("UnitTests").email("jane.doe@gravitee.io").displayName("Jane Doe"))
                         .groups(List.of())
-                        .build()
                 );
         }
 
@@ -310,14 +302,12 @@ public class IntegrationsResourceTest extends AbstractResourceTest {
                 .asEntity(ApiLogsResponse.class)
                 .extracting(ApiLogsResponse::getLinks)
                 .isEqualTo(
-                    Links
-                        .builder()
+                    new Links()
                         .self(target.queryParam("page", 2).queryParam("perPage", 5).getUri().toString())
                         .first(target.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .last(target.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
                         .previous(target.queryParam("page", 1).queryParam("perPage", 5).getUri().toString())
                         .next(target.queryParam("page", 3).queryParam("perPage", 5).getUri().toString())
-                        .build()
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
@@ -18,7 +18,9 @@ package io.gravitee.rest.api.management.v2.rest.resource.plugin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import inmemory.PolicyPluginQueryServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
@@ -118,15 +120,13 @@ public class PoliciesResourceTest extends AbstractResourceTest {
 
         assertThat(policyPlugins)
             .containsExactlyInAnyOrder(
-                PolicyPlugin.builder().id("policy-2").name("policy-2").deployed(false).build(),
-                PolicyPlugin
-                    .builder()
+                new PolicyPlugin().id("policy-2").name("policy-2").deployed(false),
+                new PolicyPlugin()
                     .id("policy-3")
                     .name("policy-3")
                     .deployed(true)
                     .flowPhaseCompatibility(
-                        PolicyPluginAllOfFlowPhaseCompatibility
-                            .builder()
+                        new PolicyPluginAllOfFlowPhaseCompatibility()
                             .HTTP_PROXY(
                                 Set.of(
                                     io.gravitee.rest.api.management.v2.rest.model.FlowPhase.REQUEST,
@@ -141,10 +141,8 @@ public class PoliciesResourceTest extends AbstractResourceTest {
                                     io.gravitee.rest.api.management.v2.rest.model.FlowPhase.PUBLISH
                                 )
                             )
-                            .build()
-                    )
-                    .build(),
-                PolicyPlugin.builder().id("policy-1").name("policy-1").deployed(false).build()
+                    ),
+                new PolicyPlugin().id("policy-1").name("policy-1").deployed(false)
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/ResourcesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/ResourcesResourceTest.java
@@ -27,18 +27,12 @@ import inmemory.ResourcePluginQueryServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.license.License;
 import io.gravitee.node.api.license.LicenseManager;
-import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ResourcePlugin;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
-import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,18 +135,16 @@ public class ResourcesResourceTest extends AbstractResourceTest {
 
         assertThat(resourcePlugins)
             .containsExactly(
-                ResourcePlugin.builder().id("resource-1").name("resource-1").deployed(false).build(),
-                ResourcePlugin
-                    .builder()
+                new ResourcePlugin().id("resource-1").name("resource-1").deployed(false),
+                new ResourcePlugin()
                     .id("resource-2")
                     .name("resource-2")
                     .description("description")
                     .category("category")
                     .icon("icon")
                     .version("1.0")
-                    .deployed(false)
-                    .build(),
-                ResourcePlugin.builder().id("resource-3").name("resource-3").deployed(true).build()
+                    .deployed(false),
+                new ResourcePlugin().id("resource-3").name("resource-3").deployed(true)
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinkResource_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinkResource_UpdateTest.java
@@ -87,13 +87,11 @@ public class PortalMenuLinkResource_UpdateTest extends AbstractResourceTest {
         portalMenuLinkCrudServiceInMemory.initWith(List.of(portalMenuLink));
 
         // When
-        var portalMenuLinkToUpdate = UpdatePortalMenuLink
-            .builder()
+        var portalMenuLinkToUpdate = new UpdatePortalMenuLink()
             .name("new menu link")
             .target("http://newTarget")
             .visibility(UpdatePortalMenuLink.VisibilityEnum.PUBLIC)
-            .order(100)
-            .build();
+            .order(100);
         final Response response = rootTarget().request().put(json(portalMenuLinkToUpdate));
 
         // Then

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinksResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/PortalMenuLinksResource_CreateTest.java
@@ -76,12 +76,10 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
     @Test
     void should_create_portal_menu_link_with_default_visibility() {
         // When
-        var portalMenuLinkToCreate = CreatePortalMenuLink
-            .builder()
+        var portalMenuLinkToCreate = new CreatePortalMenuLink()
             .name("new menu link")
             .target("http://newTarget")
-            .type(CreatePortalMenuLink.TypeEnum.EXTERNAL)
-            .build();
+            .type(CreatePortalMenuLink.TypeEnum.EXTERNAL);
         final Response response = rootTarget().request().post(json(portalMenuLinkToCreate));
 
         // Then
@@ -102,13 +100,11 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
     @Test
     void should_create_portal_menu_link_with_public_visibility() {
         // When
-        var portalMenuLinkToCreate = CreatePortalMenuLink
-            .builder()
+        var portalMenuLinkToCreate = new CreatePortalMenuLink()
             .name("new menu link")
             .target("http://newTarget")
             .type(CreatePortalMenuLink.TypeEnum.EXTERNAL)
-            .visibility(CreatePortalMenuLink.VisibilityEnum.PUBLIC)
-            .build();
+            .visibility(CreatePortalMenuLink.VisibilityEnum.PUBLIC);
         final Response response = rootTarget().request().post(json(portalMenuLinkToCreate));
 
         // Then
@@ -139,7 +135,7 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
             .asError()
             .hasHttpStatus(BAD_REQUEST_400)
             .hasMessage("Validation error");
-        assertThat(portalMenuLinkCrudServiceInMemory.storage()).hasSize(0);
+        assertThat(portalMenuLinkCrudServiceInMemory.storage()).isEmpty();
     }
 
     @Test
@@ -154,7 +150,7 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
             .asError()
             .hasHttpStatus(BAD_REQUEST_400)
             .hasMessage("Validation error");
-        assertThat(portalMenuLinkCrudServiceInMemory.storage()).hasSize(0);
+        assertThat(portalMenuLinkCrudServiceInMemory.storage()).isEmpty();
     }
 
     @Test
@@ -169,7 +165,7 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
             .asError()
             .hasHttpStatus(BAD_REQUEST_400)
             .hasMessage("Validation error");
-        assertThat(portalMenuLinkCrudServiceInMemory.storage()).hasSize(0);
+        assertThat(portalMenuLinkCrudServiceInMemory.storage()).isEmpty();
     }
 
     @Test
@@ -195,6 +191,6 @@ public class PortalMenuLinksResource_CreateTest extends AbstractResourceTest {
             .asError()
             .hasHttpStatus(FORBIDDEN_403)
             .hasMessage("You do not have sufficient rights to access this resource");
-        assertThat(portalMenuLinkCrudServiceInMemory.storage()).hasSize(0);
+        assertThat(portalMenuLinkCrudServiceInMemory.storage()).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemeResourceTest.java
@@ -104,7 +104,7 @@ public class ThemeResourceTest extends AbstractResourceTest {
                 )
             )
                 .thenReturn(false);
-            final Response response = rootTarget().request().put(Entity.json(UpdateThemePortal.builder().id(THEME_ID).build()));
+            final Response response = rootTarget().request().put(Entity.json(new UpdateThemePortal().id(THEME_ID)));
 
             MAPIAssertions
                 .assertThat(response)
@@ -116,7 +116,7 @@ public class ThemeResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_update_if_path_theme_id_does_not_match_body() {
-            final Response response = rootTarget().request().put(Entity.json(UpdateThemePortal.builder().id("another-id").build()));
+            final Response response = rootTarget().request().put(Entity.json(new UpdateThemePortal().id("another-id")));
 
             MAPIAssertions
                 .assertThat(response)
@@ -128,7 +128,7 @@ public class ThemeResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_not_update_non_existing_theme() {
-            final Response response = rootTarget().request().put(Entity.json(UpdateThemePortal.builder().id(THEME_ID).build()));
+            final Response response = rootTarget().request().put(Entity.json(new UpdateThemePortal().id(THEME_ID)));
             MAPIAssertions
                 .assertThat(response)
                 .hasStatus(NOT_FOUND_404)
@@ -142,7 +142,7 @@ public class ThemeResourceTest extends AbstractResourceTest {
             themeQueryService.initWith(List.of(aPortalTheme().toBuilder().referenceId("another-env").build()));
             themeCrudService.initWith(List.of(aPortalTheme().toBuilder().referenceId("another-env").build()));
 
-            final Response response = rootTarget().request().put(Entity.json(UpdateThemePortal.builder().id(THEME_ID).build()));
+            final Response response = rootTarget().request().put(Entity.json(new UpdateThemePortal().id(THEME_ID)));
             MAPIAssertions
                 .assertThat(response)
                 .hasStatus(NOT_FOUND_404)
@@ -156,29 +156,23 @@ public class ThemeResourceTest extends AbstractResourceTest {
             themeQueryService.initWith(List.of(aPortalTheme()));
             themeCrudService.initWith(List.of(aPortalTheme()));
 
-            var updateTheme = UpdateThemePortal
-                .builder()
+            var updateTheme = (UpdateThemePortal) new UpdateThemePortal()
+                .backgroundImage("background image")
+                .definition(
+                    new PortalDefinition()
+                        .data(
+                            List.of(
+                                new PortalComponentDefinition()
+                                    .name("title")
+                                    .css(List.of(new PortalCssDefinition().name("background").value("#000")))
+                            )
+                        )
+                )
                 .id(THEME_ID)
                 .name("new name")
                 .enabled(false)
-                .backgroundImage("background image")
                 .logo("background image")
-                .optionalLogo("background image")
-                .definition(
-                    PortalDefinition
-                        .builder()
-                        .data(
-                            List.of(
-                                PortalComponentDefinition
-                                    .builder()
-                                    .name("title")
-                                    .css(List.of(PortalCssDefinition.builder().name("background").value("#000").build()))
-                                    .build()
-                            )
-                        )
-                        .build()
-                )
-                .build();
+                .optionalLogo("background image");
 
             final Response response = rootTarget().request().put(Entity.json(updateTheme));
 
@@ -203,22 +197,18 @@ public class ThemeResourceTest extends AbstractResourceTest {
             themeQueryService.initWith(List.of(aPortalNextTheme()));
             themeCrudService.initWith(List.of(aPortalNextTheme()));
 
-            var updateTheme = UpdateThemePortalNext
-                .builder()
+            var updateTheme = (UpdateThemePortalNext) new UpdateThemePortalNext()
+                .definition(
+                    new PortalNextDefinition()
+                        .color(new PortalNextDefinitionColor().primary("#666").secondary("#444"))
+                        .font(new PortalNextDefinitionFont().fontFamily("Comic Sans"))
+                        .customCss("a new style")
+                )
                 .id(THEME_ID)
                 .name("new name")
                 .enabled(false)
-                .logo("background image")
                 .optionalLogo("background image")
-                .definition(
-                    PortalNextDefinition
-                        .builder()
-                        .color(PortalNextDefinitionColor.builder().primary("#666").secondary("#444").build())
-                        .font(PortalNextDefinitionFont.builder().fontFamily("Comic Sans").build())
-                        .customCss("a new style")
-                        .build()
-                )
-                .build();
+                .logo("background image");
 
             final Response response = rootTarget().request().put(Entity.json(updateTheme));
 
@@ -245,22 +235,18 @@ public class ThemeResourceTest extends AbstractResourceTest {
             themeQueryService.initWith(List.of(disabledTheme, currentThemeEnabled));
             themeCrudService.initWith(List.of(disabledTheme, currentThemeEnabled));
 
-            var updateTheme = UpdateThemePortalNext
-                .builder()
+            var updateTheme = (UpdateThemePortalNext) new UpdateThemePortalNext()
+                .definition(
+                    new PortalNextDefinition()
+                        .color(new PortalNextDefinitionColor().primary("#666").secondary("#444"))
+                        .font(new PortalNextDefinitionFont().fontFamily("Comic Sans"))
+                        .customCss("a new style")
+                )
                 .id(THEME_ID)
                 .name("new name")
                 .enabled(true)
                 .logo("background image")
-                .optionalLogo("background image")
-                .definition(
-                    PortalNextDefinition
-                        .builder()
-                        .color(PortalNextDefinitionColor.builder().primary("#666").secondary("#444").build())
-                        .font(PortalNextDefinitionFont.builder().fontFamily("Comic Sans").build())
-                        .customCss("a new style")
-                        .build()
-                )
-                .build();
+                .optionalLogo("background image");
 
             final Response response = rootTarget().request().put(Entity.json(updateTheme));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -293,7 +293,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
                 return "";
             }
         } catch (ParseException e) {
-            logger.error("Unable to parse query", e);
+            logger.debug("Unable to parse query", e);
             return query.getQuery();
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -232,7 +232,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             List<BooleanClause> clauses = ((BooleanQuery) query).clauses();
             result = clauses.size();
             for (BooleanClause clause : clauses) {
-                result += getClauseCount(clause.getQuery());
+                result += getClauseCount(clause.query());
             }
         } else if (query instanceof BoostQuery) {
             result += getClauseCount(((BoostQuery) query).getQuery());
@@ -285,7 +285,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             Set<String> rest = appendExplicitFilters(query.getQuery(), mainQuery, restQuery);
             BooleanQuery build = restQuery.build();
             if (!build.clauses().isEmpty()) {
-                mainQuery.add(build, build.clauses().getFirst().getOccur());
+                mainQuery.add(build, build.clauses().getFirst().occur());
             }
             if (!CollectionUtils.isEmpty(rest)) {
                 return String.join(" ", rest);
@@ -321,7 +321,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         BooleanClause clause
     ) {
         Set<String> rest = new HashSet<>();
-        BooleanClause.Occur currentOccur = clause != null ? clause.getOccur() : BooleanClause.Occur.FILTER;
+        BooleanClause.Occur currentOccur = clause != null ? clause.occur() : BooleanClause.Occur.FILTER;
         if (query instanceof TermQuery) {
             appendTermFilters((TermQuery) query, mainQuery, restQuery, clause, rest, currentOccur);
         } else if (query instanceof BooleanQuery) {
@@ -358,7 +358,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         if (!clauses.isEmpty()) {
             BooleanQuery.Builder subQuery = new BooleanQuery.Builder();
             for (BooleanClause _clause : clauses) {
-                Query innerQuery = _clause.getQuery();
+                Query innerQuery = _clause.query();
                 Set<String> innerRest = appendExplicitFilters(innerQuery, subQuery, restQuery, _clause);
                 if (innerRest == null) {
                     return true;
@@ -383,7 +383,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         if (Arrays.stream(AUTHORIZED_EXPLICIT_FILTER).anyMatch(field -> field.equals(term.field()))) {
             mainQuery.add(buildQueryFilter(term), currentOccur);
         } else if (clause != null) {
-            restQuery.add(buildApiFields(term.text()), clause.getOccur());
+            restQuery.add(buildApiFields(term.text()), clause.occur());
         } else {
             rest.add(term.text());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/UserDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/UserDocumentSearcher.java
@@ -67,7 +67,7 @@ public class UserDocumentSearcher extends AbstractDocumentSearcher {
     }
 
     @Override
-    public SearchResult search(ExecutionContext executionContext, Query query) throws TechnicalException {
+    public SearchResult search(ExecutionContext executionContext, Query<?> query) throws TechnicalException {
         QueryParser parser = new MultiFieldQueryParser(
             new String[] {
                 FIELD_DISPLAYNAME,
@@ -159,18 +159,18 @@ public class UserDocumentSearcher extends AbstractDocumentSearcher {
 
             logger.debug("Found {} total matching documents", topDocs.totalHits);
             for (ScoreDoc doc : collectedDocs) {
-                String reference = searcher.doc(doc.doc).get(fieldReference);
+                String reference = searcher.storedFields().document(doc.doc).get(fieldReference);
                 results.add(reference);
             }
 
-            return new SearchResult(results, topDocs.totalHits.value);
+            return new SearchResult(results, topDocs.totalHits.value());
         } catch (IOException ioe) {
             logger.error("An error occurs while getting documents from search result", ioe);
             throw new TechnicalException("An error occurs while getting documents from search result", ioe);
         }
     }
 
-    private boolean isUserIdFormat(io.gravitee.rest.api.service.search.query.Query query) {
+    private boolean isUserIdFormat(io.gravitee.rest.api.service.search.query.Query<?> query) {
         try {
             UUID.fromString(query.getQuery());
             return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
@@ -106,16 +106,18 @@ public class UserDocumentTransformer implements DocumentTransformer<UserEntity> 
         }
 
         if (user.getDisplayName() != null) {
-            TextField displayName = new TextField(FIELD_DISPLAYNAME, toLowerCaseAndStripAccents(user.getDisplayName()), Field.Store.NO);
-            displayName.setTokenStream(
+            TextField displayName = new TextField(
+                FIELD_DISPLAYNAME,
                 userFieldAnalyzer().tokenStream(FIELD_DISPLAYNAME, toLowerCaseAndStripAccents(user.getDisplayName()))
             );
             doc.add(displayName);
 
             if (!StringUtils.isEmpty(user.getLastname()) && !StringUtils.isEmpty(user.getFirstname())) {
                 String lastnameFirstname = toLowerCaseAndStripAccents(String.format("%s %s", user.getLastname(), user.getFirstname()));
-                TextField lastnameFirstnameTextField = new TextField(FIELD_LASTNAME_FIRSTNAME, lastnameFirstname, Field.Store.NO);
-                lastnameFirstnameTextField.setTokenStream(userFieldAnalyzer().tokenStream(FIELD_LASTNAME_FIRSTNAME, lastnameFirstname));
+                TextField lastnameFirstnameTextField = new TextField(
+                    FIELD_LASTNAME_FIRSTNAME,
+                    userFieldAnalyzer().tokenStream(FIELD_LASTNAME_FIRSTNAME, lastnameFirstname)
+                );
                 doc.add(lastnameFirstnameTextField);
 
                 SortedDocValuesField lastnameFirstnameSortedField = new SortedDocValuesField(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
@@ -37,7 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>
-        <nimbus-jose-jwt.version>9.48</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
         <mongo.version>5.3.1</mongo.version>
         <owasp-java-html-sanitizer.version>20240325.1</owasp-java-html-sanitizer.version>
         <reactor-adapter.version>3.5.2</reactor-adapter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <json-unit.version>4.1.0</json-unit.version>
         <jsoup.version>1.19.1</jsoup.version>
         <kafka.version>3.7.1</kafka.version>
-        <lucene.version>9.12.1</lucene.version>
+        <lucene.version>10.1.0</lucene.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8740

## Description

This PR updates several Java dependencies version to latest

⚠️ Version 7 of `opengenerator-plugin` contains a change that breaks the use of Lombok's builder in generated models.
See https://github.com/OpenAPITools/openapi-generator/issues/15684
To work around that, I have activated the builder generation using the `generateBuilders` configuration options. This generates methods that can be used to build models using a fluent API.

We can't upgrade to the latest Liquibase version due until the following bug is fixed https://github.com/liquibase/liquibase/issues/6258

## Additional context

Any existing `/data` directory in the GRAVITEE_HOME containing Lucene index files must be cleaned before starting the Management API. (explained in https://gravitee.slab.com/posts/apim-4-8-notable-changes-n8cew4ne)

Tests done
- [X] Run repository tests 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hqqzdvfvgq.chromatic.com)
<!-- Storybook placeholder end -->
