### PR TITLE
feat(console): add envId and orgId to the loggers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetail
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
+import io.gravitee.rest.api.security.filter.ContextualLoggingFilter;
 import io.gravitee.rest.api.security.filter.CsrfIncludeFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextAuthorizationFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextFilter;
@@ -198,6 +199,7 @@ public class BasicSecurityConfigurerAdapter {
             new GraviteeContextFilter(installationTypeDomainService, accessPointQueryService, environmentService),
             CorsFilter.class
         );
+        http.addFilterAfter(new ContextualLoggingFilter(), GraviteeContextFilter.class);
         http.addFilterAfter(new GraviteeContextAuthorizationFilter(), AuthorizationFilter.class);
 
         return http.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetail
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
+import io.gravitee.rest.api.security.filter.ContextualLoggingFilter;
 import io.gravitee.rest.api.security.filter.CsrfIncludeFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextAuthorizationFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextFilter;
@@ -198,6 +199,7 @@ public class BasicSecurityConfigurerAdapter {
             new GraviteeContextFilter(installationTypeDomainService, accessPointQueryService, environmentService),
             CorsFilter.class
         );
+        http.addFilterAfter(new ContextualLoggingFilter(), GraviteeContextFilter.class);
         http.addFilterAfter(new GraviteeContextAuthorizationFilter(), AuthorizationFilter.class);
 
         return http.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/filter/ContextualLoggingFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/filter/ContextualLoggingFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.filter;
+
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ContextualLoggingFilter extends GenericFilterBean {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        MDC.clear();
+        String organization = GraviteeContext.getCurrentOrganization();
+
+        if (organization != null) {
+            MDC.put("orgId", organization);
+        }
+        String environment = GraviteeContext.getCurrentEnvironment();
+
+        if (environment != null) {
+            MDC.put("envId", environment);
+        }
+
+        log.debug("Contextual logging is on for organization: [{}] and environment: [{}]", organization, environment);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
@@ -22,6 +22,10 @@
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
+        <!--Organization ID and environment ID are both available in the MDC. Use the following pattern to add these in log statements.-->
+        <!--<encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>-->
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -35,8 +39,12 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%n</pattern>
         </encoder>
+        <!--Organization ID and environment ID are both available in the MDC. Use the following pattern to add these in log statements.-->
+        <!--<encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n%n</pattern>
+        </encoder>-->
     </appender>
 
     <appender name="FILE-UPGRADERS" class="ch.qos.logback.core.rolling.RollingFileAppender">

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -685,18 +685,30 @@ data:
               {{- else }}
               <!-- encoders are assigned the type
                   ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+              {{- if .Values.api.logging.contextualLoggingEnabled}}
+              <encoder>
+                  <pattern>{{ .Values.api.logging.stdout.contextualLoggingEncoderPattern }}</pattern>
+              </encoder>
+              {{- else}}
               <encoder>
                   <pattern>{{ .Values.api.logging.stdout.encoderPattern }}</pattern>
               </encoder>
-               {{- end }}
+             {{- end}}
+             {{- end }}
           </appender>
           {{- if .Values.api.logging.file.enabled }}
           <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
               <file>${gravitee.management.log.dir}/gravitee.log</file>
 {{ .Values.api.logging.file.rollingPolicy | indent 14 }}
+              {{- if .Values.api.logging.contextualLoggingEnabled}}
+              <encoder>
+                  <pattern>{{ .Values.api.logging.file.contextualLoggingEncoderPattern }}</pattern>
+              </encoder>
+              {{- else}}
               <encoder>
                   <pattern>{{ .Values.api.logging.file.encoderPattern }}</pattern>
               </encoder>
+              {{- end}}
           </appender>
           {{- end }}
 

--- a/helm/tests/api/configmap_logback_yaml_test.yaml
+++ b/helm/tests/api/configmap_logback_yaml_test.yaml
@@ -207,3 +207,72 @@ tests:
                       <appender-ref ref="FILE" />
                   </root>
               </configuration>
+
+  - it: should apply  contextual logging pattern when contextual logging enabled
+    template: api/api-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      api:
+        logging:
+          debug: true
+          contextualLoggingEnabled: true
+          stdout:
+            json: false
+          file:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["logback.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!--
+              ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+              ~
+              ~  Licensed under the Apache License, Version 2.0 (the "License");
+              ~  you may not use this file except in compliance with the License.
+              ~  You may obtain a copy of the License at
+              ~
+              ~  http://www.apache.org/licenses/LICENSE-2.0
+              ~
+              ~  Unless required by applicable law or agreed to in writing, software
+              ~  distributed under the License is distributed on an "AS IS" BASIS,
+              ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              ~  See the License for the specific language governing permissions and
+              ~  limitations under the License.
+              -->
+              <configuration>
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <!-- encoders are assigned the type
+                          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                      <encoder>
+                          <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n</pattern>
+                      </encoder>
+                  </appender>
+                  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                      <file>${gravitee.management.log.dir}/gravitee.log</file>
+                      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                          <!-- daily rollover -->
+                          <fileNamePattern>${gravitee.management.log.dir}/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
+                          <!-- keep 30 days' worth of history -->
+                          <maxHistory>30</maxHistory>
+                      </rollingPolicy>
+            
+                      <encoder>
+                          <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n%n</pattern>
+                      </encoder>
+                  </appender>
+
+                  <logger name="io.gravitee" level="DEBUG" />
+                  <logger name="org.eclipse.jetty" level="INFO" />
+
+                  <!-- Strictly speaking, the level attribute is not necessary since -->
+                  <!-- the level of the root level is set to DEBUG by default.       -->
+                  <root level="WARN">
+                      <appender-ref ref="STDOUT" />
+                      <appender-ref ref="FILE" />
+                  </root>
+              </configuration>

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -470,9 +470,11 @@ api:
   name: api
   logging:
     debug: false
+    contextualLoggingEnabled: false
     stdout:
       json: false
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+      contextualLoggingEncoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n"
     file:
       enabled: true
       rollingPolicy: |
@@ -483,6 +485,7 @@ api:
             <maxHistory>30</maxHistory>
         </rollingPolicy>
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%n"
+      contextualLoggingEncoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n%n"
     graviteeLevel: DEBUG
     jettyLevel: INFO
   restartPolicy: OnFailure


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9157

## Description

**Summary**

This Pull Request primarily introduces contextual logging functionality within the system. The changes enable the inclusion of organization and environment IDs in log entries, improving traceability and debugging capabilities.

**Main Changes**

- Added a new ContextualLoggingFilter class: Implements a filter to include organization (orgId) and environment (envId) identifiers in logging contexts using SLF4J's MDC.
- Modified security configuration files: Integrated the ContextualLoggingFilter in BasicSecurityConfigurerAdapter for both management and management-v2 modules.
- Updated logging patterns: Adjusted logback.xml and api-configmap.yaml to support contextual logging in log outputs if enabled.
- Introduced new Helm configuration options:
  `contextualLoggingEnabled`: A flag to enable/disable contextual logging.
  `contextualLoggingEncoderPattern`: A customizable logging pattern for contextual logs.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ozlfijhpcp.chromatic.com)
<!-- Storybook placeholder end -->
