### PR TITLE
fix: prevent multiple primary owners through ownership transfer

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -100,6 +100,7 @@ import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import io.gravitee.rest.api.service.exceptions.InvalidLicenseException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiImagesService;
 import io.gravitee.rest.api.service.v4.ApiImportExportService;
@@ -592,6 +593,7 @@ public class ApiResource extends AbstractResource {
         List<RoleEntity> newRoles = new ArrayList<>();
 
         if (apiTransferOwnership.getPoRole() != null) {
+            assertNoPrimaryOwnerReassignment(apiTransferOwnership.getPoRole());
             roleService
                 .findByScopeAndName(RoleScope.API, apiTransferOwnership.getPoRole(), GraviteeContext.getCurrentOrganization())
                 .ifPresent(newRoles::add);
@@ -990,6 +992,12 @@ public class ApiResource extends AbstractResource {
                 default:
                     break;
             }
+        }
+    }
+
+    private void assertNoPrimaryOwnerReassignment(String poRole) {
+        if ("PRIMARY_OWNER".equals(poRole)) {
+            throw new TransferOwnershipNotAllowedException(poRole);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResource.java
@@ -35,6 +35,8 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import io.gravitee.rest.api.service.exceptions.TransferNotAllowedException;
+import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -218,6 +220,7 @@ public class ApplicationMembersResource extends AbstractResource {
     public Response transferApplicationOwnership(@Valid @NotNull TransferOwnership transferOwnership) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         List<RoleEntity> newRoles = new ArrayList<>();
+        assertNoPrimaryOwnerReassignment(transferOwnership.getPoRole());
 
         roleService
             .findByScopeAndName(APPLICATION, transferOwnership.getPoRole(), executionContext.getOrganizationId())
@@ -231,5 +234,11 @@ public class ApplicationMembersResource extends AbstractResource {
             newRoles
         );
         return Response.ok().build();
+    }
+
+    private void assertNoPrimaryOwnerReassignment(String poRole) {
+        if ("PRIMARY_OWNER".equals(poRole)) {
+            throw new TransferOwnershipNotAllowedException(poRole);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/TransferOwnershipNotAllowedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/TransferOwnershipNotAllowedException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class TransferOwnershipNotAllowedException extends AbstractManagementException {
+
+    String role;
+
+    public TransferOwnershipNotAllowedException(String role) {
+        this.role = role;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return format("The [%s] role cannot be transferred to a Primary Owner.", role);
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "role.transferNotAllowed";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("role", role);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9658

## Description

add validation to ensure the PRIMARY_OWNER role cannot be reassigned to primary owner while transferring ownership
APP:
<img width="1295" alt="Screenshot 2025-05-20 at 1 46 39 PM" src="https://github.com/user-attachments/assets/24b27441-1038-445b-b86f-d26ec5fc53b0" />

API:
<img width="1295" alt="Screenshot 2025-05-20 at 1 42 50 PM" src="https://github.com/user-attachments/assets/60bec469-5897-4f28-b60a-d86f13d06f35" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

