### PR TITLE
fix: avoid stackoverflow on buffer append

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
@@ -53,5 +53,16 @@
             <artifactId>vertx-rx-java3</artifactId>
         </dependency>
 
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferImplBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferImplBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.buffer.netty;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@BenchmarkMode(Mode.Throughput)
+@Measurement(iterations = 5, time = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 2, time = 3)
+@State(Scope.Benchmark)
+public class BufferImplBenchmark {
+
+    private static final int count = 1000;
+    private static final String hello = "Hello";
+
+    @Benchmark
+    public void benchAppend() {
+        Buffer buffer = new BufferImpl();
+
+        for (int i = 0; i < count; i++) {
+            buffer = buffer.appendString(hello);
+        }
+
+        buffer.toString();
+    }
+
+    @Benchmark
+    public void benchAppendOld() {
+        Buffer bufferOld = new BufferOldImpl();
+
+        for (int i = 0; i < count; i++) {
+            bufferOld = bufferOld.appendString(hello);
+        }
+
+        bufferOld.toString();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferImplTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.buffer.netty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class BufferImplTest {
+
+    @Test
+    void should_construct_default() {
+        BufferImpl buffer = new BufferImpl();
+        assertEquals(0, buffer.length());
+    }
+
+    @Test
+    void should_construct_with_initial_size_hint() {
+        BufferImpl buffer = new BufferImpl(10);
+        assertEquals(0, buffer.length());
+    }
+
+    @Test
+    void should_construct_with_byte_array() {
+        byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+        BufferImpl buffer = new BufferImpl(data);
+        assertArrayEquals(data, buffer.getBytes());
+    }
+
+    @Test
+    void should_construct_with_string_and_charset_name() {
+        BufferImpl buffer = new BufferImpl("hello", "UTF-8");
+        assertEquals("hello", buffer.toString());
+    }
+
+    @Test
+    void should_construct_with_string_and_charset() {
+        BufferImpl buffer = new BufferImpl("hello", StandardCharsets.UTF_8);
+        assertEquals("hello", buffer.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void should_construct_with_string_default_charset() {
+        BufferImpl buffer = new BufferImpl("hello");
+        assertEquals("hello", buffer.toString());
+    }
+
+    @Test
+    void should_construct_with_null_string_and_charset_throws_null_pointer_exception() {
+        assertThrows(NullPointerException.class, () -> new BufferImpl(null, StandardCharsets.UTF_8));
+        assertThrows(NullPointerException.class, () -> new BufferImpl("text", (String) null));
+    }
+
+    @Test
+    void should_construct_with_null_charset_throws_null_pointer_exception() {
+        assertThrows(NullPointerException.class, () -> new BufferImpl("text", (Charset) null));
+    }
+
+    @Test
+    void should_construct_with_null_string_default_charset_throws_null_pointer_exception() {
+        assertThrows(NullPointerException.class, () -> new BufferImpl((String) null));
+    }
+
+    @Test
+    void should_append_buffer_appends_correctly() {
+        BufferImpl buffer1 = new BufferImpl("Hello");
+        BufferImpl buffer2 = new BufferImpl(" World");
+
+        buffer1.appendBuffer(buffer2);
+        assertEquals("Hello World", buffer1.toString());
+    }
+
+    @Test
+    void should_append_buffer_with_length_limit() {
+        BufferImpl buffer1 = new BufferImpl("Hello");
+        BufferImpl buffer2 = new BufferImpl(" World");
+
+        buffer1.appendBuffer(buffer2, 3);
+        assertEquals("Hello Wo", buffer1.toString());
+    }
+
+    @Test
+    void should_append_buffer_with_length_zero() {
+        BufferImpl buffer1 = new BufferImpl("Hello");
+        BufferImpl buffer2 = new BufferImpl(" World");
+
+        buffer1.appendBuffer(buffer2, 0);
+        assertEquals("Hello", buffer1.toString());
+    }
+
+    @Test
+    void should_append_buffer_with_length_greater_than_source() {
+        BufferImpl buffer1 = new BufferImpl("Hello");
+        BufferImpl buffer2 = new BufferImpl("!");
+
+        buffer1.appendBuffer(buffer2, 100); // only "!" should be appended
+        assertEquals("Hello!", buffer1.toString());
+    }
+
+    @Test
+    void should_append_empty_buffer_to_non_empty() {
+        BufferImpl buffer1 = new BufferImpl("Hello");
+        BufferImpl buffer2 = new BufferImpl();
+
+        buffer1.appendBuffer(buffer2);
+        assertEquals("Hello", buffer1.toString());
+    }
+
+    @Test
+    void should_append_to_empty_buffer() {
+        BufferImpl buffer1 = new BufferImpl();
+        BufferImpl buffer2 = new BufferImpl("Data");
+
+        buffer1.appendBuffer(buffer2);
+        assertEquals("Data", buffer1.toString());
+    }
+
+    @Test
+    void should_append_string_with_charset_name() {
+        BufferImpl buffer = new BufferImpl("Hello");
+        buffer.appendString(" World", "UTF-8");
+        assertEquals("Hello World", buffer.toString());
+    }
+
+    @Test
+    void should_append_string_with_default_charset() {
+        BufferImpl buffer = new BufferImpl("Hello");
+        buffer.appendString(" World");
+        assertEquals("Hello World", buffer.toString());
+    }
+
+    @Test
+    void should_append_multiple_buffers_in_sequence() {
+        BufferImpl buffer = new BufferImpl("Start");
+        buffer.appendBuffer(new BufferImpl("->Step1")).appendString("->Step2").appendBuffer(new BufferImpl("->End"));
+
+        assertEquals("Start->Step1->Step2->End", buffer.toString());
+    }
+
+    @Test
+    void should_append_to_composite_buffer() {
+        CompositeByteBuf composite = Unpooled.compositeBuffer();
+        composite.addComponent(true, Unpooled.copiedBuffer("Hello ", CharsetUtil.UTF_8));
+        BufferImpl buffer1 = new BufferImpl(composite);
+
+        BufferImpl buffer2 = new BufferImpl("World");
+        buffer1.appendBuffer(buffer2);
+
+        assertEquals("Hello World", buffer1.toString());
+    }
+
+    @Test
+    void should_append_large_number_of_buffers() {
+        Buffer buffer = new BufferImpl();
+        int count = 100000;
+        String hello = "Hello";
+
+        for (int i = 0; i < count; i++) {
+            buffer = buffer.appendString(hello);
+        }
+
+        ByteBuf nativeBuffer = buffer.getNativeBuffer();
+
+        assertThat(nativeBuffer).isInstanceOf(CompositeByteBuf.class);
+        assertThat(nativeBuffer.readableBytes()).isEqualTo(count * hello.length());
+        Buffer finalBuffer = buffer;
+        assertDoesNotThrow(() -> finalBuffer.toString());
+    }
+
+    @Test
+    void should_append_buffer_null_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("data");
+
+        assertThrows(NullPointerException.class, () -> buffer.appendBuffer(null));
+    }
+
+    @Test
+    void should_append_buffer_with_length_null_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("data");
+
+        assertThrows(NullPointerException.class, () -> buffer.appendBuffer(null, 5));
+    }
+
+    @Test
+    void should_append_string_with_null_string_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("base");
+
+        assertThrows(NullPointerException.class, () -> buffer.appendString(null));
+    }
+
+    @Test
+    void should_append_string_with_null_charset_name_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("base");
+
+        assertThrows(NullPointerException.class, () -> buffer.appendString("text", null));
+    }
+
+    @Test
+    void should_append_string_with_invalid_charset_name_throws_exception() {
+        BufferImpl buffer = new BufferImpl("base");
+
+        assertThrows(UnsupportedCharsetException.class, () -> buffer.appendString("test", "invalid-charset"));
+    }
+
+    @Test
+    void should_to_string_with_charset_name() {
+        BufferImpl buffer = new BufferImpl("test");
+        assertEquals("test", buffer.toString("UTF-8"));
+    }
+
+    @Test
+    void should_to_string_with_charset() {
+        BufferImpl buffer = new BufferImpl("test");
+        assertEquals("test", buffer.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void should_get_bytes_returns_correct_array() {
+        byte[] bytes = "data".getBytes(StandardCharsets.UTF_8);
+        BufferImpl buffer = new BufferImpl(bytes);
+        assertArrayEquals(bytes, buffer.getBytes());
+    }
+
+    @Test
+    void should_length_returns_correct_size() {
+        BufferImpl buffer = new BufferImpl("abc");
+        assertEquals(3, buffer.length());
+    }
+
+    @Test
+    void should_get_native_buffer_returns_same_instance() {
+        ByteBuf nativeBuf = Unpooled.buffer();
+        BufferImpl buffer = new BufferImpl(nativeBuf);
+        assertSame(nativeBuf, buffer.getNativeBuffer());
+    }
+
+    @Test
+    void should_to_string_with_null_charset_name_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("data");
+
+        assertThrows(IllegalArgumentException.class, () -> buffer.toString((String) null));
+    }
+
+    @Test
+    void should_to_string_with_invalid_charset_name_throws_exception() {
+        BufferImpl buffer = new BufferImpl("data");
+
+        assertThrows(UnsupportedCharsetException.class, () -> buffer.toString("invalid-charset"));
+    }
+
+    @Test
+    void should_to_string_with_null_charset_throws_null_pointer_exception() {
+        BufferImpl buffer = new BufferImpl("data");
+
+        assertThrows(NullPointerException.class, () -> buffer.toString((Charset) null));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferOldImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/test/java/io/gravitee/gateway/buffer/netty/BufferOldImpl.java
@@ -17,8 +17,6 @@ package io.gravitee.gateway.buffer.netty;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.reactivex.rxjava3.annotations.NonNull;
@@ -30,35 +28,35 @@ import java.util.Objects;
  * @author David BRASSELY (david at gravitee.io)
  * @author GraviteeSource Team
  */
-public class BufferImpl implements Buffer {
+public class BufferOldImpl implements Buffer {
 
     private ByteBuf buffer;
 
-    BufferImpl() {
+    BufferOldImpl() {
         this(0);
     }
 
-    BufferImpl(ByteBuf nativeBuffer) {
+    BufferOldImpl(ByteBuf nativeBuffer) {
         this.buffer = nativeBuffer;
     }
 
-    BufferImpl(int initialSizeHint) {
+    BufferOldImpl(int initialSizeHint) {
         buffer = Unpooled.unreleasableBuffer(Unpooled.buffer(initialSizeHint, Integer.MAX_VALUE));
     }
 
-    BufferImpl(byte[] bytes) {
+    BufferOldImpl(byte[] bytes) {
         buffer = Unpooled.unreleasableBuffer(Unpooled.buffer(bytes.length, Integer.MAX_VALUE)).writeBytes(bytes);
     }
 
-    BufferImpl(String str, String enc) {
+    BufferOldImpl(String str, String enc) {
         this(str.getBytes(Charset.forName(Objects.requireNonNull(enc))));
     }
 
-    BufferImpl(String str, Charset cs) {
+    BufferOldImpl(String str, Charset cs) {
         this(str.getBytes(cs));
     }
 
-    BufferImpl(String str) {
+    BufferOldImpl(String str) {
         this(str, StandardCharsets.UTF_8);
     }
 
@@ -85,20 +83,11 @@ public class BufferImpl implements Buffer {
     }
 
     private Buffer append(String str, Charset charset) {
-        return this.appendBuffer(new BufferImpl(str.getBytes(charset)));
+        return this.appendBuffer(new BufferOldImpl(str.getBytes(charset)));
     }
 
     private Buffer appendBuf(ByteBuf cb, int length) {
-        if (cb.writerIndex() > length) {
-            // Slice is needed only when appending sub part of the buffer.
-            cb = cb.slice(0, length);
-        }
-
-        if (buffer instanceof CompositeByteBuf composite && composite.maxNumComponents() == Integer.MAX_VALUE) {
-            buffer = composite.addComponent(true, cb);
-        } else {
-            buffer = new CompositeByteBuf(ByteBufAllocator.DEFAULT, false, Integer.MAX_VALUE, buffer, cb);
-        }
+        buffer = Unpooled.wrappedBuffer(buffer, cb.slice(0, length));
         return this;
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9523

## Description

This PR fixes an issue when combining a large number of buffers. This can happen when a client transfers large bodies and a policy that manipulates the request body is used.

To test the behavior before/after:

1. Generate a large json file: `yes '{"id":1,"name":"Sample","value":12345,"active":true}' | head -n 1000000 | paste -sd, - | sed 's/^/[/' | sed 's/$/]/' > output.json`
2. Deploy a V2 API with v4 emulated and a Json validation policy (schema isn't important, leave it to `{}`)
3. Send the file using curl: `curl --http1.1 -D- -k -H "Transfert-Encoding: chunked" https://localhost:8082/echo-v2/echo --data-binary @output.json`

Before the fix, it should fail with a stacktrace in the gateway's logs
