### PR TITLE
fix: delay the display of error to avoid the dismiss by ApiScoringService

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
@@ -90,10 +90,17 @@ export class ApiScoringComponent implements OnInit {
       map((response) => {
         const lastJob = response?.data?.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())?.[0];
         if (lastJob?.updatedAt && 3_600_000 > new Date().getTime() - new Date(lastJob?.updatedAt).getTime()) {
+          let message = undefined;
           if (lastJob?.status === 'ERROR') {
-            this.snackBarService.error(`The last evaluation was failed at ${lastJob.createdAt} ${lastJob.errorMessage ?? ''}`);
+            message = `The last evaluation was failed at ${lastJob.createdAt} ${lastJob.errorMessage ?? ''}`;
           } else if (lastJob?.status === 'TIMEOUT') {
-            this.snackBarService.error(`The last evaluation was timed out at ${lastJob.createdAt} ${lastJob.errorMessage ?? ''}`);
+            message = `The last evaluation was timed out at ${lastJob.createdAt} ${lastJob.errorMessage ?? ''}`;
+          }
+          // a patch to avoid dismiss caused by ApiScoringService
+          if (message) {
+            setTimeout(() => {
+              this.snackBarService.error(message);
+            }, 1_000);
           }
         }
         return lastJob?.status === 'PENDING';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8971

## Description

delay the display of error to avoid the dismiss by ApiScoringService
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ngfzlyusoa.chromatic.com)
<!-- Storybook placeholder end -->
