### PR TITLE
APIM-9278: Move Application metadata to Notifications tab

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
@@ -19,7 +19,7 @@
   <mat-card-content>
     <div class="gio-metadata__header">
       <div class="gio-metadata__header__title">
-        <h3>{{ referenceType }} metadata</h3>
+        <h3>{{ headerTitle }} metadata</h3>
         <p>{{ description }}</p>
       </div>
       <div class="gio-metadata__header__action">
@@ -32,7 +32,7 @@
           aria-label="add-metadata"
           data-testid="add_metadata_button"
         >
-          <mat-icon>add</mat-icon> Add {{ referenceType }} Metadata
+          <mat-icon>add</mat-icon> Add {{ headerTitle }} Metadata
         </button>
       </div>
     </div>

--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.ts
@@ -87,6 +87,7 @@ export class GioMetadataComponent implements OnInit, OnDestroy {
   displayedColumns: string[];
   permissionPrefix: string;
   referenceType: 'API' | 'Application' | 'Global';
+  headerTitle: string;
   totalResults: number;
   form: FormGroup;
 
@@ -116,6 +117,7 @@ export class GioMetadataComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.referenceType = this.metadataSaveServices.type;
+    this.headerTitle = this.referenceType === 'Application' ? 'Notification Template' : this.referenceType;
     this.permissionPrefix = this.referenceType === 'Global' ? 'environment' : this.referenceType.toLowerCase();
     this.displayedColumns = ['key', 'name', 'format', 'value', 'actions'];
     this.filterLocally = this.metadataSaveServices.paginate !== true;

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.spec.ts
@@ -80,11 +80,10 @@ describe('ApplicationNavigationComponent', () => {
     });
 
     it('should build sub menu items', () => {
-      expect(component.subMenuItems.length).toEqual(7);
+      expect(component.subMenuItems.length).toEqual(6);
       expect(component.subMenuItems.map((item) => item.displayName)).toEqual([
         'Global settings',
         'User and group access',
-        'Metadata',
         'Subscriptions',
         'Analytics',
         'Logs',
@@ -102,7 +101,6 @@ describe('ApplicationNavigationComponent', () => {
             'Members',
             'Groups',
             'Transfer ownership',
-            'Metadata',
             'Subscriptions',
             'Analytics',
             'Logs',

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.ts
@@ -98,11 +98,6 @@ export class ApplicationNavigationComponent implements OnInit, OnDestroy {
                 },
               ],
             },
-            {
-              displayName: 'Metadata',
-              routerLink: 'metadata',
-              permissions: ['application-metadata-r'],
-            },
             ...(application.api_key_mode === 'SHARED'
               ? [
                   {

--- a/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
@@ -19,7 +19,6 @@ import { RouterModule, Routes } from '@angular/router';
 import { ApplicationNavigationComponent } from './application-navigation/application-navigation.component';
 import { EnvApplicationListComponent } from './list/env-application-list.component';
 import { ApplicationGuard } from './application.guard';
-import { ApplicationMetadataComponent } from './details/metadata/application-metadata.component';
 import { ApplicationAnalyticsComponent } from './details/analytics/application-analytics.component';
 import { ApplicationLogsComponent } from './details/logs/application-logs.component';
 import { ApplicationLogComponent } from './details/logs/application-log.component';
@@ -74,18 +73,6 @@ const applicationRoutes: Routes = [
         path: '',
         redirectTo: 'general',
         pathMatch: 'full',
-      },
-      {
-        path: 'metadata',
-        component: ApplicationMetadataComponent,
-        data: {
-          permissions: {
-            anyOf: ['application-metadata-r'],
-          },
-          docs: {
-            page: 'management-application-metadata',
-          },
-        },
       },
       {
         path: 'subscriptions',

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.scss
@@ -1,5 +1,11 @@
-@use '../../../../scss/gio-layout' as gio-layout;
+$container-padding-top: 24px;
+$container-padding-bottom: 48px;
+
+@mixin application-metadata-content-container {
+  display: block;
+  padding: $container-padding-top 0 $container-padding-bottom 0;
+}
 
 :host {
-  @include gio-layout.gio-responsive-content-container;
+  @include application-metadata-content-container;
 }

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
@@ -54,7 +54,7 @@ export class ApplicationMetadataComponent implements OnInit, OnDestroy {
       update: (updateMetadata) => this.applicationMetadataService.updateMetadata(applicationId, updateMetadata),
       delete: (metadataKey) => this.applicationMetadataService.deleteMetadata(applicationId, metadataKey),
     };
-    this.description = `Create Application metadata to retrieve custom information about your API`;
+    this.description = `Create notification template of application metadata to retrieve custom information about your API`;
 
     this.applicationService
       .getById(applicationId)

--- a/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.html
@@ -15,37 +15,40 @@
     limitations under the License.
 
 -->
-<mat-card>
-  <mat-card-content>
-    <div class="notifications">
-      <div class="notifications__header">
-        <div class="notifications__title">
-          <h3 class="notifications__title__main">Notifications</h3>
-          <div class="notifications__title__subtitle">
-            Configure your own Developer Portal notifications using Portal, Email or Webhook notifier
+<div>
+  <mat-card>
+    <mat-card-content>
+      <div class="notifications">
+        <div class="notifications__header">
+          <div class="notifications__title">
+            <h3 class="notifications__title__main">Notifications</h3>
+            <div class="notifications__title__subtitle">
+              Configure your own Developer Portal notifications using Portal, Email or Webhook notifier
+            </div>
           </div>
+
+          <button
+            *ngIf="canAdd"
+            mat-raised-button
+            [attr.aria-label]="'Add notification'"
+            (click)="addNotification()"
+            data-testid="add-notification"
+            color="primary"
+          >
+            <mat-icon svgIcon="gio:plus"></mat-icon>Add notification
+          </button>
         </div>
 
-        <button
-          *ngIf="canAdd"
-          mat-raised-button
-          [attr.aria-label]="'Add notification'"
-          (click)="addNotification()"
-          data-testid="add-notification"
-          color="primary"
-        >
-          <mat-icon svgIcon="gio:plus"></mat-icon>Add notification
-        </button>
+        <notification-list
+          [canUpdate]="canUpdate"
+          [canDelete]="canDelete"
+          [loading]="loading"
+          [notifications]="notificationsSummary$ | async"
+          (delete)="deleteNotification($event)"
+          (edit)="editNotification($event)"
+        ></notification-list>
       </div>
-
-      <notification-list
-        [canUpdate]="canUpdate"
-        [canDelete]="canDelete"
-        [loading]="loading"
-        [notifications]="notificationsSummary$ | async"
-        (delete)="deleteNotification($event)"
-        (edit)="editNotification($event)"
-      ></notification-list>
-    </div>
-  </mat-card-content>
-</mat-card>
+    </mat-card-content>
+  </mat-card>
+  <application-metadata />
+</div>

--- a/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.spec.ts
@@ -35,6 +35,10 @@ import { fakeNotificationSettings, fakePortalNotificationSettings } from '../../
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { fakeHooks } from '../../../../entities/notification/hooks.fixture';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Application } from '../../../../entities/application/Application';
+import { Metadata } from '../../../../entities/metadata/metadata';
+import { fakeMetadata } from '../../../../entities/metadata/metadata.fixture';
+import { fakeApplication } from '../../../../entities/application/Application.fixture';
 
 describe('AppNotificationComponent', () => {
   const APPLICATION_ID = 'an-app-id';
@@ -109,6 +113,8 @@ describe('AppNotificationComponent', () => {
 
     expectNotificationSettingsRequest();
     expectNotifiersRequest();
+    expectGetApplication(fakeApplication());
+    expectMetadataList();
   }
 
   afterEach(() => {
@@ -534,5 +540,17 @@ describe('AppNotificationComponent', () => {
       fakeNotifier({ id: NOTIFIER_EMAIL_ID, type: 'EMAIL', name: NOTIFIER_EMAIL_NAME }),
       fakeNotifier({ id: NOTIFIER_WEBHOOK_ID, type: 'WEBHOOK', name: NOTIFIER_WEBHOOK_NAME }),
     ]);
+  }
+
+  function expectGetApplication(application: Application) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' })
+      .flush(application);
+  }
+
+  function expectMetadataList(list: Metadata[] = [fakeMetadata({ key: 'key1' }), fakeMetadata({ key: 'key2' })]) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}/metadata/`, method: 'GET' })
+      .flush(list);
   }
 });

--- a/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.module.ts
@@ -24,10 +24,20 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ApplicationNotificationComponent } from './application-notification.component';
 
 import { NotificationModule } from '../../../../components/notification';
+import { ApplicationMetadataModule } from '../metadata/application-metadata.module';
 
 @NgModule({
   declarations: [ApplicationNotificationComponent],
   exports: [],
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatDialogModule, NotificationModule, MatSnackBarModule],
+  imports: [
+    ApplicationMetadataModule,
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    NotificationModule,
+    MatSnackBarModule,
+  ],
 })
 export class ApplicationNotificationModule {}

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-metadata/application-metadata.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-metadata/application-metadata.component.html
@@ -16,26 +16,22 @@
 
 -->
 
-<div class="page__content">
-  <div class="main">
-    <div class="page__box form">
-      <div class="page__box-title">
-        <h3 class="title">
-          {{ 'application.metadata.list.title' | translate }}
-          <span *ngIf="metadata">({{ metadata.length - 1 }})</span>
-        </h3>
-      </div>
-      <div class="page__box-content">
-        <gv-table [items]="metadata" [options]="metadataOptions" order="key" nosort rowheight="52px"></gv-table>
-      </div>
-      <div class="page__box-footer form__actions" *ngIf="hasUpdatePermission && hasMetadata">
-        <gv-button primary outlined [disabled]="!this.canReset()" (click)="this.reset()">{{
-          'application.metadata.reset.title' | translate
-        }}</gv-button>
-        <gv-button primary icon="general:save" [disabled]="!this.canUpdate()" (click)="this.updateMetadata($event)">{{
-          'application.metadata.update.title' | translate
-        }}</gv-button>
-      </div>
-    </div>
+<div class="page__box form">
+  <div class="page__box-title">
+    <h3 class="title">
+      {{ 'application.metadata.list.title' | translate }}
+      <span *ngIf="metadata">({{ metadata.length - 1 }})</span>
+    </h3>
+  </div>
+  <div class="page__box-content">
+    <gv-table [items]="metadata" [options]="metadataOptions" order="key" nosort rowheight="52px"></gv-table>
+  </div>
+  <div class="page__box-footer form__actions" *ngIf="hasUpdatePermission && hasMetadata">
+    <gv-button primary outlined [disabled]="!this.canReset()" (click)="this.reset()">{{
+      'application.metadata.reset.title' | translate
+    }}</gv-button>
+    <gv-button primary icon="general:save" [disabled]="!this.canUpdate()" (click)="this.updateMetadata($event)">{{
+      'application.metadata.update.title' | translate
+    }}</gv-button>
   </div>
 </div>

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-notifications/application-notifications.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-notifications/application-notifications.component.html
@@ -36,4 +36,5 @@
       </div>
     </div>
   </div>
+  <app-application-metadata />
 </div>

--- a/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
@@ -26,7 +26,6 @@ import { ApplicationCreationComponent } from '../application/application-creatio
 import { ApplicationGeneralComponent } from '../application/application-general/application-general.component';
 import { ApplicationLogsComponent } from '../application/application-logs/application-logs.component';
 import { ApplicationMembersComponent } from '../application/application-members/application-members.component';
-import { ApplicationMetadataComponent } from '../application/application-metadata/application-metadata.component';
 import { ApplicationNotificationsComponent } from '../application/application-notifications/application-notifications.component';
 import { ApplicationSubscriptionsComponent } from '../application/application-subscriptions/application-subscriptions.component';
 import { SubscriptionsComponent } from '../subscriptions/subscriptions.component';
@@ -112,22 +111,12 @@ const routes: Routes = [
         },
       },
       {
-        path: 'metadata',
-        component: ApplicationMetadataComponent,
-        data: {
-          icon: 'home:book-open',
-          title: 'route.metadata',
-          animation: { type: 'slide', group: 'app', index: 2 },
-          expectedPermissions: ['METADATA-R'],
-        },
-      },
-      {
         path: 'subscriptions',
         component: ApplicationSubscriptionsComponent,
         data: {
           icon: 'home:key',
           title: 'route.subscriptions',
-          animation: { type: 'slide', group: 'app', index: 3 },
+          animation: { type: 'slide', group: 'app', index: 2 },
           expectedPermissions: ['SUBSCRIPTION-R'],
         },
       },
@@ -137,7 +126,7 @@ const routes: Routes = [
         data: {
           icon: 'communication:group',
           title: 'route.members',
-          animation: { type: 'slide', group: 'app', index: 4 },
+          animation: { type: 'slide', group: 'app', index: 3 },
           expectedPermissions: ['MEMBER-R'],
         },
       },
@@ -148,7 +137,7 @@ const routes: Routes = [
           icon: 'shopping:chart-line#1',
           menu: { slots: { right: GvSelectDashboardComponent } },
           title: 'route.analyticsApplication',
-          animation: { type: 'slide', group: 'app', index: 5 },
+          animation: { type: 'slide', group: 'app', index: 4 },
           expectedPermissions: ['ANALYTICS-R'],
         },
         resolve: {
@@ -161,7 +150,7 @@ const routes: Routes = [
         data: {
           icon: 'communication:clipboard-list',
           title: 'route.logsApplication',
-          animation: { type: 'slide', group: 'app', index: 6 },
+          animation: { type: 'slide', group: 'app', index: 5 },
           expectedPermissions: ['LOG-R'],
         },
       },
@@ -171,7 +160,7 @@ const routes: Routes = [
         data: {
           icon: 'general:notifications#2',
           title: 'route.notifications',
-          animation: { type: 'slide', group: 'app', index: 7 },
+          animation: { type: 'slide', group: 'app', index: 6 },
           expectedPermissions: ['NOTIFICATION-R'],
         },
       },
@@ -183,7 +172,7 @@ const routes: Routes = [
           icon: 'home:alarm-clock',
           title: 'route.alerts',
           expectedFeature: FeatureEnum.alert,
-          animation: { type: 'slide', group: 'app', index: 8 },
+          animation: { type: 'slide', group: 'app', index: 7 },
           expectedPermissions: ['ALERT-R'],
         },
       },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9278

## Description

Moved application metadata to the Notification tabs on both console and portal.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

- Console Notification Tab
![image](https://github.com/user-attachments/assets/8e053aa9-81f1-4148-b3c6-bf051b6df61e)


- Portal Notification Tab
![image](https://github.com/user-attachments/assets/d4b2cbb9-5bab-4f5b-a208-f63165d39680)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cnurdhjznm.chromatic.com)
<!-- Storybook placeholder end -->
