### PR TITLE
fix(console): prevent permission changes when 'Allows invitation via …

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ajs.ts
@@ -101,6 +101,7 @@ const GroupComponentAjs: ng.IComponentOptions = {
                 this.updateMode &&
                 (this.isSuperAdmin || (this.group.manageable && (this.group.system_invitation || this.group.email_invitation)));
 
+              this.enableDependentMember = this.isSuperAdmin && !(this.group.manageable && this.group.system_invitation);
               this.apiRoles = [{ scope: 'API', name: '', system: false }].concat(apiRolesResponse);
               this.applicationRoles = [{ scope: 'APPLICATION', name: '', system: false }].concat(applicationRolesResponse);
               this.invitations = invitationsResponse.data;
@@ -167,7 +168,7 @@ const GroupComponentAjs: ng.IComponentOptions = {
 
       this.update = () => {
         GroupService.updateEventRules(this.group, this.apiByDefault, this.applicationByDefault);
-
+        this.enableDependentMember = this.isSuperAdmin && !(this.group.manageable && this.group.system_invitation);
         if (!this.updateMode) {
           GroupService.create(this.group).then((response) => {
             ngRouter.navigate(['../', response.data.id], { relativeTo: this.activatedRoute });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
@@ -225,7 +225,7 @@
                         ng-false-value="''"
                         ng-change="$ctrl.updateRole(member)"
                         aria-label="Administrator of this group"
-                        ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
+                        ng-disabled="$ctrl.enableDependentMember"
                       >
                       </md-checkbox>
                     </td>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9326

## Description

Fix to prevent permission changes when 'Allows invitation via user search' is not saved

## Additional context

### BEFORE
https://github.com/user-attachments/assets/2aa29a5b-4375-4c93-a5b1-0ae83ce2194c

### AFTER
https://github.com/user-attachments/assets/c40f4272-e70e-4a54-9f63-fbf0e1f56f03
