### PR TITLE
fix: Use Java Date instead of SQL now() for updated_at timestamp

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -227,7 +227,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
             return apiKey;
         }
         jdbcTemplate.update("insert into " + keySubscriptions + " ( key_id, subscription_id ) values ( ?, ? )", id, subscriptionId);
-        jdbcTemplate.update("update " + this.tableName + " set updated_at=now() where id=?", id);
+        jdbcTemplate.update("update " + this.tableName + " set updated_at=? where id=?", new Date(), id);
         return findById(id);
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7306

## Description

Replaced SQL now() with Java’s new Date() to ensure compatibility across databases.
This resolves UncategorizedSQLException due to 'now' is not a recognized built-in function name.