### PR TITLE
fix: improve search performance by removing leading default wildcard

### DIFF
--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
@@ -339,7 +339,7 @@ class LogsFiltersController {
       }
 
       if (key === 'body') {
-        val = '*' + val + '*';
+        val += '*';
       }
       const params = val.constructor === Array && val.length > 1 ? LogsFiltersController.convert(val) : val;
       query += this.map(key, this.fields, true) + ':' + params;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8836

## Description

Improved search performance by removing the leading wildcard from default queries and letting the end user to use leading wildcard (manually) only if required.

Time difference --

With leading wildcard:
<img width="1335" alt="Screenshot 2025-03-10 at 12 16 37 PM" src="https://github.com/user-attachments/assets/59bec61f-93a3-4d1d-8b8c-365a0ff73b62" />


Without leading wildcard:
<img width="1335" alt="Screenshot 2025-03-10 at 12 17 01 PM" src="https://github.com/user-attachments/assets/2ad3ee55-4fef-4321-b919-830ba474982b" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vhfkbcohye.chromatic.com)
<!-- Storybook placeholder end -->
