### PR TITLE
Improve renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,11 @@
 {
     "extends": ["github>gravitee-io/renovate-config","config:js-app"],
+    "circleci": {
+      "fileMatch": [
+        "(^|/).circleci/src/config.ts$",
+        "(^|/).circleci/config.yml$"
+      ]
+    },
     "packageRules": [
         {
             // Group all angular related packages updates together

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
-    "extends": ["github>gravitee-io/renovate-config","config:js-app", "schedule:earlyMondays"],
+    "extends": ["github>gravitee-io/renovate-config","config:js-app"],
     "packageRules": [
         {
             // Group all angular related packages updates together


### PR DESCRIPTION
## Description

Remove the schedule only once a week preset.

Configure to detect orb version update. This is an attempt to configure renovate to detect orb versions.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

