### PR TITLE
fix: use HttpContext to handle non error 404

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/api-scoring.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-scoring.service.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { catchError } from 'rxjs/operators';
 
 import { ApiScoring, ApiScoringTriggerResponse } from '../management/api/scoring/api-scoring.model';
 import { Constants } from '../entities/Constants';
 import { ApisScoringOverview, ApisScoringResponse } from '../management/api-score/api-score.model';
+import { ACCEPT_404 } from '../shared/interceptors/http-error.interceptor';
 
 @Injectable()
 export class ApiScoringService {
@@ -33,11 +34,10 @@ export class ApiScoringService {
   ) {}
 
   public getApiScoring(apiId: string): Observable<ApiScoring> {
-    return this.httpClient.get<ApiScoring>(`${this.constants.env.v2BaseURL}/apis/${apiId}/scoring`).pipe(
+    const context = new HttpContext().set(ACCEPT_404, true);
+    return this.httpClient.get<ApiScoring>(`${this.constants.env.v2BaseURL}/apis/${apiId}/scoring`, { context }).pipe(
       catchError((err) => {
-        // normally 404 is intercepted by the HttpErrorInterceptor and displayed as a snack error, but for this request, it should be dismissed.
         if (err.status === 404) {
-          this.matSnackBar.dismiss();
           return of(undefined);
         }
         throw err;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8971

## Description

Instead of let interceptor display snackbar and dismiss it because 404
isn’t an error in this case, we put in HTTP context a boolean to say to
interceptor to not display error.

The previous this create some problem because we are not sure that ths
error displayed was due to 404 response or other thing.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xocbveapka.chromatic.com)
<!-- Storybook placeholder end -->
