### PR TITLE
fix: add missing mapping between repository and entity

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1753,6 +1753,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         entity.setRequest(subscription.getRequest());
         entity.setReason(subscription.getReason());
         entity.setApplication(subscription.getApplication());
+        entity.setApplicationName(subscription.getApplicationName());
         entity.setStartingAt(subscription.getStartingAt());
         entity.setEndingAt(subscription.getEndingAt());
         entity.setCreatedAt(subscription.getCreatedAt());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9067

## Description

Because of a missing mapping, the application name of a subscription entity was always null.
So this piece of code was never executed:
https://github.com/gravitee-io/gravitee-api-management/blob/4.7.x/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java#L844-L849

And so the application name in the subscription was never updated.