### PR TITLE
fix: add default group only at creation time - 4.5.x

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
@@ -34,7 +34,7 @@ public class ValidateFederatedApiDomainService {
         if (newApi.getDefinitionVersion() != DefinitionVersion.FEDERATED) {
             throw new ValidationDomainException("Definition version is unsupported, should be FEDERATED");
         }
-        newApi.setGroups(groupValidationService.validateAndSanitize(Set.of(), newApi.getEnvironmentId(), primaryOwner));
+        newApi.setGroups(groupValidationService.validateAndSanitize(Set.of(), newApi.getEnvironmentId(), primaryOwner, true));
 
         // Reset lifecycle state as Federated API are not deployed on Gateway
         newApi.setLifecycleState(null);
@@ -46,7 +46,8 @@ public class ValidateFederatedApiDomainService {
         var groupIds = groupValidationService.validateAndSanitize(
             updateApi.getGroups(),
             existingApi.getEnvironmentId(),
-            primaryOwnerEntity
+            primaryOwnerEntity,
+            false
         );
         updateApi.setGroups(groupIds);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/GroupValidationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/GroupValidationServiceTest.java
@@ -56,7 +56,9 @@ public class GroupValidationServiceTest {
 
     @Test
     public void should_throw_when_groups_provided_do_not_exist() {
-        var throwable = catchThrowable(() -> groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER));
+        var throwable = catchThrowable(() ->
+            groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, false)
+        );
 
         assertThat(throwable).isInstanceOf(InvalidDataException.class);
     }
@@ -81,7 +83,7 @@ public class GroupValidationServiceTest {
         );
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, true);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1, "default-group-1", "default-group-2");
@@ -103,7 +105,7 @@ public class GroupValidationServiceTest {
         );
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, false);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1);
@@ -111,7 +113,7 @@ public class GroupValidationServiceTest {
 
     @Test
     public void should_do_nothing_when_no_groups() {
-        Set<String> validatedGroups = groupValidationService.validateAndSanitize(Set.of(), ENVIRONMENT_ID, null);
+        Set<String> validatedGroups = groupValidationService.validateAndSanitize(Set.of(), ENVIRONMENT_ID, null, false);
         assertThat(validatedGroups).isEmpty();
     }
 
@@ -122,7 +124,7 @@ public class GroupValidationServiceTest {
         var primaryOwner = PRIMARY_OWNER.toBuilder().id("group-id").type(PrimaryOwnerEntity.Type.GROUP).build();
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, primaryOwner);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, primaryOwner, false);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1, "group-id");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9168
https://gravitee.atlassian.net/browse/APIM-7730

## Description

Add default groups to APIs only at API creation time, not during an update.