### PR TITLE
fix(console): utilize full card width in groups and related tables

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -194,246 +194,239 @@
           </button>
         </mat-menu>
       </mat-card-header>
-      <mat-card-content>
-        @if (maxInvitationsLimitReached) {
-          <gio-banner-info
-            >The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been
-            disabled.
-          </gio-banner-info>
-        }
-        <mat-tab-group (selectedIndexChange)="onTabChange($event)">
-          <mat-tab label="Members">
-            @if (groupMembers$ | async; as members) {
+      @if (maxInvitationsLimitReached) {
+        <gio-banner-info
+          >The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been disabled.
+        </gio-banner-info>
+      }
+      <mat-tab-group (selectedIndexChange)="onTabChange($event)">
+        <mat-tab label="Members">
+          @if (groupMembers$ | async; as members) {
+            <gio-table-wrapper
+              [length]="noOfFilteredMembers"
+              [filters]="membersDefaultFilters"
+              (filtersChange)="filterGroupMembers($event)"
+            >
+              <table mat-table [dataSource]="filteredMembers" id="membersDataTable" aria-hidden="false" aria-label="Members Data Table">
+                <ng-container matColumnDef="name">
+                  <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+                  <td mat-cell *matCellDef="let row">
+                    <div>
+                      {{ row.displayName }}
+                      @if (row.roles['GROUP'] === 'ADMIN') {
+                        <span class="gio-badge-primary" tooltip="User is an administrator of the group">Admin</span>
+                      }
+                    </div>
+                  </td>
+                </ng-container>
+
+                <ng-container matColumnDef="defaultApiRole">
+                  <th mat-header-cell *matHeaderCellDef id="defaultApiRole">API Role</th>
+                  <td mat-cell *matCellDef="let row">
+                    <div>{{ row.roles['API'] }}</div>
+                  </td>
+                </ng-container>
+
+                <ng-container matColumnDef="defaultApplicationRole">
+                  <th mat-header-cell *matHeaderCellDef id="defaultApplicationRole">Application Role</th>
+                  <td mat-cell *matCellDef="let row">
+                    <div>{{ row.roles['APPLICATION'] }}</div>
+                  </td>
+                </ng-container>
+
+                <ng-container matColumnDef="defaultIntegrationRole">
+                  <th mat-header-cell *matHeaderCellDef id="defaultIntegrationRole">Integration Role</th>
+                  <td mat-cell *matCellDef="let row">
+                    <div>{{ row.roles['INTEGRATION'] }}</div>
+                  </td>
+                </ng-container>
+
+                <ng-container matColumnDef="actions">
+                  <th mat-header-cell *matHeaderCellDef id="actions"></th>
+                  <td mat-cell *matCellDef="let row">
+                    <button
+                      mat-button
+                      (click)="openEditMemberDialog(row)"
+                      matTooltip="Modify member settings"
+                      aria-hidden="false"
+                      aria-label="Click to edit group"
+                    >
+                      <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+                    </button>
+                    <button
+                      mat-button
+                      [disabled]="deleteDisabled"
+                      (click)="openDeleteMemberDialog(row)"
+                      matTooltip="Remove member from group"
+                      aria-hidden="false"
+                      aria-label="Click to delete group"
+                    >
+                      <mat-icon svgIcon="gio:trash"></mat-icon>
+                    </button>
+                  </td>
+                </ng-container>
+                <tr mat-header-row *matHeaderRowDef="memberColumnDefs"></tr>
+                <tr mat-row *matRowDef="let row; columns: memberColumnDefs"></tr>
+                <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+                  <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="memberColumnDefs.length">
+                    No members available to display
+                  </td>
+                </tr>
+              </table>
+            </gio-table-wrapper>
+          }
+        </mat-tab>
+        <mat-tab label="Invitations" lazy>
+          <ng-template matTabContent>
+            @if (invitations$ | async; as data) {
               <gio-table-wrapper
-                [length]="noOfFilteredMembers"
-                [filters]="membersDefaultFilters"
-                (filtersChange)="filterGroupMembers($event)"
+                [length]="noOfInvitations"
+                [filters]="invitationsDefaultFilters"
+                (filtersChange)="filterGroupInvitations($event)"
               >
-                <table mat-table [dataSource]="filteredMembers" id="membersDataTable" aria-hidden="false" aria-label="Members Data Table">
-                  <ng-container matColumnDef="name">
-                    <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+                <table
+                  mat-table
+                  [dataSource]="filteredInvitations"
+                  id="invitationsDataTable"
+                  aria-hidden="false"
+                  aria-label="Invitations Data Table"
+                >
+                  <ng-container matColumnDef="guestEmail">
+                    <th mat-header-cell *matHeaderCellDef id="guestEmail">Email</th>
                     <td mat-cell *matCellDef="let row">
-                      <div>
-                        {{ row.displayName }}
-                        @if (row.roles['GROUP'] === 'ADMIN') {
-                          <span class="gio-badge-primary" tooltip="User is an administrator of the group">Admin</span>
-                        }
-                      </div>
+                      <div>{{ row.email }}</div>
                     </td>
                   </ng-container>
 
-                  <ng-container matColumnDef="defaultApiRole">
-                    <th mat-header-cell *matHeaderCellDef id="defaultApiRole">API Role</th>
+                  <ng-container matColumnDef="guestApiRole">
+                    <th mat-header-cell *matHeaderCellDef id="guestApiRole">API Role</th>
                     <td mat-cell *matCellDef="let row">
-                      <div>{{ row.roles['API'] }}</div>
+                      <div>{{ row.api_role }}</div>
                     </td>
                   </ng-container>
 
-                  <ng-container matColumnDef="defaultApplicationRole">
-                    <th mat-header-cell *matHeaderCellDef id="defaultApplicationRole">Application Role</th>
+                  <ng-container matColumnDef="guestApplicationRole">
+                    <th mat-header-cell *matHeaderCellDef id="guestApplicationRole">Application Role</th>
                     <td mat-cell *matCellDef="let row">
-                      <div>{{ row.roles['APPLICATION'] }}</div>
+                      <div>{{ row.application_role }}</div>
                     </td>
                   </ng-container>
 
-                  <ng-container matColumnDef="defaultIntegrationRole">
-                    <th mat-header-cell *matHeaderCellDef id="defaultIntegrationRole">Integration Role</th>
+                  <ng-container matColumnDef="guestInvitedOn">
+                    <th mat-header-cell *matHeaderCellDef id="guestInvitedOn">Invitation Date</th>
                     <td mat-cell *matCellDef="let row">
-                      <div>{{ row.roles['INTEGRATION'] }}</div>
+                      <div>{{ row.created_at | date: 'MMM dd, yyyy' }}</div>
                     </td>
                   </ng-container>
 
-                  <ng-container matColumnDef="actions">
-                    <th mat-header-cell *matHeaderCellDef id="actions"></th>
+                  <ng-container matColumnDef="guestActions">
+                    <th mat-header-cell *matHeaderCellDef id="guestActions"></th>
                     <td mat-cell *matCellDef="let row">
                       <button
                         mat-button
-                        (click)="openEditMemberDialog(row)"
-                        matTooltip="Modify member settings"
+                        (click)="deleteInvitation(row.id, row.email)"
+                        matTooltip="Delete invitation"
                         aria-hidden="false"
-                        aria-label="Click to edit group"
-                      >
-                        <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-                      </button>
-                      <button
-                        mat-button
-                        [disabled]="deleteDisabled"
-                        (click)="openDeleteMemberDialog(row)"
-                        matTooltip="Remove member from group"
-                        aria-hidden="false"
-                        aria-label="Click to delete group"
+                        aria-label="Click to delete invitation"
                       >
                         <mat-icon svgIcon="gio:trash"></mat-icon>
                       </button>
                     </td>
                   </ng-container>
-                  <tr mat-header-row *matHeaderRowDef="memberColumnDefs"></tr>
-                  <tr mat-row *matRowDef="let row; columns: memberColumnDefs"></tr>
+                  <tr mat-header-row *matHeaderRowDef="invitationColumnDefs"></tr>
+                  <tr mat-row *matRowDef="let row; columns: invitationColumnDefs"></tr>
                   <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-                    <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="memberColumnDefs.length">
-                      No members available to display
+                    <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="invitationColumnDefs.length">
+                      No invitations sent to display
                     </td>
                   </tr>
                 </table>
               </gio-table-wrapper>
             }
-          </mat-tab>
-          <mat-tab label="Invitations" lazy>
-            <ng-template matTabContent>
-              @if (invitations$ | async; as data) {
-                <gio-table-wrapper
-                  [length]="noOfInvitations"
-                  [filters]="invitationsDefaultFilters"
-                  (filtersChange)="filterGroupInvitations($event)"
-                >
-                  <table
-                    mat-table
-                    [dataSource]="filteredInvitations"
-                    id="invitationsDataTable"
-                    aria-hidden="false"
-                    aria-label="Invitations Data Table"
-                  >
-                    <ng-container matColumnDef="guestEmail">
-                      <th mat-header-cell *matHeaderCellDef id="guestEmail">Email</th>
-                      <td mat-cell *matCellDef="let row">
-                        <div>{{ row.email }}</div>
-                      </td>
-                    </ng-container>
-
-                    <ng-container matColumnDef="guestApiRole">
-                      <th mat-header-cell *matHeaderCellDef id="guestApiRole">API Role</th>
-                      <td mat-cell *matCellDef="let row">
-                        <div>{{ row.api_role }}</div>
-                      </td>
-                    </ng-container>
-
-                    <ng-container matColumnDef="guestApplicationRole">
-                      <th mat-header-cell *matHeaderCellDef id="guestApplicationRole">Application Role</th>
-                      <td mat-cell *matCellDef="let row">
-                        <div>{{ row.application_role }}</div>
-                      </td>
-                    </ng-container>
-
-                    <ng-container matColumnDef="guestInvitedOn">
-                      <th mat-header-cell *matHeaderCellDef id="guestInvitedOn">Invitation Date</th>
-                      <td mat-cell *matCellDef="let row">
-                        <div>{{ row.created_at | date: 'MMM dd, yyyy' }}</div>
-                      </td>
-                    </ng-container>
-
-                    <ng-container matColumnDef="guestActions">
-                      <th mat-header-cell *matHeaderCellDef id="guestActions"></th>
-                      <td mat-cell *matCellDef="let row">
-                        <button
-                          mat-button
-                          (click)="deleteInvitation(row.id, row.email)"
-                          matTooltip="Delete invitation"
-                          aria-hidden="false"
-                          aria-label="Click to delete invitation"
-                        >
-                          <mat-icon svgIcon="gio:trash"></mat-icon>
-                        </button>
-                      </td>
-                    </ng-container>
-                    <tr mat-header-row *matHeaderRowDef="invitationColumnDefs"></tr>
-                    <tr mat-row *matRowDef="let row; columns: invitationColumnDefs"></tr>
-                    <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-                      <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="invitationColumnDefs.length">
-                        No invitations sent to display
-                      </td>
-                    </tr>
-                  </table>
-                </gio-table-wrapper>
-              }
-            </ng-template>
-          </mat-tab>
-        </mat-tab-group>
-      </mat-card-content>
+          </ng-template>
+        </mat-tab>
+      </mat-tab-group>
     </mat-card>
 
     <mat-card class="group__form__card">
       <mat-card-header>
         <mat-card-subtitle>APIs</mat-card-subtitle>
       </mat-card-header>
-      <mat-card-content>
-        @if (groupAPIs$ | async; as data) {
-          <gio-table-wrapper [length]="noOfAPIs" [filters]="apisDefaultFilters" (filtersChange)="filterGroupAPIs($event)">
-            <table mat-table [dataSource]="filteredAPIs" id="groupApisDataTable" aria-hidden="false" aria-label="Group APIs Data Table">
-              <ng-container matColumnDef="apiName">
-                <th mat-header-cell *matHeaderCellDef id="apiName">Name</th>
-                <td mat-cell *matCellDef="let row">
-                  <div>
-                    {{ row.name }}
-                    @if (row.visibility === 'PUBLIC') {
-                      <span class="gio-badge-warning">Public</span>
-                    }
+      @if (groupAPIs$ | async; as data) {
+        <gio-table-wrapper [length]="noOfAPIs" [filters]="apisDefaultFilters" (filtersChange)="filterGroupAPIs($event)">
+          <table mat-table [dataSource]="filteredAPIs" id="groupApisDataTable" aria-hidden="false" aria-label="Group APIs Data Table">
+            <ng-container matColumnDef="apiName">
+              <th mat-header-cell *matHeaderCellDef id="apiName">Name</th>
+              <td mat-cell *matCellDef="let row">
+                <div>
+                  {{ row.name }}
+                  @if (row.visibility === 'PUBLIC') {
+                    <span class="gio-badge-warning">Public</span>
+                  }
 
-                    @if (row.visibility === 'PRIVATE') {
-                      <span class="gio-badge-primary">Private</span>
-                    }
-                  </div>
-                </td>
-              </ng-container>
+                  @if (row.visibility === 'PRIVATE') {
+                    <span class="gio-badge-primary">Private</span>
+                  }
+                </div>
+              </td>
+            </ng-container>
 
-              <ng-container matColumnDef="apiVersion">
-                <th mat-header-cell *matHeaderCellDef id="apiVersion">Version</th>
-                <td mat-cell *matCellDef="let row">
-                  <div>{{ row.version }}</div>
-                </td>
-              </ng-container>
+            <ng-container matColumnDef="apiVersion">
+              <th mat-header-cell *matHeaderCellDef id="apiVersion">Version</th>
+              <td mat-cell *matCellDef="let row">
+                <div>{{ row.version }}</div>
+              </td>
+            </ng-container>
 
-              <tr mat-header-row *matHeaderRowDef="groupAPIColumnDefs"></tr>
-              <tr mat-row *matRowDef="let row; columns: groupAPIColumnDefs"></tr>
-              <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-                <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="groupAPIColumnDefs.length">No dependent APIs to display</td>
-              </tr>
-            </table>
-          </gio-table-wrapper>
-        }
-      </mat-card-content>
+            <tr mat-header-row *matHeaderRowDef="groupAPIColumnDefs"></tr>
+            <tr mat-row *matRowDef="let row; columns: groupAPIColumnDefs"></tr>
+            <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+              <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="groupAPIColumnDefs.length">No dependent APIs to display</td>
+            </tr>
+          </table>
+        </gio-table-wrapper>
+      }
     </mat-card>
 
     <mat-card class="group__form__card">
       <mat-card-header>
         <mat-card-subtitle>Applications</mat-card-subtitle>
       </mat-card-header>
-      <mat-card-content>
-        @if (groupApplications$ | async; as data) {
-          <gio-table-wrapper
-            [length]="noOfApplications"
-            [filters]="applicationsDefaultFilters"
-            (filtersChange)="filterGroupApplications($event)"
+      @if (groupApplications$ | async; as data) {
+        <gio-table-wrapper
+          [length]="noOfApplications"
+          [filters]="applicationsDefaultFilters"
+          (filtersChange)="filterGroupApplications($event)"
+        >
+          <table
+            mat-table
+            [dataSource]="filteredApplications"
+            id="groupApplicationsDataTable"
+            aria-hidden="false"
+            aria-label="Group Applications Data Table"
           >
-            <table
-              mat-table
-              [dataSource]="filteredApplications"
-              id="groupApplicationsDataTable"
-              aria-hidden="false"
-              aria-label="Group Applications Data Table"
-            >
-              <ng-container matColumnDef="applicationName">
-                <th mat-header-cell *matHeaderCellDef id="applicationName">Name</th>
-                <td mat-cell *matCellDef="let row">
-                  <div>
-                    {{ row.name }}
+            <ng-container matColumnDef="applicationName">
+              <th mat-header-cell *matHeaderCellDef id="applicationName">Name</th>
+              <td mat-cell *matCellDef="let row">
+                <div>
+                  {{ row.name }}
 
-                    @if (row.disable_membership_notifications) {
-                      <span class="gio-badge-warning">Membership Notifications Disabled</span>
-                    }
-                  </div>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="groupApplicationsColumnDefs"></tr>
-              <tr mat-row *matRowDef="let row; columns: groupApplicationsColumnDefs"></tr>
-              <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-                <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="groupApplicationsColumnDefs.length">
-                  No dependent applications to display
-                </td>
-              </tr>
-            </table>
-          </gio-table-wrapper>
-        }
-      </mat-card-content>
+                  @if (row.disable_membership_notifications) {
+                    <span class="gio-badge-warning">Membership Notifications Disabled</span>
+                  }
+                </div>
+              </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="groupApplicationsColumnDefs"></tr>
+            <tr mat-row *matRowDef="let row; columns: groupApplicationsColumnDefs"></tr>
+            <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+              <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="groupApplicationsColumnDefs.length">
+                No dependent applications to display
+              </td>
+            </tr>
+          </table>
+        </gio-table-wrapper>
+      }
     </mat-card>
   }
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
@@ -44,64 +44,64 @@
         </gio-form-slide-toggle>
       </form>
     }
-
-    @if (groups$ | async; as data) {
-      <gio-table-wrapper [length]="noOfRecords" [filters]="defaultFilters" (filtersChange)="filterData($event)">
-        <table mat-table [dataSource]="filteredData" id="groupsDataTable" aria-label="Groups Data Table">
-          <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef id="name">Name</th>
-            <td mat-cell *matCellDef="let row">
-              <div>
-                {{ row.name }}
-                @if (row.shouldAddToNewAPIs) {
-                  <span class="gio-badge-primary" tooltip="Group will be automatically added to new applications"
-                    >Automatically associated to APIs</span
-                  >
-                }
-
-                @if (row.shouldAddToNewApplications) {
-                  <span tooltip="Group will be automatically added to new APIs" class="gio-badge-primary"
-                    >Automatically associated to Applications</span
-                  >
-                }
-              </div>
-            </td>
-          </ng-container>
-
-          <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef id="actions"></th>
-            <td mat-cell *matCellDef="let row">
-              <button mat-button [routerLink]="['.', row.id]" matTooltip="Edit group" aria-hidden="false" aria-label="Click to edit group">
-                <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-              </button>
-              <button
-                mat-button
-                (click)="deleteGroup(row)"
-                [disabled]="deleteGroupDisabled()"
-                matTooltip="Delete group"
-                aria-hidden="false"
-                aria-label="Click to delete group"
-              >
-                <mat-icon svgIcon="gio:trash"></mat-icon>
-              </button>
-            </td>
-          </ng-container>
-
-          <tr mat-header-row *matHeaderRowDef="columnDefs"></tr>
-          <tr mat-row *matRowDef="let row; columns: columnDefs"></tr>
-          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="columnDefs.length">
-              @if (isLoading) {
-                <div class="mat-body">Loading...</div>
-              } @else {
-                <div class="mat-body">No groups available to display.</div>
-              }
-            </td>
-          </tr>
-        </table>
-      </gio-table-wrapper>
-    }
   </mat-card-content>
+
+  @if (groups$ | async; as data) {
+    <gio-table-wrapper [length]="noOfRecords" [filters]="defaultFilters" (filtersChange)="filterData($event)">
+      <table mat-table [dataSource]="filteredData" id="groupsDataTable" aria-label="Groups Data Table">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+          <td mat-cell *matCellDef="let row">
+            <div>
+              {{ row.name }}
+              @if (row.shouldAddToNewAPIs) {
+                <span class="gio-badge-primary" tooltip="Group will be automatically added to new applications"
+                  >Automatically associated to APIs</span
+                >
+              }
+
+              @if (row.shouldAddToNewApplications) {
+                <span tooltip="Group will be automatically added to new APIs" class="gio-badge-primary"
+                  >Automatically associated to Applications</span
+                >
+              }
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef id="actions"></th>
+          <td mat-cell *matCellDef="let row">
+            <button mat-button [routerLink]="['.', row.id]" matTooltip="Edit group" aria-hidden="false" aria-label="Click to edit group">
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <button
+              mat-button
+              (click)="deleteGroup(row)"
+              [disabled]="deleteGroupDisabled"
+              matTooltip="Delete group"
+              aria-hidden="false"
+              aria-label="Click to delete group"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="columnDefs"></tr>
+        <tr mat-row *matRowDef="let row; columns: columnDefs"></tr>
+        <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="columnDefs.length">
+            @if (isLoading) {
+              <div class="mat-body">Loading...</div>
+            } @else {
+              <div class="mat-body">No groups available to display.</div>
+            }
+          </td>
+        </tr>
+      </table>
+    </gio-table-wrapper>
+  }
 </mat-card>
 
 <gio-save-bar [form]="settingsForm" [formInitialValues]="initialSettings" (submitted)="saveSettings()"></gio-save-bar>

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { catchError, filter, finalize, map, switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import {
@@ -119,7 +119,7 @@ export class GroupsComponent implements OnInit {
   filteredData: GroupsResponse[] = [];
   noOfRecords: number = 0;
   isLoading: boolean = false;
-  deleteGroupDisabled = signal(false);
+  deleteGroupDisabled = false;
   addGroupDisabled = false;
 
   private groups = new BehaviorSubject<Group[]>([]);
@@ -278,9 +278,9 @@ export class GroupsComponent implements OnInit {
     const canDeleteGroup = this.permissionService.hasAnyMatching(['environment-group-d']);
 
     if (isOnlyGroupWithAPIRolePrimaryOwner) {
-      this.deleteGroupDisabled.set(true);
+      this.deleteGroupDisabled = true;
     } else if (!canDeleteGroup) {
-      this.deleteGroupDisabled.set(true);
+      this.deleteGroupDisabled = true;
     }
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2492

## Description

This small change allows groups and related tables to utilize full card width i.e. not the width of card content. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dwbncifwvs.chromatic.com)
<!-- Storybook placeholder end -->
