### PR TITLE
fix(console): disable empty group form only when mode is edit

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -734,7 +734,7 @@ export class GroupComponent implements OnInit {
   }
 
   private disableForm() {
-    if (!this.canUpdateGroup()) {
+    if (this.mode === 'edit' && !this.canUpdateGroup()) {
       this.groupForm.disable();
       this.disableAddGroupToExistingAPIs = true;
       this.disableAddGroupToExistingApplications = true;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9462

## Description

When user does not have update permission and has create permission on groups and tries to create a group, the empty group form should be enabled.

![image](https://github.com/user-attachments/assets/be6b7b15-5d0a-428a-8d3d-30335acfaaf9)

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/cf4ff3cc-38d6-4df0-9cfa-7db6533eedc8" />

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/c33a9ca6-99b6-4b49-936f-16efdb80e7f2" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pewesedede.chromatic.com)
<!-- Storybook placeholder end -->
