### PR TITLE
fix: documentation tab for read only users

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -869,7 +869,7 @@ const apisRoutes: Routes = [
             data: {
               docs: null,
               permissions: {
-                anyOf: ['api-documentation-u'],
+                anyOf: ['api-documentation-u', 'api-documentation-r'],
               },
             },
             component: ApiDocumentationV4DefaultPageComponent,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9013

## Description

allow users to open documentation tab with api-documentation-r permission

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uahjwjfgli.chromatic.com)
<!-- Storybook placeholder end -->
