### PR TITLE
feat: add subscription configuration in new portal [ PART 2/4 ]

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/index.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './subscription-consumer-configuration.component';

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
@@ -19,7 +19,7 @@
   <mat-card-header>
     <div class="configuration__header">
       <div class="m3-title-medium configuration__header__title" i18n="@@subscriptionConfiguration">Configuration</div>
-      <a mat-stroked-button class="configuration__header__button">Configure</a>
+      <a mat-stroked-button class="configuration__header__button" [routerLink]="'configure'">Configure</a>
     </div>
   </mat-card-header>
   <mat-card-content>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
@@ -1,0 +1,105 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card appearance="outlined" class="configuration">
+  <mat-card-header>
+    <div class="configuration__header">
+      <div class="m3-title-medium configuration__header__title" i18n="@@subscriptionConfiguration">Configuration</div>
+      <a mat-stroked-button class="configuration__header__button">Configure</a>
+    </div>
+  </mat-card-header>
+  <mat-card-content>
+    <div class="configuration__content">
+      @if (hasChannel) {
+        <div class="configuration__field">
+          <span class="m3-title-small" i18n="@@subscriptionConfigurationChannel">Channel:</span>
+          <span class="m3-body-medium">{{ consumerConfiguration().channel }}</span>
+        </div>
+      }
+
+      @if (consumerConfiguration().entrypointConfiguration) {
+        <div class="configuration__field">
+          <span class="m3-title-small" i18n="@@subscriptionConfigurationCallbackURL">Callback URL:</span>
+          <span class="m3-body-medium">
+            {{ consumerConfiguration().entrypointConfiguration.callbackUrl }}
+          </span>
+        </div>
+
+        @if (hasHeaders) {
+          <mat-list role="list">
+            <span class="m3-title-small" i18n="@@subscriptionConfigurationHeaders">Headers:</span>
+            @for (header of consumerConfiguration().entrypointConfiguration?.headers; track header) {
+              <mat-list-item>
+                <div class="configuration__field">
+                  <span class="m3-title-small">{{ header.name }}:</span>
+                  <span class="m3-body-medium">{{ header.value }}</span>
+                </div>
+              </mat-list-item>
+            }
+          </mat-list>
+        }
+
+        @if (consumerConfiguration().entrypointConfiguration?.auth) {
+          <div class="configuration__field">
+            <span class="m3-title-small" i18n="@@subscriptionConfigurationAuthType">Authentification type:</span>
+            <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.auth?.type }}</span>
+          </div>
+        }
+
+        @if (consumerConfiguration().entrypointConfiguration?.retry) {
+          <mat-list role="list">
+            <span class="m3-title-small" i18n="@@subscriptionConfigurationHeaders">Retry:</span>
+            <mat-list-item>
+              <div class="configuration__field">
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryOption">Option:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.retryOption }}</span>
+              </div>
+            </mat-list-item>
+
+            <mat-list-item>
+              <div class="configuration__field">
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryType">Strategy:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.retryStrategy }}</span>
+              </div>
+            </mat-list-item>
+
+            <mat-list-item>
+              <div class="configuration__field">
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryInitialDelay">initial delay in seconds:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.initialDelaySeconds }}</span>
+              </div>
+            </mat-list-item>
+
+            <mat-list-item>
+              <div class="configuration__field">
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryMaxAttempts">Maximum attempts:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.maxAttempts }}</span>
+              </div>
+            </mat-list-item>
+
+            <mat-list-item>
+              <div class="configuration__field">
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryMaxDelaySeconds">Maximum delay:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.maxDelaySeconds }}</span>
+              </div>
+            </mat-list-item>
+          </mat-list>
+        }
+      }
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
@@ -24,80 +24,78 @@
   </mat-card-header>
   <mat-card-content>
     <div class="configuration__content">
-      @if (hasChannel) {
-        <div class="configuration__field">
+      @if (hasChannel()) {
+        <div class="configuration__block configuration__field">
           <span class="m3-title-small" i18n="@@subscriptionConfigurationChannel">Channel:</span>
           <span class="m3-body-medium">{{ consumerConfiguration().channel }}</span>
         </div>
       }
 
       @if (consumerConfiguration().entrypointConfiguration) {
-        <div class="configuration__field">
+        <div class="configuration__block configuration__field">
           <span class="m3-title-small" i18n="@@subscriptionConfigurationCallbackURL">Callback URL:</span>
           <span class="m3-body-medium">
             {{ consumerConfiguration().entrypointConfiguration.callbackUrl }}
           </span>
         </div>
 
-        @if (hasHeaders) {
-          <mat-list role="list">
-            <span class="m3-title-small" i18n="@@subscriptionConfigurationHeaders">Headers:</span>
-            @for (header of consumerConfiguration().entrypointConfiguration?.headers; track header) {
-              <mat-list-item>
-                <div class="configuration__field">
-                  <span class="m3-title-small">{{ header.name }}:</span>
-                  <span class="m3-body-medium">{{ header.value }}</span>
-                </div>
-              </mat-list-item>
-            }
-          </mat-list>
+        @if (headers().length) {
+          <span class="m3-title-medium" i18n="@@subscriptionConfigurationHeaders">Headers</span>
+          <table class="table-light table-light--fit-content">
+            <thead>
+              <tr>
+                <th i18n="@@subscriptionConfigurationHeadersName">Name</th>
+                <th i18n="@@subscriptionConfigurationHeadersValue">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (header of consumerConfiguration().entrypointConfiguration.headers; track header) {
+                <tr>
+                  <td>{{ header.name }}</td>
+                  <td>{{ header.value }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
         }
 
-        @if (consumerConfiguration().entrypointConfiguration?.auth) {
-          <div class="configuration__field">
+        @if (consumerConfiguration().entrypointConfiguration.auth) {
+          <div class="configuration__block configuration__field">
             <span class="m3-title-small" i18n="@@subscriptionConfigurationAuthType">Authentification type:</span>
-            <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.auth?.type }}</span>
+            <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.auth.type }}</span>
           </div>
         }
 
-        @if (consumerConfiguration().entrypointConfiguration?.retry) {
-          <mat-list role="list">
-            <span class="m3-title-small" i18n="@@subscriptionConfigurationHeaders">Retry:</span>
-            <mat-list-item>
-              <div class="configuration__field">
-                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryOption">Option:</span>
-                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.retryOption }}</span>
-              </div>
-            </mat-list-item>
+        @if (consumerConfiguration().entrypointConfiguration.retry) {
+          <div class="configuration__block">
+            <span class="m3-title-medium" i18n="@@subscriptionConfigurationRetry">Retry</span>
+            <div class="configuration__field">
+              <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryOption">Option:</span>
+              <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.retry.retryOption }}</span>
+            </div>
 
-            <mat-list-item>
+            @if (consumerConfiguration().entrypointConfiguration.retry.retryOption === 'Retry On Fail') {
               <div class="configuration__field">
                 <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryType">Strategy:</span>
-                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.retryStrategy }}</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.retry.retryStrategy }}</span>
               </div>
-            </mat-list-item>
 
-            <mat-list-item>
               <div class="configuration__field">
-                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryInitialDelay">initial delay in seconds:</span>
-                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.initialDelaySeconds }}</span>
+                <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryInitialDelay">Initial delay in seconds:</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.retry.initialDelaySeconds }}</span>
               </div>
-            </mat-list-item>
 
-            <mat-list-item>
               <div class="configuration__field">
                 <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryMaxAttempts">Maximum attempts:</span>
-                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.maxAttempts }}</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.retry.maxAttempts }}</span>
               </div>
-            </mat-list-item>
 
-            <mat-list-item>
               <div class="configuration__field">
                 <span class="m3-title-small" i18n="@@subscriptionConfigurationRetryMaxDelaySeconds">Maximum delay:</span>
-                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration?.retry?.maxDelaySeconds }}</span>
+                <span class="m3-body-medium">{{ consumerConfiguration().entrypointConfiguration.retry.maxDelaySeconds }}</span>
               </div>
-            </mat-list-item>
-          </mat-list>
+            }
+          </div>
         }
       }
     </div>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
@@ -19,7 +19,9 @@
   <mat-card-header>
     <div class="configuration__header">
       <div class="m3-title-medium configuration__header__title" i18n="@@subscriptionConfiguration">Configuration</div>
-      <a mat-stroked-button class="configuration__header__button" [routerLink]="'configure'">Configure</a>
+      @if (canConfigure()) {
+        <a mat-stroked-button class="configuration__header__button" [routerLink]="'configure'">Configure</a>
+      }
     </div>
   </mat-card-header>
   <mat-card-content>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,39 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  flex-flow: column;
-}
-
-.subscriptions-details {
-  &__navigate-back {
+.configuration {
+  &__header {
     display: flex;
+    width: 100%;
     align-items: center;
-    padding-left: 8px;
-    cursor: pointer;
-    gap: 8px;
+    justify-content: space-between;
+
+    &__title {
+      padding: 8px 0 24px;
+    }
   }
 
-  &__arrow_backward {
-    cursor: pointer;
-    transform: scale(0.8);
-  }
-
-  &__container {
+  &__content {
     display: flex;
-    flex-direction: row;
-    padding-top: 32px;
-    margin-bottom: 20px;
-    gap: 32px;
-  }
+    flex-flow: column;
+    gap: 10px;
 
-  &__subscription-info {
-    min-width: 38%;
-  }
+    mat-list-item {
+      height: fit-content;
+    }
 
-  &__error {
-    align-self: center;
-    padding: 36px 0;
+    .configuration__field {
+      display: flex;
+      gap: 8px;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.scss
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../../../../../scss/m3-adapter';
+
 .configuration {
   &__header {
     display: flex;
@@ -30,8 +32,8 @@
     flex-flow: column;
     gap: 10px;
 
-    mat-list-item {
-      height: fit-content;
+    .configuration__block {
+      margin-bottom: 8px;
     }
 
     .configuration__field {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
@@ -18,11 +18,12 @@ import { MatAnchor } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { MatTableModule } from '@angular/material/table';
+import { RouterLink } from '@angular/router';
 
 import { SubscriptionConsumerConfiguration } from '../../../../../../entities/subscription';
 
 @Component({
-  imports: [MatCardModule, MatListModule, MatAnchor, MatTableModule],
+  imports: [MatCardModule, MatListModule, MatAnchor, MatTableModule, RouterLink],
   selector: 'app-subscription-consumer-configuration',
   standalone: true,
   templateUrl: './subscription-consumer-configuration.component.html',

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
@@ -30,6 +30,7 @@ import { SubscriptionConsumerConfiguration } from '../../../../../../entities/su
   styleUrls: ['./subscription-consumer-configuration.component.scss'],
 })
 export class SubscriptionConsumerConfigurationComponent {
+  canConfigure: InputSignal<boolean> = input<boolean>(false);
   consumerConfiguration: InputSignal<SubscriptionConsumerConfiguration> = input.required<SubscriptionConsumerConfiguration>();
   hasChannel = computed(() => !!this.consumerConfiguration().channel);
   headers = computed(() => this.consumerConfiguration().entrypointConfiguration?.headers ?? []);

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, effect, input, InputSignal } from '@angular/core';
+import { Component, computed, input, InputSignal } from '@angular/core';
 import { MatAnchor } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
+import { MatTableModule } from '@angular/material/table';
 
 import { SubscriptionConsumerConfiguration } from '../../../../../../entities/subscription';
 
 @Component({
-  imports: [MatCardModule, MatListModule, MatAnchor],
+  imports: [MatCardModule, MatListModule, MatAnchor, MatTableModule],
   selector: 'app-subscription-consumer-configuration',
   standalone: true,
   templateUrl: './subscription-consumer-configuration.component.html',
@@ -29,15 +30,7 @@ import { SubscriptionConsumerConfiguration } from '../../../../../../entities/su
 })
 export class SubscriptionConsumerConfigurationComponent {
   consumerConfiguration: InputSignal<SubscriptionConsumerConfiguration> = input.required<SubscriptionConsumerConfiguration>();
-  hasChannel: boolean = false;
-  hasHeaders: boolean = false;
-
-  constructor() {
-    effect(() => {
-      const consumerConfiguration: SubscriptionConsumerConfiguration = this.consumerConfiguration();
-      const entrypointConfiguration = consumerConfiguration.entrypointConfiguration;
-      this.hasChannel = !!consumerConfiguration.channel;
-      this.hasHeaders = !!entrypointConfiguration?.headers && entrypointConfiguration?.headers?.length > 0;
-    });
-  }
+  hasChannel = computed(() => !!this.consumerConfiguration().channel);
+  headers = computed(() => this.consumerConfiguration().entrypointConfiguration?.headers ?? []);
+  displayedColumns = ['name', 'value'];
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, effect, input, InputSignal } from '@angular/core';
+import { MatAnchor } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+
+import { SubscriptionConsumerConfiguration } from '../../../../../../entities/subscription';
+
+@Component({
+  imports: [MatCardModule, MatListModule, MatAnchor],
+  selector: 'app-subscription-consumer-configuration',
+  standalone: true,
+  templateUrl: './subscription-consumer-configuration.component.html',
+  styleUrls: ['./subscription-consumer-configuration.component.scss'],
+})
+export class SubscriptionConsumerConfigurationComponent {
+  consumerConfiguration: InputSignal<SubscriptionConsumerConfiguration> = input.required<SubscriptionConsumerConfiguration>();
+  hasChannel: boolean = false;
+  hasHeaders: boolean = false;
+
+  constructor() {
+    effect(() => {
+      const consumerConfiguration: SubscriptionConsumerConfiguration = this.consumerConfiguration();
+      const entrypointConfiguration = consumerConfiguration.entrypointConfiguration;
+      this.hasChannel = !!consumerConfiguration.channel;
+      this.hasHeaders = !!entrypointConfiguration?.headers && entrypointConfiguration?.headers?.length > 0;
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -46,6 +46,11 @@
         [apiKeyConfigUsername]="detailsVM.result.apiKeyConfigUsername" />
     </div>
   }
+
+  @if (detailsVM.result && !!detailsVM.result.consumerConfiguration) {
+    <app-subscription-consumer-configuration
+      [consumerConfiguration]="detailsVM.result.consumerConfiguration"></app-subscription-consumer-configuration>
+  }
 } @else {
   <app-loader />
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -49,7 +49,8 @@
 
   @if (detailsVM.result && !!detailsVM.result.consumerConfiguration) {
     <app-subscription-consumer-configuration
-      [consumerConfiguration]="detailsVM.result.consumerConfiguration"></app-subscription-consumer-configuration>
+      [consumerConfiguration]="detailsVM.result.consumerConfiguration"
+      [canConfigure]="!['CLOSED', 'REJECTED'].includes(detailsVM.result.subscriptionStatus)"></app-subscription-consumer-configuration>
   }
 } @else {
   <app-loader />

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -226,7 +226,9 @@ describe('SubscriptionsDetailsComponent', () => {
   });
 
   function expectSubscriptionWithKeys(subscriptionResponse: Subscription = fakeSubscription()) {
-    httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions/testSubscriptionId?include=keys`).flush(subscriptionResponse);
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/subscriptions/testSubscriptionId?include=keys&include=consumerConfiguration`)
+      .flush(subscriptionResponse);
   }
 
   function expectSubscriptionList(subscriptionResponse: SubscriptionsResponse = fakeSubscriptionResponse(), apiId: string) {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -17,12 +17,11 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
-import { MatFormField, MatFormFieldModule } from '@angular/material/form-field';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
-import { MatInput, MatInputModule } from '@angular/material/input';
+import { MatInputModule } from '@angular/material/input';
 import { RouterLink } from '@angular/router';
 import { catchError, forkJoin, map, Observable, switchMap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
@@ -66,16 +65,11 @@ interface SubscriptionDetailsData {
     MatIcon,
     MatCardModule,
     RouterLink,
-    MatButton,
     AsyncPipe,
-    CapitalizeFirstPipe,
     FormsModule,
     MatFormFieldModule,
     MatInputModule,
     ReactiveFormsModule,
-    MatFormField,
-    MatInput,
-    MatIconButton,
     AsyncPipe,
     ApiAccessComponent,
     SubscriptionInfoComponent,

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -160,14 +160,16 @@ export class SubscriptionsDetailsComponent implements OnInit {
                 },
               };
             }
-          } else if (plan.planMode === 'PUSH' && subscription.consumerConfiguration != null) {
-            return {
-              result: {
-                ...subscriptionDetails,
-                consumerConfiguration: subscription.consumerConfiguration,
-              },
-            };
           }
+        }
+
+        if (plan.planMode === 'PUSH' && !!subscription.consumerConfiguration) {
+          return {
+            result: {
+              ...subscriptionDetails,
+              consumerConfiguration: subscription.consumerConfiguration,
+            },
+          };
         }
 
         return { result: subscriptionDetails };

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
@@ -24,8 +24,6 @@
 }
 
 .api-tab-subscriptions__table {
-  overflow: hidden;
-
   &-row {
     cursor: pointer;
   }

--- a/gravitee-apim-portal-webui-next/src/app/app.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.scss
@@ -29,9 +29,3 @@
   padding: 0 24px;
   margin: auto;
 }
-
-::ng-deep {
-  .mdc-text-field--filled:not(.mdc-text-field--disabled) {
-    --mdc-filled-text-field-container-color: #{m3-adapter.$surface-variant};
-  }
-}

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -40,6 +40,7 @@ import { ResetPasswordComponent } from './log-in/reset-password/reset-password.c
 import { LogOutComponent } from './log-out/log-out.component';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
+import { ConsumerConfigurationComponent } from '../components';
 import { anonymousGuard } from '../guards/anonymous.guard';
 import { authGuard } from '../guards/auth.guard';
 import { catalogCategoriesViewGuard } from '../guards/catalog-categories-view.guard';
@@ -96,8 +97,11 @@ const apiRoutes: Routes = [
               },
               {
                 path: ':subscriptionId',
-                component: SubscriptionsDetailsComponent,
                 data: { breadcrumb: { skip: true } },
+                children: [
+                  { path: '', component: SubscriptionsDetailsComponent },
+                  { path: 'configure', component: ConsumerConfigurationComponent },
+                ],
               },
             ],
           },

--- a/gravitee-apim-portal-webui-next/src/components/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './subscription';

--- a/gravitee-apim-portal-webui-next/src/components/subscription/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './webhook/consumer-configuration';

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.html
@@ -1,0 +1,78 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="form-headers">
+  <div class="form-headers__title">
+    <span class="m3-title-medium" i18n="@@subscriptionConfigurationHeaders">Headers</span>
+  </div>
+  <form [formGroup]="mainForm">
+    <table mat-table [dataSource]="headersFormArray.controls" formArrayName="headers" class="form-headers__table">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef i18n="@@subscriptionConfigurationHeaderName">Name</th>
+        <td mat-cell *matCellDef="let control; let i = index" [formGroupName]="i">
+          <mat-form-field class="form-headers__table__form-field">
+            <input
+              [id]="'header-name-' + i"
+              formControlName="name"
+              matInput
+              placeholder="Name..."
+              [matAutocomplete]="headerNamesAutocomplete"
+              [matAutocompleteDisabled]="autocompleteDisabled()" />
+            <mat-autocomplete #headerNamesAutocomplete="matAutocomplete">
+              @for (headerName of getFilteredHeaderNames(i, control.value.name) | async; track headerName) {
+                <mat-option [value]="headerName">{{ headerName }}</mat-option>
+              }
+            </mat-autocomplete>
+          </mat-form-field>
+          @if (control.get('name')?.hasError('pattern')) {
+            <mat-error
+              >Header name must not contain spaces. (RegExp: {{ control.get('name')?.getError('pattern')?.requiredPattern }})</mat-error
+            >
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="value">
+        <th mat-header-cell *matHeaderCellDef i18n="@@subscriptionConfigurationHeaderValue">Value</th>
+        <td mat-cell *matCellDef="let control; let i = index" [formGroupName]="i">
+          <mat-form-field class="form-headers__table__form-field"
+            ><input [id]="'header-value-' + i" formControlName="value" matInput placeholder="Value..."
+          /></mat-form-field>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let control; let i = index">
+          @if (headersFormArray.controls.length - 1 !== i && !mainForm.disabled) {
+            <button
+              class="form-headers--delete-button"
+              mat-icon-button
+              aria-label="Delete"
+              [disabled]="mainForm.disabled"
+              (click)="onDeleteHeader(i)">
+              <mat-icon>cancel</mat-icon>
+            </button>
+          }
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </form>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme';
+@use '../../../../scss/m3-adapter';
+
+.form-headers {
+  margin-bottom: 18px;
+
+  &__title {
+    display: flex;
+    margin-bottom: 10px;
+    gap: 8px;
+  }
+
+  &__table {
+    margin-top: 10px;
+
+    --mat-table-background-color: color-mix(in srgb, #{m3-adapter.$surface-variant} 30%, transparent);
+
+    &__form-field {
+      display: flex;
+      padding-top: 10px;
+
+      --mat-form-field-container-height: 40px;
+      --mat-form-field-container-vertical-padding: 8px;
+      --mat-form-field-subscript-text-line-height: 0;
+      --mat-form-field-subscript-text-size: 0;
+      --mdc-filled-text-field-disabled-container-color: #{theme.$card-background-color};
+      --mdc-filled-text-field-container-color: #{theme.$card-background-color};
+      --mdc-filled-text-field-disabled-input-text-color: var(--mdc-filled-text-field-input-text-color);
+      --mdc-filled-text-field-input-text-color: var(--mdc-filled-text-field-input-text-color);
+    }
+
+    .mat-column-actions {
+      width: 5%;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.scss
@@ -28,8 +28,6 @@
   &__table {
     margin-top: 10px;
 
-    --mat-table-background-color: color-mix(in srgb, #{m3-adapter.$surface-variant} 30%, transparent);
-
     &__form-field {
       display: flex;
       padding-top: 10px;

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { AsyncPipe } from '@angular/common';
+import { Component, ElementRef, forwardRef, input, InputSignal, OnInit, ViewChild } from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  FormArray,
+  FormControl,
+  FormGroup,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validator,
+  Validators,
+} from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatIconButton } from '@angular/material/button';
+import { MatOptionModule } from '@angular/material/core';
+import { MatError } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatTable, MatTableModule } from '@angular/material/table';
+import { dropRight, isEmpty } from 'lodash';
+import { Observable, of } from 'rxjs';
+import { map, startWith, tap } from 'rxjs/operators';
+
+import { FormHeaderFieldMapper, HEADER_NAMES } from './consumer-configuration-headers.model';
+import { Header } from '../../../../entities/subscription';
+
+/**
+ * Based on https://particles.gravitee.io/?path=/docs/components-form-headers--readme
+ */
+@Component({
+  selector: 'app-consumer-configuration-headers',
+  templateUrl: './consumer-configuration-headers.component.html',
+  styleUrls: ['./consumer-configuration-headers.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ConsumerConfigurationHeadersComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => ConsumerConfigurationHeadersComponent),
+      multi: true,
+    },
+  ],
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatIconModule,
+    MatInputModule,
+    MatAutocompleteModule,
+    MatOptionModule,
+    MatError,
+    MatIconButton,
+    AsyncPipe,
+    MatTableModule,
+  ],
+})
+export class ConsumerConfigurationHeadersComponent implements OnInit, ControlValueAccessor, Validator {
+  @ViewChild(MatTable) table!: MatTable<Header>;
+  public headerFieldMapper: InputSignal<FormHeaderFieldMapper> = input<FormHeaderFieldMapper>({
+    keyName: 'name',
+    valueName: 'value',
+  });
+  public autocompleteDisabled: InputSignal<boolean> = input<boolean>(false);
+  public headersFormArray = new FormArray([
+    new FormGroup({
+      name: new FormControl('', Validators.pattern('^\\S*$')),
+      value: new FormControl(''),
+    }),
+  ]);
+  public mainForm = new FormGroup({
+    headers: this.headersFormArray,
+  });
+  displayedColumns: string[] = ['name', 'value', 'actions'];
+
+  private headers: Header[] = [];
+  private filteredHeaderNames: Observable<string[]>[] = [];
+
+  constructor(
+    private readonly fm: FocusMonitor,
+    private readonly elRef: ElementRef,
+  ) {}
+
+  public ngOnInit(): void {
+    // When user start to complete last header add new empty one at the end
+    this.headersFormArray?.valueChanges
+      .pipe(
+        map(headers =>
+          headers.map(header => ({
+            name: header.name ?? '',
+            value: header.value ?? '',
+          })),
+        ),
+        tap(headers => headers.length > 0 && this._onChange(removeLastEmptyHeader(headers))),
+        tap((headers: Header[]) => {
+          if (headers.length > 0 && (headers[headers.length - 1].name !== '' || headers[headers.length - 1].value !== '')) {
+            this.addEmptyHeader();
+            if (this.table) this.table.renderRows();
+          }
+        }),
+      )
+      .subscribe();
+
+    this.fm.monitor(this.elRef.nativeElement, true).subscribe(() => {
+      this._onTouched();
+    });
+  }
+
+  public initHeadersForm(): void {
+    // Clear all previous headers
+    this.headersFormArray.clear();
+
+    // Populate headers array from headers
+    this.headers.forEach(({ name, value }, headerIndex) => {
+      this.headersFormArray.push(
+        new FormGroup({
+          name: this.initKeyFormControl(name, headerIndex),
+          value: new FormControl({ value, disabled: this.headersFormArray.disabled }),
+        }),
+        {
+          emitEvent: false,
+        },
+      );
+    });
+
+    // add one empty header at the end
+    this.addEmptyHeader();
+    if (this.table) this.table.renderRows();
+  }
+
+  public writeValue(value: Record<string, string>[] | null): void {
+    if (!value) {
+      return;
+    }
+
+    this.headers = [...(value ?? [])].map((header: Record<string, string>) => ({
+      name: header[this.headerFieldMapper().keyName],
+      value: header[this.headerFieldMapper().valueName],
+    }));
+
+    this.initHeadersForm();
+  }
+
+  public registerOnChange(fn: (headers: unknown) => void): void {
+    if (this.headerFieldMapper()) {
+      this._onChange = (headers: Header[] | null) => fn(this.toHeaders(headers));
+      return;
+    }
+    this._onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    if (isDisabled === this.headersFormArray.disabled) {
+      // do nothing if the disabled state is not changed
+      return;
+    }
+
+    if (isDisabled) {
+      this.headersFormArray.disable({ emitEvent: false });
+      this.removeLastHeader();
+      return;
+    }
+    this.headersFormArray.enable({ emitEvent: false });
+    this.addEmptyHeader();
+  }
+
+  public validate(_control: AbstractControl): ValidationErrors | null {
+    if (this.headersFormArray.invalid) {
+      return { invalid: true };
+    }
+    return null;
+  }
+
+  public getFilteredHeaderNames(headerIndex: number, headerName: string | null | undefined): Observable<string[]> {
+    if (!this.filteredHeaderNames[headerIndex]) {
+      return this.filteredHeaderNames[headerIndex];
+    }
+    if (headerName != null && headerName != '') {
+      this.filteredHeaderNames[headerIndex] = of(headerName).pipe(map(value => this._filter(value)));
+      return this.filteredHeaderNames[headerIndex];
+    }
+    return of(HEADER_NAMES);
+  }
+
+  public onDeleteHeader(headerIndex: number): void {
+    this._onTouched();
+    this.mainForm.controls.headers.removeAt(headerIndex);
+    this.table.renderRows();
+  }
+
+  private _onChange: (_headers: Header[] | null) => void = () => ({});
+  private _onTouched: () => void = () => ({});
+
+  private initKeyFormControl(key: string, headerIndex: number) {
+    const control = new FormControl({ value: key, disabled: this.headersFormArray.disabled }, Validators.pattern('^\\S*$'));
+    const filteredKeys = control.valueChanges.pipe(
+      startWith(''),
+      map(value => this._filter(value ?? '')),
+    );
+    this.filteredHeaderNames.splice(headerIndex, 0, filteredKeys);
+    return control;
+  }
+
+  private addEmptyHeader() {
+    if (this.headersFormArray.disabled) {
+      return;
+    }
+
+    this.headersFormArray.push(
+      new FormGroup({
+        name: this.initKeyFormControl('', this.headersFormArray.length),
+        value: new FormControl(''),
+      }),
+      { emitEvent: false },
+    );
+  }
+
+  private removeLastHeader() {
+    this.headersFormArray.removeAt(this.headersFormArray.length - 1, { emitEvent: false });
+  }
+
+  private _filter(value: string): string[] {
+    const filterValue = value.toLowerCase();
+    return HEADER_NAMES.filter(option => option.toLowerCase().includes(filterValue));
+  }
+
+  private toHeaders(headers: Header[] | null) {
+    return [...(headers ?? [])].map(header => {
+      return {
+        [this.headerFieldMapper().keyName]: header.name,
+        [this.headerFieldMapper().valueName]: header.value,
+      };
+    });
+  }
+}
+
+const removeLastEmptyHeader = (headers: Header[]) => {
+  const lastHeader = headers[headers.length - 1];
+
+  if (lastHeader && isEmpty(lastHeader.name) && isEmpty(lastHeader.value)) {
+    return dropRight(headers);
+  }
+  return headers;
+};

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.model.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type FormHeaderFieldMapper = {
+  keyName: string;
+  valueName: string;
+};
+
+export const HEADER_NAMES = [
+  'Accept',
+  'Accept-Charset',
+  'Accept-Encoding',
+  'Accept-Language',
+  'Accept-Ranges',
+  'Access-Control-Allow-Credentials',
+  'Access-Control-Allow-Headers',
+  'Access-Control-Allow-Methods',
+  'Access-Control-Allow-Origin',
+  'Access-Control-Expose-Headers',
+  'Access-Control-Max-Age',
+  'Access-Control-Request-Headers',
+  'Access-Control-Request-Method',
+  'Age',
+  'Allow',
+  'Authorization',
+  'Cache-Control',
+  'Connection',
+  'Content-Disposition',
+  'Content-Encoding',
+  'Content-ID',
+  'Content-Language',
+  'Content-Length',
+  'Content-Location',
+  'Content-MD5',
+  'Content-Range',
+  'Content-Type',
+  'Cookie',
+  'Date',
+  'ETag',
+  'Expires',
+  'Expect',
+  'Forwarded',
+  'From',
+  'Host',
+  'If-Match',
+  'If-Modified-Since',
+  'If-None-Match',
+  'If-Unmodified-Since',
+  'Keep-Alive',
+  'Last-Modified',
+  'Location',
+  'Link',
+  'Max-Forwards',
+  'MIME-Version',
+  'Origin',
+  'Pragma',
+  'Proxy-Authenticate',
+  'Proxy-Authorization',
+  'Proxy-Connection',
+  'Range',
+  'Referer',
+  'Retry-After',
+  'Server',
+  'Set-Cookie',
+  'Set-Cookie2',
+  'TE',
+  'Trailer',
+  'Transfer-Encoding',
+  'Upgrade',
+  'User-Agent',
+  'Vary',
+  'Via',
+  'Warning',
+  'WWW-Authenticate',
+  'X-Forwarded-For',
+  'X-Forwarded-Proto',
+  'X-Forwarded-Server',
+  'X-Forwarded-Host',
+  'X-Forwarded-Port',
+  'X-Forwarded-Prefix',
+];

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/index.ts
@@ -13,5 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './webhook/consumer-configuration';
-export * from './webhook/consumer-configuration-headers';
+export * from './consumer-configuration-headers.component';

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.html
@@ -1,0 +1,71 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="retry">
+  <span class="m3-title-medium" i18n="@@consumerConfigurationRetry">Retry</span>
+  <form [formGroup]="retryForm" class="retry__form">
+    <mat-form-field>
+      <mat-label i18n="@@consumerConfigurationRetryOption">Retry option</mat-label>
+      <mat-select formControlName="retryOption">
+        @for (retryOption of retryOptions; track retryOption) {
+          <mat-option [value]="retryOption">{{ retryOption }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    @if (!!retryForm.controls.retryStrategy) {
+      <mat-form-field>
+        <mat-label i18n="@@consumerConfigurationRetryStrategy">Retry strategy</mat-label>
+        <mat-select formControlName="retryStrategy">
+          @for (retryStrategy of retryStrategies; track retryStrategy) {
+            <mat-option [value]="retryStrategy">{{ retryStrategy }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    @if (!!retryForm.controls.maxAttempts) {
+      <mat-form-field>
+        <mat-label i18n="@@consumerConfigurationRetryMaxAttempts">Maximum attempts</mat-label>
+        <input matInput type="number" formControlName="maxAttempts" />
+        @if (retryForm.controls.maxAttempts.hasError('min') || retryForm.controls.maxAttempts.hasError('required')) {
+          <mat-error i18n="@@consumerConfigurationRetryMaxAttemptsMin">Minimal value for maximum attempts is 1</mat-error>
+        }
+      </mat-form-field>
+    }
+
+    @if (!!retryForm.controls.initialDelaySeconds) {
+      <mat-form-field>
+        <mat-label i18n="@@consumerConfigurationRetryInitialDelaySeconds">Initial delay in seconds</mat-label>
+        <input matInput type="number" formControlName="initialDelaySeconds" />
+        @if (retryForm.controls.initialDelaySeconds.hasError('min') || retryForm.controls.initialDelaySeconds.hasError('required')) {
+          <mat-error i18n="@@consumerConfigurationRetryInitialDelaySecondsMin">Minimal value for initial delay seconds is 1</mat-error>
+        }
+      </mat-form-field>
+    }
+
+    @if (!!retryForm.controls.maxDelaySeconds) {
+      <mat-form-field>
+        <mat-label i18n="@@consumerConfigurationRetryMaxDelaySeconds">Maximum delay in seconds</mat-label>
+        <input matInput type="number" formControlName="maxDelaySeconds" />
+        @if (retryForm.controls.maxDelaySeconds.hasError('min') || retryForm.controls.maxDelaySeconds.hasError('required')) {
+          <mat-error i18n="@@consumerConfigurationRetryMaxDelaySecondsMin">Minimal value for maximum delay seconds is 1</mat-error>
+        }
+      </mat-form-field>
+    }
+  </form>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.scss
@@ -13,24 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FormControl, FormGroup } from '@angular/forms';
+.retry {
+  display: flex;
+  flex-flow: column;
+  gap: 8px;
 
-import { Header, RetryConfiguration } from '../../../../entities/subscription';
-
-export type ConsumerConfigurationForm = FormGroup<{
-  channel: FormControl<string | null>;
-  consumerConfiguration: FormGroup<{
-    callbackUrl: FormControl<string>;
-    headers: FormControl<Header[] | null>;
-    retry: FormControl<RetryConfiguration>;
-  }>;
-}>;
-
-export type ConsumerConfigurationValues = {
-  channel: string | null;
-  consumerConfiguration: {
-    callbackUrl: string;
-    headers: Header[] | null;
-    retry: RetryConfiguration;
-  };
-};
+  &__form {
+    display: flex;
+    flex-flow: column;
+    gap: 8px;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, forwardRef } from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  FormControl,
+  FormGroup,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validator,
+  Validators,
+} from '@angular/forms';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelect } from '@angular/material/select';
+
+import { RetryFormType, RetryFormValues } from './consumer-configuration-retry.model';
+import { RetryOptions, RetryOptionsType, RetryStrategies, RetryStrategiesType } from '../../../../entities/subscription';
+
+@Component({
+  imports: [ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatOption, MatSelect],
+  selector: 'app-consumer-configuration-retry',
+  standalone: true,
+  templateUrl: './consumer-configuration-retry.component.html',
+  styleUrls: ['./consumer-configuration-retry.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ConsumerConfigurationRetryComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => ConsumerConfigurationRetryComponent),
+      multi: true,
+    },
+  ],
+})
+export class ConsumerConfigurationRetryComponent implements ControlValueAccessor, Validator {
+  defaultRetryOption: RetryOptionsType = 'No Retry';
+  retryForm: RetryFormType = new FormGroup({
+    retryOption: new FormControl<RetryOptionsType>(this.defaultRetryOption, { validators: [Validators.required], nonNullable: true }),
+  });
+  retryOptions = RetryOptions;
+  retryStrategies = RetryStrategies;
+
+  constructor() {
+    this.retryForm.valueChanges.subscribe(value => {
+      this.updateFormControls();
+      this._onChange(this.toRetryFormValues(value));
+    });
+  }
+
+  writeValue(value: RetryFormValues | null): void {
+    if (!value) {
+      this.retryForm.reset({ retryOption: this.defaultRetryOption }, { emitEvent: false });
+      return;
+    }
+
+    this.retryForm.controls.retryOption.setValue(value.retryOption ?? this.defaultRetryOption, { emitEvent: false });
+    this.updateFormControls();
+    if (value.retryOption !== this.defaultRetryOption) {
+      this.retryForm.patchValue(
+        {
+          retryStrategy: value.retryStrategy ?? 'LINEAR',
+          maxAttempts: value.maxAttempts ?? 1,
+          initialDelaySeconds: value.initialDelaySeconds ?? 1,
+          maxDelaySeconds: value.maxDelaySeconds ?? 1,
+        },
+        { emitEvent: false },
+      );
+    }
+  }
+
+  registerOnChange(fn: (value: RetryFormValues | null) => void): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    isDisabled ? this.retryForm.disable() : this.retryForm?.enable();
+  }
+
+  validate(_: AbstractControl): ValidationErrors | null {
+    return this.retryForm.valid ? null : { invalidForm: { valid: false, message: 'Retry form is invalid' } };
+  }
+
+  private updateFormControls(): void {
+    if (this.retryForm.controls.retryOption.value !== this.defaultRetryOption) {
+      this.retryForm.addControl('retryStrategy', new FormControl<RetryStrategiesType>('LINEAR', Validators.required), { emitEvent: false });
+      this.retryForm.addControl('maxAttempts', new FormControl<number | null>(1, [Validators.required, Validators.min(1)]), {
+        emitEvent: false,
+      });
+      this.retryForm.addControl('initialDelaySeconds', new FormControl<number | null>(1, [Validators.required, Validators.min(1)]), {
+        emitEvent: false,
+      });
+      this.retryForm.addControl('maxDelaySeconds', new FormControl<number | null>(1, [Validators.required, Validators.min(1)]), {
+        emitEvent: false,
+      });
+    } else {
+      this.retryForm.removeControl('retryStrategy', { emitEvent: false });
+      this.retryForm.removeControl('maxAttempts', { emitEvent: false });
+      this.retryForm.removeControl('initialDelaySeconds', { emitEvent: false });
+      this.retryForm.removeControl('maxDelaySeconds', { emitEvent: false });
+    }
+  }
+
+  private toRetryFormValues(values: Partial<RetryFormValues>): RetryFormValues {
+    return {
+      retryOption: values.retryOption ?? this.defaultRetryOption,
+      retryStrategy: values.retryStrategy ?? null,
+      maxAttempts: values.maxAttempts ?? null,
+      initialDelaySeconds: values.initialDelaySeconds ?? null,
+      maxDelaySeconds: values.maxDelaySeconds ?? null,
+    };
+  }
+
+  private _onTouched: () => void = () => ({});
+  private _onChange: (value: RetryFormValues | null) => void = () => ({});
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.model.ts
@@ -15,22 +15,20 @@
  */
 import { FormControl, FormGroup } from '@angular/forms';
 
-import { Header, RetryConfiguration } from '../../../../entities/subscription';
+import { RetryOptionsType, RetryStrategiesType } from '../../../../entities/subscription';
 
-export type ConsumerConfigurationForm = FormGroup<{
-  channel: FormControl<string | null>;
-  consumerConfiguration: FormGroup<{
-    callbackUrl: FormControl<string>;
-    headers: FormControl<Header[] | null>;
-    retry: FormControl<RetryConfiguration>;
-  }>;
+export type RetryFormType = FormGroup<{
+  retryOption: FormControl<RetryOptionsType>;
+  retryStrategy?: FormControl<RetryStrategiesType | null>;
+  maxAttempts?: FormControl<number | null>;
+  initialDelaySeconds?: FormControl<number | null>;
+  maxDelaySeconds?: FormControl<number | null>;
 }>;
 
-export type ConsumerConfigurationValues = {
-  channel: string | null;
-  consumerConfiguration: {
-    callbackUrl: string;
-    headers: Header[] | null;
-    retry: RetryConfiguration;
-  };
-};
+export interface RetryFormValues {
+  retryOption: RetryOptionsType;
+  retryStrategy: RetryStrategiesType | null;
+  maxAttempts: number | null;
+  initialDelaySeconds: number | null;
+  maxDelaySeconds: number | null;
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/index.ts
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './webhook/consumer-configuration';
-export * from './webhook/consumer-configuration-headers';
-export * from './webhook/consumer-configuration-retry';
+export * from './consumer-configuration-retry.component';

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
@@ -34,11 +34,47 @@
           <mat-form-field class="consumer-configuration__form__fields">
             <mat-label i18n="@@consumerConfigurationCallbackUrl">Callback URL</mat-label>
             <input matInput formControlName="callbackUrl" />
+            @if (consumerConfigurationForm.controls.consumerConfiguration.controls.callbackUrl.hasError('required')) {
+              <mat-error i18n="@@consumerConfigurationCallbackUrlRequired">Callback URL is required</mat-error>
+            }
+            @if (consumerConfigurationForm.controls.consumerConfiguration.controls.callbackUrl.hasError('pattern')) {
+              <mat-error i18n="@@consumerConfigurationCallbackUrlPattern"
+                >Callback URL should respect this pattern "^(http|https):"
+              </mat-error>
+            }
           </mat-form-field>
 
           <app-consumer-configuration-headers
             [formControl]="consumerConfigurationForm.controls.consumerConfiguration.controls.headers"></app-consumer-configuration-headers>
         </form>
+
+        @if (error) {
+          <div class="m3-title-medium" i18n="@@consumerConfigurationErrorMessage" aria-label="Error message">
+            The consumer configuration update has failed. Try again, and if the issue persists, contact your portal administrator.
+          </div>
+        }
+
+        <div class="consumer-configuration__form__actions">
+          <button
+            (click)="submit()"
+            mat-flat-button
+            class="secondary-button"
+            [disabled]="consumerConfigurationForm.invalid || (formUnchanged$ | async)"
+            i18n="@@saveSubscriptionConfiguration"
+            aria-label="Save subscription configuration"
+            data-testId="save">
+            Save
+          </button>
+          <button
+            (click)="reset()"
+            mat-stroked-button
+            [disabled]="formUnchanged$ | async"
+            i18n="@@discardSubscriptionConfigurationChanges"
+            aria-label="Discard changes"
+            data-testId="discard">
+            Discard changes
+          </button>
+        </div>
       </form>
     }
   </mat-card-content>

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card appearance="outlined" class="consumer-configuration">
+  <mat-card-header class="consumer-configuration__header">
+    <div class="consumer-configuration__navigate-back m3-title-small" i18n="@@subscriptionDetailsBackButton" [routerLink]="['../']">
+      <mat-icon class="consumer-configuration__arrow_backward">arrow_backward</mat-icon>
+      Subscription details
+    </div>
+  </mat-card-header>
+  <mat-card-content class="consumer-configuration__header">
+    @if (!!consumerConfigurationForm) {
+      <form [formGroup]="consumerConfigurationForm">
+        <mat-form-field class="consumer-configuration__form__fields">
+          <mat-label i18n="@@consumerConfigurationChannel">Channel</mat-label>
+          <input matInput formControlName="channel" />
+        </mat-form-field>
+
+        <form formGroupName="consumerConfiguration">
+          <mat-form-field class="consumer-configuration__form__fields">
+            <mat-label i18n="@@consumerConfigurationCallbackUrl">Callback URL</mat-label>
+            <input matInput formControlName="callbackUrl" />
+          </mat-form-field>
+        </form>
+      </form>
+    }
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
@@ -35,6 +35,9 @@
             <mat-label i18n="@@consumerConfigurationCallbackUrl">Callback URL</mat-label>
             <input matInput formControlName="callbackUrl" />
           </mat-form-field>
+
+          <app-consumer-configuration-headers
+            [formControl]="consumerConfigurationForm.controls.consumerConfiguration.controls.headers"></app-consumer-configuration-headers>
         </form>
       </form>
     }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
@@ -46,6 +46,9 @@
 
           <app-consumer-configuration-headers
             [formControl]="consumerConfigurationForm.controls.consumerConfiguration.controls.headers"></app-consumer-configuration-headers>
+
+          <app-consumer-configuration-retry
+            [formControl]="consumerConfigurationForm.controls.consumerConfiguration.controls.retry"></app-consumer-configuration-retry>
         </form>
 
         @if (error) {

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
@@ -39,6 +39,7 @@
     &__fields {
       display: flex;
       width: 100%;
+      margin-bottom: 10px;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
@@ -41,5 +41,12 @@
       width: 100%;
       margin-bottom: 10px;
     }
+
+    &__actions {
+      display: flex;
+      flex-direction: row;
+      margin-top: 20px;
+      gap: 8px;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.scss
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.consumer-configuration {
+  display: flex;
+  flex-flow: column;
+  gap: 32px;
+
+  &__navigate-back {
+    display: flex;
+    align-items: center;
+    padding-left: 8px;
+    cursor: pointer;
+    gap: 8px;
+  }
+
+  &__arrow_backward {
+    cursor: pointer;
+    transform: scale(0.8);
+  }
+
+  &__form {
+    display: flex;
+    flex-flow: column;
+    gap: 12px;
+
+    &__fields {
+      display: flex;
+      width: 100%;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.spec.ts
@@ -83,6 +83,20 @@ describe('SubscriptionsDetailsComponent', () => {
       expect(await componentHarness.getInputTextFromControlName('callbackUrl')).toStrictEqual(
         consumerConfiguration.entrypointConfiguration?.callbackUrl,
       );
+      expect(await componentHarness.computeHeadersTableCells()).toEqual([
+        {
+          name: 'Content-Type',
+          value: 'application/json',
+        },
+        {
+          name: 'X-Custom-Key',
+          value: '1234',
+        },
+        {
+          name: '',
+          value: '',
+        },
+      ]);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+
+import { ConsumerConfigurationComponent } from './consumer-configuration.component';
+import { ConsumerConfigurationComponentHarness } from './consumer-configuration.harness';
+import { fakeSubscription, Subscription } from '../../../../entities/subscription';
+import { fakeSubscriptionConsumerConfiguration } from '../../../../entities/subscription/subscription-consumer-configuration.fixture';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+@Component({
+  selector: 'app-test-component',
+  template: ` <app-consumer-configuration #consumerConfiguration></app-consumer-configuration>`,
+  standalone: true,
+  imports: [ConsumerConfigurationComponent],
+})
+class TestComponent {
+  @ViewChild('consumerConfiguration') consumerConfiguration!: ConsumerConfigurationComponent;
+}
+
+describe('SubscriptionsDetailsComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+  let componentHarness: ConsumerConfigurationComponentHarness;
+
+  const API_ID = 'testApiId';
+  const SUBSCRIPTION_ID = 'subscriptionId';
+  const PLAN_ID = 'plan-id';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent, AppTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { subscriptionId: SUBSCRIPTION_ID } } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    componentHarness = await loader.getHarness(ConsumerConfigurationComponentHarness);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('consumerConfiguration tests', () => {
+    const initComponent = (subscription: Subscription) => {
+      expectSubscription(subscription);
+      fixture.detectChanges();
+    };
+
+    it('should create component with a basic configuration', async () => {
+      const consumerConfiguration = fakeSubscriptionConsumerConfiguration();
+      const subscription = fakeSubscription({ status: 'ACCEPTED', api: API_ID, plan: PLAN_ID, consumerConfiguration });
+      initComponent(subscription);
+
+      expect(await componentHarness.getInputTextFromControlName('channel')).toStrictEqual(consumerConfiguration.channel);
+      expect(await componentHarness.getInputTextFromControlName('callbackUrl')).toStrictEqual(
+        consumerConfiguration.entrypointConfiguration?.callbackUrl,
+      );
+    });
+  });
+
+  function expectSubscription(subscriptionResponse: Subscription = fakeSubscription()) {
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/subscriptions/${SUBSCRIPTION_ID}?include=keys&include=consumerConfiguration`)
+      .flush(subscriptionResponse);
+  }
+});

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
@@ -31,6 +31,7 @@ import { ConsumerConfigurationForm, ConsumerConfigurationValues } from './consum
 import { Subscription, SubscriptionConsumerConfiguration, UpdateSubscription } from '../../../../entities/subscription';
 import { SubscriptionService } from '../../../../services/subscription.service';
 import { ConsumerConfigurationHeadersComponent } from '../consumer-configuration-headers';
+import { ConsumerConfigurationRetryComponent } from '../consumer-configuration-retry/consumer-configuration-retry.component';
 
 @Component({
   imports: [
@@ -46,6 +47,7 @@ import { ConsumerConfigurationHeadersComponent } from '../consumer-configuration
     ConsumerConfigurationHeadersComponent,
     AsyncPipe,
     MatButton,
+    ConsumerConfigurationRetryComponent,
   ],
   selector: 'app-consumer-configuration',
   standalone: true,
@@ -113,6 +115,7 @@ export class ConsumerConfigurationComponent implements OnInit {
             validators: [Validators.required, Validators.pattern(/^(http|https):/)],
           }),
           headers: new FormControl(entrypointConfiguration?.headers),
+          retry: new FormControl(entrypointConfiguration?.retry, { nonNullable: true }),
         }),
       });
       this.initialValues = this.consumerConfigurationForm.getRawValue();
@@ -140,6 +143,7 @@ export class ConsumerConfigurationComponent implements OnInit {
           ...consumerConfiguration.entrypointConfiguration,
           callbackUrl: updatedValues.consumerConfiguration.callbackUrl,
           headers: updatedValues.consumerConfiguration.headers ?? [],
+          retry: updatedValues.consumerConfiguration.retry,
         },
       },
     };

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
@@ -25,9 +25,21 @@ import { tap } from 'rxjs';
 
 import { SubscriptionConsumerConfiguration } from '../../../../entities/subscription';
 import { SubscriptionService } from '../../../../services/subscription.service';
+import { ConsumerConfigurationHeadersComponent } from '../consumer-configuration-headers';
 
 @Component({
-  imports: [MatCard, MatCardHeader, MatCardContent, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatLabel, MatIcon, RouterLink],
+  imports: [
+    MatCard,
+    MatCardHeader,
+    MatCardContent,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatLabel,
+    MatIcon,
+    RouterLink,
+    ConsumerConfigurationHeadersComponent,
+  ],
   selector: 'app-consumer-configuration',
   standalone: true,
   templateUrl: './consumer-configuration.component.html',
@@ -59,6 +71,7 @@ export class ConsumerConfigurationComponent {
         channel: new FormControl(consumerConfiguration.channel),
         consumerConfiguration: new FormGroup({
           callbackUrl: new FormControl(entrypointConfiguration?.callbackUrl),
+          headers: new FormControl(entrypointConfiguration?.headers),
         }),
       });
     }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatCard, MatCardContent, MatCardHeader } from '@angular/material/card';
+import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { tap } from 'rxjs';
+
+import { SubscriptionConsumerConfiguration } from '../../../../entities/subscription';
+import { SubscriptionService } from '../../../../services/subscription.service';
+
+@Component({
+  imports: [MatCard, MatCardHeader, MatCardContent, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatLabel, MatIcon, RouterLink],
+  selector: 'app-consumer-configuration',
+  standalone: true,
+  templateUrl: './consumer-configuration.component.html',
+  styleUrls: ['./consumer-configuration.component.scss'],
+})
+export class ConsumerConfigurationComponent {
+  consumerConfigurationForm: FormGroup | undefined;
+
+  constructor(
+    private readonly subscriptionService: SubscriptionService,
+    private readonly route: ActivatedRoute,
+  ) {
+    this.subscriptionService
+      .get(this.route.snapshot.params['subscriptionId'])
+      .pipe(
+        tap(subscription => {
+          const consumerConfiguration = subscription.consumerConfiguration;
+          this.initForm(consumerConfiguration);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private initForm(consumerConfiguration: SubscriptionConsumerConfiguration | undefined): void {
+    if (consumerConfiguration) {
+      const entrypointConfiguration = consumerConfiguration.entrypointConfiguration;
+      this.consumerConfigurationForm = new FormGroup({
+        channel: new FormControl(consumerConfiguration.channel),
+        consumerConfiguration: new FormGroup({
+          callbackUrl: new FormControl(entrypointConfiguration?.callbackUrl),
+        }),
+      });
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
@@ -31,7 +31,7 @@ import { ConsumerConfigurationForm, ConsumerConfigurationValues } from './consum
 import { Subscription, SubscriptionConsumerConfiguration, UpdateSubscription } from '../../../../entities/subscription';
 import { SubscriptionService } from '../../../../services/subscription.service';
 import { ConsumerConfigurationHeadersComponent } from '../consumer-configuration-headers';
-import { ConsumerConfigurationRetryComponent } from '../consumer-configuration-retry/consumer-configuration-retry.component';
+import { ConsumerConfigurationRetryComponent } from '../consumer-configuration-retry';
 
 @Component({
   imports: [

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
@@ -15,6 +15,8 @@
  */
 
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatErrorHarness } from '@angular/material/form-field/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
@@ -24,6 +26,37 @@ export class ConsumerConfigurationComponentHarness extends ComponentHarness {
   async getInputTextFromControlName(formControlName: string): Promise<string> {
     const input: MatInputHarness = await this.locatorFor(MatInputHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
     return input.getValue();
+  }
+
+  async setInputTextValueFromControlName(formControlName: string, newValue: string): Promise<void> {
+    const input: MatInputHarness = await this.locatorFor(MatInputHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
+    await input.setValue(newValue);
+    return input.blur();
+  }
+
+  async getError(): Promise<string> {
+    const matError = await this.locatorFor(MatErrorHarness)();
+    return matError.getText();
+  }
+
+  async isSaveButtonDisabled(): Promise<boolean> {
+    const saveBtn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testId="save"]' }))();
+    return saveBtn.isDisabled();
+  }
+
+  async save(): Promise<void> {
+    const saveBtn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testId="save"]' }))();
+    return saveBtn.click();
+  }
+
+  async reset(): Promise<void> {
+    const saveBtn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testId="discard"]' }))();
+    return saveBtn.click();
+  }
+
+  async isResetButtonDisabled(): Promise<boolean> {
+    const resetBtn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testId="discard"]' }))();
+    return resetBtn.isDisabled();
   }
 
   async computeHeadersTableCells(): Promise<{ name: string; value: string }[]> {

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
@@ -18,6 +18,7 @@ import { ComponentHarness, parallel } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatErrorHarness } from '@angular/material/form-field/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 export class ConsumerConfigurationComponentHarness extends ComponentHarness {
@@ -32,6 +33,16 @@ export class ConsumerConfigurationComponentHarness extends ComponentHarness {
     const input: MatInputHarness = await this.locatorFor(MatInputHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
     await input.setValue(newValue);
     return input.blur();
+  }
+
+  async selectOption(formControlName: string, newValue: string): Promise<void> {
+    const select = await this.locatorFor(MatSelectHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
+    return select.clickOptions({ text: newValue });
+  }
+
+  async getSelectedOption(formControlName: string): Promise<string> {
+    const select = await this.locatorFor(MatSelectHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
+    return select.getValueText();
   }
 
   async getError(): Promise<string> {

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
 
 export class ConsumerConfigurationComponentHarness extends ComponentHarness {
   public static hostSelector = 'app-consumer-configuration';
@@ -23,5 +24,19 @@ export class ConsumerConfigurationComponentHarness extends ComponentHarness {
   async getInputTextFromControlName(formControlName: string): Promise<string> {
     const input: MatInputHarness = await this.locatorFor(MatInputHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
     return input.getValue();
+  }
+
+  async computeHeadersTableCells(): Promise<{ name: string; value: string }[]> {
+    const table = await this.locatorFor(MatTableHarness)();
+    const rows = await table.getRows();
+    return await parallel(() =>
+      rows.map(async (row, index) => {
+        const nameInput = await this.locatorFor(MatInputHarness.with({ selector: `#header-name-${index}` }))();
+        const valueInput = await this.locatorFor(MatInputHarness.with({ selector: `#header-value-${index}` }))();
+        const name = await nameInput.getValue();
+        const value = await valueInput.getValue();
+        return { name, value };
+      }),
+    );
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class ConsumerConfigurationComponentHarness extends ComponentHarness {
+  public static hostSelector = 'app-consumer-configuration';
+
+  async getInputTextFromControlName(formControlName: string): Promise<string> {
+    const input: MatInputHarness = await this.locatorFor(MatInputHarness.with({ selector: `[formcontrolname='${formControlName}']` }))();
+    return input.getValue();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.models.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.models.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { Header } from '../../../../entities/subscription';
+
+export type ConsumerConfigurationForm = FormGroup<{
+  channel: FormControl<string | null>;
+  consumerConfiguration: FormGroup<{
+    callbackUrl: FormControl<string>;
+    headers: FormControl<Header[] | null>;
+  }>;
+}>;
+
+export type ConsumerConfigurationValues = {
+  channel: string | null;
+  consumerConfiguration: {
+    callbackUrl: string;
+    headers: Header[] | null;
+  };
+};

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './consumer-configuration.component';

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './truststore';
+export * from './keystore';

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/keystore.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/keystore.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type SslKeyStore = JKSKeyStore | PEMKeyStore | PKCS12KeyStore;
+
+export type SslKeyStoreType = '' | 'JKS' | 'PKCS12' | 'PEM';
+
+export interface BaseKeyStore {
+  type?: SslKeyStoreType;
+}
+
+export interface JKSKeyStore extends BaseKeyStore {
+  path?: string;
+  content?: string;
+  password?: string;
+  alias?: string;
+  keyPassword?: string;
+}
+
+export interface PEMKeyStore extends BaseKeyStore {
+  keyPath?: string;
+  keyContent?: string;
+  certPath?: string;
+  certContent?: string;
+}
+
+export interface PKCS12KeyStore extends BaseKeyStore {
+  path?: string;
+  content?: string;
+  password?: string;
+  alias?: string;
+  keyPassword?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/truststore.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/truststore.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type SslTrustStoreType = '' | 'JKS' | 'PKCS12' | 'PEM';
+
+export type SslTrustStore = JKSTrustStore | PEMTrustStore | PKCS12TrustStore;
+
+export interface BaseTrustStore {
+  type?: SslTrustStoreType;
+}
+
+export interface JKSTrustStore extends BaseTrustStore {
+  path?: string;
+  content?: string;
+  password?: string;
+}
+
+export interface PEMTrustStore extends BaseTrustStore {
+  path?: string;
+  content?: string;
+}
+
+export interface PKCS12TrustStore extends BaseTrustStore {
+  path?: string;
+  content?: string;
+  password?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './subscription-consumer-configuration';
+export * from './subscription.fixture';
+export * from './subscriptions-response';
+export * from './subscription';

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {SubscriptionConsumerConfiguration} from "./subscription-consumer-configuration";
+import {isFunction} from "rxjs/internal/util/isFunction";
+
+export function fakeSubscriptionConsumerConfiguration(modifier?: Partial<SubscriptionConsumerConfiguration> | ((baseSubscriptionConsumerConfiguration: SubscriptionConsumerConfiguration) => SubscriptionConsumerConfiguration)): SubscriptionConsumerConfiguration {
+  const base: SubscriptionConsumerConfiguration = {
+    entrypointId: 'webhook',
+    channel: 'test',
+    entrypointConfiguration: {
+      auth: {
+        type: "none"
+      },
+      callbackUrl: "https://webhook.example/1234",
+      ssl: {
+        keyStore: {
+          type: ""
+        },
+        hostnameVerifier: false,
+        trustStore: {
+          "type": ""
+        },
+        trustAll: true
+      },
+      retry: {
+        retryOption: "No Retry"
+      }
+    }
+  }
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
@@ -13,33 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {SubscriptionConsumerConfiguration} from "./subscription-consumer-configuration";
-import {isFunction} from "rxjs/internal/util/isFunction";
+import { isFunction } from 'rxjs/internal/util/isFunction';
 
-export function fakeSubscriptionConsumerConfiguration(modifier?: Partial<SubscriptionConsumerConfiguration> | ((baseSubscriptionConsumerConfiguration: SubscriptionConsumerConfiguration) => SubscriptionConsumerConfiguration)): SubscriptionConsumerConfiguration {
+import { SubscriptionConsumerConfiguration } from './subscription-consumer-configuration';
+
+export function fakeSubscriptionConsumerConfiguration(
+  modifier?:
+    | Partial<SubscriptionConsumerConfiguration>
+    | ((baseSubscriptionConsumerConfiguration: SubscriptionConsumerConfiguration) => SubscriptionConsumerConfiguration),
+): SubscriptionConsumerConfiguration {
   const base: SubscriptionConsumerConfiguration = {
     entrypointId: 'webhook',
     channel: 'test',
     entrypointConfiguration: {
+      callbackUrl: 'https://webhook.example/1234',
+      headers: [
+        {
+          name: 'Content-Type',
+          value: 'application/json',
+        },
+        {
+          name: 'X-Custom-Key',
+          value: '1234',
+        },
+      ],
       auth: {
-        type: "none"
+        type: 'none',
       },
-      callbackUrl: "https://webhook.example/1234",
       ssl: {
         keyStore: {
-          type: ""
+          type: '',
         },
         hostnameVerifier: false,
         trustStore: {
-          "type": ""
+          type: '',
         },
-        trustAll: true
+        trustAll: true,
       },
       retry: {
-        retryOption: "No Retry"
-      }
-    }
-  }
+        retryOption: 'No Retry',
+      },
+    },
+  };
 
   if (isFunction(modifier)) {
     return modifier(base);

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
@@ -66,9 +66,15 @@ export interface SslOptions {
   keyStore?: SslKeyStore;
 }
 
+export const RetryOptions = ['No Retry', 'Retry On Fail'] as const;
+export type RetryOptionsType = (typeof RetryOptions)[number];
+
+export const RetryStrategies = ['LINEAR', 'EXPONENTIAL'];
+export type RetryStrategiesType = (typeof RetryStrategies)[number];
+
 export interface RetryConfiguration {
-  retryOption: 'No Retry' | 'Retry On Fail';
-  retryStrategy?: 'LINEAR' | 'EXPONENTIAL';
+  retryOption: RetryOptionsType;
+  retryStrategy?: RetryStrategiesType;
   maxAttempts?: number;
   initialDelaySeconds?: number;
   maxDelaySeconds?: number;

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SslKeyStore, SslTrustStore } from '../ssl';
+
+export interface SubscriptionConsumerConfiguration {
+  entrypointId: string;
+  channel?: string;
+  entrypointConfiguration?: WebhookSubscriptionConfiguration;
+}
+
+export interface WebhookSubscriptionConfiguration {
+  callbackUrl: string;
+  headers?: Header[];
+  auth?: WebhookSubscriptionConfigurationAuth;
+  ssl?: SslOptions;
+  retry?: RetryConfiguration;
+}
+
+export interface Header {
+  name: string;
+  value: string;
+}
+
+export type WebhookSubscriptionConfigurationAuthType = 'none' | 'basic' | 'token' | 'oauth2';
+
+export interface WebhookSubscriptionConfigurationAuth {
+  type: WebhookSubscriptionConfigurationAuthType;
+  basic?: BasicAuthConfiguration;
+  token?: TokenAuthConfiguration;
+  oauth2?: Oauth2AuthConfiguration;
+}
+
+export interface BasicAuthConfiguration {
+  username: string;
+  password: string;
+}
+
+export interface TokenAuthConfiguration {
+  value: string;
+}
+
+export interface Oauth2AuthConfiguration {
+  endpoint: string;
+  clientId: string;
+  clientSecret: string;
+  scopes?: string[];
+}
+
+export interface SslOptions {
+  hostnameVerifier?: boolean;
+  trustAll?: boolean;
+  trustStore?: SslTrustStore;
+  keyStore?: SslKeyStore;
+}
+
+export interface RetryConfiguration {
+  retryOption: 'No Retry' | 'Retry On Fail';
+  retryStrategy?: 'LINEAR' | 'EXPONENTIAL';
+  maxAttempts?: number;
+  initialDelaySeconds?: number;
+  maxDelaySeconds?: number;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
@@ -17,16 +17,16 @@ import { SslKeyStore, SslTrustStore } from '../ssl';
 
 export interface SubscriptionConsumerConfiguration {
   entrypointId: string;
-  channel?: string;
-  entrypointConfiguration?: WebhookSubscriptionConfiguration;
+  channel: string | null;
+  entrypointConfiguration: WebhookSubscriptionConfiguration;
 }
 
 export interface WebhookSubscriptionConfiguration {
   callbackUrl: string;
-  headers?: Header[];
-  auth?: WebhookSubscriptionConfigurationAuth;
-  ssl?: SslOptions;
-  retry?: RetryConfiguration;
+  headers: Header[];
+  auth: WebhookSubscriptionConfigurationAuth;
+  ssl: SslOptions;
+  retry: RetryConfiguration;
 }
 
 export interface Header {

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { SubscriptionConsumerConfiguration } from './subscription-consumer-configuration';
+
 export interface Subscription {
   id: string;
   api: string;
@@ -25,6 +27,7 @@ export interface Subscription {
   status: SubscriptionStatusEnum;
   subscribed_by?: string;
   keys?: SubscriptionDataKeys[];
+  consumerConfiguration?: SubscriptionConsumerConfiguration;
 }
 
 export type SubscriptionStatusEnum = 'PENDING' | 'ACCEPTED' | 'CLOSED' | 'REJECTED' | 'PAUSED';

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -61,3 +61,7 @@ export interface CreateSubscription {
   plan: string;
   request?: string;
 }
+
+export interface UpdateSubscription extends Omit<Subscription, 'consumerConfiguration'> {
+  configuration?: SubscriptionConsumerConfiguration;
+}

--- a/gravitee-apim-portal-webui-next/src/scss/m3-adapter.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/m3-adapter.scss
@@ -73,11 +73,15 @@ After migrating to Material 3, these classes can be deleted.
   line-height: 24px;
 }
 
-.m3-title-small {
+%m3-title-small {
   font-size: 14px;
   font-weight: 500;
   letter-spacing: 0.1px;
   line-height: 20px;
+}
+
+.m3-title-small {
+  @extend %m3-title-small;
 }
 
 .m3-body-large {
@@ -87,11 +91,15 @@ After migrating to Material 3, these classes can be deleted.
   line-height: 24px;
 }
 
-.m3-body-medium {
+%m3-body-medium {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: 0.25px;
   line-height: 20px;
+}
+
+.m3-body-medium {
+  @extend %m3-body-medium;
 }
 
 .m3-body-small {

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -49,6 +49,7 @@ table.mat-mdc-table {
   --mat-table-row-item-outline-color: #{theme.$table-border-color};
   --mat-table-background-color: #{theme.$table-header-background-color};
 
+  overflow: hidden;
   border: 1px solid theme.$table-border-color;
   border-radius: 16px;
 

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -16,6 +16,7 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
 @use '../scss/theme';
+@use './m3-adapter';
 
 .secondary-button {
   @include mat.button-color(theme.$light-theme, $color-variant: secondary);
@@ -35,7 +36,9 @@ mat-dialog-container {
 }
 
 mat-form-field {
-  --mdc-filled-text-field-container-color: var(--mdc-outlined-card-container-color);
+  --mdc-filled-text-field-container-color: #{m3-adapter.$surface-variant};
+  --mdc-filled-text-field-disabled-container-color: #{m3-adapter.$surface-variant};
+  --mdc-filled-text-field-disabled-input-text-color: var(--mdc-filled-text-field-input-text-color);
 }
 
 mat-expansion-panel {

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -47,7 +47,7 @@ mat-expansion-panel {
 
 table.mat-mdc-table {
   --mat-table-row-item-outline-color: #{theme.$table-border-color};
-  --mat-table-background-color: #{theme.$table-header-background-color};
+  --mat-table-background-color: color-mix(in srgb, #{m3-adapter.$surface-variant} 30%, transparent);
 
   overflow: hidden;
   border: 1px solid theme.$table-border-color;

--- a/gravitee-apim-portal-webui-next/src/scss/table-light.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/table-light.scss
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use './theme';
+@use './m3-adapter';
+
+table.table-light {
+  border: 1px solid theme.$table-border-color;
+  border-radius: theme.$table-border-radius;
+  margin-bottom: 16px;
+  border-collapse: inherit;
+  border-spacing: 0;
+
+  &--fit-content {
+    width: fit-content;
+    min-width: 400px;
+  }
+
+  th,
+  td {
+    padding: 8px;
+    border-bottom: 1px solid theme.$table-border-color;
+  }
+
+  thead {
+    @extend %m3-title-small;
+
+    background-color: theme.$card-background-color;
+    text-align: left;
+    text-transform: uppercase;
+
+    & > tr:first-child > th:first-child {
+      border-top-left-radius: theme.$table-border-radius;
+    }
+
+    & > tr:first-child > th:last-child {
+      border-top-right-radius: theme.$table-border-radius;
+    }
+  }
+
+  tbody {
+    @extend %m3-body-medium;
+
+    background-color: theme.$card-background-color;
+
+    & > tr:last-child > td:first-child {
+      border-bottom: 0;
+      border-bottom-left-radius: theme.$table-border-radius;
+    }
+
+    & > tr:last-child > td:last-child {
+      border-bottom: 0;
+      border-bottom-right-radius: theme.$table-border-radius;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/scss/theme/_index.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/_index.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
@@ -38,5 +38,6 @@ $banner-text-color: var(--mdc-outlined-text-field-focus-label-text-color);
 $chip-background: color-mix(in srgb, $primary-main-color 20%, transparent);
 $table-border-color: color-mix(in srgb, $secondary-main-color 35%, transparent);
 $table-header-background-color: color-mix(in srgb, $banner-background-color 8%, transparent);
+$table-border-radius: var(--gio-app-table-border-radius, 4px);
 $select-panel-background-color: color-mix(in srgb, $banner-background-color 12%, $card-background-color);
 $calendar-background-color: color-mix(in srgb, $banner-background-color 50%, $card-background-color);

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -17,9 +17,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { SubscriptionService } from './subscription.service';
-import { SubscriptionStatusEnum } from '../entities/subscription/subscription';
-import { fakeSubscriptionResponse } from '../entities/subscription/subscription.fixture';
-import { SubscriptionsResponse } from '../entities/subscription/subscriptions-response';
+import { SubscriptionStatusEnum, fakeSubscriptionResponse, SubscriptionsResponse } from '../entities/subscription';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('SubscriptionService', () => {

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -18,7 +18,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { CreateSubscription, Subscription, SubscriptionStatusEnum } from '../entities/subscription/subscription';
+import { CreateSubscription, Subscription, SubscriptionStatusEnum, UpdateSubscription } from '../entities/subscription/subscription';
 import { SubscriptionsResponse } from '../entities/subscription/subscriptions-response';
 
 @Injectable({
@@ -55,5 +55,9 @@ export class SubscriptionService {
 
   subscribe(createSubscription: CreateSubscription): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.configService.baseURL}/subscriptions`, createSubscription);
+  }
+
+  update(subscriptionId: string, updatedSubscription: UpdateSubscription) {
+    return this.http.put<Subscription>(`${this.configService.baseURL}/subscriptions/${subscriptionId}`, updatedSubscription);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -48,7 +48,9 @@ export class SubscriptionService {
   }
 
   get(subscriptionId: string): Observable<Subscription> {
-    return this.http.get<Subscription>(`${this.configService.baseURL}/subscriptions/${subscriptionId}?include=keys`);
+    return this.http.get<Subscription>(
+      `${this.configService.baseURL}/subscriptions/${subscriptionId}?include=keys&include=consumerConfiguration`,
+    );
   }
 
   subscribe(createSubscription: CreateSubscription): Observable<Subscription> {

--- a/gravitee-apim-portal-webui-next/src/styles.scss
+++ b/gravitee-apim-portal-webui-next/src/styles.scss
@@ -22,6 +22,7 @@
 @use '@angular/material' as mat;
 @use '@angular/material-experimental' as matx;
 @use './scss/theme';
+@use 'scss/table-light';
 
 @include mat.core();
 @include mat.color-variants-backwards-compatibility(theme.$light-theme);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5672

## Description

add subscription configuration in new portal

- here we display minimal configuration info and allow users to edit configuration if it's not rejected or closed
- we allow to configure the
   - callback url
   - channel
   - headers
   - retry

Next part is ssl and last part is authentification

Here is a small video to show you how it behaves but obviously if you try it and want to change the style of the page you can call me 👨🏼‍🎨 🎨 🖼️

https://github.com/user-attachments/assets/759d3aff-4cb1-487b-a07c-66dfbbcf45fc


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

