### PR TITLE
fix: change debug request payload to match the api spec

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/debug-api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/debug-api-v2.service.ts
@@ -39,7 +39,10 @@ export class DebugApiV2Service {
     apiId: string,
   ): Observable<Event> {
     return this.http.post<Event>(`${this.constants.env.v2BaseURL}/apis/${apiId}/debug`, {
-      request,
+      path: request.path,
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
     });
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9567

## Description

Fixed an issue with V4 API HTTP Proxy debug mode where the payload sent to the backend did not match the specification, causing debug mode to malfunction.

