### PR TITLE
fix: correct order for policy execution with jdbc

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -736,7 +736,7 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
                         ps.setString(4, flowStep.getDescription());
                         ps.setString(5, flowStep.getConfiguration());
                         ps.setBoolean(6, flowStep.isEnabled());
-                        ps.setInt(7, flowStep.getOrder());
+                        ps.setInt(7, i); //setOrder
                         ps.setString(8, flowStep.getCondition());
                         ps.setString(9, phase.name());
                         ps.setString(10, flowStep.getMessageCondition());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
@@ -92,12 +92,12 @@ public class FlowRepositoryTest extends AbstractManagementRepositoryTest {
         preStep.setName("pre-step");
         preStep.setPolicy("policy");
         preStep.setCondition("pre-condition");
-        preStep.setOrder(1);
+        preStep.setOrder(0);
         flow.setPre(List.of(preStep));
         flow.setReferenceId("my-orga");
         flow.setReferenceType(FlowReferenceType.ORGANIZATION);
         flow.setUpdatedAt(new Date(1470157767000L));
-        flow.setOrder(2);
+        flow.setOrder(0);
         List<FlowConsumer> consumers = new ArrayList<>();
         consumers.add(new FlowConsumer(FlowConsumerType.TAG, "tag-1"));
         flow.setConsumers(consumers);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
@@ -123,27 +123,27 @@ public class FlowV4RepositoryTest extends AbstractManagementRepositoryTest {
         requestStep.setName("request-step");
         requestStep.setPolicy("policy");
         requestStep.setCondition("request-condition");
-        requestStep.setOrder(1);
+        requestStep.setOrder(0);
         flow.setRequest(List.of(requestStep));
 
         FlowStep publishStep = new FlowStep();
         publishStep.setName("publish-step");
         publishStep.setPolicy("policy");
         publishStep.setCondition("publish-condition");
-        publishStep.setOrder(1);
+        publishStep.setOrder(0);
         flow.setPublish(List.of(publishStep));
 
         FlowStep subscribeStep = new FlowStep();
         subscribeStep.setName("subscribe-step");
         subscribeStep.setPolicy("policy");
         subscribeStep.setCondition("subscribe-condition");
-        subscribeStep.setOrder(1);
+        subscribeStep.setOrder(0);
         flow.setSubscribe(List.of(subscribeStep));
 
         flow.setReferenceId("my-orga");
         flow.setReferenceType(FlowReferenceType.ORGANIZATION);
         flow.setUpdatedAt(new Date(1470157767000L));
-        flow.setOrder(2);
+        flow.setOrder(0);
         flow.setTags(Set.of("tag-1"));
 
         Flow flowCreated = flowRepository.create(flow);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9331

## Description

fix: correct order for policy execution with jdbc

Before: 


https://github.com/user-attachments/assets/ba67eb72-4e93-4f08-87a8-482c0d14c3bb


After: 

https://github.com/user-attachments/assets/f58b533e-d6fb-499a-9fec-a580a5f66e58


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

