### PR TITLE
fix: add text to indicate max image size

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -83,7 +83,9 @@
             <gio-form-file-picker class="details-card__header__right-coll__media__picture" formControlName="picture" accept="image/*">
               <gio-form-file-picker-label>API picture</gio-form-file-picker-label>
               <gio-form-file-picker-add-button class="details-card__header__right-coll__media__picture__btn">
-                <span class="details-card__header__right-coll__media__picture__btn__text"> Click here or drag an image </span>
+                <span class="details-card__header__right-coll__media__picture__btn__text">
+                  Click here or drag an image <br />Max 500KB</span
+                >
                 <gio-avatar
                   class="details-card__header__right-coll__media__picture__btn__default-avatar"
                   [size]="108"
@@ -97,7 +99,9 @@
             <gio-form-file-picker class="details-card__header__right-coll__media__background" formControlName="background" accept="image/*">
               <gio-form-file-picker-label>API background</gio-form-file-picker-label>
               <gio-form-file-picker-add-button class="details-card__header__right-coll__media__background__btn">
-                <span class="details-card__header__right-coll__media__background__btn__text"> Click here or drag an image </span>
+                <span class="details-card__header__right-coll__media__background__btn__text">
+                  Click here or drag an image <br />Max 500KB</span
+                >
               </gio-form-file-picker-add-button>
               <gio-form-file-picker-empty><span>No background defined</span></gio-form-file-picker-empty>
             </gio-form-file-picker>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.scss
@@ -98,6 +98,7 @@ $typography: map.get(gio.$mat-theme, typography);
             .details-card__header__right-coll__media__picture__btn__text {
               opacity: 1;
               visibility: visible;
+              line-height: 1.8;
             }
           }
         }
@@ -112,6 +113,7 @@ $typography: map.get(gio.$mat-theme, typography);
               justify-content: center;
               align-items: center;
               height: 114px;
+              line-height: 1.8;
             }
           }
         }

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -49,7 +49,9 @@
             <gio-form-file-picker class="details-card__header__right-coll__media__picture" formControlName="picture" accept="image/*">
               <gio-form-file-picker-label>Application picture</gio-form-file-picker-label>
               <gio-form-file-picker-add-button class="details-card__header__right-coll__media__picture__btn">
-                <span class="details-card__header__right-coll__media__picture__btn__text"> Click here or drag an image </span>
+                <span class="details-card__header__right-coll__media__picture__btn__text">
+                  Click here or drag an image <br />Max 500KB</span
+                >
                 <gio-avatar class="details-card__header__right-coll__media__picture__btn__default-avatar" [size]="108"></gio-avatar>
               </gio-form-file-picker-add-button>
               <gio-form-file-picker-empty>
@@ -59,7 +61,9 @@
             <gio-form-file-picker class="details-card__header__right-coll__media__background" formControlName="background" accept="image/*">
               <gio-form-file-picker-label>Application background</gio-form-file-picker-label>
               <gio-form-file-picker-add-button class="details-card__header__right-coll__media__background__btn">
-                <span class="details-card__header__right-coll__media__background__btn__text"> Click here or drag an image </span>
+                <span class="details-card__header__right-coll__media__background__btn__text">
+                  Click here or drag an image <br />Max 500KB</span
+                >
               </gio-form-file-picker-add-button>
               <gio-form-file-picker-empty><span>No background defined</span></gio-form-file-picker-empty>
             </gio-form-file-picker>

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.scss
@@ -107,6 +107,7 @@ $typography: map.get(gio.$mat-theme, typography);
             .details-card__header__right-coll__media__picture__btn__text {
               opacity: 1;
               visibility: visible;
+              line-height: 1.8;
             }
           }
         }
@@ -121,6 +122,7 @@ $typography: map.get(gio.$mat-theme, typography);
               justify-content: center;
               align-items: center;
               height: 114px;
+              line-height: 1.8;
             }
           }
         }

--- a/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.html
@@ -61,8 +61,14 @@
               <gio-form-file-picker formControlName="picture" accept="image/*">
                 <gio-form-file-picker-label>Picture</gio-form-file-picker-label>
                 <gio-form-file-picker-add-button class="general__right__image-upload__picture__btn">
-                  <span class="general__right__image-upload__picture__text"> Click here or drag an image </span>
-                  <gio-avatar [size]="108" [name]="category.name"></gio-avatar>
+                  <div class="general__right__image-upload__picture">
+                    <span class="general__right__image-upload__picture__text"> Click here or drag an image <br />Max 500KB</span>
+                    <gio-avatar
+                      class="general__right__image-upload__picture__default-avatar"
+                      [size]="108"
+                      [name]="category.name"
+                    ></gio-avatar>
+                  </div>
                 </gio-form-file-picker-add-button>
                 <gio-form-file-picker-empty>
                   <gio-avatar
@@ -79,7 +85,7 @@
               >
                 <gio-form-file-picker-label>Background</gio-form-file-picker-label>
                 <gio-form-file-picker-add-button>
-                  <span class="general__right__image-upload__background__text"> Click here or drag an image </span>
+                  <span class="general__right__image-upload__background__text"> Click here or drag an image <br />Max 500KB</span>
                 </gio-form-file-picker-add-button>
                 <gio-form-file-picker-empty><span>No background defined</span></gio-form-file-picker-empty>
               </gio-form-file-picker>

--- a/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.scss
@@ -36,7 +36,18 @@ $typography: map.get(gio.$mat-theme, typography);
       gap: 6px;
 
       &__picture {
-        flex: 0 0 0;
+        flex: 0 0 0%;
+
+        &:hover {
+          .general__right__image-upload__picture__default-avatar {
+            opacity: 0.1;
+          }
+          .general__right__image-upload__picture__text {
+            opacity: 1;
+            visibility: visible;
+            line-height: 1.8;
+          }
+        }
 
         &__btn {
           position: relative;
@@ -58,16 +69,6 @@ $typography: map.get(gio.$mat-theme, typography);
           justify-content: center;
           align-items: center;
         }
-
-        &:hover {
-          .general__right__image-upload__picture__default-avatar {
-            opacity: 0.1;
-          }
-          .general__right__image-upload__picture__text {
-            opacity: 1;
-            visibility: visible;
-          }
-        }
       }
 
       &__background {
@@ -79,6 +80,7 @@ $typography: map.get(gio.$mat-theme, typography);
           justify-content: center;
           align-items: center;
           height: 114px;
+          line-height: 1.8;
         }
       }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9614

## Description

No size limit information was shown in the UI when uploading API pictures. 
Added a matTooltip to the upload button to inform users of the 500KB limit.

Current:

https://github.com/user-attachments/assets/06929d07-ca01-4ab4-a5dc-c9f8d4d65101


Updated:


https://github.com/user-attachments/assets/1a8ac1eb-14fa-4db5-ad05-e648b365ce52




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mtbdunypec.chromatic.com)
<!-- Storybook placeholder end -->
