### PR TITLE
chore: bump gravitee-expression-language to 4.1.0

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/TemplateContextAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/TemplateContextAdapter.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.policy.adapter.context;
 
 import io.gravitee.el.TemplateContext;
+import io.gravitee.el.spel.context.DeferredFunctionHolder;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -59,6 +60,11 @@ public class TemplateContextAdapter implements TemplateContext {
 
     @Override
     public void setDeferredVariable(String name, Single<?> deferred) {
+        // Should never be called in a V3 context.
+    }
+
+    @Override
+    public void setDeferredFunctionHolderVariable(String s, DeferredFunctionHolder deferredFunctionHolder) {
         // Should never be called in a V3 context.
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/TemplateEngineAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/TemplateEngineAdapter.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.policy.adapter.context;
 
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.reactivex.rxjava3.core.Maybe;
 
 /**
@@ -52,6 +53,11 @@ public class TemplateEngineAdapter implements TemplateEngine {
     @Override
     public <T> Maybe<T> eval(String expression, Class<T> clazz) {
         return templateEngine.eval(expression, clazz);
+    }
+
+    @Override
+    public <T> T evalBlocking(String expression, Class<T> clazz) throws ExpressionEvaluationException {
+        return templateEngine.evalBlocking(expression, clazz);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.3</gravitee-exchange.version>
-        <gravitee-expression-language.version>4.0.4</gravitee-expression-language.version>
+        <gravitee-expression-language.version>4.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.11.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-476

## Description

Update the gravitee-expression-language library to 4.1.0.
This version of gravitee-expression-language brings a new capability to execute reactive function and is backward compatible. 

Note that this new capability is **not yet actively used in APIM**. Upgrading the dependency should have no impact. A use case could be the support for fetching secrets dynamically using EL expressions such as:

```
org.apache.kafka.common.security.plain.PlainLoginModule required \
 username="admin" \
 password="{#secrets.get(#context.principal.claims['role'])} ";
```

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jwedgwdmlm.chromatic.com)
<!-- Storybook placeholder end -->
