### PR TITLE
fix(console): toggle group role in edit member dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -124,11 +124,10 @@ export class EditMemberDialogComponent implements OnInit {
   }
 
   private initializeForm() {
-    const groupRole = this.member.roles['GROUP'];
     this.editMemberForm = new FormGroup({
       displayName: new FormControl<string>(this.member.displayName),
       groupAdmin: new FormControl<boolean>({
-        value: !!groupRole && groupRole.name === 'ADMIN',
+        value: this.member.roles['GROUP'] === 'ADMIN',
         disabled: !this.group.system_invitation,
       }),
       defaultAPIRole: new FormControl<string>(this.member.roles['API']),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9246

## Description

The toggle in the edit member dialog is disabled irrespective of the group role present in the member roles.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sosbofhxhn.chromatic.com)
<!-- Storybook placeholder end -->
