### PR TITLE
[UI BUG] Global Alert configuration does not refresh properly after change

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
@@ -82,11 +82,10 @@ export class AlertComponent extends UpgradeComponent {
     });
 
     this.reload.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
-      Promise.all([
-        this.ajsAlertService.listAlerts(AlertScope.API, true, apiId).then((response) => {
-          return response.data;
-        }),
-      ]).then(([alerts]) => {
+      const listAlertPromise = apiId
+        ? this.ajsAlertService.listAlerts(AlertScope.API, true, apiId).then((response) => response.data)
+        : this.ajsAlertService.listAlerts(AlertScope.ENVIRONMENT, true).then((response) => response.data);
+      Promise.all([listAlertPromise]).then(([alerts]) => {
         // Hack to Force the binding between Angular and AngularJS
         this.ngOnChanges({
           alerts: new SimpleChange(null, alerts, false),


### PR DESCRIPTION
resolved global alert error while update by updating the AlertScope of the list alert api call from API to ENVIRONMENT for update event.

## Issue

https://gravitee.atlassian.net/browse/APIM-9123

## Description

[UI BUG] Global Alert configuration does not refresh properly after change.
UI bug when we Save/Edit a pre-existing Alert on APIM.

When we edit then save an existing alert after the save of the alert all the content in the Alert is deleted but when we exit the alert and then go back to the same alert we edited we will see that in fact all the information is saved.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lkfpwukmsl.chromatic.com)
<!-- Storybook placeholder end -->
