### PR TITLE
fix: proxy connector don’t send query chunked if not need

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -33,6 +33,7 @@ import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.common.util.URIUtils;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
@@ -126,9 +127,13 @@ public class HttpConnector implements ProxyConnector {
                 .map(this::customizeHttpClientRequest)
                 .flatMap(httpClientRequest -> {
                     observableHttpClientRequest.httpClientRequest(httpClientRequest.getDelegate());
-                    return httpClientRequest.rxSend(
-                        request.chunks().map(buffer -> io.vertx.rxjava3.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
-                    );
+                    if (requestWithBody(request)) {
+                        return httpClientRequest.rxSend(
+                            request.chunks().map(buffer -> io.vertx.rxjava3.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
+                        );
+                    } else {
+                        return httpClientRequest.rxSend();
+                    }
                 })
                 .doOnSuccess(endpointResponse -> {
                     response.status(endpointResponse.statusCode());
@@ -269,5 +274,9 @@ public class HttpConnector implements ProxyConnector {
         if (parametersToAdd != null && !parametersToAdd.isEmpty()) {
             parametersToAdd.forEach((key, values) -> parameters.computeIfAbsent(key, k -> new ArrayList<>()).addAll(values));
         }
+    }
+
+    private static boolean requestWithBody(HttpRequest request) {
+        return request.headers().contains(HttpHeaderNames.TRANSFER_ENCODING) || request.headers().contains(HttpHeaderNames.CONTENT_LENGTH);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -23,7 +23,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static io.gravitee.gateway.api.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.HOST;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_ENDPOINT;
@@ -166,7 +165,6 @@ class HttpConnectorTest {
     @Test
     void shouldExecuteGetRequest() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
 
@@ -186,7 +184,6 @@ class HttpConnectorTest {
 
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.parameters()).thenReturn(parameters);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         configuration.setTarget("http://localhost:" + wiremock.port() + "/team?foo=bar");
         cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
@@ -211,7 +208,6 @@ class HttpConnectorTest {
     @Test
     void shouldExecuteGetRequestWhenEndpointAttributeOverridenWithAbsoluteUrl() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("http://127.0.0.1:" + wiremock.port());
 
         wiremock.stubFor(get("/").willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -232,7 +228,6 @@ class HttpConnectorTest {
 
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.parameters()).thenReturn(parameters);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("http://127.0.0.1:" + wiremock.port() + "/?foo=bar");
 
         wiremock.stubFor(get(urlPathEqualTo("/")).willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -255,7 +250,6 @@ class HttpConnectorTest {
     @Test
     void shouldExecuteGetRequestWhenAttributeOverridenWithAbsoluteUrlAndPath() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("http://127.0.0.1:" + wiremock.port() + "/team/subPath");
 
         wiremock.stubFor(get(urlPathEqualTo("/team/subPath")).willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -276,7 +270,6 @@ class HttpConnectorTest {
 
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.parameters()).thenReturn(parameters);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("http://127.0.0.1:" + wiremock.port() + "/team/subPath?foo=bar");
 
         wiremock.stubFor(get(urlPathEqualTo("/team/subPath")).willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -304,7 +297,6 @@ class HttpConnectorTest {
 
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.parameters()).thenReturn(parameters);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("/subPath?foo=bar");
 
         wiremock.stubFor(get(urlPathEqualTo("/team/subPath")).willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -327,6 +319,7 @@ class HttpConnectorTest {
     @Test
     void shouldExecutePostRequest() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.headers()).thenReturn(HttpHeaders.create().add(TRANSFER_ENCODING, "chunked"));
         when(request.chunks())
             .thenReturn(
                 Flowable.just(Buffer.buffer(REQUEST_BODY_CHUNK1), Buffer.buffer(REQUEST_BODY_CHUNK2), Buffer.buffer(REQUEST_BODY_CHUNK3))
@@ -348,8 +341,8 @@ class HttpConnectorTest {
     @Test
     void shouldExecutePostRequestChunked() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.headers()).thenReturn(HttpHeaders.create().add(TRANSFER_ENCODING, "chunked"));
         when(request.chunks()).thenReturn(Flowable.just(Buffer.buffer(REQUEST_BODY)));
-        requestHeaders.set(CONTENT_LENGTH, "" + REQUEST_BODY_LENGTH);
 
         wiremock.stubFor(post("/team").withRequestBody(new EqualToPattern(REQUEST_BODY)).willReturn(ok(BACKEND_RESPONSE_BODY)));
 
@@ -360,15 +353,14 @@ class HttpConnectorTest {
         wiremock.verify(
             1,
             postRequestedFor(urlPathEqualTo("/team"))
-                .withHeader(CONTENT_LENGTH, new EqualToPattern("" + REQUEST_BODY_LENGTH))
-                .withRequestBody(new EqualToPattern(REQUEST_BODY))
+                .withHeader(TRANSFER_ENCODING, new EqualToPattern("chunked"))
+                .withRequestBody(new EqualToPattern(REQUEST_BODY.trim()))
         );
     }
 
     @Test
     void shouldPropagateRequestHeadersAndRemoveHopHeaders() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         requestHeaders.add("X-Custom", List.of("value1", "value2"));
         HttpConnector.HOP_HEADERS.forEach(header -> requestHeaders.add(header.toString(), "should be removed"));
@@ -393,7 +385,6 @@ class HttpConnectorTest {
     @Test
     void shouldAddOrReplaceRequestHeadersWithConfiguration() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         sharedConfiguration.setHeaders(List.of(new HttpHeader("X-To-Be-Overriden", "Override"), new HttpHeader("X-To-Be-Added", "Added")));
 
         requestHeaders.add("X-Custom", "value1");
@@ -420,7 +411,6 @@ class HttpConnectorTest {
     @Test
     void shouldOverrideHostWithRequestHostHeader() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(request.originalHost()).thenReturn("localhost:8082");
 
         // Simulated a policy that force the host header to use when calling the backend endpoint.
@@ -447,7 +437,6 @@ class HttpConnectorTest {
     @Test
     void shouldNotOverrideRequestHostHeaderWhenSameAsRequestOriginalHost() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(request.originalHost()).thenReturn("api.gravitee.io");
         when(request.host()).thenReturn("api.gravitee.io");
 
@@ -475,7 +464,6 @@ class HttpConnectorTest {
         requestHeaders = new VertxHttpHeaders(new HeadersMultiMap());
         when(request.headers()).thenReturn(requestHeaders);
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         requestHeaders.add("X-Custom", List.of("value1", "value2"));
         HttpConnector.HOP_HEADERS.forEach(header -> requestHeaders.add(header.toString(), "should be removed"));
@@ -500,7 +488,6 @@ class HttpConnectorTest {
     @Test
     void shouldPropagateResponseHeaders() throws InterruptedException {
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         wiremock.stubFor(
             get("/team")
@@ -525,7 +512,6 @@ class HttpConnectorTest {
 
         when(response.headers()).thenReturn(responseHeaders);
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
 
         wiremock.stubFor(
             get("/team")
@@ -561,7 +547,6 @@ class HttpConnectorTest {
         parameters.add("foo2", "bar2");
 
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(request.parameters()).thenReturn(parameters);
 
         wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
@@ -580,13 +565,12 @@ class HttpConnectorTest {
 
     @Test
     void shouldExecuteRequestWithQueryParametersMergedWithTargetQueryParams() throws InterruptedException {
-        final LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        var parameters = new LinkedMultiValueMap<String, String>();
         parameters.add("foo1", "bar1");
         parameters.add("foo2", "bar2");
         parameters.add("foo3", null);
 
         when(request.method()).thenReturn(HttpMethod.GET);
-        when(request.chunks()).thenReturn(Flowable.empty());
         when(request.parameters()).thenReturn(parameters);
 
         configuration.setTarget("http://localhost:" + wiremock.port() + "/team?param1=value1&param2=value2");
@@ -620,6 +604,6 @@ class HttpConnectorTest {
     }
 
     private void assertNoTimeout(TestObserver<Void> obs) throws InterruptedException {
-        assertThat(obs.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue().as("Should complete before timeout");
+        assertThat(obs.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).as("Should complete before timeout").isTrue();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9573

## Description

When gateway send an HTTP request, it send it as chunked. In some case this produce errors because server wait end of query and timeout.

This changeset don’t chunk the query, if the request isn’t chunked.

A server that produce this error: https://www.w3schools.com/xml/tempconvert.asmx
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lhfnrwbqdk.chromatic.com)
<!-- Storybook placeholder end -->
