### PR TITLE
fix:APIM-9123 Global Alert configuration does not refresh properly af…

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
@@ -89,11 +89,10 @@ export class AlertComponent extends UpgradeComponent {
     });
 
     this.reload.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
-      Promise.all([
-        this.ajsAlertService.listAlerts(AlertScope.API, true, this.apiId).then((response) => {
-          return response.data;
-        }),
-      ]).then(([alerts]) => {
+      const listAlertPromise = this.apiId
+        ? this.ajsAlertService.listAlerts(AlertScope.API, true, this.apiId).then((response) => response.data)
+        : this.ajsAlertService.listAlerts(AlertScope.ENVIRONMENT, true).then((response) => response.data);
+      Promise.all([listAlertPromise]).then(([alerts]) => {
         // Hack to Force the binding between Angular and AngularJS
         this.ngOnChanges({
           alerts: new SimpleChange(null, alerts, false),


### PR DESCRIPTION
…ter change

## Issue

https://gravitee.atlassian.net/browse/APIM-9123
## Description

[UI BUG] Global Alert configuration does not refresh properly after change.
UI bug when we Save/Edit a pre-existing Alert on APIM.

When we edit then save an existing alert after the save of the alert all the content in the Alert is deleted but when we exit the alert and then go back to the same alert we edited we will see that in fact all the information is saved.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-etitxnhves.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/11428/console](https://pr.team-apim.gravitee.dev/11428/console)
      Portal: [https://pr.team-apim.gravitee.dev/11428/portal](https://pr.team-apim.gravitee.dev/11428/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/11428/api/management](https://pr.team-apim.gravitee.dev/11428/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/11428](https://pr.team-apim.gravitee.dev/11428)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/11428](https://pr.gateway-v3.team-apim.gravitee.dev/11428)

<!-- Environment placeholder end -->
