### PR TITLE
fix(console): display user groups when creating applications

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.html
@@ -31,6 +31,7 @@
         <application-creation-form
           [applicationTypes]="applicationTypes"
           [applicationFormGroup]="applicationFormGroup"
+          [requireUserGroups]="requireUserGroups"
         ></application-creation-form>
       }
     </mat-card-content>

--- a/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
@@ -87,6 +87,7 @@ export class ApplicationCreationComponent implements OnInit {
     groups: new FormControl([]),
   });
 
+  requireUserGroups = false;
   public applicationTypes$ = this.applicationTypesService.getEnabledApplicationTypes().pipe(
     map((types) =>
       types.map((type) => {
@@ -173,6 +174,7 @@ export class ApplicationCreationComponent implements OnInit {
         tap((consoleSettings) => {
           if (consoleSettings.userGroup.required.enabled) {
             this.applicationFormGroup.controls.groups?.setValidators(Validators.required);
+            this.requireUserGroups = true;
           }
         }),
         takeUntilDestroyed(this.destroyRef),

--- a/gravitee-apim-console-webui/src/management/application/creation/components/application-creation-form.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation/components/application-creation-form.component.html
@@ -50,15 +50,23 @@
       <mat-label>Domain</mat-label>
     </mat-form-field>
 
-    <mat-form-field>
-      <mat-label>Select Groups</mat-label>
-      <mat-hint>Select user groups to add to the application</mat-hint>
-      <mat-select formControlName="groups" multiple>
-        @for (group of groupsList | async; track group) {
-          <mat-option [value]="group.id">{{ group.name }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+    @if (hasGroupsToAdd || requireUserGroups) {
+      <mat-form-field>
+        <mat-label>Select Groups</mat-label>
+        <mat-select formControlName="groups" multiple>
+          @for (group of groupsList | async; track group) {
+            <mat-option [value]="group.id">{{ group.name }}</mat-option>
+          }
+        </mat-select>
+        <mat-hint>Select user groups to add to the application</mat-hint>
+      </mat-form-field>
+    }
+    @if (!hasGroupsToAdd && requireUserGroups) {
+      <gio-banner-error
+        >The current user is not associated to any groups. Add the user to one or more groups or disable the option to make group selection
+        mandatory while creating applications.</gio-banner-error
+      >
+    }
 
     <h3 class="form__securityTitle">Security</h3>
     @if (applicationTypes.length === 0) {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
@@ -42,7 +42,7 @@
       }
 
       @if (ownershipTransferMessage) {
-        <mat-hint>{{ ownershipTransferMessage }}</mat-hint>
+        <gio-banner-info>{{ ownershipTransferMessage }}</gio-banner-info>
       }
     </form>
   }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
@@ -27,6 +27,7 @@ import { Observable, of, startWith } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { MatListModule } from '@angular/material/list';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
 
 import { GroupMembership } from '../../../../../entities/group/groupMember';
 import { RoleName } from '../membershipState';
@@ -50,6 +51,7 @@ import { DeleteMemberDialogData } from '../group.component';
     MatChip,
     MatChipRemove,
     MatChipSet,
+    GioBannerModule,
   ],
   templateUrl: './delete-member-dialog.component.html',
   styleUrl: './delete-member-dialog.component.scss',

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
@@ -70,7 +70,7 @@
     }
 
     @if (ownershipTransferMessage) {
-      <mat-hint>{{ ownershipTransferMessage }}</mat-hint>
+      <gio-banner-info>{{ ownershipTransferMessage }}</gio-banner-info>
     }
   </form>
 </mat-dialog-content>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -28,7 +28,7 @@ import { MatInput } from '@angular/material/input';
 import { Observable, of, startWith } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
-import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { RoleName } from '../membershipState';
@@ -64,6 +64,7 @@ import { Group } from '../../../../../entities/group/group';
     MatChipRemove,
     MatChipSet,
     GioFormSlideToggleModule,
+    GioBannerModule,
   ],
   templateUrl: './edit-member-dialog.component.html',
   styleUrl: './edit-member-dialog.component.scss',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9249

## Description

Modified the group selection logic to display only the groups the user is a member of when the setting to add at least one group is enabled, instead of showing all available groups.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qrcyfqyblt.chromatic.com)
<!-- Storybook placeholder end -->
