### PR TITLE
fix: export API map excludes params correctly

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ExportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ExportApiUseCase.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.api.use_case;
 
-import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static java.util.Objects.requireNonNull;
 
 import io.gravitee.apim.core.UseCase;
@@ -23,12 +22,16 @@ import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import jakarta.annotation.Nullable;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class ExportApiUseCase {
@@ -45,12 +48,12 @@ public class ExportApiUseCase {
         };
     }
 
-    public record Input(String apiId, AuditInfo auditInfo, @Nullable Collection<ApiExportDomainService.Excludable> excluded) {
-        public static Input of(String apiId, AuditInfo auditInfo, @Nullable Collection<String> excluded) {
+    public record Input(String apiId, AuditInfo auditInfo, @Nullable Collection<Excludable> excluded) {
+        public static Input of(String apiId, AuditInfo auditInfo, @Nullable Collection<Excludable> excluded) {
             return new Input(
                 requireNonNull(apiId, "apiId should not be null"),
                 requireNonNull(auditInfo, "auditInfo should not be null"),
-                stream(excluded).map(ApiExportDomainService.Excludable::valueOf).toList()
+                excluded == null ? List.of() : excluded
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/Excludable.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/Excludable.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.domain_service;
+package io.gravitee.apim.core.audit.model;
 
-import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
-import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.audit.model.Excludable;
-import java.util.Collection;
-
-public interface ApiExportDomainService {
-    GraviteeDefinition export(String apiId, AuditInfo auditInfo, Collection<Excludable> excludeAdditionalData);
+public enum Excludable {
+    GROUPS,
+    PLANS,
+    MEMBERS,
+    PAGES_MEDIA,
+    METADATA,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.async_job.crud_service.AsyncJobCrudService;
 import io.gravitee.apim.core.async_job.model.AsyncJob;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.json.GraviteeDefinitionSerializer;
@@ -81,9 +82,7 @@ public class ScoreApiRequestUseCase {
             .toList();
 
         var export$ = Flowable
-            .fromCallable(() ->
-                apiExportDomainService.export(input.apiId, input.auditInfo, EnumSet.noneOf(ApiExportDomainService.Excludable.class))
-            )
+            .fromCallable(() -> apiExportDomainService.export(input.apiId, input.auditInfo, EnumSet.noneOf(Excludable.class)))
             .map(this::assetToScore)
             // export service throw error in some case (like if API isn't V4)
             .onErrorResumeNext(th -> Flowable.empty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.apim.infra.domain_service.api;
 
-import static io.gravitee.apim.core.api.domain_service.ApiExportDomainService.Excludable.GROUPS;
-import static io.gravitee.apim.core.api.domain_service.ApiExportDomainService.Excludable.MEMBERS;
-import static io.gravitee.apim.core.api.domain_service.ApiExportDomainService.Excludable.METADATA;
-import static io.gravitee.apim.core.api.domain_service.ApiExportDomainService.Excludable.PAGES_MEDIA;
+import static io.gravitee.apim.core.audit.model.Excludable.GROUPS;
+import static io.gravitee.apim.core.audit.model.Excludable.MEMBERS;
+import static io.gravitee.apim.core.audit.model.Excludable.METADATA;
+import static io.gravitee.apim.core.audit.model.Excludable.PAGES_MEDIA;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_DOCUMENTATION;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_MEMBER;
@@ -35,6 +35,7 @@ import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.api.model.import_definition.PageExport;
 import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
 import io.gravitee.apim.core.integration.model.Integration;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import io.gravitee.apim.core.media.query_service.MediaQueryService;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
@@ -113,7 +114,7 @@ class ApiExportDomainServiceImplTest {
         when(apiCrudService.findById(anyString())).thenReturn(Optional.of(api));
 
         // When
-        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(ApiExportDomainService.Excludable.class));
+        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(Excludable.class));
 
         // Then
         assertThat(export.api().type()).isEqualTo(ApiType.PROXY);
@@ -143,7 +144,7 @@ class ApiExportDomainServiceImplTest {
             .thenReturn(false);
 
         // When
-        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(ApiExportDomainService.Excludable.class));
+        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(Excludable.class));
 
         // Then
         assertThat(export.api().type()).isEqualTo(ApiType.PROXY);
@@ -164,7 +165,7 @@ class ApiExportDomainServiceImplTest {
         when(apiCrudService.findById(anyString())).thenReturn(Optional.of(api));
 
         // When
-        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(ApiExportDomainService.Excludable.class));
+        GraviteeDefinition export = sut.export(apiId, AuditInfo.builder().build(), EnumSet.noneOf(Excludable.class));
 
         // Then
         assertThat(export.api().type()).isEqualTo(ApiType.NATIVE);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9159

## Description

Map API excluded params in ressources, this is params validation responsability.

Move enum to model because it’s part of functional of feature.

