### PR TITLE
fix: disable adding members beyond max invitations limit in a group

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -116,7 +116,7 @@
               (click)="addToExistingAPIs(group)"
               matTooltip="Click to add this group to all existing APIs"
             >
-              <mat-icon>add</mat-icon>
+              <mat-icon svgIcon="gio:plus"></mat-icon>
               Add Group To Existing APIs
             </button>
           }
@@ -139,7 +139,7 @@
               (click)="addToExistingApplications(group)"
               matTooltip="Click to add this group to all existing applications"
             >
-              <mat-icon>add</mat-icon>
+              <mat-icon svgIcon="gio:plus"></mat-icon>
               Add Group To Existing Applications
             </button>
           }
@@ -162,69 +162,65 @@
     <mat-card class="group__form__card">
       <mat-card-header>
         <mat-card-subtitle>Dependents</mat-card-subtitle>
-
-        @if (canAddMembers) {
+        <button
+          class="group__form__card__actions"
+          mat-raised-button
+          color="primary"
+          [disabled]="!canAddMembers"
+          [matMenuTriggerFor]="addMembersMenu"
+          matTooltip="Search and invite users to the group"
+        >
+          <mat-icon svgIcon="gio:plus"></mat-icon>
+          Add Users
+        </button>
+        <mat-menu #addMembersMenu="matMenu" xPosition="before" yPosition="below">
           <button
-            class="group__form__card__actions"
-            mat-raised-button
-            color="primary"
-            [matMenuTriggerFor]="addMembersMenu"
-            matTooltip="Search and invite users to the group"
+            mat-menu-item
+            (click)="openAddMembersDialog()"
+            [disabled]="!group.system_invitation"
+            aria-hidden="false"
+            aria-label="Click to invite user via search"
           >
-            <mat-icon>add</mat-icon>
-            Add Users
+            <mat-icon svgIcon="gio:search"></mat-icon>
+            User Search
           </button>
-          <mat-menu #addMembersMenu="matMenu" xPosition="before" yPosition="below">
-            <button
-              mat-menu-item
-              (click)="openAddMembersDialog()"
-              [disabled]="!group.system_invitation"
-              aria-hidden="false"
-              aria-label="Click to invite user via search"
-            >
-              <mat-icon svgIcon="gio:search"></mat-icon>
-              User Search
-            </button>
-            <button
-              mat-menu-item
-              (click)="openInviteMemberDialog()"
-              [disabled]="!group.email_invitation"
-              aria-hidden="false"
-              aria-label="Click to invite user via email"
-            >
-              <mat-icon svgIcon="gio:mail"></mat-icon>
-              Email Invitation
-            </button>
-          </mat-menu>
-        }
+          <button
+            mat-menu-item
+            (click)="openInviteMemberDialog()"
+            [disabled]="!group.email_invitation"
+            aria-hidden="false"
+            aria-label="Click to invite user via email"
+          >
+            <mat-icon svgIcon="gio:mail"></mat-icon>
+            Email Invitation
+          </button>
+        </mat-menu>
       </mat-card-header>
       <mat-card-content>
-        <span *ngIf="group.max_invitation <= noOfMembers"
-          ><mat-icon>info</mat-icon> The number of members in this group has reached maximum allowed. Adding users via search and email
-          invitation have been disabled.</span
-        >
+        @if (maxInvitationsLimitReached) {
+          <mat-icon svgIcon="gio:info"></mat-icon
+          ><span
+            >The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been
+            disabled.</span
+          >
+        }
         <mat-tab-group (selectedIndexChange)="onTabChange($event)">
           <mat-tab label="Members">
             @if (groupMembers$ | async; as members) {
-              <gio-table-wrapper [length]="noOfGroupMembers" [filters]="membersDefaultFilters" (filtersChange)="filterGroupMembers($event)">
-                <table
-                  mat-table
-                  [dataSource]="filteredGroupMembers"
-                  id="membersDataTable"
-                  aria-hidden="false"
-                  aria-label="Members Data Table"
-                >
+              <gio-table-wrapper
+                [length]="noOfFilteredMembers"
+                [filters]="membersDefaultFilters"
+                (filtersChange)="filterGroupMembers($event)"
+              >
+                <table mat-table [dataSource]="filteredMembers" id="membersDataTable" aria-hidden="false" aria-label="Members Data Table">
                   <ng-container matColumnDef="name">
                     <th mat-header-cell *matHeaderCellDef id="name">Name</th>
                     <td mat-cell *matCellDef="let row">
                       <div>
-                        {{ row.displayName
-                        }}<span
-                          class="gio-badge-primary"
-                          tooltip="User is an administrator of the group"
-                          *ngIf="row.roles['GROUP'] === 'ADMIN'"
-                          >Admin</span
-                        >
+                        {{ row.displayName }}
+                        @if (row.roles['GROUP'] === 'ADMIN') {
+                          <span class="gio-badge-primary" tooltip="User is an administrator of the group">Admin</span>
+                        }
                       </div>
                     </td>
                   </ng-container>
@@ -289,13 +285,13 @@
             <ng-template matTabContent>
               @if (invitations$ | async; as data) {
                 <gio-table-wrapper
-                  [length]="noOfGroupInvitations"
+                  [length]="noOfInvitations"
                   [filters]="invitationsDefaultFilters"
                   (filtersChange)="filterGroupInvitations($event)"
                 >
                   <table
                     mat-table
-                    [dataSource]="filteredGroupInvitations"
+                    [dataSource]="filteredInvitations"
                     id="invitationsDataTable"
                     aria-hidden="false"
                     aria-label="Invitations Data Table"
@@ -364,14 +360,8 @@
       </mat-card-header>
       <mat-card-content>
         @if (groupAPIs$ | async; as data) {
-          <gio-table-wrapper [length]="noOfGroupAPIs" [filters]="apisDefaultFilters" (filtersChange)="filterGroupAPIs($event)">
-            <table
-              mat-table
-              [dataSource]="filteredGroupAPIs"
-              id="groupApisDataTable"
-              aria-hidden="false"
-              aria-label="Group APIs Data Table"
-            >
+          <gio-table-wrapper [length]="noOfAPIs" [filters]="apisDefaultFilters" (filtersChange)="filterGroupAPIs($event)">
+            <table mat-table [dataSource]="filteredAPIs" id="groupApisDataTable" aria-hidden="false" aria-label="Group APIs Data Table">
               <ng-container matColumnDef="apiName">
                 <th mat-header-cell *matHeaderCellDef id="apiName">Name</th>
                 <td mat-cell *matCellDef="let row">
@@ -413,13 +403,13 @@
       <mat-card-content>
         @if (groupApplications$ | async; as data) {
           <gio-table-wrapper
-            [length]="noOfGroupApplications"
+            [length]="noOfApplications"
             [filters]="applicationsDefaultFilters"
             (filtersChange)="filterGroupApplications($event)"
           >
             <table
               mat-table
-              [dataSource]="filteredGroupApplications"
+              [dataSource]="filteredApplications"
               id="groupApplicationsDataTable"
               aria-hidden="false"
               aria-label="Group Applications Data Table"

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -65,7 +65,7 @@ describe('GroupComponent', () => {
     event_rules: [],
     lock_api_role: false,
     lock_application_role: false,
-    max_invitation: 10,
+    max_invitation: 2,
     name: 'Group 1',
     roles: {},
     system_invitation: false,
@@ -459,6 +459,45 @@ describe('GroupComponent', () => {
   });
 
   describe('Search and invite users', () => {
+    it('should disable add users button when maximum allowed members have been added', async () => {
+      await init(GROUP.id);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            {
+              name: 'OWNER',
+              scope: 'INTEGRATION',
+            },
+          ],
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            {
+              name: 'OWNER',
+              scope: 'INTEGRATION',
+            },
+          ],
+        },
+      ]);
+      expectGetGroupAPIs();
+      expectGetGroupApplications();
+      const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
+      const disabled = await buttonHarness.isDisabled();
+      expect(disabled).toEqual(true);
+    });
+
     it('should display menu to search and invite users', async () => {
       await init(GROUP.id);
       expectGetGroup();
@@ -653,8 +692,8 @@ describe('GroupComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/${type}/roles`).flush(roles);
   }
 
-  function expectGetGroupMembers() {
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`).flush(GROUP_MEMBERS);
+  function expectGetGroupMembers(members: Member[] = GROUP_MEMBERS) {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`).flush(members);
   }
 
   function expectGetGroupAPIs() {

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
@@ -26,7 +26,7 @@
       aria-hidden="false"
       aria-label="Click to create group"
     >
-      <mat-icon>add</mat-icon>
+      <mat-icon svgIcon="gio:plus"></mat-icon>
       Add Group
     </button>
   </mat-card-header>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9192

## Description

The add members button is not disabled when max invitations limit has reached in a group while it should be disabled.

https://github.com/user-attachments/assets/91f40b33-2e82-4894-8bac-7f986cbb8600



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kmaipkshta.chromatic.com)
<!-- Storybook placeholder end -->
