### PR TITLE
fix: api overlapping context config

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -32,7 +32,6 @@ import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeTransformer;
 import io.reactivex.rxjava3.core.Single;
-import java.util.function.Function;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -203,9 +202,12 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
         this.contextPath = contextPath;
         if (contextPath == null || contextPath.isEmpty()) {
             this.pathInfo = path();
-        } else {
+        } else if (path().length() > 1) {
             this.pathInfo = path().substring(contextPath.length() - 1);
+        } else {
+            this.pathInfo = "";
         }
+
         return this;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
@@ -44,7 +44,7 @@ public class GatewayConfiguration implements InitializingBean {
     static final String ORGANIZATION_SYSTEM_PROPERTY = "organizations";
     private static final String ORGANIZATIONS_SEPARATOR = ",";
 
-    private static final String ALLOW_OVERLAPPING_API_CONTEXTS_PROPERTY = "gravitee.api.allowOverlappingContext";
+    private static final String ALLOW_OVERLAPPING_API_CONTEXTS_PROPERTY = "api.allowOverlappingContext";
 
     private Optional<List<String>> shardingTags;
     private Optional<String> zone;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/overlapping/HttpRequestKeylessV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/overlapping/HttpRequestKeylessV4IntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.overlapping;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.dynamicrouting.DynamicRoutingPolicy;
+import io.gravitee.policy.dynamicrouting.configuration.DynamicRoutingPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Benoit Bordigoni (benoit.bordigoni at graviteesource.com)
+ * @author Gravitee Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpRequestKeylessV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put(
+            "dynamic-routing",
+            PolicyBuilder.build("dynamic-routing", DynamicRoutingPolicy.class, DynamicRoutingPolicyConfiguration.class)
+        );
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        gatewayConfigurationBuilder.setYamlProperty("api.allowOverlappingContext", "true");
+    }
+
+    @Test
+    @DisplayName("Should receive 200 - OK on overlapping context paths in the same API")
+    @DeployApi("/apis/v4/http/overlapping/api-2-in-1.json")
+    void should_get200_overlapping_path_in_single_api(HttpClient httpClient) throws InterruptedException {
+        assertCalls(httpClient);
+    }
+
+    @Test
+    @DisplayName("Should receive 200 - OK on overlapping context two APIs")
+    @DeployApi({ "/apis/v4/http/overlapping/api-0.json", "/apis/v4/http/overlapping/api-2.json" })
+    void should_get200_overlapping_path_in_2_apis(HttpClient httpClient) throws InterruptedException {
+        assertCalls(httpClient);
+    }
+
+    private void assertCalls(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get("/endpoint0").willReturn(ok("response from backend 0")));
+        wiremock.stubFor(get("/endpoint0/foo").willReturn(ok("response from backend 0/foo")));
+        wiremock.stubFor(get("/endpoint2").willReturn(ok("response from backend 2")));
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test/v2")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("response from backend 2");
+                return true;
+            })
+            .assertNoErrors();
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/foo")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("response from backend 0/foo");
+                return true;
+            })
+            .assertNoErrors();
+        httpClient
+            .rxRequest(HttpMethod.GET, "")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("response from backend 0");
+                return true;
+            })
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-0.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-0.json
@@ -1,0 +1,101 @@
+{
+    "id": "http-route-demo-0",
+    "name": "http-route-demo-0",
+    "version": "v1alpha1",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "entrypoints": [
+                {
+                    "qos": "auto",
+                    "type": "http-proxy"
+                }
+            ],
+            "pathMappings": [],
+            "paths": [
+                {
+                    "path": "/"
+                }
+            ],
+            "servers": [],
+            "type": "http"
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "rule-0",
+            "type": "http-proxy",
+            "sharedConfiguration": {},
+            "endpoints": [
+                {
+                    "name": "backend-0",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint0"
+                    },
+                    "secondary": false,
+                    "tenants": []
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "default",
+        "matchRequired": true
+    },
+    "flows": [
+        {
+            "name": "rule-0-match0",
+            "enabled": true,
+            "selectors": [
+                {
+                    "methods": [],
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "type": "http"
+                },
+                {
+                    "condition": "{#request.contextPath eq '/'}",
+                    "type": "condition"
+                }
+            ],
+            "request": [
+                {
+                    "enabled": true,
+                    "policy": "dynamic-routing",
+                    "configuration": {
+                        "rules": [
+                            {
+                                "pattern": "(.*)",
+                                "url": "rule-0:{#group[0]}"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "apiVersion": "v1alpha1",
+    "plans": [
+        {
+            "id": "170d5427-c05b-ae75-3d9f-60f91a44fef2",
+            "tags": [],
+            "status": "published",
+            "characteristics": [],
+            "validation": "AUTO",
+            "type": "API",
+            "definitionVersion": "V4",
+            "security": {
+                "type": "key-less",
+                "configuration": {}
+            },
+            "mode": "standard",
+            "flows": [],
+            "excludedGroups": [],
+            "name": "default"
+        }
+    ]
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-2-in-1.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-2-in-1.json
@@ -1,0 +1,152 @@
+{
+    "id": "http-route-demo-2-in-1",
+    "name": "http-route-demo-2-in-1",
+    "version": "v1alpha1",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "entrypoints": [
+                {
+                    "qos": "auto",
+                    "type": "http-proxy"
+                }
+            ],
+            "pathMappings": [],
+            "paths": [
+                {
+                    "path": "/test/v2"
+                },
+                {
+                    "path": "/"
+                }
+            ],
+            "servers": [],
+            "type": "http"
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "rule-0",
+            "type": "http-proxy",
+            "sharedConfiguration": {},
+            "endpoints": [
+                {
+                    "name": "backend-0",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint0"
+                    },
+                    "secondary": false,
+                    "tenants": []
+                }
+            ]
+        },
+        {
+            "name": "rule-2",
+            "type": "http-proxy",
+            "sharedConfiguration": {},
+            "endpoints": [
+                {
+                    "name": "backend-0",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint2"
+                    },
+                    "secondary": false,
+                    "tenants": []
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "default",
+        "matchRequired": true
+    },
+    "flows": [
+        {
+            "name": "rule-2-match0",
+            "enabled": true,
+            "selectors": [
+                {
+                    "methods": [],
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "type": "http"
+                },
+                {
+                    "condition": "{#request.contextPath eq '/test/v2/'}",
+                    "type": "condition"
+                }
+            ],
+            "request": [
+                {
+                    "enabled": true,
+                    "policy": "dynamic-routing",
+                    "configuration": {
+                        "rules": [
+                            {
+                                "pattern": "(.*)",
+                                "url": "rule-2:{#group[0]}"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "name": "rule-0-match0",
+            "enabled": true,
+            "selectors": [
+                {
+                    "methods": [],
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "type": "http"
+                },
+                {
+                    "condition": "{#request.contextPath eq '/'}",
+                    "type": "condition"
+                }
+            ],
+            "request": [
+                {
+                    "enabled": true,
+                    "policy": "dynamic-routing",
+                    "configuration": {
+                        "rules": [
+                            {
+                                "pattern": "(.*)",
+                                "url": "rule-0:{#group[0]}"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "apiVersion": "v1alpha1",
+    "plans": [
+        {
+            "id": "170d5427-c05b-ae75-3d9f-60f91a44fef2",
+            "tags": [],
+            "status": "published",
+            "characteristics": [],
+            "validation": "AUTO",
+            "type": "API",
+            "definitionVersion": "V4",
+            "security": {
+                "type": "key-less",
+                "configuration": {}
+            },
+            "mode": "standard",
+            "flows": [],
+            "excludedGroups": [],
+            "name": "default"
+        }
+    ]
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-2.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/overlapping/api-2.json
@@ -1,0 +1,101 @@
+{
+    "id": "http-route-demo-2",
+    "name": "http-route-demo-2",
+    "version": "v1alpha1",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "entrypoints": [
+                {
+                    "qos": "auto",
+                    "type": "http-proxy"
+                }
+            ],
+            "pathMappings": [],
+            "paths": [
+                {
+                    "path": "/test/v2"
+                }
+            ],
+            "servers": [],
+            "type": "http"
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "rule-2",
+            "type": "http-proxy",
+            "sharedConfiguration": {},
+            "endpoints": [
+                {
+                    "name": "backend-0",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint2"
+                    },
+                    "secondary": false,
+                    "tenants": []
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "default",
+        "matchRequired": true
+    },
+    "flows": [
+        {
+            "name": "rule-2-match0",
+            "enabled": true,
+            "selectors": [
+                {
+                    "methods": [],
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "type": "http"
+                },
+                {
+                    "condition": "{#request.contextPath eq '/test/v2/'}",
+                    "type": "condition"
+                }
+            ],
+            "request": [
+                {
+                    "enabled": true,
+                    "policy": "dynamic-routing",
+                    "configuration": {
+                        "rules": [
+                            {
+                                "pattern": "(.*)",
+                                "url": "rule-2:{#group[0]}"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "apiVersion": "v1alpha1",
+    "plans": [
+        {
+            "id": "170d5427-c05b-ae75-3d9f-60f91a44fef2",
+            "tags": [],
+            "status": "published",
+            "characteristics": [],
+            "validation": "AUTO",
+            "type": "API",
+            "definitionVersion": "V4",
+            "security": {
+                "type": "key-less",
+                "configuration": {}
+            },
+            "mode": "standard",
+            "flows": [],
+            "excludedGroups": [],
+            "name": "default"
+        }
+    ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1177

## Description

* AbstractHttpRequest build was biased by context path having a length > 1 leading to error with KubeGateway API
* Integration test added to test behaviors

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgucqgqjds.chromatic.com)
<!-- Storybook placeholder end -->
