### PR TITLE
fix(service): only load context path for swagger page for v2 and v4 h…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -610,15 +610,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     private String getContextPath(GenericApiEntity genericApiEntity) {
-        if (genericApiEntity.getDefinitionVersion() == DefinitionVersion.FEDERATED) {
-            return null;
-        }
-
-        if (genericApiEntity.getDefinitionVersion() != DefinitionVersion.V4) {
-            ApiEntity apiEntity = (ApiEntity) genericApiEntity;
+        if (genericApiEntity instanceof ApiEntity apiEntity) {
             return apiEntity.getContextPath();
-        } else {
-            io.gravitee.rest.api.model.v4.api.ApiEntity apiEntity = (io.gravitee.rest.api.model.v4.api.ApiEntity) genericApiEntity;
+        } else if (genericApiEntity instanceof io.gravitee.rest.api.model.v4.api.ApiEntity apiEntity) {
             return apiEntity
                 .getListeners()
                 .stream()
@@ -628,6 +622,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 .map(listener -> listener.getPaths().get(0).getPath())
                 .orElse(null);
         }
+        return null;
     }
 
     private void sanitizeMarkdown(PageEntity pageEntity) {


### PR DESCRIPTION
…ttp APIs

## Issue

https://gravitee.atlassian.net/browse/APIM-9244

## Description

An error was being thrown when Native APIs were cast to v4 ApiEntity to extract the context path. This does not exist for Native APIs and Native APIs have their own class, NativeApiEntity. 

The fix only searches for the context path for v2 and v4 HTTP APIs.

![Screenshot 2025-04-01 at 16 08 53](https://github.com/user-attachments/assets/46ef73b7-fbe2-4c1f-9465-55e144749096)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->


