### PR TITLE
fix(portal): keep serving classic portal from dist/ folder after Angular upgrade

### DIFF
--- a/gravitee-apim-portal-webui/angular.json
+++ b/gravitee-apim-portal-webui/angular.json
@@ -14,7 +14,8 @@
           "builder": "@angular/build:application",
           "options": {
             "outputPath": {
-              "base": "dist"
+              "base": "dist",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": ["src/polyfills.ts"],


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

After upgrading to Angular 19, the file structure of the built application for the Classic Portal was moved to `dist/browser`.
By specifying `"browser": ""` in the `angular.json` file, the Classic Portal will be served directly in the `dist/` folder.

![Screenshot 2025-04-07 at 15 58 50](https://github.com/user-attachments/assets/92a34e21-b712-4ceb-a496-58cb2bc8a9ce)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/11425/console](https://pr.team-apim.gravitee.dev/11425/console)
      Portal: [https://pr.team-apim.gravitee.dev/11425/portal](https://pr.team-apim.gravitee.dev/11425/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/11425/api/management](https://pr.team-apim.gravitee.dev/11425/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/11425](https://pr.team-apim.gravitee.dev/11425)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/11425](https://pr.gateway-v3.team-apim.gravitee.dev/11425)

<!-- Environment placeholder end -->
