### PR TITLE
feat: change`Kafka domain` to a `Kafka Bootstrap Domain Pattern`

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
@@ -46,12 +46,17 @@
         @case ('KAFKA') {
           <div class="kafka">
             <mat-form-field class="kafka__domain">
-              <mat-label>Default Kafka domain</mat-label>
+              <mat-label>Default Kafka Bootstrap Domain Pattern</mat-label>
               <input matInput formControlName="kafkaDomain" />
+
               <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('maxLength')"
-                >Kafka Domain must be less than 192 characters.</mat-error
+                >Kafka Domain must be less than 201 characters.</mat-error
               >
-              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('format')">Kafka Domain is not valid.</mat-error>
+              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('required')">Kafka Bootstrap Domain Pattern is required.</mat-error>
+              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('apiHostMissing')">
+                Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.
+              </mat-error>
+              <mat-hint> To be configured according to the gateway configuration. e.g: {{ '{apiHost}.mycompany.org' }} </mat-hint>
             </mat-form-field>
             <mat-form-field class="kafka__port">
               <mat-label>Default Kafka port</mat-label>

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.scss
@@ -7,10 +7,15 @@
   }
   .kafka {
     display: flex;
+    align-items: flex-start;
     gap: 8px;
 
+    &__domain {
+      flex: 1 1 auto;
+    }
+
     &__port {
-      flex: 1;
+      flex: 0 0 120px;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
@@ -20,7 +20,7 @@ import { shareReplay } from 'rxjs/operators';
 
 import { Entrypoint } from '../../../../entities/entrypoint/entrypoint';
 import { TagService } from '../../../../services-ngx/tag.service';
-import { kafkaDomainValidator, portValidator } from '../org-settings-entrypoints-and-sharding-tags.utils';
+import { kafkaBootstrapDomainPatternValidator, portValidator } from '../org-settings-entrypoints-and-sharding-tags.utils';
 
 export type OrgSettingAddMappingDialogData = {
   target: Entrypoint['target'];
@@ -67,9 +67,12 @@ export class OrgSettingAddMappingDialogComponent {
         break;
       }
       case 'KAFKA': {
-        const [kafkaDomain, kafkaPort] = this.entrypoint?.value?.split(':') ?? ['', '9092'];
+        const [kafkaDomain, kafkaPort] = this.entrypoint?.value?.split(':') ?? ['{apiHost}', '9092'];
 
-        this.mappingForm.addControl('kafkaDomain', new FormControl(kafkaDomain, [Validators.required, kafkaDomainValidator]));
+        this.mappingForm.addControl(
+          'kafkaDomain',
+          new FormControl(kafkaDomain, [Validators.required, kafkaBootstrapDomainPatternValidator]),
+        );
         this.mappingForm.addControl('kafkaPort', new FormControl(kafkaPort, [Validators.required, portValidator]));
         break;
       }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
@@ -81,13 +81,19 @@
               <mat-icon *ngIf="isReadonlySetting(configForm.key, 'kafkaDomain')" class="org-settings-tags__configuration__icon" matPrefix
                 >lock</mat-icon
               >
-              <mat-label>Default Kafka domain</mat-label>
+              <mat-label>Default Kafka Bootstrap Domain Pattern</mat-label>
               <input #kafkaDomainInput matInput formControlName="kafkaDomain" />
               <gio-clipboard-copy-icon matSuffix [contentToCopy]="kafkaDomainInput.value"></gio-clipboard-copy-icon>
               <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('maxLength')"
-                >Kafka Domain must be less than 192 characters.</mat-error
+                >Kafka Domain must be less than 201 characters.</mat-error
               >
-              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('format')">Kafka Domain is not valid.</mat-error>
+              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('required')"
+                >Kafka Bootstrap Domain Pattern is required.</mat-error
+              >
+              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('apiHostMissing')">
+                Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.
+              </mat-error>
+              <mat-hint> To be configured according to the gateway configuration. e.g: {{ '{apiHost}.mycompany.org' }} </mat-hint>
             </mat-form-field>
             <mat-form-field
               [matTooltip]="providedConfigurationMessage"

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
@@ -105,7 +105,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
             portal: {
               entrypoint: 'https://api.company.com',
               tcpPort: 4082,
-              kafkaDomain: 'kafka.domain.com',
+              kafkaDomain: '{apiHost}.kafka.domain.com',
               kafkaPort: 9092,
             },
           }),
@@ -120,7 +120,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
         await tcpPortInput.setValue('8888');
 
         const kafkaDomainInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaDomain]' }));
-        await kafkaDomainInput.setValue('kafka-gateway.company.com');
+        await kafkaDomainInput.setValue('{apiHost}.kafka-gateway.company.com');
 
         const kafkaPortInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaPort]' }));
         expect(await kafkaPortInput.getValue()).toEqual('9092');
@@ -134,7 +134,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
             portal: {
               entrypoint: 'https://my-new-api.company.com',
               tcpPort: 8888,
-              kafkaDomain: 'kafka-gateway.company.com',
+              kafkaDomain: '{apiHost}.kafka-gateway.company.com',
               kafkaPort: 1600,
             },
           }),
@@ -147,7 +147,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
             portal: {
               entrypoint: 'https://api.company.com',
               tcpPort: 4082,
-              kafkaDomain: 'kafka.domain.com',
+              kafkaDomain: '{apiHost}.kafka.domain.com',
               kafkaPort: 9092,
             },
             metadata: { readonly: ['portal.entrypoint', 'portal.tcpPort', 'portal.kafkaDomain', 'portal.kafkaPort'] },
@@ -166,7 +166,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
 
         const kafkaDomainInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaDomain]' }));
 
-        expect(await kafkaDomainInput.getValue()).toEqual('kafka.domain.com');
+        expect(await kafkaDomainInput.getValue()).toEqual('{apiHost}.kafka.domain.com');
         expect(await kafkaDomainInput.isDisabled()).toEqual(true);
 
         const kafkaPortInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaPort]' }));
@@ -176,6 +176,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       });
 
       it.each([
+        undefined,
         '!invalid',
         'in valid',
         'too-long-string.ertmkcowxvhpzjaqfiptpddcmmcfqfkwha.xergowgbqkwrsajowkjjqjxmshzibwraekfv.lmdozkplwxxvrfjlwvpebcmzskivwezndfcjgpmld.zilqrkgamlbczjemrkhtsylfpkumhbpnk.qrcxgoeggadkewfbqpjnatmsrjflrqjhryzth',
@@ -187,14 +188,14 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
             portal: {
               entrypoint: 'https://api.company.com',
               tcpPort: 4082,
-              kafkaDomain: '',
+              kafkaDomain: '{apiHost}',
               kafkaPort: 9092,
             },
           }),
         );
 
         const kafkaDomainInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaDomain]' }));
-        await kafkaDomainInput.setValue('kafka.domain.com');
+        await kafkaDomainInput.setValue('{apiHost}.kafka.domain.com');
 
         const saveBar = await loader.getHarness(GioSaveBarHarness);
         expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
@@ -205,26 +206,25 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       });
 
       it.each([
-        'valid',
-        'nice-domain.dev',
-        'long-string.ertmkcowxvhpzjaqfiptpddcmmcfqfkwha.xergowgbqkwrsajowkjjqjxmshzibwraekfv.lmdozkplwxxvrfjlwvpebcmzskivwezndfcjgpmld.zilqrkgamlbczjemrkhtsylfpkumhbpnk',
-        'sarzahlltkxeevpajsnncxgvqfqmnmfmvvtnzalgrwqvltvllqvvttneeylokks.long-segment',
-        '',
-        undefined,
+        '{apiHost}valid',
+        '{apiHost}nice-domain.dev',
+        '{apiHost}long-string.ertmkcowxvhpzjaqfiptpddcmmcfqfkwha.xergowgbqkwrsajowkjjqjxmshzibwraekfv.lmdozkplwxxvrfjlwvpebcmzskivwezndfcjgpmld.zilqrkgamlbczjemrkhtsylfpkumhbpnk',
+        '{apiHost}sarzahlltkxeevpajsnncxgvqfqmnmfmvvtnzalgrwqvltvllqvvttneeylokks.long-segment',
+        '{apiHost}',
       ])('should have valid Kafka Domain', async (value: string) => {
         expectPortalSettingsGetRequest(
           fakePortalSettings({
             portal: {
               entrypoint: 'https://api.company.com',
               tcpPort: 4082,
-              kafkaDomain: '',
+              kafkaDomain: '{apiHost}.initial',
               kafkaPort: 9092,
             },
           }),
         );
 
         const kafkaDomainInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaDomain]' }));
-        await kafkaDomainInput.setValue('kafka.domain.com');
+        await kafkaDomainInput.setValue('{apiHost}.kafka.domain.com');
 
         const saveBar = await loader.getHarness(GioSaveBarHarness);
         expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
@@ -485,7 +485,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const entrypointKafkaDomainInput = await addMappingDialog.getHarness(
         MatInputHarness.with({ selector: '[formControlName=kafkaDomain]' }),
       );
-      await entrypointKafkaDomainInput.setValue('entry.my');
+      await entrypointKafkaDomainInput.setValue('{apiHost}.entry.my');
 
       const entrypointKafkaPortInput = await addMappingDialog.getHarness(MatInputHarness.with({ selector: '[formControlName=kafkaPort]' }));
       await entrypointKafkaPortInput.setValue('9092');
@@ -497,7 +497,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const req = httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/entrypoints/` });
       expect(req.request.body).toStrictEqual({
         target: 'KAFKA',
-        value: 'entry.my:9092',
+        value: '{apiHost}.entry.my:9092',
         tags: ['tag-1'],
       });
     });

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
@@ -19,11 +19,11 @@ import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { GioConfirmDialogComponent, GioConfirmDialogData, GioLicenseService } from '@gravitee/ui-particles-angular';
+import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData, GioLicenseService } from '@gravitee/ui-particles-angular';
 
 import { OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData } from './dialog/org-settings-add-tag-dialog.component';
 import { OrgSettingAddMappingDialogComponent, OrgSettingAddMappingDialogData } from './dialog/org-settings-add-mapping-dialog.component';
-import { kafkaDomainValidator, portValidator } from './org-settings-entrypoints-and-sharding-tags.utils';
+import { kafkaBootstrapDomainPatternValidator, portValidator } from './org-settings-entrypoints-and-sharding-tags.utils';
 
 import { Entrypoint } from '../../../entities/entrypoint/entrypoint';
 import { PortalSettings } from '../../../entities/portal/portalSettings';
@@ -156,7 +156,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
                   value: portalSettings.portal.kafkaDomain,
                   disabled: PortalSettingsService.isReadonly(portalSettings, 'portal.kafkaDomain'),
                 },
-                [kafkaDomainValidator],
+                [kafkaBootstrapDomainPatternValidator],
               ),
               kafkaPort: new UntypedFormControl(
                 {
@@ -248,7 +248,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   onAddTagClicked() {
     this.matDialog
       .open<OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData, Tag>(OrgSettingAddTagDialogComponent, {
-        width: '450px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {},
         role: 'dialog',
         id: 'addTagDialog',
@@ -272,7 +272,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   onEditTagClicked(tag: TagTableDS[number]) {
     this.matDialog
       .open<OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData, Tag>(OrgSettingAddTagDialogComponent, {
-        width: '450px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           tag: this.tags.find((t) => t.id === tag.id),
         },
@@ -323,7 +323,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
 
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
-        width: '500px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           title: 'Delete a tag',
           content: `Are you sure you want to delete the tag <strong>${tag.name}</strong>?
@@ -374,7 +374,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   onAddEntrypointClicked(target: Entrypoint['target']) {
     this.matDialog
       .open<OrgSettingAddMappingDialogComponent, OrgSettingAddMappingDialogData, Entrypoint>(OrgSettingAddMappingDialogComponent, {
-        width: '450px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           target,
         },
@@ -402,7 +402,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
 
     this.matDialog
       .open<OrgSettingAddMappingDialogComponent, OrgSettingAddMappingDialogData, Entrypoint>(OrgSettingAddMappingDialogComponent, {
-        width: '450px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           target: entrypointToEdit.target,
           entrypoint: entrypointToEdit,
@@ -429,7 +429,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   onDeleteEntrypointClicked(entrypoint: EntrypointTableDS[number]) {
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
-        width: '500px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           title: 'Delete a entrypoint',
           content: `Are you sure you want to delete the entrypoint <strong>${entrypoint.url}</strong>?`,

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.utils.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.utils.ts
@@ -16,23 +16,27 @@
 
 import { UntypedFormControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
-import { HOST_PATTERN_REGEX } from '../../../shared/utils';
-
 export const portValidator: ValidatorFn = (control: UntypedFormControl): ValidationErrors | null => {
   const tcpPort = control.value;
   return tcpPort < 1025 || tcpPort > 65535 ? { invalidPort: true } : null;
 };
 
-export const kafkaDomainValidator: ValidatorFn = (control: UntypedFormControl): ValidationErrors | null => {
+export const kafkaBootstrapDomainPatternValidator: ValidatorFn = (control: UntypedFormControl): ValidationErrors | null => {
   const kafkaDomain: string = control.value;
-  if (kafkaDomain?.length) {
-    // Max length of URL (255) - reserved characters for host prefix (63) - "." to separate host prefix and domain (1) = 191 max characters
-    if (kafkaDomain.length > 191) {
-      return { maxLength: true };
-    }
-    if (!HOST_PATTERN_REGEX.test(kafkaDomain)) {
-      return { format: true };
-    }
+  // Check if the value is empty
+  if (!kafkaDomain) {
+    return { required: true };
   }
+  // Check if the value not contain {apiHost}
+  if (!kafkaDomain.includes('{apiHost}')) {
+    return { apiHostMissing: true };
+  }
+  // Best effort to avoid too long domain names
+  // Max length of URL (255) - reserved characters for host prefix (63) - "." to separate host prefix and domain (1) = 191 max characters
+  // + 10 characters for `{apiHost}` = 201 max characters
+  if (kafkaDomain.length > 201) {
+    return { maxLength: true };
+  }
+
   return null;
 };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -37,7 +37,7 @@ public enum Key {
     PORTAL_TOP_APIS("portal.top-apis", List.class, false, new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_ENTRYPOINT("portal.entrypoint", "https://api.company.com", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_TCP_PORT("portal.tcpPort", "4082", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
-    PORTAL_KAFKA_DOMAIN("portal.kafkaDomain", "", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    PORTAL_KAFKA_DOMAIN("portal.kafkaDomain", "{apiHost}", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_KAFKA_PORT("portal.kafkaPort", "9092", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_APIKEY_HEADER("portal.apikey.header", "X-Gravitee-Api-Key", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_SUPPORT_ENABLED("portal.support.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
@@ -314,9 +314,15 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
         final String port,
         final Set<String> tags
     ) {
-        var domainSegment = domain != null && !domain.isBlank() ? "." + domain : "";
-
-        var target = host + domainSegment + ":" + port;
+        String kafkaDomain;
+        if (domain == null || domain.isBlank()) {
+            kafkaDomain = host;
+        } else if (domain.contains("{apiHost}")) {
+            kafkaDomain = domain.replace("{apiHost}", host);
+        } else {
+            kafkaDomain = host + "." + domain;
+        }
+        var target = kafkaDomain + ":" + port;
         return new ApiEntrypointEntity(tags, target, host);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
@@ -636,14 +636,16 @@ class ApiEntrypointServiceImplTest {
             .thenReturn(
                 List.of(
                     AccessPoint.builder().host("domain1:1234").target(AccessPoint.Target.KAFKA_GATEWAY).build(),
-                    AccessPoint.builder().host("domain2").target(AccessPoint.Target.KAFKA_GATEWAY).build()
+                    AccessPoint.builder().host("domain2").target(AccessPoint.Target.KAFKA_GATEWAY).build(),
+                    AccessPoint.builder().host("{apiHost}-trial.domain3:1234").target(AccessPoint.Target.KAFKA_GATEWAY).build()
                 )
             );
 
         var apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
 
-        assertThat(apiEntrypoints).hasSize(2);
+        assertThat(apiEntrypoints).hasSize(3);
         assertThat(apiEntrypoints.get(0).getTarget()).isEqualTo("kafka-host.domain1:1234");
         assertThat(apiEntrypoints.get(1).getTarget()).isEqualTo("kafka-host.domain2:9092");
+        assertThat(apiEntrypoints.get(2).getTarget()).isEqualTo("kafka-host-trial.domain3:1234");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -692,7 +692,7 @@ notifiers:
 #          host: '{environment}.{organization}.{account}.example.com'
 #          secured: true
 #        kafka-gateway:
-#          host: '{environment}.{organization}.{account}.example.com'
+#          host: '{apiHost}.{environment}.{organization}.{account}.example.com'
 #          secured: true
 
 # External Authentication


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9540

## Description

Force the user to define a {apiHost} for the kafka default domain. For the backend, this is optional, if not present it contacts `apiHost + . + default domain`.

The kafka reactor will do the same.



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-icurdiawwp.chromatic.com)
<!-- Storybook placeholder end -->
