### PR TITLE
Dashboard analytics error - the given id must not be null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
@@ -120,7 +120,6 @@ public class EnvironmentAnalyticsResource {
     @Path("/response-time-over-time")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
     public EnvironmentAnalyticsOverPeriodResponse getResponseTimeOverTime(@QueryParam("from") Long from, @QueryParam("to") Long to) {
         Instant end = to != null ? Instant.ofEpochMilli(to) : Instant.now();
         Instant start = from != null ? Instant.ofEpochMilli(from) : end.minus(Duration.ofDays(1));
@@ -144,7 +143,6 @@ public class EnvironmentAnalyticsResource {
     @Path("/response-status-overtime")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
     public EnvironmentAnalyticsResponseStatusOvertimeResponse getResponseStatusOvertime(
         @QueryParam("from") Long from,
         @QueryParam("to") Long to
@@ -167,7 +165,6 @@ public class EnvironmentAnalyticsResource {
     @Path("/top-apps-by-request-count")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
     public EnvironmentAnalyticsTopAppsByRequestCountResponse getTopAppsByRequestCount(@BeanParam @Valid TimeRangeParam timeRangeParam) {
         var params = AnalyticsQueryParameters.builder().from(timeRangeParam.getFrom()).to(timeRangeParam.getTo()).build();
         var input = new SearchEnvironmentTopAppsByRequestCountUseCase.Input(GraviteeContext.getExecutionContext(), params);
@@ -184,7 +181,6 @@ public class EnvironmentAnalyticsResource {
     @Path("/top-failed-apis")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
     public EnvironmentAnalyticsTopFailedApisResponse getTopFailedApis(@BeanParam @Valid TimeRangeParam timeRangeParam) {
         var params = AnalyticsQueryParameters.builder().from(timeRangeParam.getFrom()).to(timeRangeParam.getTo()).build();
         var input = new SearchEnvironmentTopFailedApisUseCase.Input(GraviteeContext.getExecutionContext(), params);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9418

## Description

While testing the Homescreen dashboard, I noticed a bug that only affects users without the Admin role.

If you're using the Gravitee Console with an Admin role, everything works as expected—you can view all APIs and their metrics.

However, if you're logged in with **any role other than ADMIN** (e.g., **USER**), you'll likely encounter an error similar to the one shown below:
![image](https://github.com/user-attachments/assets/c8386dfb-fef1-4e8e-8bf7-04edac40b2dc)


## Additional context

**Bug Explanation**
When a user with a non-admin role (e.g., USER) accesses certain environmental analytics, they trigger permission checks like the following:

```
@Permissions({
  @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ })
})
```

Since this check references API_ANALYTICS, it assumes that the call is tied to a specific API. The system tries to validate access by extracting the API ID from the request URI, using UriInfo in the requestContext.

**The issue:**
When the call is coming from the dashboard, the URI doesn't contain an API ID—so the lookup fails. Specifically, getId() in PermissionFilter.java (line 114) returns null, and access is denied.

Admins bypass this issue because the permission check is short-circuited early for users with admin rights.

**Fix:**
Removed permission checks for the buggy dashboard analytics. The initial v4 analytics didn’t include these checks, so this change restores consistency with existing behavior.

Only 4 widgets were affected.
The remaining widgets function correctly as they don’t implement these permission checks.

