### PR TITLE
APIM 8948 fix reload app list after restore

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
@@ -181,6 +181,18 @@ export class EnvApplicationListComponent implements OnInit, OnDestroy {
         filter((confirm) => confirm === true),
         switchMap(() => this.applicationService.restore(application.applicationId)),
         tap(() => this.snackBarService.success(`Application ${application.name} has been restored`)),
+        switchMap(() =>
+          this.applicationService
+            .list(
+              this.filters.status,
+              this.filters.searchTerm,
+              toOrder(this.filters.sort),
+              this.filters.pagination.index,
+              this.filters.pagination.size,
+            )
+            .pipe(catchError(() => of(new PagedResult<Application>()))),
+        ),
+        tap((applications) => this.setDataSourceFromApplicationsList(applications)),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() =>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8948

## Description

After restoring deleted app, refresh the page.
Test case for the same. Renamed existing expectApplicationsListRequest method to expectActiveApplicationsListRequest and made one more for Archived one.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fiyfwtwmzc.chromatic.com)
<!-- Storybook placeholder end -->
