### PR TITLE
fix: Fix unauthorized API key exception when using the shared API key…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -227,6 +227,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
             return apiKey;
         }
         jdbcTemplate.update("insert into " + keySubscriptions + " ( key_id, subscription_id ) values ( ?, ? )", id, subscriptionId);
+        jdbcTemplate.update("update " + this.tableName + " set updated_at=now() where id=?", id);
         return findById(id);
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.repository.mongodb.management.internal.key;
 
-import static com.mongodb.client.model.Aggregates.lookup;
-import static com.mongodb.client.model.Aggregates.match;
-import static com.mongodb.client.model.Aggregates.sort;
-import static com.mongodb.client.model.Aggregates.unwind;
+import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.gte;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Filters.or;
+import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.push;
+import static com.mongodb.client.model.Updates.set;
 
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.model.Sorts;
@@ -146,7 +145,7 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
     public UpdateResult addSubscription(String id, String subscriptionId) {
         return mongoTemplate
             .getCollection(mongoTemplate.getCollectionName(ApiKeyMongo.class))
-            .updateOne(eq("_id", id), push("subscriptions", subscriptionId));
+            .updateOne(eq("_id", id), combine(push("subscriptions", subscriptionId), set("updatedAt", new Date())));
     }
 
     private List<ApiKeyMongo> getListFromAggregate(AggregateIterable<Document> aggregate) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -65,14 +65,7 @@ import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1071,6 +1064,46 @@ public class ApiKeyServiceTest {
                     apiKey.getSubscriptions().contains("sub3")
                 )
             );
+    }
+
+    @Test
+    public void should_not_duplicate_subscription_and_update_updatedAt_when_adding_existing_subscription() throws TechnicalException {
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setId("id-of-apikey-2");
+        existingApiKey.setKey("dummy-key");
+
+        Date originalUpdatedAt = new Date();
+        existingApiKey.setUpdatedAt(originalUpdatedAt);
+        existingApiKey.setSubscriptions(new ArrayList<>(Arrays.asList("subscription2", "subscriptionX")));
+
+        ApiKey updatedApiKey = new ApiKey();
+        updatedApiKey.setId("id-of-apikey-2");
+        updatedApiKey.setKey("dummy-key");
+
+        Date newUpdatedAt = new Date(originalUpdatedAt.getTime() + 1000);
+        updatedApiKey.setUpdatedAt(newUpdatedAt);
+        updatedApiKey.setSubscriptions(new ArrayList<>(Arrays.asList("subscription2", "subscriptionX")));
+
+        when(apiKeyRepository.findById("id-of-apikey-2")).thenReturn(Optional.of(existingApiKey));
+        when(apiKeyRepository.addSubscription("id-of-apikey-2", "subscription2")).thenReturn(Optional.of(updatedApiKey));
+
+        Optional<ApiKey> apiKeyOpt = apiKeyRepository.findById("id-of-apikey-2");
+        assertTrue("API key should exist", apiKeyOpt.isPresent());
+        ApiKey apiKey = apiKeyOpt.get();
+        List<String> initialSubscriptions = apiKey.getSubscriptions();
+        assertEquals("Initial subscriptions count should be 2", 2, initialSubscriptions.size());
+
+        Optional<ApiKey> resultOpt = apiKeyRepository.addSubscription("id-of-apikey-2", "subscription2");
+        assertTrue("Updated API key should be returned", resultOpt.isPresent());
+        ApiKey resultApiKey = resultOpt.get();
+        List<String> updatedSubscriptions = resultApiKey.getSubscriptions();
+
+        long count = updatedSubscriptions.stream().filter(s -> s.equals("subscription2")).count();
+        assertEquals("Subscription 'subscription2' should appear only once", 1, count);
+
+        assertEquals("Subscription count should remain unchanged", 2, updatedSubscriptions.size());
+
+        assertTrue("updatedAt should be updated to a later time", resultApiKey.getUpdatedAt().after(existingApiKey.getUpdatedAt()));
     }
 
     private ApiKey buildTestApiKey(String id) {


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-7306

## Description

Fixed an issue where an API key using the Shared API Key feature could only access the first subscribed API, while subsequent subscriptions were unauthorized. The fix ensures that new subscriptions are correctly added, and the updatedAt timestamp is refreshed whenever an API key is updated.

## Additional context


