### PR TITLE
fix(gateway): message reporters lacking api name value

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
@@ -131,6 +131,7 @@ public abstract class AbstractApiReactor extends AbstractLifecycleComponent<Reac
 
     protected void prepareCommonAttributes(MutableExecutionContext ctx) {
         ctx.setAttribute(ContextAttributes.ATTR_API, api.getId());
+        ctx.setAttribute(ContextAttributes.ATTR_API_NAME, api.getName());
         ctx.setAttribute(ContextAttributes.ATTR_API_DEPLOYED_AT, api.getDeployedAt().getTime());
         ctx.setAttribute(ContextAttributes.ATTR_ORGANIZATION, api.getOrganizationId());
         ctx.setAttribute(ContextAttributes.ATTR_ENVIRONMENT, api.getEnvironmentId());

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.30.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.31.0</gravitee-reporter-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9095

## Description

because of reactor-message being updated to 3.0.2 from 3.0.0 we have to include api name with reporter-api
https://github.com/gravitee-io/gravitee-api-management/pull/11279

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pngklluvzj.chromatic.com)
<!-- Storybook placeholder end -->
