### PR TITLE
fix: ignore unknown access control groups during import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -849,10 +849,9 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                                     }
                                 }
                             );
-                            if (groupId != null) {
-                                accessControlEntity.setReferenceId(groupId);
-                            }
+                            accessControlEntity.setReferenceId(groupId);
                         })
+                        .filter(accessControlEntity -> accessControlEntity.getReferenceId() != null)
                         .collect(toSet())
                 );
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -21,28 +21,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import io.gravitee.rest.api.model.MemberEntity;
-import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.model.PlanEntity;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
-import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.apim.core.documentation.model.AccessControl;
+import io.gravitee.apim.core.json.JsonProcessingException;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.ApiMetadataService;
+import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.PlanService;
@@ -54,14 +45,11 @@ import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -100,6 +88,9 @@ public class ApiDuplicatorServiceImplTest {
 
     @Mock
     private ApiEntity apiEntity;
+
+    @Mock
+    private GroupService groupService;
 
     @Spy
     private ObjectMapper objectMapper = (new ServiceConfiguration()).objectMapper();
@@ -406,5 +397,57 @@ public class ApiDuplicatorServiceImplTest {
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
 
         return new ImportApiJsonNode(objectMapper.readTree(toBeImport));
+    }
+
+    @Test
+    public void shouldIgnoreUnknownAccessControlGroups() throws IOException {
+        ImportApiJsonNode pagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.with-access-controls.json");
+        apiDuplicatorService.createOrUpdatePages(GraviteeContext.getExecutionContext(), apiEntity, pagesNode);
+
+        verify(pageService, times(1))
+            .createOrUpdatePages(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(pageEntities ->
+                    pageEntities.size() == 2 && pageEntities.stream().allMatch(page -> page.getAccessControls().isEmpty())
+                ),
+                eq(API_ID)
+            );
+    }
+
+    @Test
+    public void shouldPreserveValidAccessControlGroups() throws IOException {
+        ImportApiJsonNode pagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.with-access-controls.json");
+        GroupEntity mockGroupEntity = new GroupEntity();
+        mockGroupEntity.setId("group-id-1");
+        mockGroupEntity.setName("TestGroup");
+        when(groupService.findByName(eq(GraviteeContext.getExecutionContext().getEnvironmentId()), eq("TestGroup")))
+            .thenReturn(Collections.singletonList(mockGroupEntity));
+        apiDuplicatorService.createOrUpdatePages(GraviteeContext.getExecutionContext(), apiEntity, pagesNode);
+
+        verify(pageService, times(1))
+            .createOrUpdatePages(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(pageEntities ->
+                    pageEntities.size() == 2 &&
+                    pageEntities
+                        .stream()
+                        .allMatch(page -> {
+                            if (page.getName().equals("toto")) {
+                                return (
+                                    page.getAccessControls().size() == 1 &&
+                                    page
+                                        .getAccessControls()
+                                        .stream()
+                                        .anyMatch(accessControl -> "group-id-1".equals(accessControl.getReferenceId()))
+                                );
+                            }
+                            if (page.getName().equals("petstore")) {
+                                return page.getAccessControls().isEmpty();
+                            }
+                            return true; // For other pages, no specific checks
+                        })
+                ),
+                eq(API_ID)
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -376,8 +376,9 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                                 accessControlOk &&
                                 pageEntity.getAccessControls().contains(new AccessControlEntity("known_group_id", "GROUP"));
                         } else if (pageEntity.getOrder() == 4) {
+                            // unknown group
                             accessControlOk =
-                                accessControlOk && pageEntity.getAccessControls().contains(new AccessControlEntity("group_id", "GROUP"));
+                                accessControlOk && (pageEntity.getAccessControls() == null || pageEntity.getAccessControls().isEmpty());
                         }
                     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -481,10 +481,12 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                         if (pageEntity.getOrder() == 3) {
                             accessControlOk =
                                 accessControlOk &&
+                                pageEntity.getAccessControls() != null &&
                                 pageEntity.getAccessControls().contains(new AccessControlEntity("known_group_id", "GROUP"));
                         } else if (pageEntity.getOrder() == 4) {
+                            // unknown group
                             accessControlOk =
-                                accessControlOk && pageEntity.getAccessControls().contains(new AccessControlEntity("group_id", "GROUP"));
+                                accessControlOk && (pageEntity.getAccessControls() == null || pageEntity.getAccessControls().isEmpty());
                         }
                     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.with-access-controls.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.with-access-controls.json
@@ -1,0 +1,36 @@
+{
+    "name": "with-pages",
+    "pages": [
+        {
+            "name": "toto",
+            "type": "MARKDOWN",
+            "order": 1,
+            "lastContributor": "admin",
+            "published": false,
+            "visibility": "PUBLIC",
+            "source": {
+                "type": "http-fetcher",
+                "configuration": {
+                    "url": "https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/master/README.md"
+                }
+            },
+            "excludedAccessControls": false,
+            "accessControls": [
+                {
+                    "referenceId": "TestGroup",
+                    "referenceType": "GROUP"
+                }
+            ]
+        },
+        {
+            "name": "petstore",
+            "type": "SWAGGER",
+            "order": 2,
+            "visibility": "PUBLIC",
+            "lastContributor": "admin",
+            "published": false,
+            "excludedAccessControls": false,
+            "accessControls": []
+        }
+    ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9014

## Description

fix: ignore unknown access control groups from api definition during import

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

