### PR TITLE
fix(console): initialize default API and application roles while adding group members

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
@@ -22,7 +22,7 @@
       <mat-label>Default API Role</mat-label>
       <mat-select formControlName="defaultAPIRole" (selectionChange)="onAPIRoleChange()">
         @for (role of defaultAPIRoles; track role.id) {
-          <mat-option [value]="role.name" [disabled]="disabledAPIRoles().has(role.id)">{{ role.name }}</mat-option>
+          <mat-option [value]="role.name" [disabled]="disabledAPIRoles.has(role.id)">{{ role.name }}</mat-option>
         }
       </mat-select>
     </mat-form-field>
@@ -70,6 +70,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-raised-button color="primary" [disabled]="disableSubmit()" (click)="submit()">Add Users</button>
+  <button mat-raised-button color="primary" [disabled]="disableSubmit" (click)="submit()">Add Users</button>
   <button mat-raised-button mat-dialog-close>Cancel</button>
 </mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject, OnInit, signal } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
@@ -71,8 +71,8 @@ export class AddMembersDialogComponent implements OnInit {
     defaultIntegrationRole: FormControl<string>;
     searchTerm: FormControl<string>;
   }>;
-  disabledAPIRoles = signal(new Set<string>());
-  disableSubmit = signal(false);
+  disabledAPIRoles = new Set<string>();
+  disableSubmit = false;
 
   private group: Group;
   private members: Member[] = [];
@@ -103,13 +103,16 @@ export class AddMembersDialogComponent implements OnInit {
 
   private initializeForm() {
     this.addMemberForm = new FormGroup({
-      defaultAPIRole: new FormControl({ value: 'USER', disabled: false }),
-      defaultApplicationRole: new FormControl<string>({ value: 'USER', disabled: false }),
+      defaultAPIRole: new FormControl({ value: this.data.group.roles['API'] ?? 'USER', disabled: false }),
+      defaultApplicationRole: new FormControl<string>({
+        value: this.data.group.roles['APPLICATION'] ?? 'USER',
+        disabled: false,
+      }),
       defaultIntegrationRole: new FormControl<string>({ value: 'USER', disabled: false }),
       searchTerm: new FormControl<string>({ value: '', disabled: false }),
     });
     this.disableSearch();
-    this.disableSubmit.set(true);
+    this.disableSubmit = true;
   }
 
   private disableSearch() {
@@ -153,10 +156,8 @@ export class AddMembersDialogComponent implements OnInit {
   }
 
   private disableAPIRoleOptions() {
-    this.disabledAPIRoles.set(
-      new Set(
-        this.defaultAPIRoles.filter((role) => this.isPrimaryOwnerDisabled(role) || this.isSystemRoleDisabled(role)).map((role) => role.id),
-      ),
+    this.disabledAPIRoles = new Set(
+      this.defaultAPIRoles.filter((role) => this.isPrimaryOwnerDisabled(role) || this.isSystemRoleDisabled(role)).map((role) => role.id),
     );
   }
 
@@ -256,7 +257,7 @@ export class AddMembersDialogComponent implements OnInit {
         this.addMemberForm.controls.searchTerm.addValidators(Validators.required);
       }
     }
-    this.disableSubmit.set(this.memberships.length === 0);
+    this.disableSubmit = this.memberships.length === 0;
   }
 
   private filterPrimaryOwners() {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -37,7 +37,6 @@ import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { Role } from '../../../../../entities/role/role';
 import { GroupMembership } from '../../../../../entities/group/groupMember';
-import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { SearchableUser } from '../../../../../entities/user/searchableUser';
 import { UsersService } from '../../../../../services-ngx/users.service';
 import { Member } from '../../../../../entities/management-api-v2';
@@ -101,7 +100,6 @@ export class EditMemberDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: EditMemberDialogData,
     private usersService: UsersService,
     private matDialogRef: MatDialogRef<EditMemberDialogComponent>,
-    private snackBarService: SnackBarService,
     private permissionService: GioPermissionService,
     private settingsService: EnvironmentSettingsService,
   ) {}

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -32,8 +32,9 @@
           <mat-form-field aria-hidden="false" aria-label="Select default API role" class="group__form__card__form-field">
             <mat-label>Default API Role</mat-label>
             <mat-select formControlName="defaultAPIRole" class="group__form__card__form-select">
+              <mat-option></mat-option>
               @for (role of defaultAPIRoles; track role.id) {
-                <mat-option [value]="role.name">{{ role.name }}</mat-option>
+                <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
               }
             </mat-select>
           </mat-form-field>
@@ -41,8 +42,9 @@
           <mat-form-field aria-hidden="false" aria-label="Select default application role" class="group__form__card__form-field">
             <mat-label>Default Application Role</mat-label>
             <mat-select formControlName="defaultApplicationRole" class="group__form__card__form-select">
+              <mat-option></mat-option>
               @for (role of defaultApplicationRoles; track role.id) {
-                <mat-option [value]="role.name">{{ role.name }}</mat-option>
+                <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
               }
             </mat-select>
           </mat-form-field>
@@ -259,7 +261,7 @@
                       </button>
                       <button
                         mat-button
-                        [disabled]="disableDelete()"
+                        [disabled]="deleteDisabled"
                         (click)="openDeleteMemberDialog(row)"
                         matTooltip="Remove member from group"
                         aria-hidden="false"

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -459,6 +459,45 @@ describe('GroupComponent', () => {
   });
 
   describe('Search and invite users', () => {
+    it('should initialize api and application default roles', async () => {
+      await init(GROUP.id);
+      expectGetGroup({
+        disable_membership_notifications: false,
+        email_invitation: false,
+        event_rules: [],
+        lock_api_role: false,
+        lock_application_role: false,
+        max_invitation: 10,
+        manageable: true,
+        name: 'Group 1',
+        roles: { API: 'USER', APPLICATION: 'OWNER' },
+        system_invitation: true,
+        id: '1',
+      });
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers();
+      expectGetGroupAPIs();
+      expectGetGroupApplications();
+      const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
+      await buttonHarness.click();
+      const menuHarness = await harnessLoader.getHarness(MatMenuHarness);
+      const userSearchMenuItem = await menuHarness.getHarness(
+        MatMenuItemHarness.with({ selector: '[aria-label="Click to invite user via search"]' }),
+      );
+      await userSearchMenuItem.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const matSelectHarnesses = await dialogHarness.getAllHarnesses(MatSelectHarness);
+      expect(matSelectHarnesses.length).toEqual(3);
+      await matSelectHarnesses[0].open();
+      const apiRoleOptions = await matSelectHarnesses[0].getOptions();
+      expect(await apiRoleOptions[3].isSelected()).toEqual(true);
+      await matSelectHarnesses[1].open();
+      const applicationRoleOptions = await matSelectHarnesses[1].getOptions();
+      expect(await applicationRoleOptions[0].isSelected()).toEqual(true);
+    });
+
     it('should disable add users button when maximum allowed members have been added', async () => {
       await init(GROUP.id);
       expectGetGroup();
@@ -721,7 +760,14 @@ describe('GroupComponent', () => {
 
   function expectGetDefaultRoles() {
     expectGetRolesList('API');
-    expectGetRolesList('APPLICATION', [{ id: '5', name: 'OWNER', scope: 'APPLICATION' }]);
+    expectGetRolesList('APPLICATION', [
+      { id: '5', name: 'OWNER', scope: 'APPLICATION' },
+      {
+        id: '7',
+        name: 'USER',
+        scope: 'APPLICATION',
+      },
+    ]);
     expectGetRolesList('INTEGRATION', [{ id: '6', name: 'OWNER', scope: 'INTEGRATION' }]);
   }
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -19,11 +19,10 @@ import { GroupMembership } from 'src/entities/group/groupMember';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { BehaviorSubject, EMPTY, Observable, of, switchMap, tap } from 'rxjs';
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { catchError, filter, map } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
-import { isEmpty } from 'lodash';
 import {
   GIO_DIALOG_WIDTH,
   GioBannerModule,
@@ -188,7 +187,6 @@ export class GroupComponent implements OnInit {
       size: 5,
     },
   };
-  noOfMembers: number = 0;
   noOfFilteredMembers: number = 0;
   filteredMembers: Member[] = [];
   noOfInvitations: number = 0;
@@ -199,7 +197,7 @@ export class GroupComponent implements OnInit {
   filteredApplications: any[] = [];
   canAddMembers = false;
   maxInvitationsLimitReached = false;
-  disableDelete = signal(false);
+  deleteDisabled = false;
 
   private group = new BehaviorSubject<Group>(null);
   private groupMembers = new BehaviorSubject<Member[]>([]);
@@ -262,11 +260,11 @@ export class GroupComponent implements OnInit {
   private initializeForm(group: Group) {
     this.groupForm = new FormGroup({
       name: new FormControl<string>(group.name, { validators: Validators.required }),
-      defaultAPIRole: new FormControl<string>(!isEmpty(group.roles) ? group.roles['API'] : undefined),
-      defaultApplicationRole: new FormControl<string>(!isEmpty(group.roles) ? group.roles['APPLICATION'] : undefined),
+      defaultAPIRole: new FormControl<string>(group.roles ? group.roles.API : null),
+      defaultApplicationRole: new FormControl<string>(group.roles ? group.roles.APPLICATION : null),
       maxNumberOfMembers: new FormControl<number>(group.max_invitation),
-      shouldAllowInvitationViaSearch: new FormControl<boolean>(group.system_invitation !== undefined ? group.system_invitation : false),
-      shouldAllowInvitationViaEmail: new FormControl<boolean>(group.email_invitation !== undefined ? group.email_invitation : false),
+      shouldAllowInvitationViaSearch: new FormControl<boolean>(group.system_invitation ? group.system_invitation : false),
+      shouldAllowInvitationViaEmail: new FormControl<boolean>(group.email_invitation ? group.email_invitation : false),
       canAdminChangeAPIRole: new FormControl<boolean>(!group.lock_api_role),
       canAdminChangeApplicationRole: new FormControl<boolean>(!group.lock_application_role),
       shouldNotifyWhenMemberAdded: new FormControl<boolean>(!group.disable_membership_notifications),
@@ -345,11 +343,11 @@ export class GroupComponent implements OnInit {
   private updateEventRules(): void {
     const eventRules = [];
 
-    if (this.groupForm.controls['shouldAddToNewAPIs'].value) {
+    if (this.groupForm.controls.shouldAddToNewAPIs.value) {
       eventRules.push({ event: 'API_CREATE' });
     }
 
-    if (this.groupForm.controls['shouldAddToNewApplications'].value) {
+    if (this.groupForm.controls.shouldAddToNewApplications.value) {
       eventRules.push({ event: 'APPLICATION_CREATE' });
     }
 
@@ -359,14 +357,14 @@ export class GroupComponent implements OnInit {
   private updateRoles(): void {
     const roles: any = {};
 
-    if (this.groupForm.controls['defaultAPIRole'].value) {
-      roles['API'] = this.groupForm.controls['defaultAPIRole'].value;
+    if (this.groupForm.controls.defaultAPIRole.value) {
+      roles['API'] = this.groupForm.controls.defaultAPIRole.value;
     } else {
       delete roles['API'];
     }
 
-    if (this.groupForm.controls['defaultApplicationRole'].value) {
-      roles['APPLICATION'] = this.groupForm.controls['defaultApplicationRole'].value;
+    if (this.groupForm.controls.defaultApplicationRole.value) {
+      roles['APPLICATION'] = this.groupForm.controls.defaultApplicationRole.value;
     } else {
       delete roles['APPLICATION'];
     }
@@ -378,28 +376,46 @@ export class GroupComponent implements OnInit {
     const formControls = this.groupForm.controls;
     return {
       ...this.group.value,
-      name: formControls['name'].value,
-      max_invitation: formControls['maxNumberOfMembers'].value,
-      lock_api_role: !formControls['canAdminChangeAPIRole'].value,
-      lock_application_role: !formControls['canAdminChangeApplicationRole'].value,
-      system_invitation: formControls['shouldAllowInvitationViaSearch'].value,
-      email_invitation: formControls['shouldAllowInvitationViaEmail'].value,
-      disable_membership_notifications: !formControls['shouldNotifyWhenMemberAdded'].value,
+      name: formControls.name.value,
+      max_invitation: formControls.maxNumberOfMembers.value,
+      lock_api_role: !formControls.canAdminChangeAPIRole.value,
+      lock_application_role: !formControls.canAdminChangeApplicationRole.value,
+      system_invitation: formControls.shouldAllowInvitationViaSearch.value,
+      email_invitation: formControls.shouldAllowInvitationViaEmail.value,
+      disable_membership_notifications: !formControls.shouldNotifyWhenMemberAdded.value,
     };
   }
 
   private initializeDefaultRoles(): void {
-    this.roleService.list('API').subscribe((roles: Role[]) => {
-      this.defaultAPIRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
-    });
+    this.roleService
+      .list('API')
+      .pipe(
+        tap((roles: Role[]) => {
+          this.defaultAPIRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
 
-    this.roleService.list('APPLICATION').subscribe((roles) => {
-      this.defaultApplicationRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
-    });
+    this.roleService
+      .list('APPLICATION')
+      .pipe(
+        tap((roles: Role[]) => {
+          this.defaultApplicationRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
 
-    this.roleService.list('INTEGRATION').subscribe((roles) => {
-      this.defaultIntegrationRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
-    });
+    this.roleService
+      .list('INTEGRATION')
+      .pipe(
+        tap((roles: Role[]) => {
+          this.defaultIntegrationRoles = roles.sort((a, b) => a.name.localeCompare(b.name));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   saveOrUpdate(): void {
@@ -408,9 +424,8 @@ export class GroupComponent implements OnInit {
 
     this.groupService
       .saveOrUpdate(this.mode, this.mapUpdatedGroup())
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (group) => {
+      .pipe(
+        tap((group: Group) => {
           this.snackBarService.success(`Successfully saved the group.`);
 
           if (this.mode === 'new') {
@@ -418,9 +433,10 @@ export class GroupComponent implements OnInit {
           } else {
             this.initializeGroup();
           }
-        },
-        error: () => this.snackBarService.error(`Error occurred while saving the group.`),
-      });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   openDeleteMemberDialog(member: Member): void {
@@ -712,7 +728,7 @@ export class GroupComponent implements OnInit {
 
   private disableDeleteMember(): void {
     const groupMembers = this.groupMembers.value;
-    this.disableDelete.set(groupMembers.length === 1 && groupMembers[0].roles['API'] === RoleName.PRIMARY_OWNER);
+    this.deleteDisabled = groupMembers.length === 1 && groupMembers[0].roles['API'] === RoleName.PRIMARY_OWNER;
   }
 
   private disableForm() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9206

## Description

The default API and application roles of the members should be initialized as the default roles defined at the group level.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jkermxxbki.chromatic.com)
<!-- Storybook placeholder end -->
