### PR TITLE
 Fix race condition causing missing subscription keys by synchronizing key table update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
@@ -141,7 +141,9 @@ public class AcceptSubscriptionDomainService {
         var acceptedSubscription = subscription.acceptBy(auditInfo.actor().userId(), startingAt, endingAt, reason);
 
         if (plan.isApiKey()) {
-            generateApiKeyDomainService.generate(acceptedSubscription, auditInfo, customKey);
+            synchronized (this) {
+                generateApiKeyDomainService.generate(acceptedSubscription, auditInfo, customKey);
+            }
         }
         subscriptionCrudService.update(acceptedSubscription);
 


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-7382

## Description
When multiple subscription calls are made to a shared API key application, all calls seem to succeed, but some subscriptions end up without the API key. This issue affects both v2 and v4 APIs, where simultaneous requests result in a race condition that causes the key binding to fail on certain subscriptions.

## Additional context

Reproduction Steps
1. Create an application configured to use a shared API key.
2. Add initial subscriptions to trigger the shared API key setup.
3. Create and publish API key plans for at least three APIs with auto-subscription enabled.
4. Send simultaneous subscription requests.

For sending the subscription requests, you can use the following script. Remember to update the value of applicationId with your own test application, and ensure you have a JSON file named plan_list.json with data in the following format:

`[ { "_id": "30f89c18-ac35-4290-b89c-18ac35c2901b" }, { "_id": "d5d02f76-0e94-466e-902f-760e94466ee7" }, { "_id": "337cc9fa-3287-4f6d-bcc9-fa32876f6d6c" } ]`

The script is:

[run_subscriptions.txt](https://github.com/user-attachments/files/19486367/run_subscriptions.txt)


The Fix
The root cause was a race condition during the API key generation process. The fix involved adding a synchronized block around the critical database update code to ensure that key generation for subscriptions is thread-safe and that all concurrent requests correctly bind the API key.

