### PR TITLE
fix(portal-next): mark global white-space for code tag as important t…

### DIFF
--- a/gravitee-apim-portal-webui-next/src/scss/helper.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/helper.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,5 +26,5 @@ code {
   margin: 0;
   background-color: m3-adapter.$surface-variant;
   font-size: 85%;
-  white-space: break-spaces;
+  white-space: break-spaces !important; // Overrides Swagger-UI inline styling of bash language
 }


### PR DESCRIPTION
…o override swagger inline adjustment

## Issue

https://gravitee.atlassian.net/browse/APIM-9230

## Description

Fix extra-wide curl command in swagger doc when user tries out OpenAPI documentation.

https://github.com/user-attachments/assets/2a226a14-3cce-4023-ba7e-273823a2afff


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

