### PR TITLE
fix: restrict modification of Primary Owner role for applications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -140,6 +140,8 @@ public class MembershipService_UpdateMembershipForApiTest {
         when(membershipRepository.findById("existing-membership-id")).thenReturn(Optional.of(existingMembership));
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization()))
             .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization()))
+            .thenReturn(Optional.of(new RoleEntity()));
 
         MemberEntity updatedMember = membershipService.updateMembershipForApi(
             GraviteeContext.getExecutionContext(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8854

## Description

fixed issue where the Primary Owner (PO) role could be modified via cURL requests.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/11400/console](https://pr.team-apim.gravitee.dev/11400/console)
      Portal: [https://pr.team-apim.gravitee.dev/11400/portal](https://pr.team-apim.gravitee.dev/11400/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/11400/api/management](https://pr.team-apim.gravitee.dev/11400/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/11400](https://pr.team-apim.gravitee.dev/11400)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/11400](https://pr.gateway-v3.team-apim.gravitee.dev/11400)

<!-- Environment placeholder end -->
