### PR TITLE
fix(service): return no apis on search if api authorization result empty

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -175,6 +175,10 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
             .stream()
             .toList();
 
+        if (apiIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         Map<String, Object> filters = new HashMap<>();
         filters.put("api", apiIds);
         return apiSearchService.searchIds(executionContext, query, filters, null);
@@ -188,6 +192,10 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
         );
 
         List<String> apiIds = categoryApisOutput.results().stream().map(result -> result.api().getId()).collect(Collectors.toList());
+
+        if (apiIds.isEmpty()) {
+            return Collections.emptyList();
+        }
 
         Map<String, Object> filters = new HashMap<>();
         filters.put("api", apiIds);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9395

## Description

If a user had no APIs published in the developer portal but had APIs created in the console, then all APIs were shown in the portal, regardless of visibility or being unpublished.

The fix will not return any APIs if the `ApiAuthorizationService` returns an empty list of valid IDs.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-myvgklrybb.chromatic.com)
<!-- Storybook placeholder end -->
