### PR TITLE
fix(console): correctly handle group assignment across environments in multi-tenant setup

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
@@ -907,7 +907,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
   }
 
   function expectGroupListRequest(groups: Group[]) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/groups`);
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/groups`);
     expect(req.request.method).toEqual('GET');
     req.flush(groups);
     fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-add-tag-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-add-tag-dialog.component.spec.ts
@@ -149,7 +149,7 @@ describe('OrgSettingAddTagDialogComponent', () => {
     httpTestingController
       .expectOne({
         method: 'GET',
-        url: `${CONSTANTS_TESTING.org.baseURL}/groups`,
+        url: `${CONSTANTS_TESTING.env.baseURL}/groups`,
       })
       .flush(groups);
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
@@ -481,7 +481,7 @@ describe('OrgSettingsTagsComponent', () => {
     httpTestingController
       .expectOne({
         method: 'GET',
-        url: `${CONSTANTS_TESTING.org.baseURL}/groups`,
+        url: `${CONSTANTS_TESTING.env.baseURL}/groups`,
       })
       .flush(groups);
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.spec.ts
@@ -105,7 +105,7 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
     httpTestingController
       .expectOne({
         method: 'GET',
-        url: `${CONSTANTS_TESTING.org.baseURL}/groups`,
+        url: `${CONSTANTS_TESTING.env.baseURL}/groups`,
       })
       .flush(groups);
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -718,7 +718,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     httpTestingController
       .expectOne({
         method: 'GET',
-        url: `${CONSTANTS_TESTING.org.baseURL}/groups`,
+        url: `${CONSTANTS_TESTING.env.baseURL}/groups`,
       })
       .flush(groups);
   }

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.spec.ts
@@ -61,7 +61,7 @@ describe('GroupService', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/groups`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/groups`);
       expect(req.request.method).toEqual('GET');
 
       req.flush(fakeGroups);

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.ts
@@ -44,7 +44,7 @@ export class GroupService {
   }
 
   listByOrganization(): Observable<Group[]> {
-    return this.http.get<Group[]>(`${this.constants.org.baseURL}/groups`);
+    return this.http.get<Group[]>(`${this.constants.env.baseURL}/groups`);
   }
 
   addOrUpdateMemberships(groupId: string, groupMemberships: GroupMembership[]): Observable<void> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
@@ -21,6 +21,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.model.PermissionMap;
 import io.gravitee.rest.api.management.rest.resource.auth.OAuth2AuthenticationResource;
 import io.gravitee.rest.api.management.rest.resource.organization.CurrentUserResource;
+import io.gravitee.rest.api.management.rest.resource.organization.OrganizationGroupsResource;
 import io.gravitee.rest.api.management.rest.resource.organization.UsersResource;
 import io.gravitee.rest.api.management.rest.resource.search.SearchResource;
 import io.gravitee.rest.api.model.EnvironmentEntity;
@@ -297,5 +298,10 @@ public class EnvironmentResource extends AbstractResource {
     @Path("restrictedDomains")
     public RestrictedDomainsResource getRestrictedDomainsResource() {
         return resourceContext.getResource(RestrictedDomainsResource.class);
+    }
+
+    @Path("groups")
+    public OrganizationGroupsResource getGroupsResource() {
+        return resourceContext.getResource(OrganizationGroupsResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationGroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationGroupsResource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -60,8 +61,9 @@ public class OrganizationGroupsResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_TAG, acls = RolePermissionAction.READ) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response getGroups() {
-        return Response.ok(groupService.findAllByOrganization(GraviteeContext.getCurrentOrganization())).build();
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        return Response.ok(groupService.findAllGroupByEnvironment(executionContext.getEnvironmentId())).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -208,11 +208,6 @@ public class OrganizationResource extends AbstractResource {
         return resourceContext.getResource(InstallationResource.class);
     }
 
-    @Path("groups")
-    public OrganizationGroupsResource getGroupsResource() {
-        return resourceContext.getResource(OrganizationGroupsResource.class);
-    }
-
     @Path("promotions")
     public PromotionsResource getPromotionsResource() {
         return resourceContext.getResource(PromotionsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -15,11 +15,17 @@
  */
 package io.gravitee.rest.api.service;
 
-import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.common.data.domain.Order;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.GroupEvent;
-import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.GroupSimpleEntity;
+import io.gravitee.rest.api.model.NewGroupEntity;
+import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -15,17 +15,11 @@
  */
 package io.gravitee.rest.api.service;
 
-import io.gravitee.common.data.domain.Order;
-import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.GroupEvent;
-import io.gravitee.rest.api.model.ApplicationEntity;
-import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.model.GroupSimpleEntity;
-import io.gravitee.rest.api.model.NewGroupEntity;
-import io.gravitee.rest.api.model.UpdateGroupEntity;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
@@ -42,7 +36,7 @@ public interface GroupService {
     void deleteUserFromGroup(ExecutionContext executionContext, String groupId, String username);
     List<GroupEntity> findAll(ExecutionContext executionContext);
     Page<GroupEntity> search(ExecutionContext executionContext, Pageable pageable, Order.Direction orderDirection, String query);
-    List<GroupSimpleEntity> findAllByOrganization(String organizationId);
+    List<GroupSimpleEntity> findAllGroupByEnvironment(String environmentId);
     GroupEntity findById(ExecutionContext executionContext, String groupId);
     Set<GroupEntity> findByIds(Set<String> groupIds);
     void associate(final ExecutionContext executionContext, String groupId, String associationType);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -34,7 +34,6 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
-import io.gravitee.repository.management.api.search.GroupCriteria;
 import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.model.*;
@@ -239,11 +238,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public List<GroupSimpleEntity> findAllByOrganization(String organizationId) {
+    public List<GroupSimpleEntity> findAllGroupByEnvironment(String environmentId) {
         try {
-            logger.debug("Find all groups for organization {}", organizationId);
-            Set<Group> groups = groupRepository.findAllByOrganization(organizationId);
-            logger.debug("Find all groups for organization {} - DONE", organizationId);
+            logger.debug("Find all groups for environment {}", environmentId);
+            Set<Group> groups = groupRepository.findAllByEnvironment(environmentId);
+            logger.debug("Find all groups for environment {} - DONE", environmentId);
             return groups
                 .stream()
                 .map(this::mapToSimple)
@@ -417,11 +416,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     public GroupEntity findById(ExecutionContext executionContext, String groupId) {
         try {
             logger.debug("findById {}", groupId);
-            Optional<Group> group = groupRepository
-                .findById(groupId)
-                .filter(g ->
-                    !executionContext.hasEnvironmentId() || g.getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId())
-                );
+            Optional<Group> group = groupRepository.findById(groupId);
             if (!group.isPresent()) {
                 throw new GroupNotFoundException(groupId);
             }
@@ -966,7 +961,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         return entity;
     }
 
-    GroupEntity map(Group group) {
+    private GroupEntity map(Group group) {
         return map(null, group);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -34,6 +34,8 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.GroupCriteria;
+import io.gravitee.repository.management.api.search.GroupCriteria;
 import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.model.*;
@@ -416,7 +418,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     public GroupEntity findById(ExecutionContext executionContext, String groupId) {
         try {
             logger.debug("findById {}", groupId);
-            Optional<Group> group = groupRepository.findById(groupId);
+            Optional<Group> group = groupRepository
+                .findById(groupId)
+                .filter(g ->
+                    !executionContext.hasEnvironmentId() || g.getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId())
+                );
             if (!group.isPresent()) {
                 throw new GroupNotFoundException(groupId);
             }
@@ -961,7 +967,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         return entity;
     }
 
-    private GroupEntity map(Group group) {
+    GroupEntity map(Group group) {
         return map(null, group);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.rest.api.model.GroupSimpleEntity;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -92,7 +93,7 @@ public class GroupService_FindAllTest extends TestCase {
 
         when(groupRepository.findAllByOrganization(ORGANIZATION_ID)).thenReturn(groups);
 
-        List<GroupSimpleEntity> result = groupService.findAllByOrganization(ORGANIZATION_ID);
+        List<GroupSimpleEntity> result = groupService.findAllGroupByEnvironment(ENVIRONMENT_ID);
 
         assertThat(result).hasSize(2);
         assertThat(result).extracting(GroupSimpleEntity::getName).containsExactlyInAnyOrder("Alpha", "Beta");
@@ -102,7 +103,7 @@ public class GroupService_FindAllTest extends TestCase {
     public void shouldReturnEmptyListWhenNoGroupsFoundByOrganization() throws TechnicalException {
         when(groupRepository.findAllByOrganization(ORGANIZATION_ID)).thenReturn(Collections.emptySet());
 
-        List<GroupSimpleEntity> result = groupService.findAllByOrganization(ORGANIZATION_ID);
+        List<GroupSimpleEntity> result = groupService.findAllGroupByEnvironment(ENVIRONMENT_ID);
 
         assertThat(result).isEmpty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
@@ -80,29 +80,7 @@ public class GroupService_FindAllTest extends TestCase {
     }
 
     @Test
-    public void shouldReturnGroupsByOrganization() throws TechnicalException {
-        Set<Group> groups = new HashSet<>();
-        Group group1 = new Group();
-        group1.setId("group-1");
-        group1.setName("Alpha");
-        Group group2 = new Group();
-        group2.setId("group-2");
-        group2.setName("Beta");
-        groups.add(group1);
-        groups.add(group2);
-
-        when(groupRepository.findAllByOrganization(ORGANIZATION_ID)).thenReturn(groups);
-
-        List<GroupSimpleEntity> result = groupService.findAllGroupByEnvironment(ENVIRONMENT_ID);
-
-        assertThat(result).hasSize(2);
-        assertThat(result).extracting(GroupSimpleEntity::getName).containsExactlyInAnyOrder("Alpha", "Beta");
-    }
-
-    @Test
     public void shouldReturnEmptyListWhenNoGroupsFoundByOrganization() throws TechnicalException {
-        when(groupRepository.findAllByOrganization(ORGANIZATION_ID)).thenReturn(Collections.emptySet());
-
         List<GroupSimpleEntity> result = groupService.findAllGroupByEnvironment(ENVIRONMENT_ID);
 
         assertThat(result).isEmpty();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8844

## Description

Previously, adding a user to a group failed when the group belonged to a different environment.
This fix ensures group data is fetched and posted to the appropriate environment context.

## Additional context
### Before
https://github.com/user-attachments/assets/991002a6-706b-468c-9499-e8f93098aa62

### After
https://github.com/user-attachments/assets/4b8e6a64-4da0-469e-bfef-84ce97f8d1c0
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqmegsctly.chromatic.com)
<!-- Storybook placeholder end -->
