### PR TITLE
fix: align tenant name character limit across UI and API

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.html
@@ -27,8 +27,8 @@
       <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput formControlName="name" required data-testid="tenant-name" />
-        <mat-hint align="end">{{ tenantForm.get('name').value?.length ?? 0 }}/30</mat-hint>
-        <mat-error *ngIf="tenantForm.get('name').hasError('maxlength')">Name has to be less than 30 characters long.</mat-error>
+        <mat-hint align="end">{{ tenantForm.get('name').value?.length ?? 0 }}/40</mat-hint>
+        <mat-error *ngIf="tenantForm.get('name').hasError('maxlength')">Name has to be less than 40 characters long.</mat-error>
         <mat-error *ngIf="tenantForm.get('name').hasError('minlength')">Name has to be more than 2 characters long.</mat-error>
         <mat-error *ngIf="tenantForm.get('name').hasError('required')">Name is required.</mat-error>
       </mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.spec.ts
@@ -129,5 +129,16 @@ describe('GioConfirmDialogComponent', () => {
         description: 'Internal tenant',
       });
     });
+    it('should disable submit if name exceeds 40 characters', async () => {
+      fixture.detectChanges();
+      const submitButton = await loader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
+      const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
+      // 41-character string
+      const longName = 'A'.repeat(41);
+      await nameInput.setValue(longName);
+      expect(await submitButton.isDisabled()).toBeTruthy();
+      expect(component.tenantForm.controls['name'].valid).toBeFalsy();
+      expect(component.tenantForm.controls['name'].errors?.['maxlength']).toBeTruthy();
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.ts
@@ -42,7 +42,7 @@ export class OrgSettingAddTenantComponent {
     this.isUpdate = !!this.tenant;
 
     this.tenantForm = new UntypedFormGroup({
-      name: new UntypedFormControl(this.tenant?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(30)]),
+      name: new UntypedFormControl(this.tenant?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(40)]),
       description: new UntypedFormControl(this.tenant?.description, [Validators.maxLength(160)]),
     });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.spec.ts
@@ -214,4 +214,22 @@ describe('OrgSettingsTenantsComponent', () => {
       })
       .flush(tenants);
   }
+
+  it('should not submit tenant form if name is too long', async () => {
+    permissionsService._setPermissions(['organization-tenant-c']);
+    fixture.detectChanges();
+    respondToGetTenants([fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
+    fixture.detectChanges();
+    const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to add a tenant"]' }));
+    await addButton.click();
+    const nameInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
+    await nameInput.setValue('A'.repeat(41)); // greater than allowed characters
+    const submitButton = await rootLoader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
+    expect(await submitButton.isDisabled()).toBeTruthy();
+
+    httpTestingController.expectNone({
+      method: 'POST',
+      url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tenants`,
+    });
+  });
 });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTenantEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTenantEntity.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public class NewTenantEntity {
 
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 40)
     private String name;
 
     private String description;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/TenantEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/TenantEntity.java
@@ -28,7 +28,7 @@ public class TenantEntity {
     private String id;
 
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 40)
     private String name;
 
     private String description;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateTenantEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateTenantEntity.java
@@ -28,7 +28,7 @@ public class UpdateTenantEntity {
     private String id;
 
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 40)
     private String name;
 
     private String description;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9451

## Description

Increased tenant name character limit from 30 to 40 characters and ensured consistent validation between frontend and backend.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-udnklvgfxw.chromatic.com)
<!-- Storybook placeholder end -->
