### PR TITLE
fix(console): fix missing dropdown values for 'not equals to' operator in filters

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ajs-spec.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ajs-spec.ts
@@ -114,4 +114,29 @@ describe('AlertTriggerConditionStringComponent', () => {
       });
     });
   });
+
+  /* This `describe` block is testing the `onSearch` method of the `AlertTriggerConditionStringComponent`. */
+  describe('onSearch', () => {
+    beforeEach(() => {
+      alertTriggerConditionStringComponent.values = [{ value: 'default' }, { value: 'env' }, { value: 'org' }];
+    });
+
+    it('should show all values when searchTerm is empty', () => {
+      alertTriggerConditionStringComponent.searchTerm = '';
+      alertTriggerConditionStringComponent.onSearch();
+      expect(alertTriggerConditionStringComponent.filteredValues).toEqual(alertTriggerConditionStringComponent.values);
+    });
+
+    it('should filter values by searchTerm (case-insensitive)', () => {
+      alertTriggerConditionStringComponent.searchTerm = 'def';
+      alertTriggerConditionStringComponent.onSearch();
+      expect(alertTriggerConditionStringComponent.filteredValues).toEqual([{ value: 'default' }]);
+    });
+
+    it('should return no results if searchTerm does not match', () => {
+      alertTriggerConditionStringComponent.searchTerm = 'zzz';
+      alertTriggerConditionStringComponent.onSearch();
+      expect(alertTriggerConditionStringComponent.filteredValues).toEqual([]);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
@@ -30,12 +30,23 @@ const AlertTriggerConditionStringComponent: ng.IComponentOptions = {
   controller: [
     '$injector',
     function ($injector) {
-      this.$onInit = () => {
-        // Get the metric field according to the condition property
+      this.$onInit = async () => {
         const metric = find(this.metrics as Metrics[], (metric) => metric.key === this.condition.property);
 
         if (metric.loader) {
           this.values = metric.loader(this.referenceType, this.referenceId, $injector);
+          this.filteredValues = this.values; // initialize filtered list
+        }
+
+        this.searchTerm = '';
+      };
+
+      this.onSearch = () => {
+        if (!this.searchTerm || this.searchTerm.trim() === '') {
+          this.filteredValues = this.values;
+        } else {
+          const term = this.searchTerm.toLowerCase();
+          this.filteredValues = this.values.filter((item) => item.value.toLowerCase().includes(term));
         }
       };
 

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.html
@@ -26,11 +26,6 @@
     aria-label="string value condition"
     ng-disabled="$ctrl.isReadonly"
   />
-  <!--
-  <div class="hint">
-    The pattern value to compare to.
-  </div>
-  -->
   <div ng-messages="$ctrl.formAlert['condition-string-value'].$error">
     <div ng-message="required">Pattern is required.</div>
   </div>
@@ -38,12 +33,25 @@
 
 <md-input-container class="md-block" ng-if="$ctrl.displaySelect()">
   <label>Value</label>
-  <md-select ng-model="$ctrl.condition.pattern" required ng-disabled="$ctrl.isReadonly">
-    <md-option ng-value="type.key" ng-repeat="type in $ctrl.values"> {{::type.value}} </md-option>
+  <md-select
+    ng-model="$ctrl.condition.pattern"
+    required
+    data-md-container-class="triggerdemoSelectHeader"
+    ng-disabled="$ctrl.isReadonly"
+    md-on-open="$ctrl.onSearch()"
+  >
+    <md-select-header class="demo-select-header">
+      <input
+        style="border-top: none; border-right: none; border-left: none; outline: none; padding: 1% 4%; width: 92% !important; height: 100%"
+        ng-model="$ctrl.searchTerm"
+        ng-change="$ctrl.onSearch()"
+        ng-keydown="$event.stopPropagation()"
+        type="search"
+        placeholder="Search values"
+        class="demo-header-searchbox md-text"
+      />
+    </md-select-header>
+
+    <md-option ng-value="type.key" ng-repeat="type in $ctrl.filteredValues track by type.key"> {{ type.value }} </md-option>
   </md-select>
-  <!--
-  <div class="hint">
-    Select the value to compare to.
-  </div>
-  -->
 </md-input-container>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9557

## Description

The dropdown menu now properly loads values for the 'not equals to' operator. Enabled Input search on drop-down.

## Additional context

### Before
https://github.com/user-attachments/assets/65a54b1c-3a08-4ca0-b0ad-86ed74c1bb50

### After
https://github.com/user-attachments/assets/cb5ea539-a104-44af-b15c-3b972c48111c

