### PR TITLE
fix(portal-next): break words in async api documentation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-async-api/page-async-api.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-async-api/page-async-api.component.scss
@@ -1,29 +1,19 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- *
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from '@angular/core';
 
-@Component({
-  selector: 'app-page-async-api',
-  standalone: true,
-  imports: [],
-  template: `<asyncapi-component id="#async-api" [schema]="content ?? ''" cssImportPath="assets/asyncapi/default.min.css">
-  </asyncapi-component>`,
-  styleUrls: ['./page-async-api.component.scss'],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
-})
-export class PageAsyncApiComponent {
-  @Input() content!: string | undefined;
+asyncapi-component {
+  word-break: break-word;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8964

## Description

Break words in AsyncAPI so that it stays within the given width.

The URLs were expanding the width automatically when they were too long. 

![Screenshot 2025-03-18 at 09 23 33](https://github.com/user-attachments/assets/d2413b67-0935-49e3-bc6a-fe6d1ab10fd3)
![Screenshot 2025-03-18 at 09 23 19](https://github.com/user-attachments/assets/74ffbd96-3915-446f-ba20-1a9d14451e91)



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

