### PR TITLE
fix(new portal): display documentation without breaking words

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.scss
@@ -31,5 +31,4 @@ table td {
 
 p {
   word-break: break-word;
-  word-break: break-all;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7688

## Description

Display documentation without breaking words

## Additional context

Before:
<img width="1164" alt="Capture d’écran 2025-03-13 à 17 25 16" src="https://github.com/user-attachments/assets/a6433ff4-49d8-45a1-bec9-f22227a29db6" />


After:
<img width="1164" alt="Capture d’écran 2025-03-13 à 17 24 20" src="https://github.com/user-attachments/assets/9c72193f-3080-4910-8665-611bdc2c77e5" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

