### PR TITLE
fix(console): log all API calls including unauthorized (401) requests

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesResponseAdapterTest.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.log.v4.model.analytics.ResponseStatusRangesAggregate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -63,10 +65,14 @@ class SearchResponseStatusRangesResponseAdapterTest {
 
         aggregation.setBuckets(Arrays.stream(entrypoints).map(this::provideBucket).toList());
 
-        assertThat(SearchResponseStatusRangesResponseAdapter.adapt(searchResponse))
+        Optional<ResponseStatusRangesAggregate> result = SearchResponseStatusRangesResponseAdapter.adapt(searchResponse);
+
+        assertThat(result)
             .hasValueSatisfying(topHits ->
                 assertThat(topHits.getStatusRangesCountByEntrypoint().keySet()).containsExactlyInAnyOrder(entrypoints)
             );
+        assertThat(result.get().getRanges())
+            .containsExactlyInAnyOrderEntriesOf(Map.of("100.0-200.0", 1L, "200.0-300.0", 2L, "300.0-400.0", 3L, "400.0-500.0", 4L));
     }
 
     private Aggregation provideAllApiStatusAggregation() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7232

## Description

Fixed this by aggregation on status_ranges and entrypoint_id, ensuring all response codes are logged, including those that fail at the gateway.

## Additional context
### Before
<img width="1728" alt="Screenshot 2025-03-19 at 12 27 39 PM" src="https://github.com/user-attachments/assets/9a894afc-bbaf-422e-9549-082b18eac99b" />

### After
<img width="1728" alt="Screenshot 2025-03-19 at 12 18 05 PM" src="https://github.com/user-attachments/assets/d17f7329-72a2-4160-8073-058fdacf2ada" />

https://github.com/user-attachments/assets/30474957-131f-48ec-b9f1-125605b74ea0

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fsmsftnozk.chromatic.com)
<!-- Storybook placeholder end -->
