### PR TITLE
ci: remove -SNAPSHOT for console and portal build

### DIFF
--- a/.circleci/ci/src/jobs/frontend/job-console-webui-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-console-webui-build.ts
@@ -34,7 +34,9 @@ export class ConsoleWebuiBuildJob {
     const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig, environment);
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
-    const apimVersion = computeApimVersion(environment);
+    const apimVersion = ['build_rpm_&_docker_images', 'release'].includes(environment.action)
+      ? environment.graviteeioVersion
+      : computeApimVersion(environment);
 
     const steps: Command[] = [
       new commands.Checkout(),

--- a/.circleci/ci/src/jobs/frontend/job-portal-webui-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-portal-webui-build.ts
@@ -34,7 +34,9 @@ export class PortalWebuiBuildJob {
     const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig, environment);
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
-    const apimVersion = computeApimVersion(environment);
+    const apimVersion = ['build_rpm_&_docker_images', 'release'].includes(environment.action)
+      ? environment.graviteeioVersion
+      : computeApimVersion(environment);
 
     const steps: Command[] = [
       new commands.Checkout(),

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -18,11 +18,11 @@ import { generateFullReleaseConfig } from '../pipeline-full-release';
 
 describe('Full release tests', () => {
   it.each`
-    baseBranch | branch     | isDryRun | dockerTagAsLatest | graviteeioVersion  | apimVersionPath                                           | expectedResult
-    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-dry-run.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-no-dry-run.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-latest.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'release-4-2-0-alpha.yml'}
+    baseBranch | branch     | isDryRun | dockerTagAsLatest | graviteeioVersion  | apimVersionPath                                              | expectedResult
+    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-no-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-latest.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'release-4-2-0-alpha.yml'}
   `(
     'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version $graviteeioVersion',
     ({ baseBranch, branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {

--- a/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
@@ -19,8 +19,8 @@ import { generateReleaseConfig } from '../pipeline-release';
 describe('Release tests', () => {
   it.each`
     baseBranch | branch     | isDryRun | apimVersionPath                                              | graviteeioVersion  | expectedResult
-    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${'./src/pipelines/tests/resources/common/pom.xml'}          | ${'4.2.0'}         | ${'release-4-2-0-dry-run.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'4.2.0'}         | ${'release-4-2-0-snapshot.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'4.2.0'}         | ${'release-4-2-0-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'4.2.0'}         | ${'release-4-2-0.yml'}
     ${'4.2.x'} | ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'4.2.0-alpha.1'} | ${'release-4-2-0-alpha.yml'}
   `(
     'should build release config on $branch with dry run $isDryRun and graviteeio version $graviteeioVersion',

--- a/.circleci/ci/src/pipelines/tests/resources/common/pom-alpha.xml
+++ b/.circleci/ci/src/pipelines/tests/resources/common/pom-alpha.xml
@@ -48,6 +48,6 @@
         <!-- Version properties -->
         <revision>4.2.0</revision>
         <sha1>-alpha.1</sha1>
-        <changelist/>
+        <changelist>-SNAPSHOT</changelist>
     </properties>
 </project>

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -208,7 +208,7 @@ jobs:
           apim-ui-project: gravitee-apim-console-webui
       - run:
           name: Update Build version
-          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-SNAPSHOT\"/' gravitee-apim-console-webui/build.json"
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-console-webui/build.json"
       - run:
           name: Build
           command: yarn build:prod
@@ -238,7 +238,7 @@ jobs:
           apim-ui-project: gravitee-apim-portal-webui
       - run:
           name: Update Build version
-          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-SNAPSHOT\"/' gravitee-apim-portal-webui/build.json"
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui/build.json"
       - run:
           name: Build
           command: yarn build:prod
@@ -249,7 +249,7 @@ jobs:
           apim-ui-project: gravitee-apim-portal-webui-next
       - run:
           name: Update Build version
-          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-SNAPSHOT\"/' gravitee-apim-portal-webui-next/build.json"
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
       - run:
           name: Build
           command: yarn build:prod


### PR DESCRIPTION
## Issue
n/a

## Description

Corrects releases so that UIs have the build.json without the -SNAPSHOT. 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

