### PR TITLE
fix(console): admin can change API and application roles in the group…

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -739,6 +739,14 @@ export class GroupComponent implements OnInit {
       this.disableAddGroupToExistingAPIs = true;
       this.disableAddGroupToExistingApplications = true;
     }
+
+    if (!this.group.value.lock_api_role) {
+      this.groupForm.controls.defaultAPIRole.enable();
+    }
+
+    if (!this.group.value.lock_application_role) {
+      this.groupForm.controls.defaultApplicationRole.enable();
+    }
   }
 
   private shouldAllowAddMembers() {


### PR DESCRIPTION
… when permitted

## Issue

https://gravitee.atlassian.net/browse/APIM-9489

## Description

Group admin should be allowed to change default API and Application roles in the group when settings("allow admin to change default API role" and "allow admin to change default API role") are enabled.

<img width="1068" alt="Screenshot 2025-05-02 at 4 16 27 PM" src="https://github.com/user-attachments/assets/7a78205a-6e20-4c7c-8f49-5d1a06fb47a8" />

**Enabled**

<img width="1149" alt="Screenshot 2025-05-02 at 4 14 16 PM" src="https://github.com/user-attachments/assets/457a7845-ae23-4deb-9e00-85dc9cb18551" />

<img width="1073" alt="Screenshot 2025-05-02 at 4 18 58 PM" src="https://github.com/user-attachments/assets/71acf31c-0d73-4408-9f6e-45f4a7dc44f2" />

**Disabled**

<img width="1073" alt="Screenshot 2025-05-02 at 4 21 25 PM" src="https://github.com/user-attachments/assets/6d75cd45-3762-4712-b871-c2f1b9efb2cb" />

<img width="1145" alt="Screenshot 2025-05-02 at 4 22 24 PM" src="https://github.com/user-attachments/assets/08a91451-2a2c-4a01-a59e-3e3e9cf988a9" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hnuepmhsac.chromatic.com)
<!-- Storybook placeholder end -->
