### PR TITLE
feat(portal): display multiple entrypoint hosts or urls according to api type

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -38,7 +38,7 @@
       <app-api-access
         [planSecurity]="detailsVM.result.planSecurity"
         [subscriptionStatus]="detailsVM.result.subscriptionStatus"
-        [entrypointUrl]="detailsVM.result.entrypointUrl"
+        [entrypointUrls]="detailsVM.result.entrypointUrls"
         [apiKey]="detailsVM.result.apiKey"
         [clientId]="detailsVM.result.clientId"
         [clientSecret]="detailsVM.result.clientSecret"

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -54,7 +54,7 @@ interface SubscriptionDetailsData {
   subscriptionStatus: SubscriptionStatusEnum;
   apiKey?: string;
   apiKeyConfigUsername?: string;
-  entrypointUrl?: string;
+  entrypointUrls?: string[];
   clientId?: string;
   clientSecret?: string;
   apiType?: ApiType;
@@ -126,7 +126,7 @@ export class SubscriptionsDetailsComponent implements OnInit {
           planUsageConfiguration: plan.usageConfiguration,
           subscriptionStatus: subscription.status,
           apiType: api.type,
-          entrypointUrl: api?.entrypoints?.[0],
+          entrypointUrls: api?.entrypoints,
         };
 
         if (subscription.status === 'ACCEPTED') {

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.html
@@ -25,7 +25,7 @@
     [planValidation]="plan.validation"
     [apiType]="api.type" />
   @if (plan.security === 'KEY_LESS') {
-    <app-api-access [planSecurity]="plan.security" [entrypointUrl]="api.entrypoints[0]" [apiType]="api.type" />
+    <app-api-access [planSecurity]="plan.security" [entrypointUrls]="api.entrypoints" [apiType]="api.type" />
   } @else {
     <div class="subscribe-to-api-checkout__container__right-column">
       @if (showApiKeyModeSelection()) {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -31,17 +31,38 @@
 
       @if (apiType === 'NATIVE') {
         <app-native-kafka-api-access
-          [entrypointUrl]="entrypointUrl ?? ''"
+          [entrypointUrls]="entrypointUrls ?? []"
           [planSecurity]="planSecurity"
           [apiKey]="apiKey ?? ''"
           [apiKeyConfigUsername]="apiKeyConfigUsername ?? ''"
           [clientId]="clientId ?? ''" />
-      } @else if (planSecurity === 'KEY_LESS' || planSecurity === 'API_KEY') {
+      } @else {
         @if (planSecurity === 'API_KEY') {
           <app-copy-code id="api-key" class="test-1" title="API Key" [text]="apiKey ?? ''" />
         }
-        <app-copy-code id="base-url" title="Base URL" [text]="entrypointUrl ?? ''" />
-        <app-copy-code id="command-line" title="Command Line" [text]="curlCmd" />
+
+        <div class="api-access__copy-code-content__calling-api">
+          <div class="m3-title-medium" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Calling the API</div>
+          @if (entrypointUrls?.length === 1) {
+            <app-copy-code id="base-url" title="Base URL" [text]="(entrypointUrls ?? [''])[0]" />
+          } @else if (entrypointUrls && entrypointUrls.length > 1) {
+            <mat-form-field appearance="outline" subscriptSizing="dynamic">
+              <mat-label i18n="@@subscriptionDetailsApiAccessBaseUrls">Base URLs</mat-label>
+              <mat-select [(value)]="selectedEntrypointUrl" id="select-entrypoints">
+                @for (entrypointUrl of entrypointUrls ?? []; track entrypointUrl) {
+                  <mat-option [value]="entrypointUrl">{{ entrypointUrl }}</mat-option>
+                }
+              </mat-select>
+              <app-copy-code-icon
+                matSuffix
+                (click)="$event.stopPropagation()"
+                [contentToCopy]="selectedEntrypointUrl()"
+                [label]="selectedEntrypointUrl()" />
+            </mat-form-field>
+          }
+
+          <app-copy-code id="command-line" [text]="curlCmd()" />
+        </div>
       }
     </mat-card-content>
   } @else {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
@@ -36,5 +36,11 @@
     display: flex;
     flex-flow: column;
     gap: 32px;
+
+    &__calling-api {
+      display: flex;
+      flex-flow: column;
+      gap: 8px;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 import { CopyCodeHarness } from '../copy-code/copy-code.harness';
 
@@ -28,8 +29,12 @@ export class ApiAccessHarness extends ComponentHarness {
     return await this.locateCopyCodeByTitle('Base URL').then(res => res.getText());
   }
 
+  public async getBaseURLSelect(): Promise<string | undefined> {
+    return await this.locatorForOptional(MatSelectHarness.with({ selector: '#base-urls' }))().then(res => res?.getValueText());
+  }
+
   public async getCommandLine(): Promise<string> {
-    return await this.locateCopyCodeByTitle('Command Line').then(res => res.getText());
+    return await this.locateCopyCodeById('command-line').then(res => res.getText());
   }
 
   public async getClientId(): Promise<string> {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
@@ -77,6 +77,24 @@
     Use the following commands as examples for calling the API.
   </div>
 
+  @if (entrypointUrls()?.length === 1) {
+    <app-copy-code id="host-url" title="Host" [text]="(entrypointUrls() ?? [''])[0]" />
+  } @else if (entrypointUrls() && entrypointUrls().length > 1) {
+    <mat-form-field class="native-kafka-api-access__section__selectEntrypointHost" appearance="outline" subscriptSizing="dynamic">
+      <mat-label i18n="@@nativeKafkaApiAccessEntrypointsHost">Entrypoints Host</mat-label>
+      <mat-select [(value)]="selectedEntrypointHost" id="select-entrypoints">
+        @for (entrypointUrl of entrypointUrls(); track entrypointUrl) {
+          <mat-option [value]="entrypointUrl">{{ entrypointUrl }}</mat-option>
+        }
+      </mat-select>
+      <app-copy-code-icon
+        matSuffix
+        (click)="$event.stopPropagation()"
+        [contentToCopy]="selectedEntrypointHost()"
+        [label]="selectedEntrypointHost()" />
+    </mat-form-field>
+  }
+
   <mat-tab-group aria-label="Example commands">
     <mat-tab label="Producer">
       <div class="native-kafka-api-access__tab-container">

--- a/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.scss
@@ -24,6 +24,10 @@
     display: flex;
     flex-flow: column;
     gap: 8px;
+
+    &__selectEntrypointHost {
+      padding-top: 4px;
+    }
   }
 
   &__learn-more {

--- a/gravitee-apim-portal-webui-next/src/components/copy-code/copy-code.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/copy-code/copy-code.component.html
@@ -15,17 +15,17 @@
     limitations under the License.
 
 -->
-@if (!!text) {
+@if (!!text()) {
   <div class="copy-code__copy-block">
-    @if (title) {
-      <div class="m3-body-medium">{{ title }}</div>
+    @if (title().length) {
+      <div class="m3-body-medium">{{ title() }}</div>
     }
     <div class="copy-code__command-line">
       <div class="copy-code__command-line__container">
         <pre class="copy-code__command-line__container__code">{{ passwordContent() }}</pre>
       </div>
 
-      @if (mode === 'PASSWORD') {
+      @if (mode() === 'PASSWORD') {
         <button
           mat-icon-button
           matSuffix
@@ -35,7 +35,7 @@
           <mat-icon> {{ hidePassword() ? 'visibility_off' : 'visibility' }}</mat-icon>
         </button>
       }
-      <app-copy-code-icon [contentToCopy]="text" [label]="title ?? ''" />
+      <app-copy-code-icon [contentToCopy]="text()" [label]="title()" />
     </div>
   </div>
 }

--- a/gravitee-apim-portal-webui-next/src/components/copy-code/copy-code.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/copy-code/copy-code.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, Input, Signal, signal } from '@angular/core';
+import { Component, computed, input, Signal, signal } from '@angular/core';
 import { MatIconButton } from '@angular/material/button';
 import { MatSuffix } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
@@ -27,18 +27,15 @@ import { CopyCodeIconComponent } from './copy-code-icon/copy-code-icon/copy-code
   styleUrl: './copy-code.component.scss',
 })
 export class CopyCodeComponent {
-  @Input()
-  text: string = '';
+  text = input<string>('');
 
-  @Input()
-  mode: 'TEXT' | 'PASSWORD' = 'TEXT';
+  mode = input<'TEXT' | 'PASSWORD'>('TEXT');
 
-  @Input()
-  title?: string;
+  title = input<string>('');
 
   hidePassword = signal(true);
 
   passwordContent: Signal<string> = computed(() =>
-    this.hidePassword() && this.mode === 'PASSWORD' ? this.text.replaceAll(/./g, '*') : this.text,
+    this.hidePassword() && this.mode() === 'PASSWORD' ? this.text().replaceAll(/./g, '*') : this.text(),
   );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-2778

## Description

A small description of what you did in that PR.

## Additional context

For Native API with multiple hosts

https://github.com/user-attachments/assets/aefc3adf-8450-49a0-98b0-8d603ef19d9c




Improvement for Proxy API : 

![image](https://github.com/user-attachments/assets/8f146de5-3270-459b-95f4-c748dfba0f2c)
![image](https://github.com/user-attachments/assets/d1464769-07bc-468a-94d6-164daecc6ae5)



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kgwkbtzgco.chromatic.com)
<!-- Storybook placeholder end -->
