### PR TITLE
feat: replace the in-product docs with a link to the user guide

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -44,6 +44,7 @@ export interface Constants {
   isOEM: boolean;
   customization?: ConsoleCustomization;
   defaultPortal: DefaultPortal;
+  build: Build;
 }
 
 // eslint-disable-next-line no-redeclare
@@ -216,3 +217,7 @@ export interface EnvSettings {
 }
 
 export type DefaultPortal = 'classic' | 'next' | null;
+
+export interface Build {
+  version: string;
+}

--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -23,7 +23,7 @@ import { computeStyles, LicenseConfiguration } from '@gravitee/ui-particles-angu
 import { toLower, toUpper } from 'lodash';
 
 import { AppModule } from './app.module';
-import { Constants, DefaultPortal } from './entities/Constants';
+import { Build, Constants, DefaultPortal } from './entities/Constants';
 import { getFeatureInfoData } from './shared/components/gio-license/gio-license-data';
 import { ConsoleCustomization } from './entities/management-api-v2/consoleCustomization';
 import { environment } from './environments/environment';
@@ -74,7 +74,7 @@ function fetchData(): Promise<{ constants: Constants; build: any }> {
         }));
     })
     .then(({ bootstrapResponse, build, production, defaultPortal }) => {
-      const constants = prepareConstants(bootstrapResponse, defaultPortal);
+      const constants = prepareConstants(bootstrapResponse, defaultPortal, build);
 
       constants.production = production ?? true;
 
@@ -118,7 +118,14 @@ function sanitizeBaseURLs(baseURLToSanitize: string): string {
   return baseURL;
 }
 
-function prepareConstants(bootstrap: { baseURL: string; organizationId: string }, defaultPortal: DefaultPortal): Constants {
+function prepareConstants(
+  bootstrap: {
+    baseURL: string;
+    organizationId: string;
+  },
+  defaultPortal: DefaultPortal,
+  build: Build,
+): Constants {
   if (bootstrap.baseURL.endsWith('/')) {
     bootstrap.baseURL = bootstrap.baseURL.slice(0, -1);
   }
@@ -140,6 +147,7 @@ function prepareConstants(bootstrap: { baseURL: string; organizationId: string }
     },
     isOEM: false,
     defaultPortal,
+    build: build,
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.html
@@ -45,7 +45,7 @@
             <ng-template matStepLabel>Choose Provider</ng-template>
             <gio-form-selection-inline formControlName="provider" class="list">
               <gio-form-selection-inline-card
-                *ngFor="let provider of integrationProviders.active"
+                *ngFor="let provider of integrationProviderService.getActiveProviders()"
                 [value]="provider.value"
                 class="gio-radio-button"
               >
@@ -67,14 +67,14 @@
               </gio-form-selection-inline-card>
             </gio-form-selection-inline>
 
-            @if (integrationProviders.comingSoon?.length) {
+            @if (this.integrationProviderService.getComingSoonProviders()?.length) {
               <div class="badges">
                 <span class="gio-badge-neutral">Coming soon</span>
               </div>
 
               <gio-form-selection-inline class="list">
                 <gio-form-selection-inline-card
-                  *ngFor="let provider of integrationProviders.comingSoon"
+                  *ngFor="let provider of this.integrationProviderService.getComingSoonProviders()"
                   [value]="provider.value"
                   class="gio-radio-button"
                   [disabled]="true"

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.spec.ts
@@ -31,6 +31,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { CreateIntegrationPayload } from '../integrations.model';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { IntegrationProviderService } from '../integration-provider.service';
 
 describe('CreateIntegrationComponent', () => {
   let fixture: ComponentFixture<CreateIntegrationComponent>;
@@ -42,6 +43,11 @@ describe('CreateIntegrationComponent', () => {
     success: jest.fn(),
   };
 
+  const fakeIntegrationProviderService = {
+    getActiveProviders: jest.fn(),
+    getComingSoonProviders: jest.fn(),
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [CreateIntegrationComponent],
@@ -50,6 +56,10 @@ describe('CreateIntegrationComponent', () => {
         {
           provide: SnackBarService,
           useValue: fakeSnackBarService,
+        },
+        {
+          provide: IntegrationProviderService,
+          useValue: fakeIntegrationProviderService,
         },
         {
           provide: GioTestingPermissionProvider,
@@ -79,12 +89,10 @@ describe('CreateIntegrationComponent', () => {
 
   describe('choose provider', () => {
     it('should set solace value', async (): Promise<void> => {
-      fixture.componentInstance.integrationProviders = {
-        active: [
-          { icon: 'aws-api-gateway', value: 'aws-api-gateway' },
-          { icon: 'solace', value: 'solace' },
-        ],
-      };
+      fakeIntegrationProviderService.getActiveProviders.mockReturnValue([
+        { icon: 'aws-api-gateway', value: 'aws-api-gateway' },
+        { icon: 'solace', value: 'solace' },
+      ]);
 
       const radioButtonsGroup: GioFormSelectionInlineHarness = await componentHarness.getRadioButtonsGroup();
       expect(await radioButtonsGroup.getSelectedValue()).toBeUndefined();
@@ -95,9 +103,7 @@ describe('CreateIntegrationComponent', () => {
     });
 
     it('should set correct value', async (): Promise<void> => {
-      fixture.componentInstance.integrationProviders = {
-        active: [{ icon: 'aws.svg', value: 'test_my_value' }],
-      };
+      fakeIntegrationProviderService.getActiveProviders.mockReturnValue([{ icon: 'aws.svg', value: 'test_my_value' }]);
 
       const radioButtonsGroup: GioFormSelectionInlineHarness = await componentHarness.getRadioButtonsGroup();
       expect(await radioButtonsGroup.getSelectedValue()).toBeUndefined();
@@ -107,16 +113,14 @@ describe('CreateIntegrationComponent', () => {
     });
 
     it('should have correct numbers of radio buttons', async (): Promise<void> => {
-      fixture.componentInstance.integrationProviders = {
-        active: [
-          { icon: 'aws.svg', value: 'aws-api-gateway' },
-          { icon: 'solace.svg', value: 'solace' },
-          { icon: 'apigee.svg', value: 'apigee' },
-          { icon: 'azure.svg', value: 'azure-api-management' },
-          { icon: 'confluent.svg', value: 'confluent-platform' },
-        ],
-        comingSoon: [{ icon: 'kong.svg', value: 'kong' }],
-      };
+      fakeIntegrationProviderService.getActiveProviders.mockReturnValue([
+        { icon: 'aws.svg', value: 'aws-api-gateway' },
+        { icon: 'solace.svg', value: 'solace' },
+        { icon: 'apigee.svg', value: 'apigee' },
+        { icon: 'azure.svg', value: 'azure-api-management' },
+        { icon: 'confluent.svg', value: 'confluent-platform' },
+      ]);
+      fakeIntegrationProviderService.getComingSoonProviders.mockReturnValue([{ icon: 'kong.svg', value: 'kong' }]);
       const radioCards: GioFormSelectionInlineCardHarness[] = await componentHarness.getRadioCards();
       expect(radioCards.length).toEqual(6);
     });

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
@@ -20,9 +20,10 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EMPTY } from 'rxjs';
 
-import { CreateIntegrationPayload, Integration, IntegrationProvider } from '../integrations.model';
+import { CreateIntegrationPayload, Integration } from '../integrations.model';
 import { IntegrationsService } from '../../../services-ngx/integrations.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { IntegrationProviderService } from '../integration-provider.service';
 
 @Component({
   selector: 'app-create-integration',
@@ -33,18 +34,6 @@ import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 export class CreateIntegrationComponent {
   private destroyRef: DestroyRef = inject(DestroyRef);
   public isLoading: boolean = false;
-  public integrationProviders: { active?: IntegrationProvider[]; comingSoon?: IntegrationProvider[] } = {
-    active: [
-      { icon: 'aws-api-gateway', value: 'aws-api-gateway' },
-      { icon: 'solace', value: 'solace' },
-      { icon: 'apigee', value: 'apigee' },
-      { icon: 'azure', value: 'azure-api-management' },
-      { icon: 'ibm-api-connect', value: 'ibm-api-connect' },
-      { icon: 'confluent', value: 'confluent-platform' },
-      { icon: 'mulesoft', value: 'mulesoft' },
-    ],
-    comingSoon: [],
-  };
   public chooseProviderForm = this.formBuilder.group({
     provider: ['', Validators.required],
   });
@@ -59,6 +48,7 @@ export class CreateIntegrationComponent {
     private readonly router: Router,
     private readonly activatedRoute: ActivatedRoute,
     private readonly snackBarService: SnackBarService,
+    protected readonly integrationProviderService: IntegrationProviderService,
   ) {}
 
   public onSubmit(): void {

--- a/gravitee-apim-console-webui/src/management/integrations/integration-agent/integration-agent.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-agent/integration-agent.component.html
@@ -52,51 +52,18 @@
         >
           Refresh Status
         </button>
-
-        <div class="separator"></div>
-
-        <cdk-accordion class="accordion">
-          <cdk-accordion-item class="accordion__item" #accordionItem="cdkAccordionItem" [attr.aria-expanded]="accordionItem.closed">
-            <div
-              class="header"
-              (click)="accordionItem.toggle()"
-              (keydown.enter)="accordionItem.toggle()"
-              tabindex="0"
-              data-testid="accordion-header"
-            >
-              <h5 class="title">{{ accordionItem.expanded ? 'Close' : 'Open' }} the agent connection wizard</h5>
-              <mat-icon [svgIcon]="accordionItem.expanded ? 'gio:nav-arrow-up' : 'gio:nav-arrow-down'"></mat-icon>
-            </div>
-            <div *ngIf="accordionItem.expanded" class="wizard">
-              <div class="wizard__item">
-                <div class="order">1</div>
-                <div class="content">
-                  <h5 class="content__title">Agent Configuration</h5>
-                  <p class="content__desc">Copy the configuration files and place them in the same folder.</p>
-
-                  <file-preview [payload]="codeForEditor"></file-preview>
-                </div>
-              </div>
-
-              <div class="wizard__item">
-                <div class="order">2</div>
-                <div class="content">
-                  <h5 class="content__title">Agent Deployment</h5>
-                  <p class="content__desc">
-                    Replace placeholders in the configuration file with providers data. Execute the following commands in the same directory
-                    as the previously downloaded files.
-                  </p>
-                  <code>
-                    <span gioClipboardCopyWrapper [alwaysVisible]="true" contentToCopy="docker compose up -d" class="command code-area">
-                      <span class="command__text">docker compose up -d</span>
-                    </span>
-                  </code>
-                </div>
-              </div>
-            </div>
-          </cdk-accordion-item>
-        </cdk-accordion>
       </mat-card-content>
+    </mat-card>
+    <mat-card>
+      <div class="documentation">
+        <div class="documentation__header">
+          <div class="documentation__header__title">
+            <h3>Connect to the Agent</h3>
+          </div>
+          <div class="documentation__header__subtitle">Follow the documentation to learn how to configure and deploy this agent.</div>
+        </div>
+        <a mat-raised-button [disabled]="!documentationUrl" [href]="documentationUrl" target="_blank" color="link"> View documentation </a>
+      </div>
     </mat-card>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/integrations/integration-agent/integration-agent.component.scss
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-agent/integration-agent.component.scss
@@ -71,6 +71,27 @@ $typography: map.get(gio.$mat-theme, typography);
   gap: 4px;
 }
 
+.documentation {
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+      @include mat.m2-typography-level($typography, subtitle-1);
+      margin: 0;
+    }
+
+    &__subtitle {
+      color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    }
+  }
+}
+
 gio-banner-error {
   margin: 0;
   width: 100%;

--- a/gravitee-apim-console-webui/src/management/integrations/integration-provider.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-provider.service.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IntegrationProviderService } from './integration-provider.service';
+
+describe('IntegrationProviderService', () => {
+  let service: IntegrationProviderService;
+
+  beforeEach(() => {
+    service = new IntegrationProviderService();
+  });
+
+  describe('getApimDocsNameByValue', () => {
+    it('should return the correct apimDocsName for a valid value', () => {
+      const result = service.getApimDocsNameByValue('aws-api-gateway');
+      expect(result).toBe('aws-api-gateway');
+    });
+
+    it('should return undefined for an unknown value', () => {
+      const result = service.getApimDocsNameByValue('nonexistent');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getActiveProviders', () => {
+    it('should return the list of active providers', () => {
+      const providers = service.getActiveProviders();
+      expect(providers.length).toBeGreaterThan(0);
+      expect(providers).toEqual(expect.arrayContaining([expect.objectContaining({ value: 'aws-api-gateway' })]));
+    });
+  });
+
+  describe('getComingSoonProviders', () => {
+    it('should return an empty array by default', () => {
+      const providers = service.getComingSoonProviders();
+      expect(providers).toEqual([]);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/integrations/integration-provider.service.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-provider.service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+
+import { IntegrationProvider } from './integrations.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IntegrationProviderService {
+  private integrationProviders: {
+    active: IntegrationProvider[];
+    comingSoon: IntegrationProvider[];
+  } = {
+    active: [
+      { icon: 'aws-api-gateway', value: 'aws-api-gateway', apimDocsName: 'aws-api-gateway' },
+      { icon: 'solace', value: 'solace', apimDocsName: 'solace' },
+      { icon: 'apigee', value: 'apigee', apimDocsName: 'apigee-x' },
+      { icon: 'azure', value: 'azure-api-management', apimDocsName: 'azure-api-management' },
+      { icon: 'ibm-api-connect', value: 'ibm-api-connect', apimDocsName: 'ibm-api-connect' },
+      { icon: 'confluent', value: 'confluent-platform', apimDocsName: 'confluent-platform' },
+      { icon: 'mulesoft', value: 'mulesoft', apimDocsName: 'mulesoft-anypoint' },
+    ],
+    comingSoon: [],
+  };
+
+  getApimDocsNameByValue(value: string): string | undefined {
+    return this.integrationProviders.active.find((p) => p.value === value)?.apimDocsName;
+  }
+
+  getActiveProviders(): IntegrationProvider[] {
+    return this.integrationProviders.active;
+  }
+
+  getComingSoonProviders(): IntegrationProvider[] {
+    return this.integrationProviders.comingSoon;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
@@ -82,6 +82,7 @@ export interface UpdateIntegrationPayload {
 export interface IntegrationProvider {
   icon: string;
   value: string;
+  apimDocsName: string;
 }
 
 export interface FederatedAPI {

--- a/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
@@ -53,6 +53,7 @@ export const CONSTANTS_TESTING: Constants = {
     v2BaseURL: 'https://url.test:3000/management/v2/environments/DEFAULT',
   },
   v2BaseURL: 'https://url.test:3000/management/v2',
+  build: { version: '4.7.1-alpha.1' },
 };
 
 @NgModule({


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8937

## Description

Instead of using an outdated, embedded static Docker Compose file, we now link to the APIM documentation based on the Gravitee version the customer is using.

![image](https://github.com/user-attachments/assets/b7af6e2a-efac-4ee2-a676-d7bf7ad7866b)

The View Documentation button directs users to the appropriate provider’s page, including the correct APIM version in the docs.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gedjqpvacq.chromatic.com)
<!-- Storybook placeholder end -->
