### PR TITLE
fix:Dictionaries multitenant fix

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/dictionaries/OrgEnvNameBackFillIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/dictionaries/OrgEnvNameBackFillIndexUpgrader.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.dictionaries;
+
+import io.gravitee.repository.management.api.DictionaryRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component("DictionaryEnvironmentIdNameAndOrdIndexUpgrader")
+public class OrgEnvNameBackFillIndexUpgrader extends MongoUpgrader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+        OrgEnvNameBackFillIndexUpgrader.class
+    );
+
+    @Autowired
+    private EnvironmentRepository environmentRepository;
+
+    @Autowired
+    private DictionaryRepository dictionaryRepository;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        try {
+            Set<Dictionary> dictionaries = dictionaryRepository.findAll();
+            int migratedCount = 0;
+
+            for (Dictionary dict : dictionaries) {
+                String oldId = dict.getId();
+
+                if (oldId != null && oldId.split(":").length == 1) {
+                    String envId = dict.getEnvironmentId();
+                    Optional<Environment> env = environmentRepository.findById(envId);
+                    String envName = env.map(Environment::getName).orElse("Default");
+                    String orgId = env
+                        .map(Environment::getOrganizationId)
+                        .orElse("DEFAULT");
+
+                    String newId = String.join(":", oldId, envName, orgId);
+
+                    if (dictionaryRepository.findById(newId).isEmpty()) {
+                        dict.setId(newId);
+                        dictionaryRepository.create(dict);
+                        dictionaryRepository.delete(oldId);
+                        migratedCount++;
+                    }
+                }
+            }
+
+            LOG.info(
+                "Migrated %d dictionary IDs to composite format%n {}",
+                migratedCount
+            );
+            return true;
+        } catch (Exception e) {
+            LOG.error("An error occurred while backfilling EmailUniqueIndex", e);
+            return false;
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/dictionaries/OrgEnvNameBackFillIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/dictionaries/OrgEnvNameBackFillIndexUpgraderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.dictionaries;
+
+import static org.mockito.Mockito.*;
+
+import com.mongodb.client.MongoCollection;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.DictionaryRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.Environment;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@ExtendWith(MockitoExtension.class)
+public class OrgEnvNameBackFillIndexUpgraderTest {
+
+    @Mock
+    private DictionaryRepository dictionaryRepository;
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    @InjectMocks
+    private OrgEnvNameBackFillIndexUpgrader upgrader;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    void shouldMigrateOldDictionaryIds() throws TechnicalException {
+        Dictionary oldDict = new Dictionary();
+        oldDict.setId("dictId");
+        oldDict.setEnvironmentId("envId");
+
+        Environment env = new Environment();
+        env.setName("dev");
+        env.setOrganizationId("orgId");
+
+        when(mongoTemplate.getCollection("dictionaries"))
+            .thenReturn(mock(MongoCollection.class));
+        when(dictionaryRepository.findAll()).thenReturn(Set.of(oldDict));
+        when(environmentRepository.findById("envId")).thenReturn(Optional.of(env));
+        when(dictionaryRepository.findById("dictId:dev:orgId"))
+            .thenReturn(Optional.empty());
+
+        boolean result = upgrader.upgrade();
+
+        Assertions.assertTrue(result);
+
+        ArgumentCaptor<Dictionary> insertCaptor = ArgumentCaptor.forClass(
+            Dictionary.class
+        );
+        verify(dictionaryRepository).create(insertCaptor.capture());
+
+        Dictionary inserted = insertCaptor.getValue();
+        Assertions.assertEquals("dictId:dev:orgId", inserted.getId());
+
+        verify(dictionaryRepository).delete("dictId");
+    }
+
+    @Test
+    void shouldSkipIfAlreadyMigrated() throws TechnicalException {
+        Dictionary existing = new Dictionary();
+        existing.setId("dictId:dev:orgId");
+        existing.setEnvironmentId("envId");
+
+        when(dictionaryRepository.findAll()).thenReturn(Set.of(existing));
+
+        boolean result = upgrader.upgrade();
+
+        Assertions.assertTrue(result);
+        verify(dictionaryRepository, never()).create(existing);
+        verify(dictionaryRepository, never()).delete(anyString());
+    }
+
+    @Test
+    void shouldTestGetters() {
+        Assertions.assertEquals(0, upgrader.getOrder());
+        Assertions.assertEquals("v1", upgrader.version());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StopTest.java
@@ -17,12 +17,7 @@ package io.gravitee.rest.api.service.impl.configuration.dictionary;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DictionaryRepository;
@@ -31,6 +26,7 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -60,10 +56,13 @@ public class DictionaryServiceImpl_StopTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private EnvironmentService environmentService;
+
     @Test
     public void shouldStopDictionary() throws TechnicalException {
         Dictionary dictionaryInDb = new Dictionary();
-        dictionaryInDb.setId("dictionaryId");
+        dictionaryInDb.setId("dictionaryId:DEFAULT:DEFAULT");
         dictionaryInDb.setCreatedAt(new Date(1486771200000L));
         dictionaryInDb.setUpdatedAt(new Date(1486771200000L));
         dictionaryInDb.setState(LifecycleState.STARTED);
@@ -74,6 +73,7 @@ public class DictionaryServiceImpl_StopTest {
         updatedDictionary.setUpdatedAt(new Date());
         updatedDictionary.setState(LifecycleState.STOPPED);
         updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.MANUAL);
+        updatedDictionary.setId("dictionaryId:DEFAULT:DEFAULT");
         when(
             dictionaryRepository.update(
                 argThat(arg -> arg.getId().equals(dictionaryInDb.getId()) && arg.getState().equals(updatedDictionary.getState()))
@@ -91,7 +91,7 @@ public class DictionaryServiceImpl_StopTest {
                 eq(Collections.singleton(ENVIRONMENT_ID)),
                 eq(ORGANIZATION_ID),
                 eq(EventType.STOP_DICTIONARY),
-                eq("dictionaryId")
+                eq("dictionaryId:DEFAULT:DEFAULT")
             );
         verify(auditService, times(1))
             .createAuditLog(
@@ -107,7 +107,7 @@ public class DictionaryServiceImpl_StopTest {
     @Test(expected = DictionaryNotFoundException.class)
     public void shouldNotStopDictionaryBecauseDoesNotBelongToEnvironment() throws TechnicalException {
         Dictionary dictionaryInDb = new Dictionary();
-        dictionaryInDb.setId("dictionaryId");
+        dictionaryInDb.setId("dictionaryId:TEST:DEFAULT");
         dictionaryInDb.setCreatedAt(new Date(1486771200000L));
         dictionaryInDb.setUpdatedAt(new Date(1486771200000L));
         dictionaryInDb.setState(LifecycleState.STARTED);
@@ -123,7 +123,7 @@ public class DictionaryServiceImpl_StopTest {
                 eq(Collections.singleton(ENVIRONMENT_ID)),
                 eq(ORGANIZATION_ID),
                 eq(EventType.STOP_DICTIONARY),
-                eq("dictionaryId")
+                eq("dictionaryId:TEST:DEFAULT")
             );
         verify(auditService, never())
             .createAuditLog(
@@ -138,8 +138,8 @@ public class DictionaryServiceImpl_StopTest {
 
     @Test(expected = DictionaryNotFoundException.class)
     public void shouldNotStopBecauseNotFound() throws TechnicalException {
-        when(dictionaryRepository.findById("dictionaryId")).thenReturn(Optional.empty());
+        when(dictionaryRepository.findById("dictionaryId:DEFAULT:DEFAULT")).thenReturn(Optional.empty());
 
-        dictionaryService.stop(GraviteeContext.getExecutionContext(), "dictionaryId");
+        dictionaryService.stop(GraviteeContext.getExecutionContext(), "dictionaryId:DEFAULT:DEFAULT");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
@@ -17,12 +17,7 @@ package io.gravitee.rest.api.service.impl.configuration.dictionary;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DictionaryRepository;
@@ -33,6 +28,7 @@ import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -49,7 +45,7 @@ public class DictionaryServiceImpl_UpdateTest {
 
     private static final String ENVIRONMENT_ID = GraviteeContext.getCurrentEnvironment();
     private static final String ORGANIZATION_ID = GraviteeContext.getCurrentOrganization();
-    public static final String DICTIONARY_ID = "dictionaryId";
+    public static final String DICTIONARY_ID = "dictionaryId:DEFAULT:DEFAULT";
 
     @InjectMocks
     private DictionaryServiceImpl dictionaryService = new DictionaryServiceImpl();
@@ -62,6 +58,9 @@ public class DictionaryServiceImpl_UpdateTest {
 
     @Mock
     private AuditService auditService;
+
+    @Mock
+    private EnvironmentService environmentService;
 
     @Test
     public void shouldUpdateDictionary() throws TechnicalException {
@@ -113,7 +112,7 @@ public class DictionaryServiceImpl_UpdateTest {
                 eq(Collections.singleton(ENVIRONMENT_ID)),
                 eq(ORGANIZATION_ID),
                 eq(EventType.START_DICTIONARY),
-                eq("dictionaryId")
+                eq("dictionaryId:DEFAULT:DEFAULT")
             );
         verify(auditService, times(1))
             .createAuditLog(
@@ -176,7 +175,7 @@ public class DictionaryServiceImpl_UpdateTest {
                 eq(Collections.singleton(ENVIRONMENT_ID)),
                 eq(ORGANIZATION_ID),
                 eq(EventType.START_DICTIONARY),
-                eq("dictionaryId")
+                eq("dictionaryId:DEFAULT:DEFAULT")
             );
         verify(auditService, times(1))
             .createAuditLog(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9521
## Description

used formatted ID (env and org) instead of just name to do the env and org isolation of dictionary.


detail below :

Problem Statement:

In a multi-tenant, multi-environment installation, the current dictionary storage mechanism (using 'name' as the '_id', we are generating a "-" based id using IdGenerator on name) creates a critical issue. Multiple environments under the same organization (or across different organizations) cannot have dictionaries with the same name because MongoDB enforces '_id' uniqueness.
This leads to the following problems:

1. Unable to create same name dictionary in a diff env under same org(installation).
2. Deployment conflicts: Deploying the same dictionary name ('dictionaryName') in different environments ('dev', 'prod') causes overriding issues.
3. Environment isolation breach: Any API in any environment can read/overwrite dictionaries from another environment if '_id' is guessed.
4. Gateway deployment leakage: A dictionary deployed in 'dev' could overwrite or conflict with a dictionary in 'prod', causing critical runtime errors.

Initial Approaches Considered (and Rejected):

1. Compound Index on 'name', 'envId', 'orgId'

   Why Rejected : MongoDB still requires unique '_id'. Compound indexes do not prevent duplicate '_id', and '_id' collisions still occur.
   Additional Drawback : Doesn't enforce isolation on reads/writes unless explicitly queried with all 3 fields.

2. Custom repository method ('findByNameAndEnvId')

   Why Rejected: Requires updating all logic (create/update/delete/find) across services and layers.
   Risk: Missing one path could reintroduce bugs. Harder to enforce consistently in a large codebase.

3. Introduce new field in Dictionary entity ('orgId')

   Why Rejected: Would break existing data models and mappings across multiple implementations (Mongo, JDBC, mappers).
   Impact: High-risk for backward compatibility, requires changes in multiple services and DTOs.

Final Approach: Format '_id' as 'name:envId:orgId'

This approach uses the Mongo '_id' field directly to ensure uniqueness per environment and organization.

Example:

- Dictionary 'dictionaryId' in 'dev' of 'org1' = '_id = dictionaryId:dev:org1'
- Dictionary 'dictionaryId' in 'prod' of 'org1' = '_id = dictionaryId:prod:org1'

Justification:

- Prevents duplicate entries by design via the '_id' uniqueness.
- No need for compound indexes.
- Same approach works across Mongo and JDBC.
- Only one field ('id') needs to change in storage. No schema changes required.

JDBC Compatibility

- JDBC 'findById(id)' already supports full-string matching.
- Saving new dictionaries with formatted '_id' allows JDBC to retrieve them correctly.
- No extra mapping or transformation needed.

Frontend/UI Adjustments

- UI Display: Mask the ID using 'split(":"[0])' to show just the 'name'. (this is the existing implementation, so no regression)
- Routing: UI URLs continue to use the full masked ID ('name:envId:orgId'), ensuring uniqueness.
- Network Masking : Could hash or encode the ID if UI-exposed ID is still a concern. (haven't implemented, just putting here for your conideration)

Backend Adjustments

- Update all usages of 'findById()' or 'create(id)' to use the new formatted '_id'.
- Format the ID consistently using utility method: (created but since we are not unmasking, not committed in the PR)

  
 - During read operations, split the ID to get user-friendly 'name' for response.

Data Migration -

 - If existing data must be updated:

  - Written an upgrader to:

    1. Backup existing dictionaries (facing some issue with junit, have excluded for now).
    2. Format existing '_id' to 'name:envId:orgId'.
    3. Re-insert into the DB.
  - Can skip if new logic only operates on new data, but i recommend to make sure the code doesn't break for old IDs retrieval.


- Risks Mitigated:

- Cross-environment leaks
- Same-name override issues
- Broken deployments in multi-tenant setups

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pcjyawhdry.chromatic.com)
<!-- Storybook placeholder end -->
