### PR TITLE
fix: add default group only at creation time - 4.7.x

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
@@ -34,7 +34,7 @@ public class ValidateFederatedApiDomainService {
         if (newApi.getDefinitionVersion() != DefinitionVersion.FEDERATED) {
             throw new ValidationDomainException("Definition version is unsupported, should be FEDERATED");
         }
-        newApi.setGroups(groupValidationService.validateAndSanitize(Set.of(), newApi.getEnvironmentId(), primaryOwner));
+        newApi.setGroups(groupValidationService.validateAndSanitize(Set.of(), newApi.getEnvironmentId(), primaryOwner, true));
 
         // Reset lifecycle state as Federated API are not deployed on Gateway
         newApi.setLifecycleState(null);
@@ -46,7 +46,8 @@ public class ValidateFederatedApiDomainService {
         var groupIds = groupValidationService.validateAndSanitize(
             updateApi.getGroups(),
             existingApi.getEnvironmentId(),
-            primaryOwnerEntity
+            primaryOwnerEntity,
+            false
         );
         updateApi.setGroups(groupIds);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -150,7 +150,7 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         newApi.setTags(tagsValidationService.validateAndSanitize(executionContext, null, newApi.getTags()));
 
         // Validate groups
-        newApi.setGroups(groupValidationService.validateAndSanitize(newApi.getGroups(), newApi.getEnvironmentId(), primaryOwner));
+        newApi.setGroups(groupValidationService.validateAndSanitize(newApi.getGroups(), newApi.getEnvironmentId(), primaryOwner, true));
 
         // Validate and clean definition
         newApi.setApiDefinitionNativeV4(validateAndSanitizeNativeV4Definition(newApi.getApiDefinitionNativeV4(), executionContext));
@@ -173,7 +173,7 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
 
         // Validate groups
         toBeUpdatedApi.setGroups(
-            groupValidationService.validateAndSanitize(toBeUpdatedApi.getGroups(), toBeUpdatedApi.getEnvironmentId(), primaryOwner)
+            groupValidationService.validateAndSanitize(toBeUpdatedApi.getGroups(), toBeUpdatedApi.getEnvironmentId(), primaryOwner, false)
         );
 
         // Validate categories

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/GroupValidationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/GroupValidationServiceTest.java
@@ -56,7 +56,9 @@ public class GroupValidationServiceTest {
 
     @Test
     public void should_throw_when_groups_provided_do_not_exist() {
-        var throwable = catchThrowable(() -> groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER));
+        var throwable = catchThrowable(() ->
+            groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, false)
+        );
 
         assertThat(throwable).isInstanceOf(InvalidDataException.class);
     }
@@ -81,7 +83,7 @@ public class GroupValidationServiceTest {
         );
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, true);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1, "default-group-1", "default-group-2");
@@ -103,7 +105,7 @@ public class GroupValidationServiceTest {
         );
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, PRIMARY_OWNER, false);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1);
@@ -111,7 +113,7 @@ public class GroupValidationServiceTest {
 
     @Test
     public void should_do_nothing_when_no_groups() {
-        Set<String> validatedGroups = groupValidationService.validateAndSanitize(Set.of(), ENVIRONMENT_ID, null);
+        Set<String> validatedGroups = groupValidationService.validateAndSanitize(Set.of(), ENVIRONMENT_ID, null, false);
         assertThat(validatedGroups).isEmpty();
     }
 
@@ -122,7 +124,7 @@ public class GroupValidationServiceTest {
         var primaryOwner = PRIMARY_OWNER.toBuilder().id("group-id").type(PrimaryOwnerEntity.Type.GROUP).build();
 
         // When
-        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, primaryOwner);
+        var sanitized = groupValidationService.validateAndSanitize(Set.of(GROUP_1), ENVIRONMENT_ID, primaryOwner, false);
 
         // Then
         assertThat(sanitized).containsExactlyInAnyOrder(GROUP_1, "group-id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -244,7 +245,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             doAnswer(invocation -> Set.of("sanitized")).when(tagsValidationService).validateAndSanitize(any(), any(), any());
 
-            doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any());
+            doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any(), anyBoolean());
 
             doAnswer(invocationOnMock -> Set.of("sanitized")).when(categoryDomainService).toCategoryId(any(), any());
 
@@ -396,7 +397,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             doAnswer(invocation -> Set.of("sanitized")).when(tagsValidationService).validateAndSanitize(any(), any(), any());
 
-            doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any());
+            doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any(), anyBoolean());
 
             doAnswer(invocation ->
                     List.of(KafkaListener.builder().entrypoints(List.of(NativeEntrypoint.builder().type("sanitized").build())).build())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9168
https://gravitee.atlassian.net/browse/APIM-7730

## Description

Add default groups to APIs only at API creation time, not during an update.