### PR TITLE
fix: avoid status 0 in analytics when V4 emulation engine is activate…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
@@ -20,7 +20,6 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.GenericResponse;
 import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
-import io.gravitee.gateway.reactive.api.hook.PolicyMessageHook;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.gateway.reactive.core.BufferFlow;
 import io.gravitee.gateway.reactive.core.MessageFlow;
@@ -30,8 +29,6 @@ import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeTransformer;
 import io.reactivex.rxjava3.core.Single;
-import java.util.List;
-import java.util.function.Function;
 
 /**
  * Base implementation of {@link Response} that does nothing in particular and <b>can be</b> used to avoid reimplementing all methods.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -133,7 +133,9 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
         try {
             if (cancelled.compareAndSet(false, true)) {
                 log.debug("Cancelling proxy response");
-                proxyResponse.cancel();
+                if (proxyResponse != null) {
+                    proxyResponse.cancel();
+                }
                 connection.end();
             }
         } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
@@ -19,7 +19,6 @@ import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.gateway.reactive.core.context.AbstractResponse;


### PR DESCRIPTION
…d and connection is closed before upstream response processed

## Issue

https://gravitee.atlassian.net/browse/APIM-9685

## Description

This PR aims to fix a behavior that can happen when V4 emulation engine is activated. The issue is visible in the analytics with a status 0. 
It is happening when the client connection is closed before processing the backend response. In this case, the status is not updated and left to 0 (the value used to initialized it). To fix this behavior and explain to the API Publisher what happens, a check is added in the InvokerAdapter when the completable is disposed to update the status and set an error key and an error message. 
This way, we display in the analytics a 500 status with a message to explain what happen.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iythqzbkgm.chromatic.com)
<!-- Storybook placeholder end -->
