### PR TITLE
fix(console): handle null referenceId in audit entries to prevent HTTP 500 error

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -215,7 +215,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         metadata.put(metadataKey, auditEntity.getReferenceId());
                     }
                 }
-            } else if (Audit.AuditReferenceType.APPLICATION.name().equals(auditEntity.getReferenceType().name())) {
+            } else if (
+                auditEntity.getReferenceId() != null &&
+                Audit.AuditReferenceType.APPLICATION.name().equals(auditEntity.getReferenceType().name())
+            ) {
                 metadataKey = "APPLICATION:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
                     try {
@@ -228,7 +231,9 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         metadata.put(metadataKey, auditEntity.getReferenceId());
                     }
                 }
-            } else if (Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())) {
+            } else if (
+                auditEntity.getReferenceId() != null && Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())
+            ) {
                 metadataKey = "API:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
                     try {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8831

## Description

Fixed null referenceId in audit entries to prevent HTTP 500 error
I believe it's possible for the referenceId to be null when adding a default API role or a default application role to a group. This is likely the cause of the error we’re encountering. To handle this scenario, I’ve added a null check, as referenceId can indeed be null in this context.

## Additional context

### Before
I get the error because referenceID is null
https://github.com/user-attachments/assets/525eda32-2661-4628-bd2f-08678fbe1026

### After
The data loads smoothly without any errors as we move through the pages.
https://github.com/user-attachments/assets/44a99e19-1bb1-479c-9444-c58f7f4489d9

