### PR TITLE
fix: display user column in logs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -21,6 +21,7 @@ import { chain, has, now } from 'lodash';
 import AnalyticsService from '../../../../services/analytics.service';
 import TenantService from '../../../../services/tenant.service';
 import { ApiService, LogsQuery } from '../../../../services/api.service';
+import { Constants } from '../../../../entities/Constants';
 
 class ApiAnalyticsLogsControllerAjs {
   private api: any;
@@ -42,6 +43,7 @@ class ApiAnalyticsLogsControllerAjs {
     private AnalyticsService: AnalyticsService,
     private TenantService: TenantService,
     private $q: ng.IQService,
+    private Constants: Constants,
   ) {
     this.ApiService = ApiService;
     this.$scope = $scope;
@@ -170,6 +172,15 @@ class ApiAnalyticsLogsControllerAjs {
     );
   }
 }
-ApiAnalyticsLogsControllerAjs.$inject = ['ApiService', '$scope', 'ngRouter', '$timeout', 'AnalyticsService', 'TenantService', '$q'];
+ApiAnalyticsLogsControllerAjs.$inject = [
+  'ApiService',
+  '$scope',
+  'ngRouter',
+  '$timeout',
+  'AnalyticsService',
+  'TenantService',
+  '$q',
+  'Constants',
+];
 
 export default ApiAnalyticsLogsControllerAjs;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8526

## Description

display user column in logs when enabled

Pre fix:
<img width="1728" alt="Screenshot 2025-03-13 at 10 38 12 PM" src="https://github.com/user-attachments/assets/7749dc5b-62fb-49bd-b98c-411cfc8837e2" />
 
 Post fix:
<img width="1728" alt="Screenshot 2025-03-13 at 10 37 52 PM" src="https://github.com/user-attachments/assets/ac244cc0-80ac-4e71-b4f6-4e3b6eec7035" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vdkldxrhkr.chromatic.com)
<!-- Storybook placeholder end -->
