### PR TITLE
fix: hide debug mode for v4 api types other than http proxy

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -52,7 +52,7 @@ export class ApiV4MenuService implements ApiMenuService {
       ...(api.type !== 'NATIVE' ? [this.addApiTrafficMenuEntry(hasTcpListeners)] : []),
       ...(api.type !== 'NATIVE' ? [this.addApiRuntimeAlertsMenuEntry()] : []),
       ...this.addAlertsMenuEntry(),
-      this.addDebugMenuEntry(),
+      ...(api.type === 'PROXY' ? [this.addDebugMenuEntry()] : []),
     ].filter((entry) => entry != null && !entry.tabs?.every((tab) => tab.routerLink === 'DISABLED'));
 
     return { subMenuItems, groupItems: [] };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9568

## Description

According to the story requirements, the debug mode is only supported and should be visible for the V4 Http Proxy API type

