### PR TITLE
fix: handle missing userinfo attributes for IDP condition evaluation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1813,7 +1813,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 TemplateEngine templateEngine = TemplateEngine.templateEngine();
                 templateEngine.getTemplateContext().setVariable(TEMPLATE_ENGINE_PROFILE_ATTRIBUTE, userInfo);
 
-                boolean match = templateEngine.getValue(mapping.getCondition(), boolean.class);
+                boolean match = evalCondition(username, mapping.getCondition(), templateEngine);
 
                 trace(username, match, mapping.getCondition());
 
@@ -1833,6 +1833,15 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         return orgRoles;
     }
 
+    private boolean evalCondition(String userData, String condition, TemplateEngine templateEngine) {
+        try {
+            return templateEngine.eval(condition, boolean.class).blockingGet();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to evaluate condition for user: {}. Condition: {}. Error: {}", userData, condition, e.getMessage(), e);
+            return false;
+        }
+    }
+
     protected Map<String, Set<RoleEntity>> computeEnvironmentRoles(
         ExecutionContext executionContext,
         @NotNull List<RoleMappingEntity> rolesMapping,
@@ -1850,7 +1859,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             TemplateEngine templateEngine = TemplateEngine.templateEngine();
             templateEngine.getTemplateContext().setVariable(TEMPLATE_ENGINE_PROFILE_ATTRIBUTE, userInfo);
 
-            boolean match = templateEngine.getValue(mapping.getCondition(), boolean.class);
+            boolean match = evalCondition(username, mapping.getCondition(), templateEngine);
 
             trace(username, match, mapping.getCondition());
 
@@ -1945,7 +1954,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             TemplateEngine templateEngine = TemplateEngine.templateEngine();
             templateEngine.getTemplateContext().setVariable(TEMPLATE_ENGINE_PROFILE_ATTRIBUTE, userInfo);
 
-            boolean match = templateEngine.getValue(mapping.getCondition(), boolean.class);
+            boolean match = evalCondition(userInfo, mapping.getCondition(), templateEngine);
 
             trace(userId, match, mapping.getCondition());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -32,7 +32,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.common.data.domain.MetadataPage;
 import io.gravitee.common.util.Maps;
-import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.api.UserRepository;
@@ -1592,9 +1591,9 @@ public class UserServiceTest {
         userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo);
     }
 
-    @Test(expected = ExpressionEvaluationException.class)
-    public void shouldSpelEvaluationExceptionWhenWrongELGroupsMapping() throws IOException, TechnicalException {
-        reset(identityProvider, userRepository);
+    @Test
+    public void shouldReturnDefaultGroupsMappingWhenSpelEvaluationExceptionOccurs() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository, groupService);
         mockDefaultEnvironment();
 
         GroupMappingEntity condition1 = new GroupMappingEntity();
@@ -1610,9 +1609,16 @@ public class UserServiceTest {
         condition3.setGroups(Collections.singletonList("Api consumer"));
 
         when(identityProvider.getGroupMappings()).thenReturn(Arrays.asList(condition1, condition2, condition3));
+        when(userRepository.create(any())).thenReturn(mockUser());
 
         String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
         userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo);
+
+        verify(groupService, times(1)).findById(EXECUTION_CONTEXT, "Api consumer");
+
+        verify(groupService, never()).findById(EXECUTION_CONTEXT, "Others");
+        verify(groupService, never()).findById(EXECUTION_CONTEXT, "Example group");
+        verify(groupService, never()).findById(EXECUTION_CONTEXT, "soft user");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8267

## Description

When external Identity Providers (IDPs) are configured with conditions in APIM, new users logging in with incomplete user info (e.g., tokens missing expected attributes like roles) cannot log in. For example, if the condition is defined as:
{#jsonPath(#profile, '$.roles').contains('TestRole')}
and the user’s token does not include a roles field, the evaluation fails (typically throwing a NullPointerException), and the login process is interrupted. 

## Additional context

Root Cause:

APIM uses a template engine with Spring SpEL for evaluating role mapping conditions.
Missing attributes in the user info (e.g., roles) cause the SpEL expression to throw an exception.
The current implementation does not gracefully handle such exceptions, resulting in silent login failures.
Solution:

The evalCondition method has been refactored to use a try-catch block. If the condition evaluation fails (e.g., due to missing attributes), the exception is caught, a warning is logged, and the method returns false as a safe fallback.
By defaulting the condition result to false in case of an error, the login process can continue, and the user is assigned default roles.
The deprecated templateEngine.getValue method has been replaced with templateEngine.eval, as getValue is deprecated and will be removed in a future release.

