### PR TITLE
Apim 9518 improve upgrader logs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgrader.java
@@ -101,7 +101,7 @@ public class AlertsEnvironmentUpgrader implements Upgrader {
                 }
             }
         } catch (Exception e) {
-            log.error("Failed to apply upgrader {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
@@ -60,7 +60,7 @@ public class ApiCategoryOrderUpgrader implements Upgrader {
         try {
             fillApiCategoryOrderTable();
         } catch (Exception e) {
-            log.error("error occurred while applying upgrader {}", this.getClass().getSimpleName());
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiKeySubscriptionsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiKeySubscriptionsUpgrader.java
@@ -54,7 +54,7 @@ public class ApiKeySubscriptionsUpgrader implements Upgrader {
         try {
             apiKeyRepository.findAll().forEach(this::updateApiKeySubscriptions);
         } catch (Exception e) {
-            log.error("error applying upgrader {}", this.getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgrader.java
@@ -93,7 +93,7 @@ public class ApiLoggingConditionUpgrader implements Upgrader {
                 log.warn("They need to be redeployed manually to apply the patch.");
             }
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgrader.java
@@ -34,8 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -44,9 +43,8 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
+@Slf4j
 public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ApiPrimaryOwnerRemovalUpgrader.class);
 
     private final RoleRepository roleRepository;
 
@@ -94,7 +92,7 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader {
             }
             return true;
         } catch (Exception e) {
-            LOG.error("Failed to fix APIs Primary Owner removal", e);
+            log.error("Failed to fix APIs Primary Owner removal", e);
             return false;
         }
     }
@@ -135,24 +133,24 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader {
     }
 
     private void warn(List<String> apiIds) {
-        LOG.warn("");
-        LOG.warn("##############################################################");
-        LOG.warn("#                           WARNING                          #");
-        LOG.warn("##############################################################");
-        LOG.warn("");
-        LOG.warn("The following APIs do not have a Primary Owner:");
-        LOG.warn("");
-        apiIds.forEach(LOG::warn);
-        LOG.warn("");
-        LOG.warn("Please edit the services.api-primary-owner-default property of your configuration file to fix this");
-        LOG.warn("This value must refer to a valid user or group ID");
-        LOG.warn("");
-        LOG.warn("##############################################################");
-        LOG.warn("");
+        log.warn("");
+        log.warn("##############################################################");
+        log.warn("#                           WARNING                          #");
+        log.warn("##############################################################");
+        log.warn("");
+        log.warn("The following APIs do not have a Primary Owner:");
+        log.warn("");
+        apiIds.forEach(log::warn);
+        log.warn("");
+        log.warn("Please edit the services.api-primary-owner-default property of your configuration file to fix this");
+        log.warn("This value must refer to a valid user or group ID");
+        log.warn("");
+        log.warn("##############################################################");
+        log.warn("");
     }
 
     private void fix(List<String> apiIds, String apiPrimaryOwnerRoleId) throws TechnicalException {
-        LOG.info("Attempting to fix APIs without a Primary Owner from configuration");
+        log.info("Attempting to fix APIs without a Primary Owner from configuration");
         Membership membership = prepareMembership(apiPrimaryOwnerRoleId);
         for (String apiId : apiIds) {
             membership.setId(UuidString.generateRandom());
@@ -160,7 +158,7 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader {
             membershipRepository.create(membership);
         }
         String memberType = membership.getMemberType().name().toLowerCase();
-        LOG.info("APIs without a Primary Owner has been associated with {} {}", memberType, defaultPrimaryOwnerId);
+        log.info("APIs without a Primary Owner has been associated with {} {}", memberType, defaultPrimaryOwnerId);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
@@ -69,7 +69,7 @@ public class ApiV4CategoriesUpgrader implements Upgrader {
         try {
             migrateV4ApiCategories();
         } catch (Exception e) {
-            log.error("error occurred while applying upgrader {}", this.getClass().getSimpleName());
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationApiKeyModeUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationApiKeyModeUpgrader.java
@@ -83,7 +83,7 @@ public class ApplicationApiKeyModeUpgrader implements Upgrader {
                     }
                 });
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClientIdInApiKeySubscriptionsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClientIdInApiKeySubscriptionsUpgrader.java
@@ -53,7 +53,7 @@ public class ClientIdInApiKeySubscriptionsUpgrader implements Upgrader {
             criteriaBuilder.planSecurityTypes(List.of(Plan.PlanSecurityType.API_KEY.name()));
             subscriptionRepository.search(criteriaBuilder.build()).forEach(this::updateApiKeySubscriptions);
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CommandOrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CommandOrganizationUpgrader.java
@@ -53,7 +53,7 @@ public class CommandOrganizationUpgrader implements Upgrader {
         try {
             environmentRepository.findAll().forEach(this::updateCommands);
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,12 +29,8 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
+@Slf4j
 public class DefaultEnvironmentUpgrader implements Upgrader {
-
-    /**
-     * Logger.
-     */
-    private final Logger logger = LoggerFactory.getLogger(DefaultEnvironmentUpgrader.class);
 
     @Autowired
     private EnvironmentService environmentService;
@@ -43,11 +40,11 @@ public class DefaultEnvironmentUpgrader implements Upgrader {
         try {
             // initialize roles.
             if (environmentService.findByOrganization(GraviteeContext.getDefaultOrganization()).isEmpty()) {
-                logger.info("    No environment found. Add default one.");
+                log.info("    No environment found. Add default one.");
                 environmentService.initialize();
             }
         } catch (Exception e) {
-            logger.error("unable to apply upgrader {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
@@ -17,8 +17,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.rest.api.service.OrganizationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,12 +26,8 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
+@Slf4j
 public class DefaultOrganizationUpgrader implements Upgrader {
-
-    /**
-     * Logger.
-     */
-    private final Logger logger = LoggerFactory.getLogger(DefaultOrganizationUpgrader.class);
 
     @Autowired
     private OrganizationService organizationService;
@@ -41,7 +36,7 @@ public class DefaultOrganizationUpgrader implements Upgrader {
     public boolean upgrade() {
         // initialize default organization.
         if (organizationService.count().equals(0L)) {
-            logger.info("    No organization found. Add default one.");
+            log.info("    No organization found. Add default one.");
             organizationService.initialize();
         }
         return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultRolesUpgrader.java
@@ -57,7 +57,7 @@ public class DefaultRolesUpgrader implements Upgrader {
                     roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
                 });
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
@@ -90,7 +90,7 @@ public class EventsLatestUpgrader implements Upgrader {
             migrateDictionaryEvents();
             migrateOrganizationEvents();
         } catch (Exception e) {
-            log.error("error occurred while applying upgrader {}", this.getClass().getSimpleName());
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgrader.java
@@ -59,7 +59,7 @@ public class ExecutionModeUpgrader implements Upgrader {
         try {
             migrateApiEvents();
         } catch (Exception e) {
-            log.error("error occurred while applying upgrader {}", this.getClass().getSimpleName());
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/GenericNotificationConfigUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/GenericNotificationConfigUpgrader.java
@@ -74,7 +74,7 @@ public class GenericNotificationConfigUpgrader implements Upgrader {
                 .toList();
             log.info("Migrating genericNotificationConfig: {} for environments {}", genericNotificationConfigs.size(), environments);
         } catch (Exception e) {
-            log.error("Failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
         return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InstallationKeyStatusUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InstallationKeyStatusUpgrader.java
@@ -95,7 +95,7 @@ public class InstallationKeyStatusUpgrader implements Upgrader {
 
             return true;
         } catch (Exception e) {
-            log.error("unable to apply upgrader {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgrader.java
@@ -62,7 +62,7 @@ public class MetadataDefaultReferenceUpgrader implements Upgrader {
                 .toList();
             log.info("Migrating metadata: {} for environments {}", metadataList.size(), environments);
         } catch (Exception e) {
-            log.error("Failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
         return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgrader.java
@@ -58,7 +58,7 @@ public class OrphanCategoryUpgrader implements Upgrader {
                 apiRepository.update(api);
             }
         } catch (Exception e) {
-            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
@@ -127,7 +127,7 @@ public class PlansDataFixUpgrader implements Upgrader {
 
             return !upgradeFailed.get();
         } catch (Exception e) {
-            log.error("error applying upgrader {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
@@ -89,7 +89,7 @@ public class PlansFlowsDefinitionUpgrader implements Upgrader {
 
             return !upgradeFailed.get();
         } catch (Exception e) {
-            log.error("unable to apply upgrader {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgrader.java
@@ -69,7 +69,7 @@ public class PortalNotificationConfigUpgrader implements Upgrader {
                 .toList();
             log.info("Migrating portalNotificationConfig: {} for environments {}", portalNotificationConfigs.size(), environments);
         } catch (Exception e) {
-            log.error("Failed to apply {}", getClass().getSimpleName(), e);
+            log.error("Error applying upgrader", e);
             return false;
         }
         return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/QualityRulesScopingUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/QualityRulesScopingUpgrader.java
@@ -22,7 +22,6 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.QualityRuleRepository;
 import io.gravitee.repository.management.model.*;
-import io.gravitee.rest.api.model.quality.QualityRuleReferenceType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.List;
@@ -84,7 +83,7 @@ public class QualityRulesScopingUpgrader implements Upgrader {
             scopeExistingQualityRulesToEnvironments();
             return isUpgradeSuccessful();
         } catch (Exception e) {
-            log.error("error occurred while applying upgrader {}", this.getClass().getSimpleName());
+            log.error("Error applying upgrader", e);
             return false;
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9518

## Description

Add the exception object into upgrader's error logs when 
missing.
Remove manual logger instantiation.
Simplify the log message in update methods.

## Additional context

A new fix with a breaking change will be added later on master (evolution of gravitee-node).

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-axgdttqcud.chromatic.com)
<!-- Storybook placeholder end -->
