### PR TITLE
fix(console): restore changes - handle null referenceId in audit entries to prevent HTTP 500 error

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -215,7 +215,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         metadata.put(metadataKey, auditEntity.getReferenceId());
                     }
                 }
-            } else if (Audit.AuditReferenceType.APPLICATION.name().equals(auditEntity.getReferenceType().name())) {
+            } else if (
+                auditEntity.getReferenceId() != null &&
+                Audit.AuditReferenceType.APPLICATION.name().equals(auditEntity.getReferenceType().name())
+            ) {
                 metadataKey = "APPLICATION:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
                     try {
@@ -228,7 +231,9 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         metadata.put(metadataKey, auditEntity.getReferenceId());
                     }
                 }
-            } else if (Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())) {
+            } else if (
+                auditEntity.getReferenceId() != null && Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())
+            ) {
                 metadataKey = "API:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
                     try {


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-8831

## Description

Reapply reverted changes from PR [#11574](https://github.com/gravitee-io/gravitee-api-management/pull/11574)

It's possible for the referenceId to be null when adding a default API role or a default application role to a group. This is likely the cause of the error we’re encountering. To handle this scenario, I’ve added a null check, as referenceId can indeed be null in this context.

## Additional context
This PR reinstates the changes introduced in PR [#11574](https://github.com/gravitee-io/gravitee-api-management/pull/11574), which were reverted in PR [#11697](https://github.com/gravitee-io/gravitee-api-management/pull/11697) because they were not intended for the ongoing release and are instead scheduled for inclusion in the next one.

