### PR TITLE
feat: configure the retry strategy of subscription Dispatcher

### DIFF
--- a/.run/Gateway - JDBC.run.xml
+++ b/.run/Gateway - JDBC.run.xml
@@ -12,7 +12,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
     <module name="gravitee-apim-gateway-standalone-container" />
-    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000 " />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Gateway - MongoDB.run.xml
+++ b/.run/Gateway - MongoDB.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Gateway - MongoDB" type="Application" factoryName="Application" folderName="Gateway">
     <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
     <module name="gravitee-apim-gateway-standalone-container" />
-    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000 " />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Rest API - JDBC.run.xml
+++ b/.run/Rest API - JDBC.run.xml
@@ -12,7 +12,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
     <module name="gravitee-apim-rest-api-standalone-container" />
-    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000 " />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Rest API - MongoDB.run.xml
+++ b/.run/Rest API - MongoDB.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Rest API - MongoDB" type="Application" factoryName="Application" folderName="Rest API">
     <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
     <module name="gravitee-apim-rest-api-standalone-container" />
-    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000 " />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -818,6 +818,12 @@ api:
   # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
 #  pending_requests_timeout: 10000
   validateSubscription: true  # set to false if you want to skip validating the subscription, default value is true
+  # PUSH plan Subscription retry strategy
+#  subscriptionEndpointRetry:
+#    backoffStrategy: EXPONENTIAL # LINEAR or EXPONENTIAL
+#    maxRetries: -1 # The maximum number of retries to attempt. -1 for infinite retries
+#    maxDelayMs: -1 # Maximum delay to reach to stop retrying for exponential retry. -1 for infinite retry
+#    delayMs: 5000 # The initial delay in milliseconds for exponential retry or the delay between retries for linear retry
   # API level Secret manager configuration
 #  secrets:
 #    providers:

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>4.0.0-alpha.2</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.0.0-alpha.1</gravitee-resource-storage-azure-blob.version>
-        <gravitee-reactor-message.version>7.0.0-alpha.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>7.0.0-alpha.2</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>3.0.0-alpha.7</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>7.0.0-alpha.1</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8798

## Description

When there is an issue between the Gateway and the Endpoint (ex: Kafka
broker is stopped) the Platform admin can configure the retry behavior
for subscription (for PUSH plans).
Now by default, the retry is infinite and exponential meaning that the
subscriptions will never stop due to an error unless the error is a
`MessageProcessingException` (that can be throw by Entrypoint when it
fails to process the message)
The Platform admin can configure this strategy by setting the
configuration in the `gravitee.yaml` of the Gateway:

```
api:
  # ... other configuration
  subscriptionEndpointRetry:
    backoffStrategy: EXPONENTIAL # LINEAR or EXPONENTIAL
    maxRetries: -1 # The maximum number of retries to attempt. -1 for infinite retries
    maxDelayMs: -1 # Maximum delay to reach to stop retrying for exponential retry. -1 for infinite retry
    delayMs: 5000 # The initial delay in milliseconds for exponential retry or the delay between retries for linear retry
```


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-thnouhrvwq.chromatic.com)
<!-- Storybook placeholder end -->
