### PR TITLE
fix: apply custom API key in API plan subscription when used

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -239,7 +239,13 @@ public class ApiSubscriptionsResource extends AbstractResource {
 
         if (created.getStatus() == io.gravitee.rest.api.model.SubscriptionStatus.PENDING) {
             var result = acceptSubscriptionUsecase.execute(
-                AcceptSubscriptionUseCase.Input.builder().subscriptionId(created.getId()).apiId(apiId).auditInfo(getAuditInfo()).build()
+                AcceptSubscriptionUseCase.Input
+                    .builder()
+                    .subscriptionId(created.getId())
+                    .apiId(apiId)
+                    .auditInfo(getAuditInfo())
+                    .customKey(getCustomApiKey(createSubscription))
+                    .build()
             );
             subscription = subscriptionMapper.map(result.subscription());
         }
@@ -694,5 +700,11 @@ public class ApiSubscriptionsResource extends AbstractResource {
                 )
             );
         }
+    }
+
+    private String getCustomApiKey(CreateSubscription createSubscription) {
+        return (createSubscription.getCustomApiKey() != null && !createSubscription.getCustomApiKey().isEmpty())
+            ? createSubscription.getCustomApiKey()
+            : null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -82,6 +83,16 @@ public class SubscriptionFixtures {
         return AcceptSubscription
             .builder()
             .customApiKey("custom")
+            .reason("reason")
+            .startingAt(OffsetDateTime.now())
+            .endingAt(OffsetDateTime.now())
+            .build();
+    }
+
+    public static AcceptSubscription anAcceptSubscriptionWithRandomKey() {
+        return AcceptSubscription
+            .builder()
+            .customApiKey(UUID.randomUUID().toString()) // Generates a random UUID as the custom API key
             .reason("reason")
             .startingAt(OffsetDateTime.now())
             .endingAt(OffsetDateTime.now())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8573

## Description

fix: ensure custom API key is applied when creating subscription via API plan and when custom api key is used

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

