### PR TITLE
fix: disable searching members beyond max invitations limit in a group

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
@@ -109,7 +109,14 @@ export class AddMembersDialogComponent implements OnInit {
       defaultIntegrationRole: new FormControl<string>({ value: 'USER', disabled: false }),
       searchTerm: new FormControl<string>({ value: '', disabled: false }),
     });
+    this.disableSearch();
     this.disableSubmit.set(true);
+  }
+
+  private disableSearch() {
+    if (this.group.max_invitation <= this.members.length + this.selectedUsers.length) {
+      this.addMemberForm.controls.searchTerm.disable();
+    }
   }
 
   private initializeFilterFn() {
@@ -239,6 +246,7 @@ export class AddMembersDialogComponent implements OnInit {
   private changeFormState() {
     const noOfPrimaryOwners = this.filterPrimaryOwners().length;
     this.addMemberForm.controls.searchTerm.setValue('');
+    this.disableSearch();
 
     if (this.addMemberForm.controls.defaultAPIRole.value === RoleName.PRIMARY_OWNER) {
       if (noOfPrimaryOwners > 0) {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -576,6 +576,43 @@ describe('GroupComponent', () => {
       expect(disabled).toEqual(true);
     });
 
+    it('should disable user search when maximum allowed invitations limit reached', async () => {
+      await init(GROUP.id);
+      expectGetGroup({
+        disable_membership_notifications: false,
+        email_invitation: false,
+        event_rules: [],
+        lock_api_role: false,
+        lock_application_role: false,
+        max_invitation: 2,
+        manageable: true,
+        name: 'Group 1',
+        roles: {},
+        system_invitation: true,
+        id: '1',
+      });
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers();
+      expectGetGroupAPIs();
+      expectGetGroupApplications();
+      const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
+      await buttonHarness.click();
+      const menuHarness = await harnessLoader.getHarness(MatMenuHarness);
+      const userSearchMenuItem = await menuHarness.getHarness(
+        MatMenuItemHarness.with({ selector: '[aria-label="Click to invite user via search"]' }),
+      );
+      await userSearchMenuItem.click();
+      await rootLoader.getHarness(MatDialogHarness);
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      expect(await autoCompleteHarness.isDisabled()).toEqual(false);
+      await autoCompleteHarness.enterText('test');
+      const searchResults = await autoCompleteHarness.getOptions();
+      await searchResults[0].click();
+      expect(await autoCompleteHarness.isDisabled()).toEqual(true);
+    });
+
     it('should search and add users', async () => {
       await init(GROUP.id);
       expectGetGroup({


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9192

## Description

Disabled searching users in the add members dialog when maximum allowed invitation limit is reached.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gogwzjjbko.chromatic.com)
<!-- Storybook placeholder end -->
