### PR TITLE
fix: Reduce the amount of API information pushed to the standard outp…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/ApiManager.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/ApiManager.java
@@ -39,14 +39,14 @@ public class ApiManager {
     private EventManager eventManager;
 
     public void deploy(Api api) {
-        logger.info("Deployment of {}", api);
+        logger.info("Deployment of API id[{}] name[{}] version[{}]", api.getId(), api.getName(), api.getVersion());
 
         apis.put(api.getId(), api);
 
         if (api.getLifecycleState() == LifecycleState.STARTED) {
             eventManager.publishEvent(ApiEvent.DEPLOY, api);
         } else {
-            logger.debug("{} is not enabled. Skip deployment.", api);
+            logger.debug("API id[{}] name[{}] version[{}] is not enabled. Skip deployment.", api.getId(), api.getName(), api.getVersion());
         }
     }
 
@@ -58,10 +58,10 @@ public class ApiManager {
     public void undeploy(String apiId) {
         Api currentApi = apis.remove(apiId);
         if (currentApi != null) {
-            logger.info("Undeployment of {}", currentApi);
+            logger.info("Un-deploying API id[{}] name[{}] version[{}]", currentApi.getId(), currentApi.getName(), currentApi.getVersion());
 
             eventManager.publishEvent(ApiEvent.UNDEPLOY, currentApi);
-            logger.info("{} has been undeployed", apiId);
+            logger.info("API id[{}] has been un-deployed", apiId);
         }
     }
 


### PR DESCRIPTION
## Issue

Reduce log verbosity when deploying from MAPI

## Description

Today, when the management API is starting and syncing API, the entire API definition is written into the standard output / log file. This is not needed and is resource consuming.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dfnzrfhlih.chromatic.com)
<!-- Storybook placeholder end -->
