### PR TITLE
fix: access settings page for message api

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -209,6 +209,32 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
         subtitle: 'testSubtitle',
       },
     },
+    logging: {
+      maxDurationMillis: 1000,
+      audit: {
+        enabled: true,
+        trail: {
+          enabled: true,
+        },
+      },
+      user: {
+        displayed: true,
+      },
+      messageSampling: {
+        probabilistic: {
+          default: 0.01,
+          limit: 0.5,
+        },
+        count: {
+          default: 10,
+          limit: 100,
+        },
+        temporal: {
+          default: 'PT1S',
+          limit: 'PT1S',
+        },
+      },
+    },
   };
 
   return {

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -36,6 +36,7 @@ export interface PortalConfiguration {
   openAPIDocViewer?: PortalSettingsOpenAPIDocViewer;
   email?: PortalSettingsEmail;
   portalNext?: PortalSettingsPortalNext;
+  logging?: PortalSettingsLogging;
 }
 
 export type PortalSettingsMetadata = Record<string, string[]>;
@@ -229,5 +230,32 @@ export interface PortalSettingsPortalNext {
     title?: string;
     subtitle?: string;
     enabled?: boolean;
+  };
+}
+
+export interface PortalSettingsLogging {
+  maxDurationMillis?: number;
+  audit?: {
+    enabled?: boolean;
+    trail?: {
+      enabled: boolean;
+    };
+  };
+  user?: {
+    displayed?: boolean;
+  };
+  messageSampling?: {
+    probabilistic?: {
+      default: number;
+      limit: number;
+    };
+    count?: {
+      default: number;
+      limit: number;
+    };
+    temporal?: {
+      default: string;
+      limit: string;
+    };
   };
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.component.spec.ts
@@ -480,7 +480,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
   }
 
   function expectConsoleSettingsGetRequest(consoleSettingsResponse: ConsoleSettings) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/settings`);
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/portal`);
     req.flush(consoleSettingsResponse);
     expect(req.request.method).toEqual('GET');
   }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.component.ts
@@ -25,8 +25,8 @@ import { isIso8601DateValid } from './iso-8601-date.validator';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { Analytics, ApiV4, SamplingTypeEnum } from '../../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
-import { ConsoleSettings } from '../../../../../entities/consoleSettings';
-import { ConsoleSettingsService } from '../../../../../services-ngx/console-settings.service';
+import { PortalConfiguration } from '../../../../../entities/portal/portalSettings';
+import { PortalConfigurationService } from '../../../../../services-ngx/portal-configuration.service';
 
 @Component({
   selector: 'api-runtime-logs-message-settings',
@@ -37,18 +37,18 @@ export class ApiRuntimeLogsMessageSettingsComponent implements OnInit, OnDestroy
   @Input() public api: ApiV4;
   form: UntypedFormGroup;
   initialFormValue: unknown;
-  settings: ConsoleSettings;
+  settings: PortalConfiguration;
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
     private readonly apiService: ApiV2Service,
     private readonly snackBarService: SnackBarService,
-    private readonly consoleSettingsService: ConsoleSettingsService,
+    private readonly portalConfigService: PortalConfigurationService,
   ) {}
 
   public ngOnInit(): void {
-    this.consoleSettingsService
+    this.portalConfigService
       .get()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((settings) => {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
@@ -35,6 +35,7 @@ public class PortalConfigEntity {
     private PortalReCaptcha reCaptcha;
     private PortalScheduler scheduler;
     private Dashboards dashboards;
+    private Logging logging;
 
     public PortalConfigEntity() {
         super();
@@ -52,6 +53,7 @@ public class PortalConfigEntity {
         reCaptcha = new PortalReCaptcha();
         scheduler = new PortalScheduler();
         dashboards = new Dashboards();
+        logging = new Logging();
     }
 
     // Getters & Setters
@@ -165,5 +167,13 @@ public class PortalConfigEntity {
 
     public void setDashboards(Dashboards dashboards) {
         this.dashboards = dashboards;
+    }
+
+    public Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(Logging logging) {
+        this.logging = logging;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
@@ -40,6 +40,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
     private Documentation documentation;
     private OpenAPIDocViewer openAPIDocViewer;
     private PlanSettings plan;
+    private Logging logging;
 
     @Valid
     private Portal portal;
@@ -70,6 +71,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
         reCaptcha = new PortalReCaptcha();
         scheduler = new PortalScheduler();
         dashboards = new Dashboards();
+        logging = new Logging();
     }
 
     // Getters & Setters
@@ -191,6 +193,14 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
 
     public void setDashboards(Dashboards dashboards) {
         this.dashboards = dashboards;
+    }
+
+    public Logging getLogging() {
+        return logging;
+    }
+
+    public void setLogging(Logging logging) {
+        this.logging = logging;
     }
 
     // Classes

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -451,6 +451,14 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             portalConfigEntity.getScheduler(),
             portalConfigEntity.getDashboards(),
             portalConfigEntity.getDashboards().getApiStatus(),
+            portalConfigEntity.getLogging(),
+            portalConfigEntity.getLogging().getAudit(),
+            portalConfigEntity.getLogging().getAudit().getTrail(),
+            portalConfigEntity.getLogging().getUser(),
+            portalConfigEntity.getLogging().getMessageSampling(),
+            portalConfigEntity.getLogging().getMessageSampling().getCount(),
+            portalConfigEntity.getLogging().getMessageSampling().getProbabilistic(),
+            portalConfigEntity.getLogging().getMessageSampling().getTemporal(),
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -93,6 +93,11 @@ public class ConfigServiceTest {
         params.put(Key.PORTAL_ANALYTICS_ENABLED.key(), singletonList("true"));
         params.put(Key.OPEN_API_DOC_TYPE_SWAGGER_ENABLED.key(), singletonList("true"));
         params.put(Key.API_LABELS_DICTIONARY.key(), Arrays.asList("label1", "label2"));
+        params.put(Key.LOGGING_MESSAGE_SAMPLING_COUNT_LIMIT.key(), singletonList("100"));
+        params.put(LOGGING_MESSAGE_SAMPLING_COUNT_DEFAULT.key(), singletonList("10"));
+        params.put(Key.LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_LIMIT.key(), singletonList("0.5"));
+        params.put(LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_DEFAULT.key(), singletonList("0.01"));
+        params.put(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.key(), singletonList("PT1S"));
 
         when(
             mockParameterService.findAll(
@@ -124,6 +129,15 @@ public class ConfigServiceTest {
             .isEqualTo("Swagger");
         assertThat(portalSettings.getApi().getLabelsDictionary()).as("api labels").hasSize(2);
         assertThat(portalSettings.getCors().getExposedHeaders()).as("cors exposed headers").hasSize(2);
+        assertThat(portalSettings.getLogging().getMessageSampling().getCount().getLimit()).as("sampling count").isEqualTo(100);
+        assertThat(portalSettings.getLogging().getMessageSampling().getCount().getDefaultValue()).as("sampling count").isEqualTo(10);
+        assertThat(portalSettings.getLogging().getMessageSampling().getProbabilistic().getLimit())
+            .as("sampling probabilistic")
+            .isEqualTo(0.5);
+        assertThat(portalSettings.getLogging().getMessageSampling().getProbabilistic().getDefaultValue())
+            .as("sampling probabilistic")
+            .isEqualTo(0.01);
+        assertThat(portalSettings.getLogging().getMessageSampling().getTemporal().getLimit()).as("sampling temporal").isEqualTo("PT1S");
     }
 
     @Test
@@ -135,6 +149,11 @@ public class ConfigServiceTest {
         params.put(PORTAL_ANALYTICS_ENABLED.key(), singletonList("true"));
         params.put(OPEN_API_DOC_TYPE_SWAGGER_ENABLED.key(), singletonList("true"));
         params.put(PORTAL_HTTP_CORS_EXPOSED_HEADERS.key(), singletonList("OnlyOneHeader"));
+        params.put(LOGGING_MESSAGE_SAMPLING_COUNT_LIMIT.key(), singletonList("100"));
+        params.put(LOGGING_MESSAGE_SAMPLING_COUNT_DEFAULT.key(), singletonList("10"));
+        params.put(LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_LIMIT.key(), singletonList("0.5"));
+        params.put(LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_DEFAULT.key(), singletonList("0.01"));
+        params.put(LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.key(), singletonList("PT1S"));
 
         when(
             mockParameterService.findAll(
@@ -178,6 +197,19 @@ public class ConfigServiceTest {
             .contains(PORTAL_ANALYTICS_ENABLED.key())
             .as("Config metadata contains OPEN_API_DOC_TYPE_SWAGGER_ENABLED")
             .contains(OPEN_API_DOC_TYPE_SWAGGER_ENABLED.key());
+        assertThat(portalSettings.getLogging().getMessageSampling().getCount().getLimit()).as("sampling count limit").isEqualTo(100);
+        assertThat(portalSettings.getLogging().getMessageSampling().getCount().getDefaultValue())
+            .as("sampling count default")
+            .isEqualTo(10);
+        assertThat(portalSettings.getLogging().getMessageSampling().getProbabilistic().getLimit())
+            .as("sampling probabilistic limit")
+            .isEqualTo(0.5);
+        assertThat(portalSettings.getLogging().getMessageSampling().getProbabilistic().getDefaultValue())
+            .as("sampling probabilistic default")
+            .isEqualTo(0.01);
+        assertThat(portalSettings.getLogging().getMessageSampling().getTemporal().getLimit())
+            .as("sampling temporal limit")
+            .isEqualTo("PT1S");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8889

## Description

use environment level access for getting settings for console for APIs.

Current Prod:


https://github.com/user-attachments/assets/0c646d94-af2a-44f0-908a-21f97bd6ec26

New fix with /portal api for fetching settings -


https://github.com/user-attachments/assets/0597845e-cd17-441e-b96b-c153bc9bac60



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bilijaxrub.chromatic.com)
<!-- Storybook placeholder end -->
