### PR TITLE
Apim 9526 add mcp tab

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -171,6 +171,13 @@ export class ApiV4MenuService implements ApiMenuService {
       },
     ];
 
+    if (api.type === 'PROXY') {
+      tabs.push({
+        displayName: 'MCP',
+        routerLink: 'v4/mcp',
+      });
+    }
+
     if (this.permissionService.hasAnyMatching(['api-response_templates-r'])) {
       tabs.push({
         displayName: 'Response Templates',

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -90,6 +90,7 @@ import { ApiDocumentationChooseExistingPageComponent } from './documentation-v4/
 import { ApiHealthCheckDashboardV4Component } from './health-check-dashboard-v4/api-health-check-dashboard-v4.component';
 import { DebugModeV2WrapperComponent } from './debug-mode/v2-wrapper/debug-mode-v2-wrapper.component';
 import { DebugModeV4WrapperComponent } from './debug-mode/v4-wrapper/debug-mode-v4-wrapper.component';
+import { McpComponent } from './mcp/mcp.component';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -1057,6 +1058,16 @@ const apisRoutes: Routes = [
       {
         path: 'v4/cors',
         component: ApiCorsComponent,
+        data: {
+          docs: null,
+          permissions: {
+            anyOf: ['api-definition-r'],
+          },
+        },
+      },
+      {
+        path: 'v4/mcp',
+        component: McpComponent,
         data: {
           docs: null,
           permissions: {

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.html
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (api$ | async; as apiVM) {
+  @if (apiVM.hasMCPEntrypoint) {
+    Woohoo! It's added.
+  } @else {
+    <no-mcp-entrypoint [canEnableMcp]="canEnableMcp$ | async" (enableMcpEntrypoint)="addMcpEntrypoint()" />
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+  overflow: visible;
+}
+
+.mcp {
+  &__headerRightBtn {
+    margin-left: auto;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { McpComponent } from './mcp.component';
+import { McpHarness } from './mcp.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiV4, ConnectorPlugin, fakeApiV4, fakeConnectorPlugin } from '../../../entities/management-api-v2';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+
+describe('McpComponent', () => {
+  let fixture: ComponentFixture<McpComponent>;
+  let componentHarness: McpHarness;
+  let httpTestingController: HttpTestingController;
+  let routerSpy: jest.SpyInstance;
+
+  const API_ID = 'api-id';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GioTestingModule, McpComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: {
+                apiId: API_ID,
+              },
+            },
+          },
+        },
+        { provide: GioTestingPermissionProvider, useValue: ['api-definition-u'] },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(McpComponent);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, McpHarness);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    routerSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('when no mcp entrypoint is found', () => {
+    beforeEach(async () => {
+      expectGetApi(fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-proxy' }] }] }));
+    });
+    it('should display the mcp entrypoint not found message', async () => {
+      expectGetEntrypoints([]);
+
+      const mcpEntryPointNotFound = await componentHarness.getMcpEntryPointNotFound();
+      expect(mcpEntryPointNotFound).toBeTruthy();
+    });
+
+    it('should show navigate to edit view after clicking Enable MCP button if MCP Entrypoint installed', async () => {
+      expectGetEntrypoints([fakeConnectorPlugin({ id: 'mcp' })]);
+
+      const mcpEntrypointNotFound = await componentHarness.getMcpEntryPointNotFound();
+      const enableMcpButton = await mcpEntrypointNotFound.getEnableMcpButton();
+      await enableMcpButton.click();
+
+      expect(routerSpy).toHaveBeenCalledTimes(1);
+      expect(routerSpy).toHaveBeenCalledWith(['./add'], expect.anything());
+    });
+
+    it('should not navigate to adding the entrypoint if mcp entrypoint is missing', async () => {
+      expectGetEntrypoints([]);
+
+      const mcpEntrypointNotFound = await componentHarness.getMcpEntryPointNotFound();
+      const enableMcpButton = await mcpEntrypointNotFound.getEnableMcpButton();
+      expect(await enableMcpButton.isDisabled()).toBeTruthy();
+    });
+  });
+
+  function expectGetApi(api: ApiV4): void {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectGetEntrypoints(entrypoints: ConnectorPlugin[]) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`, method: 'GET' }).flush(entrypoints);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncPipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+
+import { NoMcpEntrypointComponent } from './no-mcp-entrypoint/no-mcp-entrypoint.component';
+
+import { ApiV4 } from '../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+import { ConnectorPluginsV2Service } from '../../../services-ngx/connector-plugins-v2.service';
+
+interface ApiVM extends ApiV4 {
+  hasMCPEntrypoint: boolean;
+}
+
+@Component({
+  selector: 'mcp',
+  templateUrl: './mcp.component.html',
+  styleUrls: ['./mcp.component.scss'],
+  imports: [NoMcpEntrypointComponent, AsyncPipe],
+})
+export class McpComponent implements OnInit {
+  apiId: string;
+  api$: Observable<ApiVM> = of();
+
+  canEnableMcp$: Observable<boolean> = this.connectorPluginsV2Service
+    .listEntrypointPlugins()
+    .pipe(
+      map((plugins) =>
+        plugins.some((plugin) => plugin.id === this.mcpEntrypointId && this.gioPermissionService.hasAnyMatching(['api-definition-u'])),
+      ),
+    );
+
+  private mcpEntrypointId = 'mcp';
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private router: Router,
+    private apiV2Service: ApiV2Service,
+    private gioPermissionService: GioPermissionService,
+    private connectorPluginsV2Service: ConnectorPluginsV2Service,
+  ) {
+    this.apiId = this.activatedRoute.snapshot.params['apiId'] || '';
+  }
+
+  ngOnInit() {
+    this.api$ = this.apiV2Service.getLastApiFetch(this.apiId).pipe(
+      filter((api) => api.definitionVersion === 'V4'),
+      map((api) => ({ ...api, hasMCPEntrypoint: api.listeners?.[0].entrypoints.some((e) => e.type === this.mcpEntrypointId) }) as ApiVM),
+    );
+  }
+
+  addMcpEntrypoint() {
+    this.router.navigate(['./add'], { relativeTo: this.activatedRoute });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.harness.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+import { NoMcpEntrypointHarness } from './no-mcp-entrypoint/no-mcp-entrypoint.harness';
+
+export class McpHarness extends ComponentHarness {
+  static readonly hostSelector = 'mcp';
+
+  protected locateMcpEntryPointNotFound = this.locatorForOptional(NoMcpEntrypointHarness);
+
+  async getMcpEntryPointNotFound(): Promise<NoMcpEntrypointHarness | null> {
+    return this.locateMcpEntryPointNotFound();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card>
+  <mat-card-content class="no-mcp-entrypoint">
+    <div class="no-mcp-entrypoint__icon">
+      <mat-icon svgIcon="gio:folder-plus" />
+    </div>
+    <div class="no-mcp-entrypoint__text">
+      <div class="mat-h2">Bring your tools to life by enabling MCP</div>
+      <div class="mat-body-2">Once activated, you can configure, manage and integrate tools seamlessly with your environment.</div>
+    </div>
+    <button mat-raised-button color="primary" [disabled]="!canEnableMcp()" (click)="enableMcpEntrypoint.emit(true)">Enable MCP</button>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.scss
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.no-mcp-entrypoint {
+  display: flex;
+  flex-flow: column;
+  gap: 24px;
+  align-items: center;
+
+  &__icon {
+    background: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'lighter');
+    height: 80px;
+    width: 80px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__text {
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.component.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { GioCardEmptyStateModule } from '@gravitee/ui-particles-angular';
+
+@Component({
+  selector: 'no-mcp-entrypoint',
+  templateUrl: './no-mcp-entrypoint.component.html',
+  styleUrls: ['./no-mcp-entrypoint.component.scss'],
+  imports: [MatCardModule, MatButtonModule, MatIconModule, GioCardEmptyStateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NoMcpEntrypointComponent {
+  canEnableMcp = input(false);
+  enableMcpEntrypoint = output<boolean>();
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.harness.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class NoMcpEntrypointHarness extends ComponentHarness {
+  static readonly hostSelector = 'no-mcp-entrypoint';
+  protected locateEnableMcpEntrypointButton = this.locatorFor(MatButtonHarness.with({ text: 'Enable MCP' }));
+
+  async getEnableMcpButton(): Promise<MatButtonHarness> {
+    return this.locateEnableMcpEntrypointButton();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/no-mcp-entrypoint/no-mcp-entrypoint.stories.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, StoryObj } from '@storybook/angular';
+
+import { NoMcpEntrypointComponent } from './no-mcp-entrypoint.component';
+
+export default {
+  title: 'NoMcpEntrypoint story',
+  component: NoMcpEntrypointComponent,
+  argTypes: {},
+  render: (args) => ({
+    template: `
+      <div style="width: 800px">
+        <no-mcp-entrypoint />
+      </div>
+    `,
+    props: args,
+  }),
+} as Meta;
+
+export const Default: StoryObj = {};
+Default.args = {};

--- a/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
@@ -35,6 +35,7 @@ export const CONSTANTS_TESTING: Constants = {
         enabled: false,
       },
     },
+    v2BaseURL: 'https://url.test:3000/management/v2/organizations/DEFAULT',
     // FIXME: Fill missing fields
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9526

## Description

# Summary

This Pull Request adds functionality to support the MCP feature. It introduces related UI components, routing, and additional tests to manage and enable the MCP entrypoint.

### Main Changes
- API Navigation Updates: Added a new menu item for MCP under specific conditions.
- Routing Configuration: Introduced a new route to handle the MCP feature with proper component and permission setup.
- New MCP Component: Added the necessary files for MCP (mcp.component.ts, mcp.component.html, mcp.component.scss) including its logic, UI, and styles.
- Testing for MCP: Added unit tests (mcp.component.spec.ts) and test harness (mcp.harness.ts) for MCP-related functionality.
- "No MCP Entrypoint" Message: Created a subcomponent (no-mcp-entrypoint.component.*) to display a message when there is no MCP entrypoint, including tests, stories, and styles.
- Storybook Entry: Added a Storybook entry (no-mcp-entrypoint.stories.ts) for the "No MCP Entrypoint" component.
- Testing Module: Updated gio-testing.module.ts with a V2 Base URL configuration.


![Screenshot 2025-05-12 at 15 12 38](https://github.com/user-attachments/assets/951251d9-a1eb-4c19-a17c-8abe6cc3e16c)

Next PRs:
- Add MCP entrypoint to API
- Edit configured MCP entrypoint

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-agvnsswbht.chromatic.com)
<!-- Storybook placeholder end -->
