### PR TITLE
fix(console): initialize default roles in edit member dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -124,16 +124,16 @@ export class EditMemberDialogComponent implements OnInit {
   }
 
   private initializeForm() {
-    const groupRole = this.member.roles.find((member) => member.scope === 'GROUP');
+    const groupRole = this.member.roles['GROUP'];
     this.editMemberForm = new FormGroup({
       displayName: new FormControl<string>(this.member.displayName),
       groupAdmin: new FormControl<boolean>({
         value: !!groupRole && groupRole.name === 'ADMIN',
         disabled: !this.group.system_invitation,
       }),
-      defaultAPIRole: new FormControl<string>(this.member.roles.find((member) => member.scope === 'API').name),
-      defaultApplicationRole: new FormControl<string>(this.member.roles.find((member) => member.scope === 'APPLICATION').name),
-      defaultIntegrationRole: new FormControl<string>(this.member.roles.find((member) => member.scope === 'INTEGRATION').name),
+      defaultAPIRole: new FormControl<string>(this.member.roles['API']),
+      defaultApplicationRole: new FormControl<string>(this.member.roles['APPLICATION']),
+      defaultIntegrationRole: new FormControl<string>(this.member.roles['INTEGRATION']),
       searchTerm: new FormControl<string>({ value: '', disabled: true }),
     });
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9447

## Description

The default roles are not initialized properly in the edit member dialog while editing groups. This change deals with that problem.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ghhbmevncp.chromatic.com)
<!-- Storybook placeholder end -->
