### PR TITLE
test: make activation of node monitoring possible on test sdk

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -188,6 +188,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-noop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.gateway.standalone</groupId>
             <artifactId>gravitee-apim-gateway-standalone-container</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
@@ -44,6 +44,9 @@ import io.gravitee.repository.management.api.InstallationRepository;
 import io.gravitee.repository.management.api.LicenseRepository;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.noop.ratelimit.NoOpRateLimitRepository;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.vertx.core.Vertx;
 import java.util.List;
 import java.util.function.Consumer;
@@ -80,7 +83,6 @@ public class GatewayTestContainer extends GatewayContainer {
     protected List<Class<?>> annotatedClasses() {
         List<Class<?>> classes = super.annotatedClasses();
         classes.add(GatewayTestConfiguration.class);
-        classes.remove(NodeMonitoringConfiguration.class);
         return classes;
     }
 
@@ -146,6 +148,11 @@ public class GatewayTestContainer extends GatewayContainer {
         @Bean
         public OrganizationRepository organizationRepository() {
             return Mockito.mock(OrganizationRepository.class);
+        }
+
+        @Bean
+        public RateLimitRepository<RateLimit> rateLimitRepository() {
+            return new NoOpRateLimitRepository();
         }
 
         @Bean

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/JaegerTestContainer.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/JaegerTestContainer.java
@@ -24,7 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class JaegerTestContainer extends GenericContainer<JaegerTestContainer> {
 
-    private static final String JAEGER_DOCKER_IMAGE = "jaegertracing/all-in-one:1.62.0";
+    private static final String JAEGER_DOCKER_IMAGE = "jaegertracing/all-in-one:1.69.0";
     public static final int JAEGER_COLLECTOR_GRPC_PORT = 4317;
     public static final int JAEGER_COLLECTOR_HTTP_PORT = 4318;
     public static final int JAEGER_ADMIN_PORT = 14269;

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.3.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.3.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.3.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.3.0.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.5.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.5.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.5.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.5.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -461,8 +461,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.3.0.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.3.0.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.5.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.5.0.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.3.0</gravitee-node.version>
+        <gravitee-node.version>7.5.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.7.0</gravitee-plugin.version>


### PR DESCRIPTION
## Description

This PR allows to enable the node monitoring stack on the test SDK, making it possible to develop integration tests involving probes.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wyqpalmolz.chromatic.com)
<!-- Storybook placeholder end -->
