### PR TITLE
filter current user groups

### DIFF
--- a/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
@@ -50,10 +50,11 @@ class UserController {
       if (groupsByEnvironmentKeys.length === 1) {
         this.groups = Object.values(this.user.groupsByEnvironment)[0].join(' - ');
       } else {
-        this.groups = groupsByEnvironmentKeys
-          .map((envId) => {
-            const env = this.Constants.org.environments.find((env) => env.id === envId);
-            return `[${env.name}] ${this.user.groupsByEnvironment[envId].join('/')}`;
+        this.groups = this.Constants.org.environments
+          .filter((env) => this.user.groupsByEnvironment[env.id]?.length > 0)
+          .map((env) => {
+            const groups = this.user.groupsByEnvironment[env.id];
+            return `[${env.name}] ${groups.join('/')}`;
           })
           .join(' - ');
       }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -204,7 +204,7 @@ public class CurrentUserResource extends AbstractResource {
             if (!memberships.isEmpty()) {
                 final Map<String, Set<String>> userGroups = new HashMap<>();
                 environmentService
-                    .findByOrganization(GraviteeContext.getCurrentOrganization())
+                    .findByUser(GraviteeContext.getCurrentOrganization(), userId)
                     .forEach(environment -> {
                         try {
                             final Set<Group> groups = groupRepository.findAllByEnvironment(environment.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "4.4.24-SNAPSHOT"
+  version: "4.4.23-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9185

## Description
Currently when accessing the current user account page there is an issue. All environments are always returned even if the user does not have access to one of them. So we have an empty array of group for th is environment and it creates a NPE on the frontend

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sunteqzgsn.chromatic.com)
<!-- Storybook placeholder end -->
