### PR TITLE
fix: add default group only at creation time

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -120,7 +120,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         newApiEntity.setTags(tagsValidationService.validateAndSanitize(executionContext, null, newApiEntity.getTags()));
         // Validate and clean groups
         newApiEntity.setGroups(
-            groupValidationService.validateAndSanitize(executionContext, null, newApiEntity.getGroups(), primaryOwnerEntity)
+            groupValidationService.validateAndSanitize(executionContext, null, newApiEntity.getGroups(), primaryOwnerEntity, true)
         );
         // Validate and clean listeners
         newApiEntity.setListeners(
@@ -174,7 +174,8 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
                 executionContext,
                 updateApiEntity.getId(),
                 updateApiEntity.getGroups(),
-                primaryOwnerEntity
+                primaryOwnerEntity,
+                false
             )
         );
         // Validate and clean listeners
@@ -228,7 +229,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         // Validate and clean tags
         apiEntity.setTags(tagsValidationService.validateAndSanitize(executionContext, null, apiEntity.getTags()));
         // Validate and clean groups
-        apiEntity.setGroups(groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), primaryOwnerEntity));
+        apiEntity.setGroups(
+            groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), primaryOwnerEntity, true)
+        );
         // Validate and clean listeners
         apiEntity.setListeners(
             listenerValidationService.validateAndSanitize(executionContext, null, apiEntity.getListeners(), apiEntity.getEndpointGroups())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -58,7 +58,8 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
         final ExecutionContext executionContext,
         final String apiId,
         final Set<String> groups,
-        final PrimaryOwnerEntity primaryOwnerEntity
+        final PrimaryOwnerEntity primaryOwnerEntity,
+        final boolean addDefaultGroups
     ) {
         Set<String> sanitizedGroups = new HashSet<>();
         if (groups != null && !groups.isEmpty()) {
@@ -70,13 +71,15 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
             }
         }
 
-        // Add default group
-        Set<String> defaultGroups = groupService
-            .findByEvent(executionContext.getEnvironmentId(), GroupEvent.API_CREATE)
-            .stream()
-            .map(GroupEntity::getId)
-            .collect(toSet());
-        sanitizedGroups.addAll(defaultGroups);
+        if (addDefaultGroups) {
+            // Add default groups on
+            Set<String> defaultGroups = groupService
+                .findByEvent(executionContext.getEnvironmentId(), GroupEvent.API_CREATE)
+                .stream()
+                .map(GroupEntity::getId)
+                .collect(toSet());
+            sanitizedGroups.addAll(defaultGroups);
+        }
 
         // if primary owner is a group, add it as a member of the API
         if (primaryOwnerEntity != null && ApiPrimaryOwnerMode.GROUP.name().equals(primaryOwnerEntity.getType())) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/GroupValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/GroupValidationService.java
@@ -28,6 +28,7 @@ public interface GroupValidationService {
         final ExecutionContext executionContext,
         final String apiId,
         final Set<String> groups,
-        final PrimaryOwnerEntity primaryOwnerEntity
+        final PrimaryOwnerEntity primaryOwnerEntity,
+        final boolean addDefaultGroups
     );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -137,7 +137,8 @@ public class ApiValidationServiceImplTest {
         apiValidationService.validateAndSanitizeNewApi(GraviteeContext.getExecutionContext(), newApiEntity, primaryOwnerEntity);
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null);
-        verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
+        verify(groupValidationService, times(1))
+            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity, true);
         verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), newApiEntity.getType(), null);
@@ -159,7 +160,8 @@ public class ApiValidationServiceImplTest {
         assertNull(apiEntity.getLifecycleState());
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, Set.of());
-        verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
+        verify(groupValidationService, times(1))
+            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity, true);
         verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
@@ -66,7 +66,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnValidatedGroupsWithNoApiAndExistingGroupWithoutApiPrimaryOwnerAndCurrentUserPrimaryOwner() {
+    public void shouldReturnValidatedGroupsWithNoApiAndDefaultGroupWithoutApiPrimaryOwnerAndCurrentUserPrimaryOwner() {
         // Given
         String groupId = "group";
         Set<String> groups = Set.of(groupId);
@@ -84,7 +84,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -94,7 +95,33 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnValidatedGroupsWithNoApiAndExistingGroupWithoutApiPrimaryOwnerAndCurrentGroupPrimaryOwner() {
+    public void shouldReturnValidatedGroupsWithNoApiWithoutDefaultGroupWithoutApiPrimaryOwnerAndCurrentUserPrimaryOwner() {
+        // Given
+        String groupId = "group";
+        Set<String> groups = Set.of(groupId);
+        GroupEntity groupEntity = new GroupEntity();
+        groupEntity.setId(groupId);
+        when(groupService.findByIds(groups)).thenReturn(Set.of(groupEntity));
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        GroupEntity defaultGroupEntity = new GroupEntity();
+
+        // When
+        Set<String> validatedGroups = groupValidationService.validateAndSanitize(
+            executionContext,
+            null,
+            groups,
+            new PrimaryOwnerEntity(new UserEntity()),
+            false
+        );
+
+        // Then
+        assertThat(validatedGroups).isNotNull();
+        assertThat(validatedGroups.size()).isEqualTo(1);
+        assertThat(validatedGroups.contains(groupId)).isTrue();
+    }
+
+    @Test
+    public void shouldReturnValidatedGroupsWithNoApiAndDefaultGroupWithoutApiPrimaryOwnerAndCurrentGroupPrimaryOwner() {
         // Given
         String groupId = "group";
         Set<String> groups = Set.of(groupId);
@@ -115,7 +142,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
-            new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL)
+            new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL),
+            true
         );
 
         // Then
@@ -125,7 +153,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnFilteredGroupsWithNoApiAndExistingGroupWithApiPrimaryOwner() {
+    public void shouldReturnFilteredGroupsWithNoApiAndDefaultGroupWithApiPrimaryOwner() {
         // Given
         String groupId = "group";
         Set<String> groups = Set.of(groupId);
@@ -144,7 +172,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -154,7 +183,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnValidatedGroupsWithApiAndExistingGroupsWithoutApiPrimaryOwnerAndGroupPrimaryOwner() {
+    public void shouldReturnValidatedGroupsWithApiAndDefaultGroupsWithoutApiPrimaryOwnerAndGroupPrimaryOwner() {
         // Given
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String apiId = "apiId";
@@ -180,7 +209,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -190,7 +220,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnValidatedGroupsWithApiAndExistingGroupsWithApiPrimaryOwnerAndGroupPrimaryOwner() {
+    public void shouldReturnValidatedGroupsWithApiAndDefaultGroupsWithApiPrimaryOwnerAndGroupPrimaryOwner() {
         // Given
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String apiId = "apiId";
@@ -217,7 +247,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -227,7 +258,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnValidatedGroupsWithApiAndExistingGroupsWithoutApiPrimaryOwnerAndUserPrimaryOwner() {
+    public void shouldReturnValidatedGroupsWithApiAndDefaultGroupsWithoutApiPrimaryOwnerAndUserPrimaryOwner() {
         // Given
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String apiId = "apiId";
@@ -253,7 +284,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -263,7 +295,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnFilteredGroupsWithApiAndExistingGroupsWithApiPrimaryOwnerAndUserPrimaryOwner() {
+    public void shouldReturnFilteredGroupsWithApiAndDefaultGroupsWithApiPrimaryOwnerAndUserPrimaryOwner() {
         // Given
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String apiId = "apiId";
@@ -290,7 +322,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
-            new PrimaryOwnerEntity(new UserEntity())
+            new PrimaryOwnerEntity(new UserEntity()),
+            true
         );
 
         // Then
@@ -300,7 +333,7 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnFilteredGroupsWithApiAndExistingGroupsWithApiPrimaryOwnerAndGroupPrimaryOwner() {
+    public void shouldReturnFilteredGroupsWithApiAndDefaultGroupsWithApiPrimaryOwnerAndGroupPrimaryOwner() {
         // Given
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String apiId = "apiId";
@@ -330,7 +363,8 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
-            new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL)
+            new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL),
+            true
         );
 
         // Then
@@ -353,7 +387,8 @@ public class GroupValidationServiceImplTest {
                     GraviteeContext.getExecutionContext(),
                     null,
                     groups,
-                    new PrimaryOwnerEntity(new UserEntity())
+                    new PrimaryOwnerEntity(new UserEntity()),
+                    true
                 )
             );
     }
@@ -365,7 +400,8 @@ public class GroupValidationServiceImplTest {
             GraviteeContext.getExecutionContext(),
             null,
             emptyGroups,
-            null
+            null,
+            true
         );
         Assertions.assertThat(validatedGroups).isEmpty();
         Assertions.assertThat(validatedGroups).isEqualTo(emptyGroups);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9168
https://gravitee.atlassian.net/browse/APIM-7730

## Description

Add default groups to APIs only at API creation time, not during an update.