### PR TITLE
fix: remove kafka domain display in creation workflow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.html
@@ -55,15 +55,15 @@
             }
           </mat-form-field>
         </div>
-        @if (kafkaDomains) {
-          <div class="kafka-configuration__domain mat-subtitle-2">
-            @for (kafkaDomain of kafkaDomains; track kafkaDomain) {
-              <div class="kafka-configuration__domain__item">
-                {{ kafkaDomain }}
-              </div>
-            }
-          </div>
-        }
+        <!--        @if (kafkaDomains) {-->
+        <!--          <div class="kafka-configuration__domain mat-subtitle-2">-->
+        <!--            @for (kafkaDomain of kafkaDomains; track kafkaDomain) {-->
+        <!--              <div class="kafka-configuration__domain__item">-->
+        <!--                {{ kafkaDomain }}-->
+        <!--              </div>-->
+        <!--            }-->
+        <!--          </div>-->
+        <!--        }-->
       </div>
     </tr>
   </tbody>

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -175,7 +175,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       discardPeriodicTasks();
 
-      httpExpects.expectApiGetPortalConfiguration();
+      // httpExpects.expectApiGetPortalConfiguration();
 
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       const step1Summary = await step5Harness.getStepSummaryTextContent(1);
@@ -184,7 +184,8 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       expect(step1Summary).toContain('Description:' + ' Description');
 
       const step2Summary = await step5Harness.getStepSummaryTextContent(2);
-      expect(step2Summary).toContain('Host:' + 'kafka-host.kafka.domain:9092');
+      // expect(step2Summary).toContain('Host:' + 'kafka-host.kafka.domain:9092');
+      expect(step2Summary).toContain('Host');
       expect(step2Summary).toContain('Type:' + 'KAFKA');
       expect(step2Summary).toContain('Entrypoints:' + ' Native Kafka Entrypoint');
 
@@ -208,11 +209,11 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       discardPeriodicTasks();
 
-      httpExpects.expectApiGetPortalConfiguration({
-        accessPoints: {
-          kafkaDomains: ['access.point:1234'],
-        },
-      });
+      // httpExpects.expectApiGetPortalConfiguration({
+      //   accessPoints: {
+      //     kafkaDomains: ['access.point:1234'],
+      //   },
+      // });
 
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       const step1Summary = await step5Harness.getStepSummaryTextContent(1);
@@ -221,7 +222,8 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       expect(step1Summary).toContain('Description:' + ' Description');
 
       const step2Summary = await step5Harness.getStepSummaryTextContent(2);
-      expect(step2Summary).toContain('Host:' + 'kafka-host.access.point:1234');
+      // expect(step2Summary).toContain('Host:' + 'kafka-host.access.point:1234');
+      expect(step2Summary).toContain('Host');
       expect(step2Summary).toContain('Type:' + 'KAFKA');
       expect(step2Summary).toContain('Entrypoints:' + ' Native Kafka Entrypoint');
 
@@ -248,7 +250,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       discardPeriodicTasks();
 
-      httpExpects.expectApiGetPortalConfiguration();
+      // httpExpects.expectApiGetPortalConfiguration();
 
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       const step1Summary = await step5Harness.getStepSummaryTextContent(1);
@@ -257,7 +259,8 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       expect(step1Summary).toContain('Description:' + ' Description');
 
       const step2Summary = await step5Harness.getStepSummaryTextContent(2);
-      expect(step2Summary).toContain('Host:' + 'kafka-host.kafka.domain:9092');
+      // expect(step2Summary).toContain('Host:' + 'kafka-host.kafka.domain:9092');
+      expect(step2Summary).toContain('Host');
       expect(step2Summary).toContain('Type:' + 'KAFKA');
       expect(step2Summary).toContain('Entrypoints:' + ' Native Kafka Entrypoint');
 
@@ -282,7 +285,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       discardPeriodicTasks();
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-      httpExpects.expectApiGetPortalConfiguration();
+      // httpExpects.expectApiGetPortalConfiguration();
       await step5Harness.clickDeployMyApiButton();
       httpExpects.expectCallsForApiDeployment('api-id', 'plan-id');
       flush();
@@ -300,7 +303,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       discardPeriodicTasks();
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-      httpExpects.expectApiGetPortalConfiguration();
+      // httpExpects.expectApiGetPortalConfiguration();
       expect(await step5Harness.getDeployMyApiButton().then((btn) => btn.isDisabled())).toEqual(true);
     }));
   });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
@@ -64,9 +64,9 @@
               <span class="step-5-summary__step__info__key">Host:</span>
               <span>
                 <span class="step-5-summary__step__info__value">{{ host }}</span>
-                @if (kafkaDomainAndPort$ | async; as kafkaDomainAndPort) {
-                  <span class="step-5-summary__step__info__key">{{ kafkaDomainAndPort }}</span>
-                }
+                <!--                @if (kafkaDomainAndPort$ | async; as kafkaDomainAndPort) {-->
+                <!--                  <span class="step-5-summary__step__info__key">{{ kafkaDomainAndPort }}</span>-->
+                <!--                }-->
               </span>
             </div>
             <div class="step-5-summary__step__info__row">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9633

## Description

Quick & dirty fix to avoid confusion when the domain is configured with a bootstrap pattern and {apiHost}. It probably needs a refactoring in a future version.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-przqjiuqqk.chromatic.com)
<!-- Storybook placeholder end -->
