### PR TITLE
fix(portal): wrap long strings in Table of Contents to prevent floating

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.css
@@ -37,7 +37,7 @@
 .markdown-toc > .toc-list li {
   list-style: none;
   line-height: 25px;
-  line-break: anywhere;
+  line-break: auto;
 }
 
 .toc-list {
@@ -56,7 +56,7 @@ a.toc-link {
   text-decoration: none;
   height: 100%;
   cursor: pointer;
-  white-space: nowrap;
+  white-space: normal;
   box-sizing: border-box;
 }
 

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -53,13 +53,6 @@
   overflow-wrap: break-word;
   white-space: pre-wrap;
 }
-:host ::ng-deep .toc-link {
-  display: block !important;
-  max-width: 100% !important;
-  white-space: normal !important;
-  word-break: break-word !important;
-}
-
 app-gv-markdown-toc {
   position: fixed;
   right: 42px;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8433

## Description

fixed css line break

## Additional context

### Before
<img width="1706" alt="Screenshot 2025-03-12 at 4 33 18 PM" src="https://github.com/user-attachments/assets/ffc6114e-3173-4276-932e-9a4ca3bec845" />

### After
<img width="1706" alt="Screenshot 2025-03-12 at 4 31 57 PM" src="https://github.com/user-attachments/assets/924754a5-a610-4977-a4df-3a202fe038a1" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cmmkzgstgc.chromatic.com)
<!-- Storybook placeholder end -->
