### PR TITLE
fix: SSE does not produce any remaining messages to the consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,17 @@
     <dependencyManagement>
         <dependencies>
 
+            <!--
+            Below dependency and version is to specifically handle a bug in Vertx when processing large request payload or SSE events
+            https://github.com/vert-x3/vertx-web/issues/2725
+            -->
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-rx-java3</artifactId>
+                <version>4.5.1</version>
+            </dependency>
+
+
             <!-- Gravitee dependencies -->
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9095

## Description

A commit in Vert.x introduced a bug when processing request with large payload or SSE events: https://github.com/vert-x3/vertx-rx/commit/6955e5bbbd4513d3ffc19ea84cb4bf9bed60dadb#diff-e4c8367fd97da5a3b5dd6e6925554cbcb51a3f44be29bb36060d66c3bc83825c

To get rid of the issue, we choose to stick to a specific version of the vertx-rxjava module which does not face the issue.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lrsurnlsnd.chromatic.com)
<!-- Storybook placeholder end -->
