### PR TITLE
fix: 502 errors when keepalive activated with v4 emulation engine

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -134,7 +134,7 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
             if (cancelled.compareAndSet(false, true)) {
                 log.debug("Cancelling proxy response");
                 proxyResponse.cancel();
-                connection.cancel();
+                connection.end();
             }
         } catch (Exception e) {
             log.warn("Unable to properly cancel the proxy response.", e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponseTest.java
@@ -210,7 +210,7 @@ class FlowableProxyResponseTest {
         obs.assertValueCount(1);
 
         verify(proxyResponse).cancel();
-        verify(proxyConnection).cancel();
+        verify(proxyConnection).end();
     }
 
     private void setupChunkProducer(Runnable runnable) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-499

## Description

This PR aims to fix an issue when keep alive is activated with v4 emulation engine. The issue is that the gateway is closing the connection while it is being reused by another request. This is a consequence of a call to ProxyConnection cancel methods which in the end calls io.vertx.core.http.HttpClientRequest#reset(). By calling the end method instead, the connection can be reused as wanted.

