### PR TITLE
fix(ui): remove `@storybook/theming` from yarn.lock of portal-next + console

### DIFF
--- a/gravitee-apim-console-webui/yarn.lock
+++ b/gravitee-apim-console-webui/yarn.lock
@@ -5696,15 +5696,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:8.6.11":
-  version: 8.6.11
-  resolution: "@storybook/theming@npm:8.6.11"
-  peerDependencies:
-    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/625172f789baf265e7260e4e3113b1be5d4104d70bd9599dbe2e5061889a9d0382e3154b1ff2a3ad550c78e8b80fc6b271f394ee2d632ec7cd22cdf82e48ee10
-  languageName: node
-  linkType: hard
-
 "@storybook/theming@npm:8.6.14":
   version: 8.6.14
   resolution: "@storybook/theming@npm:8.6.14"

--- a/gravitee-apim-portal-webui-next/yarn.lock
+++ b/gravitee-apim-portal-webui-next/yarn.lock
@@ -5876,15 +5876,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:8.6.11":
-  version: 8.6.11
-  resolution: "@storybook/theming@npm:8.6.11"
-  peerDependencies:
-    storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 10c0/625172f789baf265e7260e4e3113b1be5d4104d70bd9599dbe2e5061889a9d0382e3154b1ff2a3ad550c78e8b80fc6b271f394ee2d632ec7cd22cdf82e48ee10
-  languageName: node
-  linkType: hard
-
 "@storybook/theming@npm:8.6.14":
   version: 8.6.14
   resolution: "@storybook/theming@npm:8.6.14"


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

UI pipelines for Console and Portal-Next are KO. Change corrects error in `yarn.lock` for the two projects.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wjwlqdqdqw.chromatic.com)
<!-- Storybook placeholder end -->
