### PR TITLE
fix: handle null API definition version to ensure alert delivery

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -780,6 +780,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
         ExecutionContext executionContext = new ExecutionContext(environmentService.findById(api.getEnvironmentId()));
 
+        if (api.getDefinitionVersion() == null && api.getId() != null) {
+            api.setDefinitionVersion(DefinitionVersion.V2);
+        }
         var apiEntity =
             switch (api.getDefinitionVersion()) {
                 case V1, V2 -> convert(executionContext, api, getPrimaryOwner(executionContext, api));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9578

## Description

for v2 apis we don't store definitionVersion in DB.

Issue:

https://github.com/user-attachments/assets/6aff20fd-ccab-4098-8614-482e9e786ae6



Fix:

https://github.com/user-attachments/assets/7fe8ba4c-270b-4c89-a212-1e147160572f




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

