### PR TITLE
fix(console): calculate classic portal preview url when not in classic mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-theme/portalTheme.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-theme/portalTheme.controller.ts
@@ -41,7 +41,14 @@ class PortalThemeController {
     private $sce,
   ) {
     $scope.themeForm = {};
-    $scope.targetURL = Constants.env.settings.portal.url;
+
+    const targetURL: string = Constants.env.settings.portal.url;
+    if (Constants.defaultPortal !== 'classic') {
+      $scope.targetURL = `${targetURL}${targetURL.endsWith('/') ? '' : '/'}classic`;
+    } else {
+      $scope.targetURL = targetURL;
+    }
+
     $scope.maxSize = Constants.env.settings.portal.uploadMedia.maxSizeInOctet;
 
     $scope.trustSrc = function (src) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9443

## Description

When not in classic mode, the next gen portal was displayed in Settings > Portal > Theme. 
The fix calculates that if the dev portal mode is not `classic`, then `/classic` is added to the end of the URL.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uiazxqctum.chromatic.com)
<!-- Storybook placeholder end -->
