### PR TITLE
fix(console): do not edit a closed subscription

### DIFF
--- a/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.component.html
+++ b/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.component.html
@@ -21,8 +21,8 @@
     <mat-card-title>Consumer Configuration</mat-card-title>
     <mat-card-subtitle>View and edit the Push Plan consumer's subscription configuration</mat-card-subtitle>
     <div class="subscription-edit-push-config__headerRightBtn">
-      <button mat-stroked-button (click)="openConsumerConfigurationDialog()">
-        <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+      <button mat-stroked-button (click)="openConsumerConfigurationDialog()" data-testid="openConfiguration">
+        <mat-icon [svgIcon]="canEdit ? 'gio:edit-pencil' : 'gio:eye-empty'"></mat-icon>
         @if (canEdit) {
           Edit
         } @else {

--- a/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.component.ts
+++ b/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.component.ts
@@ -56,13 +56,16 @@ export class SubscriptionEditPushConfigComponent implements OnInit {
   @Input()
   consumerConfiguration!: SubscriptionConsumerConfiguration;
 
+  @Input()
+  readonly: boolean;
+
   @Output()
   consumerConfigurationChange = new EventEmitter<Partial<SubscriptionConsumerConfiguration>>();
 
   canEdit = false;
 
   ngOnInit() {
-    this.canEdit = this.permissionService.hasAnyMatching([this.updatePermission]);
+    this.canEdit = !this.readonly && this.permissionService.hasAnyMatching([this.updatePermission]);
   }
 
   get pushConfig(): PushConfigVM {

--- a/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.harness.ts
+++ b/gravitee-apim-console-webui/src/components/subscription-edit-push-config/subscription-edit-push-config.harness.ts
@@ -25,8 +25,12 @@ export class SubscriptionEditPushConfigHarness extends ComponentHarness {
     return host.text();
   }
 
-  async clickEditButton(): Promise<void> {
-    const button = await this.locatorFor(MatButtonHarness.with({ text: /Edit/ }))();
+  async clickOpenConfigurationButton(): Promise<void> {
+    const button = await this.getOpenConfigurationButton();
     await button.click();
+  }
+
+  async getOpenConfigurationButton(): Promise<MatButtonHarness> {
+    return this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=openConfiguration]' }))();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -274,6 +274,7 @@
     <subscription-edit-push-config
       [updatePermission]="'api-subscription-u'"
       [consumerConfiguration]="subscription.consumerConfiguration"
+      [readonly]="subscription.status === 'CLOSED'"
       (consumerConfigurationChange)="onConsumerConfigurationChange($event)"
     ></subscription-edit-push-config>
   }

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
@@ -1245,7 +1245,7 @@ describe('ApiSubscriptionEditComponent', () => {
       );
       expect(await apiSubscriptionEditPushConfigCard.getContentText()).toContain('myChannel');
 
-      await apiSubscriptionEditPushConfigCard.clickEditButton();
+      await apiSubscriptionEditPushConfigCard.clickOpenConfigurationButton();
 
       const apiSubscriptionEditPushConfigDialog = await rootLoader.getHarness(SubscriptionEditPushConfigDialogHarness);
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
@@ -124,6 +124,7 @@
   @if (!pageVM.subscription?.plan?.security && !!pageVM.subscription?.configuration) {
     <subscription-edit-push-config
       [updatePermission]="'application-subscription-u'"
+      [readonly]="pageVM.subscription.status === 'CLOSED'"
       [consumerConfiguration]="pageVM.subscription.configuration"
       (consumerConfigurationChange)="onConsumerConfigurationChange($event)"
     ></subscription-edit-push-config>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
@@ -158,7 +158,7 @@ describe('ApplicationSubscriptionComponent', () => {
     expect(await apiSubscriptionEditPushConfigCard.getContentText()).toContain('https://webhook.site/296b8f8b-fbbe-4516-a016-c44da934b5e0');
     expect(await apiSubscriptionEditPushConfigCard.getContentText()).toContain('myChannel');
 
-    await apiSubscriptionEditPushConfigCard.clickEditButton();
+    await apiSubscriptionEditPushConfigCard.clickOpenConfigurationButton();
 
     const apiSubscriptionEditPushConfigDialog = await rootLoader.getHarness(SubscriptionEditPushConfigDialogHarness);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9059

## Description

Introduce a readonly input in the push subscription edit component.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-twqdnwqzqt.chromatic.com)
<!-- Storybook placeholder end -->
