### PR TITLE
Apim 9526 add mcp entrypoint

### DIFF
--- a/gravitee-apim-console-webui/src/entities/entrypoint/mcp.ts
+++ b/gravitee-apim-console-webui/src/entities/entrypoint/mcp.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface MCPConfiguration {
+  mcpPath: string;
+  tools: MCPTool[];
+}
+
+export interface MCPTool {
+  toolDefinition: MCPToolDefinition;
+  gatewayMapping: MCPToolGatewayMapping;
+}
+
+export interface MCPToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+}
+
+export interface MCPToolGatewayMapping {
+  http: {
+    method: string;
+    path: string;
+    contentType?: string;
+  };
+}
+
+export const DEFAULT_MCP_ENTRYPOINT_PATH = '/mcp';
+export const MCP_ENTRYPOINT_ID = 'mcp';

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -91,6 +91,7 @@ import { ApiHealthCheckDashboardV4Component } from './health-check-dashboard-v4/
 import { DebugModeV2WrapperComponent } from './debug-mode/v2-wrapper/debug-mode-v2-wrapper.component';
 import { DebugModeV4WrapperComponent } from './debug-mode/v4-wrapper/debug-mode-v4-wrapper.component';
 import { McpComponent } from './mcp/mcp.component';
+import { EnableMcpEntrypointComponent } from './mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -1072,6 +1073,16 @@ const apisRoutes: Routes = [
           docs: null,
           permissions: {
             anyOf: ['api-definition-r'],
+          },
+        },
+      },
+      {
+        path: 'v4/mcp/enable',
+        component: EnableMcpEntrypointComponent,
+        data: {
+          docs: null,
+          permissions: {
+            anyOf: ['api-definition-u'],
           },
         },
       },

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.html
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="formGroup()">
+  <mat-form-field class="configure-mcp-entrypoint__content__mcp-path">
+    <mat-label>MCP Path</mat-label>
+    <mat-hint
+      >The MCP path an AI agent will use to connect to the API. This path is appended to the API contextPath. Default is: /mcp</mat-hint
+    >
+    <input matInput formControlName="mcpPath" required />
+    @if (formGroup().controls.mcpPath.errors?.required) {
+      <mat-error>This field is required.</mat-error>
+    }
+  </mat-form-field>
+
+  <tools-display [tools]="toolDefinitions()" />
+</form>

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.scss
@@ -1,0 +1,5 @@
+form {
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, input, Signal } from '@angular/core';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatInput, MatLabel } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+
+import { ToolsDisplayComponent } from '../tools-display/tools-display.component';
+import { MCPTool, MCPToolDefinition } from '../../../../../entities/entrypoint/mcp';
+
+export interface ConfigurationMCPForm {
+  tools: FormControl<MCPTool[]>;
+  mcpPath: FormControl<string>;
+}
+
+@Component({
+  selector: 'configure-mcp-entrypoint',
+  imports: [FormsModule, MatInput, MatLabel, ReactiveFormsModule, ToolsDisplayComponent, MatFormFieldModule],
+  templateUrl: './configure-mcp-entrypoint.component.html',
+  styleUrl: './configure-mcp-entrypoint.component.scss',
+})
+export class ConfigureMcpEntrypointComponent {
+  formGroup = input<FormGroup<ConfigurationMCPForm>>();
+
+  toolDefinitions: Signal<MCPToolDefinition[]> = computed(() => {
+    return this.formGroup()?.controls.tools.value.map((tool) => tool.toolDefinition) ?? [];
+  });
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/configure-mcp-entrypoint/configure-mcp-entrypoint.harness.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { ToolsDisplayHarness } from '../tools-display/tools-display.harness';
+
+export class ConfigureMcpEntrypointHarness extends ComponentHarness {
+  static readonly hostSelector = 'configure-mcp-entrypoint';
+
+  protected locateMcpPathFormField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '.configure-mcp-entrypoint__content__mcp-path' }),
+  );
+  protected locateMcpPathInput = this.locatorFor(MatInputHarness.with({ selector: 'input[formControlName="mcpPath"]' }));
+  protected locateToolDisplay = this.locatorFor(ToolsDisplayHarness);
+
+  async getMcpPathFormField(): Promise<MatFormFieldHarness> {
+    return this.locateMcpPathFormField();
+  }
+
+  async getMcpPathInput(): Promise<MatInputHarness> {
+    return this.locateMcpPathInput();
+  }
+
+  async getMcpPathValue(): Promise<string> {
+    const input = await this.getMcpPathInput();
+    return input.getValue();
+  }
+
+  async setMcpPathValue(value: string): Promise<void> {
+    const input = await this.getMcpPathInput();
+    await input.setValue(value);
+  }
+
+  async getMcpPathError(): Promise<string | null> {
+    const formField = await this.getMcpPathFormField();
+    const errors = await formField.getTextErrors();
+    return errors.length > 0 ? errors[0] : null;
+  }
+
+  async hasTools(): Promise<boolean> {
+    return this.locateToolDisplay().then((tools) => tools.hasTools());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.component.html
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h5>Tool Definitions</h5>
+
+@for (tool of tools(); track $index) {
+  <div>
+    {{ tool | json }}
+  </div>
+} @empty {
+  <div>No tools are configured. Add tools by importing from an OpenAPI specification.</div>
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.component.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+
+import { MCPToolDefinition } from '../../../../../entities/entrypoint/mcp';
+
+@Component({
+  selector: 'tools-display',
+  imports: [JsonPipe],
+  templateUrl: './tools-display.component.html',
+  styleUrl: './tools-display.component.scss',
+})
+export class ToolsDisplayComponent {
+  tools = input<MCPToolDefinition[]>([]);
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/tools-display/tools-display.harness.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ToolsDisplayHarness extends ComponentHarness {
+  static readonly hostSelector = 'tools-display';
+
+  private locateTitle = this.locatorFor('h5');
+  private locateToolElements = this.locatorForAll('div:not(:empty)');
+  private locateEmptyMessage = this.locatorFor('div:contains("No tools are configured")');
+
+  async getTitle(): Promise<string> {
+    const title = await this.locateTitle();
+    return title.text();
+  }
+
+  async getTools(): Promise<string[]> {
+    const toolElements = await this.locateToolElements();
+    const tools: string[] = [];
+
+    for (const element of toolElements) {
+      const text = await element.text();
+      if (!text.includes('No tools are configured')) {
+        tools.push(text.trim());
+      }
+    }
+
+    return tools;
+  }
+
+  async hasTools(): Promise<boolean> {
+    const tools = await this.getTools();
+    return tools.length > 0;
+  }
+
+  async getEmptyMessage(): Promise<string | null> {
+    try {
+      const emptyMessage = await this.locateEmptyMessage();
+      return emptyMessage.text();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.html
@@ -1,0 +1,30 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="back">
+  <a mat-button [routerLink]="'..'"><mat-icon svgIcon="gio:arrow-left" />Go back</a>
+</div>
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Enable MCP Entrypoint</mat-card-title>
+    <mat-card-subtitle>Configure the new MCP entrypoint</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content class="configure-mcp-entrypoint__content">
+    <configure-mcp-entrypoint [formGroup]="form" />
+  </mat-card-content>
+</mat-card>
+<gio-save-bar [creationMode]="true" [form]="form" [formInitialValues]="formInitialValues" (submitted)="onSubmit()" />

--- a/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.scss
@@ -1,0 +1,26 @@
+@use '../../../../scss/gio-layout' as gio-layout;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '@angular/material' as mat;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+}
+
+.configure-mcp-entrypoint {
+  &__content {
+    display: flex;
+    flex-flow: column;
+    gap: 16px;
+
+    &__mcp-path {
+      width: 80%;
+    }
+  }
+}
+
+mat-card-header {
+  margin-bottom: 16px;
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatCardHarness } from '@angular/material/card/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { EnableMcpEntrypointComponent } from './enable-mcp-entrypoint.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { Api, fakeProxyApiV4 } from '../../../../entities/management-api-v2';
+import { ConfigureMcpEntrypointHarness } from '../components/configure-mcp-entrypoint/configure-mcp-entrypoint.harness';
+
+describe('EnableMcpEntrypointComponent', () => {
+  let fixture: ComponentFixture<EnableMcpEntrypointComponent>;
+  let httpTestingController: HttpTestingController;
+  let harnessLoader: HarnessLoader;
+  let routerSpy: jest.SpyInstance;
+
+  const API_ID = 'api-id';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EnableMcpEntrypointComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { apiId: API_ID } } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EnableMcpEntrypointComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    routerSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
+
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should show creation titles and form', async () => {
+    expect(await getTitle()).toEqual('Enable MCP Entrypoint');
+    expect(await getSubtitle()).toEqual('Configure the new MCP entrypoint');
+
+    const mcpConfigurationForm = await harnessLoader.getHarness(ConfigureMcpEntrypointHarness);
+    expect(await mcpConfigurationForm.getMcpPathValue()).toEqual('/mcp');
+
+    expect(await mcpConfigurationForm.hasTools()).toEqual(false);
+
+    const saveBar = await getSaveBar();
+    expect(await saveBar.isVisible()).toEqual(true);
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+  });
+
+  it('should save configuration', async () => {
+    const mcpConfigurationForm = await harnessLoader.getHarness(ConfigureMcpEntrypointHarness);
+    await mcpConfigurationForm.setMcpPathValue('/cats-rule');
+
+    await getSaveBar().then((saveBar) => saveBar.clickSubmit());
+
+    const oldApi = fakeProxyApiV4({ id: API_ID });
+    const newApi = { ...oldApi };
+    const httpListener = newApi.listeners[0];
+    httpListener.entrypoints = [...httpListener.entrypoints, { type: 'mcp', configuration: { mcpPath: '/cats-rule', tools: [] } }];
+    newApi.listeners[0] = httpListener;
+
+    expectUpdateApiCalls(oldApi, newApi);
+
+    expect(routerSpy).toHaveBeenCalledWith(['..'], expect.anything());
+  });
+
+  /**
+   * HTTP expect calls
+   */
+  function expectGetApi(api: Api): void {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+  function expectUpdateApiCalls(oldApi: Api, newApi: Api): void {
+    expectGetApi(oldApi);
+
+    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${newApi.id}`, method: 'PUT' });
+    expect(req.request.body).toEqual(newApi);
+    req.flush(newApi);
+
+    fixture.detectChanges();
+  }
+
+  /**
+   * Get component elements
+   */
+  async function getTitle(): Promise<string> {
+    return harnessLoader.getHarness(MatCardHarness).then((card) => card.getTitleText());
+  }
+  async function getSubtitle(): Promise<string> {
+    return harnessLoader.getHarness(MatCardHarness).then((card) => card.getSubtitleText());
+  }
+  async function getSaveBar(): Promise<GioSaveBarHarness> {
+    return harnessLoader.getHarness(GioSaveBarHarness);
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/enable-mcp-entrypoint/enable-mcp-entrypoint.component.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { MatStepperModule } from '@angular/material/stepper';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { GioFormJsonSchemaModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { switchMap, tap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatFormFieldModule } from '@angular/material/form-field';
+
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { ApiV4, HttpListener } from '../../../../entities/management-api-v2';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import {
+  ConfigurationMCPForm,
+  ConfigureMcpEntrypointComponent,
+} from '../components/configure-mcp-entrypoint/configure-mcp-entrypoint.component';
+import { DEFAULT_MCP_ENTRYPOINT_PATH, MCP_ENTRYPOINT_ID, MCPConfiguration, MCPTool } from '../../../../entities/entrypoint/mcp';
+
+@Component({
+  selector: 'enable-mcp-entrypoint',
+  imports: [
+    MatCardModule,
+    MatStepperModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    GioFormJsonSchemaModule,
+    MatFormFieldModule,
+    GioIconsModule,
+    GioSaveBarModule,
+    RouterLink,
+    ConfigureMcpEntrypointComponent,
+  ],
+  templateUrl: './enable-mcp-entrypoint.component.html',
+  styleUrl: './enable-mcp-entrypoint.component.scss',
+})
+export class EnableMcpEntrypointComponent implements OnInit {
+  apiId: string = this.activatedRoute.snapshot.params['apiId'];
+
+  form: FormGroup<ConfigurationMCPForm> = new FormGroup<ConfigurationMCPForm>({
+    tools: new FormControl<MCPTool[]>([]),
+    mcpPath: new FormControl<string>(DEFAULT_MCP_ENTRYPOINT_PATH),
+  });
+
+  formInitialValues: { tools: MCPTool[]; mcpPath: string };
+
+  private destroyRef = inject(DestroyRef);
+
+  constructor(
+    private apiV2Service: ApiV2Service,
+    private snackBarService: SnackBarService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+  ) {}
+
+  ngOnInit() {
+    this.formInitialValues = this.form.getRawValue();
+  }
+
+  onSubmit() {
+    const configuration: MCPConfiguration = this.form.getRawValue();
+
+    this.apiV2Service
+      .get(this.apiId)
+      .pipe(
+        switchMap((api: ApiV4) => {
+          const listeners = api.listeners;
+          const httpListener = listeners[0] as HttpListener;
+
+          if (httpListener.entrypoints?.some((entrypoint) => entrypoint.type === MCP_ENTRYPOINT_ID)) {
+            httpListener.entrypoints = httpListener.entrypoints.map((entrypoint) =>
+              entrypoint.type === MCP_ENTRYPOINT_ID ? { ...entrypoint, configuration } : entrypoint,
+            );
+          } else {
+            httpListener.entrypoints = [...(httpListener.entrypoints || []), { type: MCP_ENTRYPOINT_ID, configuration }];
+          }
+
+          listeners[0] = httpListener;
+          return this.apiV2Service.update(this.apiId, { ...api, listeners });
+        }),
+        tap(() => {
+          this.snackBarService.success('MCP has been enabled successfully.');
+          this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.html
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.html
@@ -17,7 +17,18 @@
 -->
 @if (api$ | async; as apiVM) {
   @if (apiVM.hasMCPEntrypoint) {
-    Woohoo! It's added.
+    <mat-card>
+      <mat-card-header class="mcp-header">
+        <div class="mcp-header__title">
+          <mat-card-title>MCP Entrypoint</mat-card-title>
+          <mat-card-subtitle>API enabled as a MCP server</mat-card-subtitle>
+        </div>
+      </mat-card-header>
+      <mat-card-content>
+        <configure-mcp-entrypoint [formGroup]="form" />
+      </mat-card-content>
+    </mat-card>
+    <gio-save-bar [form]="form" [formInitialValues]="formInitialValues" (submitted)="onSubmit()" />
   } @else {
     <no-mcp-entrypoint [canEnableMcp]="canEnableMcp$ | async" (enableMcpEntrypoint)="addMcpEntrypoint()" />
   }

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.scss
@@ -21,8 +21,11 @@
   overflow: visible;
 }
 
-.mcp {
-  &__headerRightBtn {
-    margin-left: auto;
+.mcp-header {
+  margin-bottom: 16px;
+  display: flex;
+
+  &__title {
+    flex: 1;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
@@ -81,7 +81,7 @@ describe('McpComponent', () => {
       await enableMcpButton.click();
 
       expect(routerSpy).toHaveBeenCalledTimes(1);
-      expect(routerSpy).toHaveBeenCalledWith(['./add'], expect.anything());
+      expect(routerSpy).toHaveBeenCalledWith(['./enable'], expect.anything());
     });
 
     it('should not navigate to adding the entrypoint if mcp entrypoint is missing', async () => {

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.spec.ts
@@ -17,12 +17,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { McpComponent } from './mcp.component';
 import { McpHarness } from './mcp.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { ApiV4, ConnectorPlugin, fakeApiV4, fakeConnectorPlugin } from '../../../entities/management-api-v2';
+import { ApiV4, ConnectorPlugin, fakeApiV4, fakeConnectorPlugin, fakeProxyApiV4 } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 
 describe('McpComponent', () => {
@@ -35,7 +36,7 @@ describe('McpComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GioTestingModule, McpComponent],
+      imports: [GioTestingModule, McpComponent, NoopAnimationsModule],
       providers: [
         {
           provide: ActivatedRoute,
@@ -93,8 +94,65 @@ describe('McpComponent', () => {
     });
   });
 
+  describe('when mcp entrypoint is found', () => {
+    describe('when entrypoint configuration defined + empty tools', () => {
+      const API = fakeProxyApiV4({
+        id: API_ID,
+        listeners: [
+          {
+            type: 'HTTP',
+            entrypoints: [
+              { type: 'http-proxy' },
+              {
+                type: 'mcp',
+                configuration: {
+                  mcpPath: '/cats-rule',
+                  tools: [],
+                },
+              },
+            ],
+          },
+        ],
+      });
+      beforeEach(async () => {
+        expectGetApi(API);
+      });
+      it('should display the mcp entrypoint edit form', async () => {
+        const mcpConfigurationForm = await componentHarness.getConfigureMcpEntrypoint();
+        expect(await mcpConfigurationForm.getMcpPathValue()).toEqual('/cats-rule');
+        expect(await mcpConfigurationForm.hasTools()).toEqual(false);
+      });
+      it('should edit mcp entrypoint form and submit', async () => {
+        const mcpConfigurationForm = await componentHarness.getConfigureMcpEntrypoint();
+        await mcpConfigurationForm.setMcpPathValue('/dogs-drool');
+
+        const saveBar = await componentHarness.getSaveBar();
+        expect(saveBar).toBeTruthy();
+
+        await saveBar.clickSubmit();
+
+        const newApi = { ...API };
+        const httpListener = newApi.listeners[0];
+        httpListener.entrypoints = [...httpListener.entrypoints, { type: 'mcp', configuration: { mcpPath: '/dogs-drool', tools: [] } }];
+        newApi.listeners[0] = httpListener;
+
+        expectUpdateApiCalls(API, newApi);
+      });
+    });
+  });
+
   function expectGetApi(api: ApiV4): void {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectUpdateApiCalls(oldApi: ApiV4, newApi: ApiV4): void {
+    expectGetApi(oldApi);
+
+    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${newApi.id}`, method: 'PUT' });
+    expect(req.request.body).toEqual(newApi);
+    req.flush(newApi);
+
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
@@ -14,17 +14,29 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { GioFormJsonSchemaModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { NoMcpEntrypointComponent } from './no-mcp-entrypoint/no-mcp-entrypoint.component';
+import {
+  ConfigurationMCPForm,
+  ConfigureMcpEntrypointComponent,
+} from './components/configure-mcp-entrypoint/configure-mcp-entrypoint.component';
 
-import { ApiV4 } from '../../../entities/management-api-v2';
+import { ApiV4, HttpListener } from '../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { ConnectorPluginsV2Service } from '../../../services-ngx/connector-plugins-v2.service';
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { DEFAULT_MCP_ENTRYPOINT_PATH, MCP_ENTRYPOINT_ID, MCPConfiguration, MCPTool } from '../../../entities/entrypoint/mcp';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 interface ApiVM extends ApiV4 {
   hasMCPEntrypoint: boolean;
@@ -34,7 +46,18 @@ interface ApiVM extends ApiV4 {
   selector: 'mcp',
   templateUrl: './mcp.component.html',
   styleUrls: ['./mcp.component.scss'],
-  imports: [NoMcpEntrypointComponent, AsyncPipe],
+  imports: [
+    NoMcpEntrypointComponent,
+    AsyncPipe,
+    GioFormJsonSchemaModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    GioIconsModule,
+    GioPermissionModule,
+    ConfigureMcpEntrypointComponent,
+    GioSaveBarModule,
+  ],
 })
 export class McpComponent implements OnInit {
   apiId: string;
@@ -44,11 +67,18 @@ export class McpComponent implements OnInit {
     .listEntrypointPlugins()
     .pipe(
       map((plugins) =>
-        plugins.some((plugin) => plugin.id === this.mcpEntrypointId && this.gioPermissionService.hasAnyMatching(['api-definition-u'])),
+        plugins.some((plugin) => plugin.id === MCP_ENTRYPOINT_ID && this.gioPermissionService.hasAnyMatching(['api-definition-u'])),
       ),
     );
 
-  private mcpEntrypointId = 'mcp';
+  form: FormGroup<ConfigurationMCPForm> = new FormGroup<ConfigurationMCPForm>({
+    tools: new FormControl<MCPTool[]>([]),
+    mcpPath: new FormControl<string>(DEFAULT_MCP_ENTRYPOINT_PATH),
+  });
+
+  formInitialValues: { tools: MCPTool[]; mcpPath: string };
+
+  private destroyRef = inject(DestroyRef);
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -56,18 +86,63 @@ export class McpComponent implements OnInit {
     private apiV2Service: ApiV2Service,
     private gioPermissionService: GioPermissionService,
     private connectorPluginsV2Service: ConnectorPluginsV2Service,
+    private snackBarService: SnackBarService,
   ) {
     this.apiId = this.activatedRoute.snapshot.params['apiId'] || '';
   }
 
   ngOnInit() {
-    this.api$ = this.apiV2Service.getLastApiFetch(this.apiId).pipe(
+    if (!this.gioPermissionService.hasAnyMatching(['api-definition-u'])) {
+      this.form.disable();
+    }
+
+    this.api$ = this.apiV2Service.get(this.apiId).pipe(
       filter((api) => api.definitionVersion === 'V4'),
-      map((api) => ({ ...api, hasMCPEntrypoint: api.listeners?.[0].entrypoints.some((e) => e.type === this.mcpEntrypointId) }) as ApiVM),
+      map((api) => ({ ...api, hasMCPEntrypoint: api.listeners?.[0].entrypoints.some((e) => e.type === MCP_ENTRYPOINT_ID) }) as ApiVM),
+      tap((api) => {
+        if (api.hasMCPEntrypoint) {
+          this.updateFormValues(api);
+        }
+      }),
     );
   }
 
   addMcpEntrypoint() {
     this.router.navigate(['./enable'], { relativeTo: this.activatedRoute });
+  }
+
+  onSubmit() {
+    const configuration: MCPConfiguration = this.form.getRawValue();
+
+    this.apiV2Service
+      .get(this.apiId)
+      .pipe(
+        switchMap((api: ApiV4) => {
+          const listeners = api.listeners;
+          const httpListener = listeners[0] as HttpListener;
+
+          httpListener.entrypoints = httpListener.entrypoints.map((entrypoint) =>
+            entrypoint.type === MCP_ENTRYPOINT_ID ? { ...entrypoint, configuration } : entrypoint,
+          );
+
+          listeners[0] = httpListener;
+          return this.apiV2Service.update(this.apiId, { ...api, listeners });
+        }),
+        tap((api) => {
+          this.snackBarService.success('MCP entrypoint has been updated successfully.');
+          this.updateFormValues(api as ApiV4);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private updateFormValues(api: ApiV4): void {
+    const mcpConfiguration = api.listeners[0].entrypoints.find((e) => e.type === MCP_ENTRYPOINT_ID).configuration as MCPConfiguration;
+    this.form.reset({
+      mcpPath: mcpConfiguration.mcpPath,
+      tools: mcpConfiguration.tools,
+    });
+    this.formInitialValues = this.form.getRawValue();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.component.ts
@@ -68,6 +68,6 @@ export class McpComponent implements OnInit {
   }
 
   addMcpEntrypoint() {
-    this.router.navigate(['./add'], { relativeTo: this.activatedRoute });
+    this.router.navigate(['./enable'], { relativeTo: this.activatedRoute });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/mcp/mcp.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/mcp.harness.ts
@@ -14,15 +14,27 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { NoMcpEntrypointHarness } from './no-mcp-entrypoint/no-mcp-entrypoint.harness';
+import { ConfigureMcpEntrypointHarness } from './components/configure-mcp-entrypoint/configure-mcp-entrypoint.harness';
 
 export class McpHarness extends ComponentHarness {
   static readonly hostSelector = 'mcp';
 
   protected locateMcpEntryPointNotFound = this.locatorForOptional(NoMcpEntrypointHarness);
+  protected locateConfigureMcpEntrypoint = this.locatorForOptional(ConfigureMcpEntrypointHarness);
+  protected locateSaveBar = this.locatorForOptional(GioSaveBarHarness);
 
   async getMcpEntryPointNotFound(): Promise<NoMcpEntrypointHarness | null> {
     return this.locateMcpEntryPointNotFound();
+  }
+
+  async getConfigureMcpEntrypoint(): Promise<ConfigureMcpEntrypointHarness> {
+    return this.locateConfigureMcpEntrypoint();
+  }
+
+  async getSaveBar(): Promise<GioSaveBarHarness | null> {
+    return this.locateSaveBar();
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9526

## Description

This Pull Request adds functionality to manage the **MCP (Managed Control Plane)** entrypoints within the Gravitee API Management Console. It introduces new components, routes, styles, and updates existing functionality to support creating and editing MCP entrypoints.

## Main Changes

### 1. Routing Updates
- Added routes for creating and editing MCP entrypoints.
### 2. New Component
- **`ConfigureMcpEntrypointComponent`**: Handles the configuration of MCP entrypoints for both creation and editing.
### 3. HTML and SCSS
- Added templates and styles for configuring MCP entrypoints.
### 4. Tests
- Added test cases to cover the new **MCP configuration functionality**.
### 5. MCP Component Updates
- Enhanced the existing `mcp.component` to:
  - Display MCP entrypoint details.
  - Support editing MCP entrypoints.
  - Handle the configuration forms.

Creation:

<img width="1368" alt="Screenshot 2025-05-23 at 12 29 01" src="https://github.com/user-attachments/assets/b93b08df-199b-4161-8dee-b4e9f6576c8a" />



View/Update:

<img width="1369" alt="Screenshot 2025-05-23 at 12 29 43" src="https://github.com/user-attachments/assets/31dec5ed-6b77-4139-b2e6-52165bec3533" />


View/Update with a tool:

<img width="1380" alt="Screenshot 2025-05-23 at 12 51 46" src="https://github.com/user-attachments/assets/0a183fd1-c85d-435f-a0f7-125bd27200e1" />


View when cannot edit:

<img width="1372" alt="Screenshot 2025-05-23 at 12 53 59" src="https://github.com/user-attachments/assets/ee8e6158-303a-4f89-a448-f0ecb113d1f1" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vdobdhzoob.chromatic.com)
<!-- Storybook placeholder end -->
