### PR TITLE
fix: force endpoint-group-selection component  template reload after init

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
 import { Observable, of, Subject } from 'rxjs';
 import { UntypedFormGroup } from '@angular/forms';
@@ -56,6 +56,7 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
     private readonly licenseService: GioLicenseService,
     private readonly iconService: IconService,
     private readonly matDialog: MatDialog,
+    private readonly cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {
@@ -66,6 +67,7 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((endpointPlugins) => {
         this.endpoints = mapAndFilterBySupportedQos(endpointPlugins, this.requiredQos, this.iconService);
+        this.cdr.detectChanges();
       });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9705

## Description

force endpoint group selection  template reload after init

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aihhnegcnm.chromatic.com)
<!-- Storybook placeholder end -->
