### PR TITLE
docs: update openapi specification

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -15,34 +15,14 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2"
+    - url: "/management/v2"
       description: APIM Management API v2 - Default base URL
-      variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+    - url: "/management/v2/organizations/{orgId}"
       description: APIM Management API v2 - Base URL to target specific organizations
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           orgId:
               description: The unique ID of your organization
               default: DEFAULT
-
 tags:
     - name: APIs
       description: Everything about APIs

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -15,33 +15,15 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2/environments/{envId}"
+    - url: "/management/v2/environments/{envId}"
       description: APIM Management API v2 - Default base URL
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           envId:
               description: The unique ID of your environment
               default: DEFAULT
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}/environments/{envId}"
+    - url: "/management/v2/organizations/{orgId}/environments/{envId}"
       description: APIM Management API v2 - Base URL to target specific organizations
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           orgId:
               description: The unique ID of your organization
               default: DEFAULT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
@@ -14,18 +14,8 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2"
+    - url: "/management/v2"
       description: APIM Management API v2 - Default base URL
-      variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
 
 tags:
     - name: Installation

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
@@ -15,30 +15,11 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2"
+    - url: "/management/v2"
       description: APIM Management API v2 - Default base URL
-      variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+    - url: "/management/v2/organizations/{orgId}"
       description: APIM Management API v2 - Base URL to target specific organizations
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           orgId:
               description: The unique ID of your organization
               default: DEFAULT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
@@ -14,18 +14,8 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2"
+    - url: "/management/v2"
       description: APIM Management API v2 - Default base URL
-      variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
 
 tags:
     - name: Plugins - Endpoints

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -15,18 +15,9 @@ security:
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+    - url: "/management/v2/organizations/{orgId}"
       description: APIM Management API v2 - Base URL to target specific organizations
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           orgId:
               description: The unique ID of your organization
               default: DEFAULT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -11,33 +11,15 @@ info:
     version: 2.0.0
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2/environments/{envId}"
+    - url: "/management/v2/environments/{envId}"
       description: APIM Management API v2 - Default base URL
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           envId:
               description: Id or Hrid (Human readable Id) of an environment
               default: DEFAULT
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}/environments/{envId}"
+    - url: "/management/v2/organizations/{orgId}/environments/{envId}"
       description: APIM Management API v2 - Base URL to target specific organizations
       variables:
-          protocol:
-              description: The protocol you want to use to communicate with the mAPI
-              default: https
-              enum:
-                  - https
-                  - http
-          managementAPIHost:
-              description: The domain of the server hosting your Management API
-              default: localhost:8083
           orgId:
               description: The unique ID of your organization
               default: DEFAULT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
@@ -3,7 +3,7 @@ resourcePackages:
 cacheTTL: 0
 openAPI:
   servers:
-    - url: http://localhost:8083/management
+    - url: /management
   info:
     version: '${project.version}'
     title: Gravitee.io - Management API

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -12,7 +12,7 @@ info:
         url: http://www.apache.org/licenses/LICENSE-2.0
     version: "4.8.0-SNAPSHOT"
 servers:
-    - url: http://localhost:8083/portal/environments/{envId}
+    - url: /portal/environments/{envId}
       description: The portal API for a given environment
       variables:
           envId:


### PR DESCRIPTION
## Issue

N/A

## Description

Use relative URL in server's list to allow mapi V2 viewer to adapt to the current host.

Before this, the servers always starts with "https://localhost:8083"
Now the servers will use the current mAPI host.

![image](https://github.com/user-attachments/assets/e1b381df-2cec-45bb-8ef9-9f23d2e7aed9)
 
