### PR TITLE
fix(console): use banner to display information in the group page

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -198,11 +198,10 @@
       </mat-card-header>
       <mat-card-content>
         @if (maxInvitationsLimitReached) {
-          <mat-icon svgIcon="gio:info"></mat-icon
-          ><span
+          <gio-banner-info
             >The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been
-            disabled.</span
-          >
+            disabled.
+          </gio-banner-info>
         }
         <mat-tab-group (selectedIndexChange)="onTabChange($event)">
           <mat-tab label="Members">

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -26,6 +26,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { isEmpty } from 'lodash';
 import {
   GIO_DIALOG_WIDTH,
+  GioBannerModule,
   GioConfirmDialogComponent,
   GioConfirmDialogData,
   GioFormSlideToggleModule,
@@ -127,6 +128,7 @@ interface DeleteMemberDialogResult {
     MatTabsModule,
     MatMenuModule,
     GioTableWrapperModule,
+    GioBannerModule,
   ],
 })
 export class GroupComponent implements OnInit {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9269

## Description

The information that the maximum allowed number of members have been already added in the group should be displayed inside a banner to be consistent with the UI standard.

<img width="692" alt="Screenshot 2025-04-08 at 9 13 35 PM" src="https://github.com/user-attachments/assets/9ab60713-699e-4d08-b6bb-380e423bce76" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yvlolglcqu.chromatic.com)
<!-- Storybook placeholder end -->
