### PR TITLE
fix: do not use cors methods in api v2 debug mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/debug/components/policy-studio-debug-request/policy-studio-debug-request.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/debug/components/policy-studio-debug-request/policy-studio-debug-request.component.ts
@@ -37,7 +37,7 @@ export class PolicyStudioDebugRequestComponent implements OnInit {
   @Output()
   public cancelSubmitted = new EventEmitter<void>();
 
-  public httpMethods = CorsUtil.httpMethods;
+  public httpMethods = ['GET', 'DELETE', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'TRACE', 'HEAD'];
 
   public requestFormGroup: UntypedFormGroup;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9257

## Description

do not use cors methods in api v2 debug mode

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-knvgvortoz.chromatic.com)
<!-- Storybook placeholder end -->
