### PR TITLE
fix: remove trailing slash from path to prevent double slash in debug API URI

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
@@ -17,12 +17,10 @@ package io.gravitee.gateway.debug.definition;
 
 import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.definition.model.HttpResponse;
-import io.gravitee.definition.model.debug.DebugApiV2;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
-import io.gravitee.gateway.reactor.ReactableApi;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -86,6 +84,7 @@ public class DebugApiV4 extends Api implements ReactableDebugApi<io.gravitee.def
                 .flatMap(listener -> ((HttpListener) listener).getPaths().stream())
                 .map(Path::getPath)
                 .findFirst()
+                .map(path -> path.endsWith("/") ? path.substring(0, path.length() - 1) : path)
                 .orElse("") +
             request.getPath()
         );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9567

## Description

Remove trailing slash from path to prevent double slash in debug API URI


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jlkahsynve.chromatic.com)
<!-- Storybook placeholder end -->
