### PR TITLE
Kafka Access point & Sharding Tags 

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
@@ -44,20 +44,29 @@
           </mat-form-field>
         }
         @case ('KAFKA') {
-          <mat-form-field class="kafka__domain">
-            <mat-label>Default Kafka domain</mat-label>
-            <input matInput formControlName="kafkaDomain" />
-            <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('maxLength')"
-              >Kafka Domain must be less than 192 characters.</mat-error
-            >
-            <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('format')">Kafka Domain is not valid.</mat-error>
-          </mat-form-field>
-          <mat-form-field class="kafka__port">
-            <mat-label>Default Kafka port</mat-label>
-            <input matInput formControlName="kafkaPort" type="number" />
-            <mat-error *ngIf="mappingForm.get('kafkaPort').hasError('invalidPort')"
-              >Port should be in range between 1025 and 65535</mat-error
-            >
+          <div class="kafka">
+            <mat-form-field class="kafka__domain">
+              <mat-label>Default Kafka domain</mat-label>
+              <input matInput formControlName="kafkaDomain" />
+              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('maxLength')"
+                >Kafka Domain must be less than 192 characters.</mat-error
+              >
+              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('format')">Kafka Domain is not valid.</mat-error>
+            </mat-form-field>
+            <mat-form-field class="kafka__port">
+              <mat-label>Default Kafka port</mat-label>
+              <input matInput formControlName="kafkaPort" type="number" />
+              <mat-error *ngIf="mappingForm.get('kafkaPort').hasError('invalidPort')"
+                >Port should be in range between 1025 and 65535</mat-error
+              >
+            </mat-form-field>
+          </div>
+        }
+        @case ('TCP') {
+          <mat-form-field class="tcp__port">
+            <mat-label>Default TCP port</mat-label>
+            <input matInput formControlName="tcpPort" type="number" />
+            <mat-error *ngIf="mappingForm.get('tcpPort').hasError('invalidPort')">Port should be in range between 1025 and 65535</mat-error>
           </mat-form-field>
         }
       }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.scss
@@ -5,6 +5,14 @@
   mat-form-field {
     flex: 1 1 auto;
   }
+  .kafka {
+    display: flex;
+    gap: 8px;
+
+    &__port {
+      flex: 1;
+    }
+  }
 }
 
 .actions {

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
@@ -66,10 +66,10 @@ export class OrgSettingAddMappingDialogComponent {
         break;
       }
       case 'KAFKA': {
-        const [kafkaDomain, kafkaPort] = this.entrypoint?.value?.split(':') ?? ['', ''];
+        const [kafkaDomain, kafkaPort] = this.entrypoint?.value?.split(':') ?? ['', '9092'];
 
-        this.mappingForm.addControl('kafkaDomain', new FormControl(kafkaDomain ?? '', [Validators.required, kafkaDomainValidator]));
-        this.mappingForm.addControl('kafkaPort', new FormControl(kafkaPort ?? '9092', [Validators.required, portValidator]));
+        this.mappingForm.addControl('kafkaDomain', new FormControl(kafkaDomain, [Validators.required, kafkaDomainValidator]));
+        this.mappingForm.addControl('kafkaPort', new FormControl(kafkaPort, [Validators.required, portValidator]));
         break;
       }
     }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
@@ -32,6 +32,7 @@ type MappingFormGroup = {
   httpValue?: FormControl<string>;
   kafkaDomain?: FormControl<string>;
   kafkaPort?: FormControl<string>;
+  tcpPort?: FormControl<string>;
 };
 
 @Component({
@@ -72,6 +73,10 @@ export class OrgSettingAddMappingDialogComponent {
         this.mappingForm.addControl('kafkaPort', new FormControl(kafkaPort, [Validators.required, portValidator]));
         break;
       }
+      case 'TCP': {
+        this.mappingForm.addControl('tcpPort', new FormControl(this.entrypoint?.value, [Validators.required]));
+        break;
+      }
     }
   }
 
@@ -87,6 +92,9 @@ export class OrgSettingAddMappingDialogComponent {
         break;
       case 'KAFKA':
         value = formValue.kafkaDomain + ':' + formValue.kafkaPort;
+        break;
+      case 'TCP':
+        value = formValue.tcpPort;
         break;
     }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
@@ -226,6 +226,7 @@
         </button>
         <mat-menu #addMappingMenu="matMenu">
           <button mat-menu-item (click)="onAddEntrypointClicked('HTTP')">HTTP</button>
+          <button mat-menu-item (click)="onAddEntrypointClicked('TCP')">TCP</button>
           <button mat-menu-item (click)="onAddEntrypointClicked('KAFKA')">Kafka</button>
         </mat-menu>
       </div>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.management.v2.rest.model.BaseApi;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.ExposedEntrypoint;
 import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import io.gravitee.rest.api.management.v2.rest.model.IngestedApi;
 import io.gravitee.rest.api.management.v2.rest.model.IntegrationOriginContext;
@@ -452,4 +453,8 @@ public interface ApiMapper {
     ReviewEntity map(ApiReview apiReview);
 
     IngestedApi map(io.gravitee.apim.core.api.model.Api api);
+
+    ExposedEntrypoint map(io.gravitee.apim.core.api.model.ExposedEntrypoint entrypoint);
+
+    List<ExposedEntrypoint> map(List<io.gravitee.apim.core.api.model.ExposedEntrypoint> entrypoints);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
+import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
@@ -220,6 +221,9 @@ public class ApiResource extends AbstractResource {
 
     @Inject
     UpdateNativeApiUseCase updateNativeApiUseCase;
+
+    @Inject
+    GetExposedEntrypointsUseCase getExposedEntrypointsUseCase;
 
     @Context
     protected UriInfo uriInfo;
@@ -861,6 +865,23 @@ public class ApiResource extends AbstractResource {
             );
 
         return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/exposedEntrypoints")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.READ) })
+    public Response exposedEntrypoints(@PathParam("apiId") String apiId) {
+        var executionContext = GraviteeContext.getExecutionContext();
+
+        var input = new GetExposedEntrypointsUseCase.Input(
+            executionContext.getOrganizationId(),
+            executionContext.getEnvironmentId(),
+            apiId
+        );
+        var output = getExposedEntrypointsUseCase.execute(input);
+
+        return Response.ok().entity(ApiMapper.INSTANCE.map(output.exposedEntrypoints())).build();
     }
 
     private GenericApiEntity getGenericApiEntityById(String apiId, boolean prepareData) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -709,6 +709,26 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/exposedEntrypoints:
+        parameters:
+          - $ref: "#/components/parameters/envIdParam"
+          - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+              - APIs
+            summary: Get Exposed API Entrypoints
+            description: |-
+              Get the list of exposed API entry points. This list represents the API's usable entrypoints that can be used 
+              by a client. It takes into account tags associated with the API or configured AccessPoint.
+              
+              User must have the API_DEFINITION[READ] permission.
+            operationId: exposedEntrypoints
+            responses:
+                "200":
+                    $ref: "#/components/responses/ExposedEntrypointResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+
     # API Reviews
     /environments/{envId}/apis/{apiId}/reviews/_ask:
         parameters:
@@ -7465,6 +7485,14 @@ components:
               additionalProperties:
                 type: string
 
+        # API ExposedEntrypoints
+        ExposedEntrypoint:
+            type: object
+            properties:
+                value:
+                    type: string
+                    description: The url or host of the entrypoint depending on the API type
+                    example: https://my-api.domain.com/echo
 
 
     parameters:
@@ -8019,6 +8047,16 @@ components:
                             reason:
                                 type: string
                                 description: An optional reason giving details about the result.
+
+        ExposedEntrypointResponse:
+            description: List of exposed entrypoints
+            content:
+                application/json:
+                    schema:
+                        title: "ExposedEntrypointResponse"
+                        type: array
+                        items:
+                            $ref: "#/components/schemas/ExposedEntrypoint"
 
         # Analytics
         ApiAnalyticsRequestsCountResponse:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExposedEntrypointsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExposedEntrypointsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import fixtures.core.model.ApiFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_ExposedEntrypointsTest extends ApiResourceTest {
+
+    @Inject
+    private ApiCrudServiceInMemory apiCrudServiceInMemory;
+
+    @Inject
+    private ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/exposedEntrypoints";
+    }
+
+    @Test
+    public void should_get_ExposedEntrypoints() {
+        ApiDeploymentEntity deployEntity = new ApiDeploymentEntity();
+        deployEntity.setDeploymentLabel("label");
+
+        Api api = ApiFixtures.aProxyApiV4();
+        apiCrudServiceInMemory.initWith(List.of(api));
+        apiExposedEntrypointDomainServiceInMemory.initWith(List.of(new ExposedEntrypoint("http://myapi.domain.com")));
+
+        final Response response = rootTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        final List<io.gravitee.rest.api.management.v2.rest.model.ExposedEntrypoint> exposedEntrypoints = response.readEntity(
+            new GenericType<>() {}
+        );
+
+        assertNotNull(exposedEntrypoints);
+        assertEquals(1, exposedEntrypoints.size());
+        assertEquals("http://myapi.domain.com", exposedEntrypoints.get(0).getValue());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.spy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCRDExportDomainServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
@@ -48,6 +50,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
+import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
@@ -701,5 +704,13 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public GetExposedEntrypointsUseCase getExposedEntrypointsUseCase(
+        ApiCrudServiceInMemory apiCrudServiceInMemory,
+        ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory
+    ) {
+        return new GetExposedEntrypointsUseCase(apiCrudServiceInMemory, apiExposedEntrypointDomainServiceInMemory);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
@@ -42,6 +44,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
@@ -871,5 +874,13 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public GetExposedEntrypointsUseCase getExposedEntrypointsUseCase(
+        ApiCrudServiceInMemory apiCrudServiceInMemory,
+        ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory
+    ) {
+        return new GetExposedEntrypointsUseCase(apiCrudServiceInMemory, apiExposedEntrypointDomainServiceInMemory);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
@@ -41,6 +43,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
@@ -838,5 +841,13 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public GetExposedEntrypointsUseCase getExposedEntrypointsUseCase(
+        ApiCrudServiceInMemory apiCrudServiceInMemory,
+        ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory
+    ) {
+        return new GetExposedEntrypointsUseCase(apiCrudServiceInMemory, apiExposedEntrypointDomainServiceInMemory);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiExposedEntrypointDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiExposedEntrypointDomainService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import java.util.List;
+
+public interface ApiExposedEntrypointDomainService {
+    List<ExposedEntrypoint> get(String organizationId, String environmentId, Api api);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ExposedEntrypoint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ExposedEntrypoint.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+public record ExposedEntrypoint(String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetExposedEntrypointsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetExposedEntrypointsUseCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiExposedEntrypointDomainService;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetExposedEntrypointsUseCase {
+
+    private final ApiCrudService apiCrudService;
+    private final ApiExposedEntrypointDomainService apiExposedEntrypointDomainService;
+
+    public Output execute(Input input) {
+        var api = apiCrudService.get(input.apiId());
+
+        return new Output(apiExposedEntrypointDomainService.get(input.organizationId, input.environmentId, api));
+    }
+
+    public record Input(String organizationId, String environmentId, String apiId) {}
+
+    public record Output(List<ExposedEntrypoint> exposedEntrypoints) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -95,6 +95,7 @@ public interface ApiAdapter {
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     @Mapping(source = "version", target = "apiVersion")
     @Mapping(target = "metadata", ignore = true)
+    @Mapping(target = "listeners", expression = "java((List<Listener>) api.getApiListeners())")
     ApiEntity toApiEntity(Api api);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.ApiExposedEntrypointDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ApiExposedEntrypointDomainServiceLegacyWrapper implements ApiExposedEntrypointDomainService {
+
+    private final ApiEntrypointService apiEntrypointService;
+
+    @Override
+    public List<ExposedEntrypoint> get(String organizationId, String environmentId, Api api) {
+        GenericApiEntity genericApiEntity = api.getType() == ApiType.NATIVE
+            ? ApiAdapter.INSTANCE.toNativeApiEntity(api)
+            : ApiAdapter.INSTANCE.toApiEntity(api);
+
+        return apiEntrypointService
+            .getApiEntrypoints(new ExecutionContext(organizationId, environmentId), genericApiEntity)
+            .stream()
+            .map(entrypoint -> new ExposedEntrypoint(entrypoint.getTarget()))
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiExposedEntrypointDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiExposedEntrypointDomainServiceInMemory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.ApiExposedEntrypointDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApiExposedEntrypointDomainServiceInMemory
+    implements ApiExposedEntrypointDomainService, InMemoryAlternative<ExposedEntrypoint> {
+
+    final List<ExposedEntrypoint> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<ExposedEntrypoint> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ExposedEntrypoint> storage() {
+        return storage;
+    }
+
+    @Override
+    public List<ExposedEntrypoint> get(String organizationId, String environmentId, Api api) {
+        return storage;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -21,6 +21,7 @@ import inmemory.ApiCRDExportDomainServiceInMemory;
 import inmemory.ApiCategoryOrderQueryServiceInMemory;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
@@ -532,5 +533,10 @@ public class InMemoryConfiguration {
     @Bean
     public ApplicationQueryServiceInMemory applicationQueryService(ApplicationCrudServiceInMemory applicationCrudService) {
         return new ApplicationQueryServiceInMemory(applicationCrudService);
+    }
+
+    @Bean
+    public ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory() {
+        return new ApiExposedEntrypointDomainServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetExposedEntrypointsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetExposedEntrypointsUseCaseTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.ApiFixtures.aMessageApiV4;
+import static fixtures.core.model.ApiFixtures.aNativeApi;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class GetExposedEntrypointsUseCaseTest {
+
+    private final String API_ID = "api-id";
+    private final String ENV_ID = "env-id";
+    private final String ORG_ID = "org-id";
+    private final ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+    private final ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory =
+        new ApiExposedEntrypointDomainServiceInMemory();
+    private GetExposedEntrypointsUseCase getExposedEntrypointsUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getExposedEntrypointsUseCase = new GetExposedEntrypointsUseCase(apiCrudServiceInMemory, apiExposedEntrypointDomainServiceInMemory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        apiCrudServiceInMemory.reset();
+        apiExposedEntrypointDomainServiceInMemory.reset();
+    }
+
+    @Nested
+    class WithHttpV4Api {
+
+        private final Api API = aMessageApiV4().toBuilder().id(API_ID).environmentId(ENV_ID).build();
+
+        @Test
+        void should_return_exposed_entrypoint() {
+            // Given
+            apiCrudServiceInMemory.initWith(List.of(API));
+            apiExposedEntrypointDomainServiceInMemory.initWith(List.of(new ExposedEntrypoint("http://myapi.domain.com")));
+
+            // When
+            var output = getExposedEntrypointsUseCase.execute(new GetExposedEntrypointsUseCase.Input(ORG_ID, ENV_ID, API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals("http://myapi.domain.com", output.exposedEntrypoints().get(0).value());
+        }
+    }
+
+    @Nested
+    class WithNativeV4Api {
+
+        private final Api API = aNativeApi().toBuilder().id(API_ID).environmentId(ENV_ID).build();
+
+        @Test
+        void should_return_exposed_entrypoint() {
+            // Given
+            apiCrudServiceInMemory.initWith(List.of(API));
+            apiExposedEntrypointDomainServiceInMemory.initWith(List.of(new ExposedEntrypoint("myapi.kafka.domain.com:9092")));
+
+            // When
+            var output = getExposedEntrypointsUseCase.execute(new GetExposedEntrypointsUseCase.Input(ORG_ID, ENV_ID, API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals("myapi.kafka.domain.com:9092", output.exposedEntrypoints().get(0).value());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.mockito.Mockito.verify;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiExposedEntrypointDomainServiceLegacyWrapperTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+
+    @Mock
+    ApiEntrypointService apiEntrypointService;
+
+    ApiExposedEntrypointDomainServiceLegacyWrapper service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiExposedEntrypointDomainServiceLegacyWrapper(apiEntrypointService);
+    }
+
+    @Test
+    void should_call_legacy_service() {
+        service.get(ORGANIZATION_ID, ENVIRONMENT_ID, ApiFixtures.aProxyApiV4());
+
+        verify(apiEntrypointService)
+            .getApiEntrypoints(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                ApiAdapter.INSTANCE.toApiEntity(ApiFixtures.aProxyApiV4())
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
@@ -135,6 +135,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
@@ -179,6 +180,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.TCP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
@@ -252,6 +254,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
@@ -324,6 +327,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag-unmatching"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
 
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
@@ -350,6 +354,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
 
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
@@ -378,6 +383,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag-unmatching"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
 
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
@@ -407,6 +413,7 @@ class ApiEntrypointServiceImplTest {
         EntrypointEntity entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(Arrays.array("tag"));
         entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
 
         List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
@@ -443,6 +450,7 @@ class ApiEntrypointServiceImplTest {
         when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT)))
             .thenReturn("kafka.domain");
         when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("6666");
 
         var apiEntity = new NativeApiEntity();
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
@@ -455,16 +463,15 @@ class ApiEntrypointServiceImplTest {
 
         var entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(new String[] { "tag" });
-        entrypointEntity.setValue("kafka-entrypoint");
+        entrypointEntity.setValue("kafka-entrypoint:9042");
+        entrypointEntity.setTarget(EntrypointEntity.Target.KAFKA);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
-
-        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
 
         var apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
         assertThat(apiEntrypoints).hasSize(1);
         assertThat(apiEntrypoints.get(0).getHost()).isEqualTo("kafka-host");
-        assertThat(apiEntrypoints.get(0).getTarget()).isEqualTo("kafka-host.kafka.domain:9092");
+        assertThat(apiEntrypoints.get(0).getTarget()).isEqualTo("kafka-host.kafka-entrypoint:9042");
     }
 
     @Test
@@ -481,6 +488,7 @@ class ApiEntrypointServiceImplTest {
         var entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(new String[] { "unmatched-tag" });
         entrypointEntity.setValue("kafka-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.KAFKA);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
 
         when(parameterService.find(any(), eq(Key.PORTAL_ENTRYPOINT), any(), eq(ParameterReferenceType.ENVIRONMENT)))
@@ -557,6 +565,7 @@ class ApiEntrypointServiceImplTest {
         when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT)))
             .thenReturn("kafka.domain");
         when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("6666");
 
         var apiEntity = new NativeApiEntity();
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
@@ -569,17 +578,16 @@ class ApiEntrypointServiceImplTest {
 
         var entrypointEntity = new EntrypointEntity();
         entrypointEntity.setTags(new String[] { "tag1", "tag2" });
-        entrypointEntity.setValue("kafka-entrypoint");
+        entrypointEntity.setValue("kafka-entrypoint:9042");
+        entrypointEntity.setTarget(EntrypointEntity.Target.KAFKA);
         when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
-
-        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
 
         var apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
         assertThat(apiEntrypoints).hasSize(1);
         var entrypoint = apiEntrypoints.get(0);
         assertThat(entrypoint.getHost()).isEqualTo("kafka-host");
-        assertThat(entrypoint.getTarget()).isEqualTo("kafka-host.kafka.domain:9092");
+        assertThat(entrypoint.getTarget()).isEqualTo("kafka-host.kafka-entrypoint:9042");
         assertThat(entrypoint.getTags()).containsExactlyInAnyOrder("tag1", "tag2");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>3.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-reactor-message.version>6.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>2.0.6</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>3.0.0-alpha.2</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>6.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-7134
https://gravitee.atlassian.net/browse/CJ-2977

## Description

Allow console to configure sharding tags for tcp as well
Add a MapiV2 `exposedEntrypoints` endpoint that returns exposed entrypoints (kafka, http, tcp) as for the Portal
Next PR use `exposedEntrypoints` in console

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qegvezcnxp.chromatic.com)
<!-- Storybook placeholder end -->
