### PR TITLE
feat(helm): allow users to set allowed source ranges for the gateway …

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -9,6 +9,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - bump elastisearch version to 8.17.2
 - bump elastisearch helm release to 19.21.2
 - bump mongodb helm release to 13.18.5
+- allow users to set allowed source ranges for the gateway LoadBalancer service
 
 ### 4.7.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -36,3 +36,5 @@ annotations:
       description: 'bump elastisearch helm release to 19.21.2'
     - kind: fixed
       description: 'bump mongodb helm release to 13.18.5'
+    - kind: added
+      description: 'Allow users to set allowed source ranges for the gateway LoadBalancer service'

--- a/helm/templates/gateway/gateway-service.yaml
+++ b/helm/templates/gateway/gateway-service.yaml
@@ -32,6 +32,12 @@ spec:
   {{- if .Values.gateway.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.gateway.service.loadBalancerIP }}"
   {{- end }}
+  {{- if eq .Values.gateway.service.type "LoadBalancer" }}
+  {{- if .Values.gateway.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: 
+  {{ toYaml .Values.gateway.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- end }}
   type: "{{ .Values.gateway.service.type }}"
   {{- if eq .Values.gateway.service.type "NodePort" "LoadBalancer" }}
   externalTrafficPolicy: {{ .Values.gateway.service.externalTrafficPolicy }}

--- a/helm/tests/gateway/service_test.yaml
+++ b/helm/tests/gateway/service_test.yaml
@@ -194,3 +194,18 @@ tests:
       - equal:
           path: metadata.annotations["loadbalancer.openstack.org/proxy-protocol"]
           value: "true"
+
+
+  - it: Should set loadBalancerSourceRanges
+    template: gateway/gateway-service.yaml
+    set:
+      gateway:
+        service:
+          type: LoadBalancer
+          loadBalancerSourceRanges:
+            - 35.191.0.0/16
+    asserts:
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value:
+            - "35.191.0.0/16"


### PR DESCRIPTION
Allow users to set allowed source ranges for the gateway LoadBalancer service

## Issue

## Description

Added a value `gateway.service.loadBalancerSourceRanges` to the helm chart that will only be used if the service type is LoadBalancer and will allow users to set the source range for the load balancer.
