### PR TITLE
chore: bump callout http policy to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>
         <gravitee-policy-basic-authentication.version>1.6.0</gravitee-policy-basic-authentication.version>
         <gravitee-policy-cache.version>2.0.7</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>4.0.1</gravitee-policy-callout-http.version>
+        <gravitee-policy-callout-http.version>4.0.2</gravitee-policy-callout-http.version>
         <gravitee-policy-circuit-breaker.version>1.1.5</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9355

## Description

Update callout http policy version to 4.0.2
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-onfoegkpie.chromatic.com)
<!-- Storybook placeholder end -->
