### PR TITLE
Use exception wrapper in upgrader

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.AlertTriggerRepository;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -81,30 +82,28 @@ public class AlertsEnvironmentUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            Set<AlertTrigger> alertTriggers = alertTriggerRepository.findAll();
-            for (AlertTrigger alertTrigger : alertTriggers) {
-                switch (alertTrigger.getReferenceType()) {
-                    case "PLATFORM":
-                        handlePlatformAlert(alertTrigger);
-                        break;
-                    case "API":
-                        handleApiAlert(alertTrigger);
-                        break;
-                    case "APPLICATION":
-                        handleApplicationAlert(alertTrigger);
-                        break;
-                    default:
-                        log.error("unsupported reference type {}", alertTrigger.getReferenceType());
-                        break;
-                }
-            }
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
 
+    private boolean applyUpgrade() throws TechnicalException {
+        Set<AlertTrigger> alertTriggers = alertTriggerRepository.findAll();
+        for (AlertTrigger alertTrigger : alertTriggers) {
+            switch (alertTrigger.getReferenceType()) {
+                case "PLATFORM":
+                    handlePlatformAlert(alertTrigger);
+                    break;
+                case "API":
+                    handleApiAlert(alertTrigger);
+                    break;
+                case "APPLICATION":
+                    handleApplicationAlert(alertTrigger);
+                    break;
+                default:
+                    log.error("unsupported reference type {}", alertTrigger.getReferenceType());
+                    break;
+            }
+        }
         return true;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -56,18 +57,11 @@ public class ApiCategoryOrderUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            fillApiCategoryOrderTable();
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
-
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::fillApiCategoryOrderTable);
     }
 
-    private void fillApiCategoryOrderTable() throws TechnicalException {
+    private boolean fillApiCategoryOrderTable() throws TechnicalException {
         this.categoryRepository.findAll()
             .forEach(category -> {
                 var order = new AtomicInteger(0);
@@ -93,5 +87,6 @@ public class ApiCategoryOrderUpgrader implements Upgrader {
                         }
                     });
             });
+        return true;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgrader.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.*;
 import io.gravitee.repository.management.api.search.ApiCriteria;
@@ -82,19 +83,16 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            Set<Organization> organizations = organizationRepository.findAll();
-            for (Organization org : organizations) {
-                if (!checkOrganization(org.getId())) {
-                    return false;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                Set<Organization> organizations = organizationRepository.findAll();
+                for (Organization org : organizations) {
+                    if (!checkOrganization(org.getId())) {
+                        return false;
+                    }
                 }
-            }
-            return true;
-        } catch (Exception e) {
-            log.error("Failed to fix APIs Primary Owner removal", e);
-            return false;
-        }
+                return true;
+            });
     }
 
     private boolean checkOrganization(String organizationId) throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import lombok.extern.slf4j.Slf4j;
@@ -34,19 +35,14 @@ public class DefaultEnvironmentUpgrader implements Upgrader {
     private EnvironmentService environmentService;
 
     @Override
-    public boolean upgrade() {
-        try {
-            // initialize roles.
-            if (environmentService.findByOrganization(GraviteeContext.getDefaultOrganization()).isEmpty()) {
-                log.info("    No environment found. Add default one.");
-                environmentService.initialize();
-            }
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
-
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                if (environmentService.findByOrganization(GraviteeContext.getDefaultOrganization()).isEmpty()) {
+                    log.info("    No environment found. Add default one.");
+                    environmentService.initialize();
+                }
+                return true;
+            });
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.rest.api.service.OrganizationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +34,14 @@ public class DefaultOrganizationUpgrader implements Upgrader {
     private OrganizationService organizationService;
 
     @Override
-    public boolean upgrade() {
-        // initialize default organization.
-        if (organizationService.count().equals(0L)) {
-            log.info("    No organization found. Add default one.");
-            organizationService.initialize();
-        }
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                if (organizationService.count().equals(0L)) {
+                    log.info("    No organization found. Add default one.");
+                    organizationService.initialize();
+                }
+                return true;
+            });
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentFederationAgentRoleUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentFederationAgentRoleUpgrader.java
@@ -19,6 +19,7 @@ import static io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -42,21 +43,17 @@ public class EnvironmentFederationAgentRoleUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            organizationRepository
-                .findAll()
-                .stream()
-                .filter(organization -> shouldCreateEnvironmentFederationAgentRole(organization.getId()))
-                .forEach(organization -> {
-                    roleService.create(new ExecutionContext(organization.getId()), ROLE_ENVIRONMENT_FEDERATION_AGENT);
-                });
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
-
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                organizationRepository
+                    .findAll()
+                    .stream()
+                    .filter(organization -> shouldCreateEnvironmentFederationAgentRole(organization.getId()))
+                    .forEach(organization -> {
+                        roleService.create(new ExecutionContext(organization.getId()), ROLE_ENVIRONMENT_FEDERATION_AGENT);
+                    });
+                return true;
+            });
     }
 
     private boolean shouldCreateEnvironmentFederationAgentRole(String organizationId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.DictionaryRepository;
@@ -84,17 +85,13 @@ public class EventsLatestUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            migrateApiEvents();
-            migrateDictionaryEvents();
-            migrateOrganizationEvents();
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
-
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                migrateApiEvents();
+                migrateDictionaryEvents();
+                migrateOrganizationEvents();
+                return true;
+            });
     }
 
     private void migrateApiEvents() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationPrimaryOwnerUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationPrimaryOwnerUpgrader.java
@@ -19,6 +19,7 @@ import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.I
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -77,23 +78,21 @@ public class IntegrationPrimaryOwnerUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            environmentRepository
-                .findAll()
-                .forEach(environment -> {
-                    ExecutionContext executionContext = new ExecutionContext(environment);
-                    try {
-                        setPrimaryOwnersForIntegrations(executionContext);
-                    } catch (TechnicalException e) {
-                        log.error("An error occurs while updating primary owner for integrations", e);
-                    }
-                });
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
 
+    private boolean applyUpgrade() throws TechnicalException {
+        environmentRepository
+            .findAll()
+            .forEach(environment -> {
+                ExecutionContext executionContext = new ExecutionContext(environment);
+                try {
+                    setPrimaryOwnersForIntegrations(executionContext);
+                } catch (TechnicalException e) {
+                    log.error("An error occurs while updating primary owner for integrations", e);
+                }
+            });
         return true;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
@@ -50,19 +51,15 @@ public class OrphanCategoryUpgrader implements Upgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
-            Set<Api> updatedApis = findAndFixApisWithOrphanCategories();
-            for (Api api : updatedApis) {
-                log.info("Removing orphan categories for API [{}]", api.getId());
-                apiRepository.update(api);
-            }
-        } catch (Exception e) {
-            log.error("Error applying upgrader", e);
-            return false;
-        }
-
-        return true;
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+                Set<Api> updatedApis = findAndFixApisWithOrphanCategories();
+                for (Api api : updatedApis) {
+                    log.info("Removing orphan categories for API [{}]", api.getId());
+                    apiRepository.update(api);
+                }
+                return true;
+            });
     }
 
     private Set<Api> findAndFixApisWithOrphanCategories() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AlertsEnvironmentUpgraderTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.AlertTriggerRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
@@ -62,11 +64,11 @@ public class AlertsEnvironmentUpgraderTest {
         upgrader = new AlertsEnvironmentUpgrader(alertTriggerRepository, alertTriggerConverter, apiRepository, applicationRepository);
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws Exception {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws UpgraderException, TechnicalException {
         when(alertTriggerRepository.findAll()).thenThrow(new RuntimeException());
 
-        Assert.assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(alertTriggerRepository, times(1)).findAll();
         verifyNoMoreInteractions(alertTriggerRepository);
@@ -139,13 +141,13 @@ public class AlertsEnvironmentUpgraderTest {
         verifyNoMoreInteractions(alertTriggerRepository);
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_missing_application() throws Exception {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_missing_application() throws UpgraderException, TechnicalException {
         when(alertTriggerRepository.findAll()).thenReturn(Set.of(buildTestAlert("alert-id-2", "alert-name-2", "APPLICATION", "app-id-1")));
 
         when(applicationRepository.findById("app-id-1")).thenReturn(Optional.empty());
 
-        Assert.assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(alertTriggerRepository, times(1)).findAll();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgraderTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
@@ -144,8 +146,8 @@ public class ApiCategoryOrderUpgraderTest {
         verify(apiCategoryOrderRepository, times(1)).create(eq(catOrder2));
     }
 
-    @Test
-    public void shouldReturnFalseWhenExceptionOccursDuringUpgrade() throws Exception {
+    @Test(expected = UpgraderException.class)
+    public void shouldReturnFalseWhenExceptionOccursDuringUpgrade() throws TechnicalException, UpgraderException {
         Category category1 = new Category();
         category1.setKey("category1");
         category1.setId("id1");
@@ -153,7 +155,6 @@ public class ApiCategoryOrderUpgraderTest {
         when(categoryRepository.findAll()).thenReturn(Set.of(category1));
 
         when(apiRepository.search(any(), any())).thenThrow(new RuntimeException());
-        boolean result = apiCategoryOrderUpgrader.upgrade();
-        assertFalse(result);
+        apiCategoryOrderUpgrader.upgrade();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiKeySubscriptionsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiKeySubscriptionsUpgraderTest.java
@@ -16,9 +16,9 @@
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
@@ -45,18 +45,18 @@ public class ApiKeySubscriptionsUpgraderTest {
     @Mock
     ApiKeyRepository apiKeyRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(apiKeyRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(apiKeyRepository, times(1)).findAll();
         verifyNoMoreInteractions(apiKeyRepository);
     }
 
     @Test
-    public void testUpgrade_shouldCreateListOfSubscriptionsFromSubscription() throws TechnicalException {
+    public void testUpgrade_shouldCreateListOfSubscriptionsFromSubscription() throws TechnicalException, UpgraderException {
         ApiKey key1 = apiKeyWithSubscription("subscription-1");
         ApiKey key2 = apiKeyWithSubscription("subscription-2");
         ApiKey key3 = apiKeyWithSubscription("subscription-3");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgraderTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.Logging;
 import io.gravitee.definition.model.Proxy;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -77,30 +78,28 @@ public class ApiLoggingConditionUpgraderTest {
         when(environmentRepository.findAll()).thenReturn(Collections.singleton(environment));
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(environmentRepository, times(1)).findAll();
         verifyNoMoreInteractions(environmentRepository);
     }
 
     @Test
-    public void upgrade_should_not_run_cause_already_executed_successfully() {
+    public void upgrade_should_not_run_cause_already_executed_successfully() throws UpgraderException {
         boolean success = upgrader.upgrade();
 
         assertTrue(success);
     }
 
-    @Test
-    public void upgrade_should_run_and_set_failure_status_on_exception() {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_run_and_set_failure_status_on_exception() throws UpgraderException {
         doThrow(new RuntimeException("test exception")).when(upgrader).fixApis(any());
 
-        boolean success = upgrader.upgrade();
-
-        assertFalse(success);
+        upgrader.upgrade();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiPrimaryOwnerRemovalUpgraderTest.java
@@ -23,6 +23,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.*;
 import io.gravitee.repository.management.api.search.Pageable;
@@ -94,18 +95,18 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         logger.addAppender(appender);
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenThrow(new RuntimeException());
 
-        Assert.assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(organizationRepository, times(1)).findAll();
         verifyNoMoreInteractions(organizationRepository);
     }
 
     @Test
-    public void shouldWarnAndStopWithPrimaryOwnerMissingAndNoConfigurationProperty() throws TechnicalException {
+    public void shouldWarnAndStopWithPrimaryOwnerMissingAndNoConfigurationProperty() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenReturn(Set.of(organization()));
 
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
@@ -131,7 +132,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
     }
 
     @Test
-    public void shouldFixWithUserWithPrimaryOwnerMissingAndConfigurationProperty() throws TechnicalException {
+    public void shouldFixWithUserWithPrimaryOwnerMissingAndConfigurationProperty() throws TechnicalException, UpgraderException {
         ReflectionTestUtils.setField(upgrader, "defaultPrimaryOwnerId", DEFAULT_PRIMARY_OWNER_ID);
 
         when(organizationRepository.findAll()).thenReturn(Set.of(organization()));
@@ -163,7 +164,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
     }
 
     @Test
-    public void shouldFixWithGroupWithPrimaryOwnerMissingAndConfigurationProperty() throws TechnicalException {
+    public void shouldFixWithGroupWithPrimaryOwnerMissingAndConfigurationProperty() throws TechnicalException, UpgraderException {
         ReflectionTestUtils.setField(upgrader, "defaultPrimaryOwnerId", DEFAULT_PRIMARY_OWNER_ID);
 
         when(organizationRepository.findAll()).thenReturn(Set.of(organization()));
@@ -191,7 +192,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
     }
 
     @Test
-    public void shouldNotFixWithoutPrimaryOwnerMissing() throws TechnicalException {
+    public void shouldNotFixWithoutPrimaryOwnerMissing() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenReturn(Set.of(organization()));
 
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgraderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Api;
@@ -130,11 +131,10 @@ public class ApiV4CategoriesUpgraderTest {
         verify(apiRepository, never()).update(any());
     }
 
-    @Test
+    @Test(expected = UpgraderException.class)
     public void shouldReturnFalseWhenExceptionOccursDuringUpgrade() throws Exception {
         when(categoryRepository.findAll()).thenThrow(new RuntimeException());
-        boolean result = apiV4CategoriesUpgrader.upgrade();
-        assertFalse(result);
+        apiV4CategoriesUpgrader.upgrade();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationApiKeyModeUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationApiKeyModeUpgraderTest.java
@@ -17,9 +17,9 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.repository.management.model.ApiKeyMode.*;
 import static io.gravitee.repository.management.model.Plan.PlanSecurityType.*;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.PlanRepository;
@@ -51,11 +51,11 @@ public class ApplicationApiKeyModeUpgraderTest {
     @Mock
     private SubscriptionRepository subscriptionRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(planRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(planRepository, times(1)).findAll();
         verifyNoMoreInteractions(planRepository);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClientIdInApiKeySubscriptionsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClientIdInApiKeySubscriptionsUpgraderTest.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.model.Subscription;
@@ -43,18 +43,18 @@ public class ClientIdInApiKeySubscriptionsUpgraderTest {
     @Mock
     SubscriptionRepository subscriptionRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(subscriptionRepository.search(any())).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(subscriptionRepository, times(1)).search(any());
         verifyNoMoreInteractions(subscriptionRepository);
     }
 
     @Test
-    public void testUpgrade_shouldRemoveClientIdFromApiKeySubscriptionsOnly() throws TechnicalException {
+    public void testUpgrade_shouldRemoveClientIdFromApiKeySubscriptionsOnly() throws TechnicalException, UpgraderException {
         Subscription apiKeySubscriptionWithoutClientId = apiKeySubscription(null);
         Subscription apiKeySubscriptionWithClientId = apiKeySubscription("client-id");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CommandOrganizationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CommandOrganizationUpgraderTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -48,11 +49,11 @@ public class CommandOrganizationUpgraderTest {
     @InjectMocks
     CommandOrganizationUpgrader upgrader;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(environmentRepository, times(1)).findAll();
         verifyNoMoreInteractions(environmentRepository);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgraderTest.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.service.EnvironmentService;
 import java.util.List;
@@ -40,18 +40,18 @@ public class DefaultEnvironmentUpgraderTest {
     @InjectMocks
     private final DefaultEnvironmentUpgrader upgrader = new DefaultEnvironmentUpgrader();
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(environmentService.findByOrganization(any())).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(environmentService, times(1)).findByOrganization(any());
         verifyNoMoreInteractions(environmentService);
     }
 
     @Test
-    public void shouldCreateDefaultEnvironment() {
+    public void shouldCreateDefaultEnvironment() throws UpgraderException {
         when(environmentService.findByOrganization(any())).thenReturn(List.of());
 
         upgrader.upgrade();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgraderTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.rest.api.service.OrganizationService;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,14 +39,14 @@ public class DefaultOrganizationUpgraderTest {
     private final DefaultOrganizationUpgrader upgrader = new DefaultOrganizationUpgrader();
 
     @Test
-    public void shouldInitializeOrganisation() {
+    public void shouldInitializeOrganisation() throws UpgraderException {
         when(organizationService.count()).thenReturn(0L);
         upgrader.upgrade();
         verify(organizationService, times(1)).initialize();
     }
 
     @Test
-    public void shouldNotInitializeOrganisation() {
+    public void shouldNotInitializeOrganisation() throws UpgraderException {
         when(organizationService.count()).thenReturn(1L);
         upgrader.upgrade();
         verify(organizationService, never()).initialize();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultRoleUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultRoleUpgraderTest.java
@@ -17,9 +17,9 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.rest.api.model.permissions.RoleScope.API;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
@@ -52,18 +52,18 @@ public class DefaultRoleUpgraderTest {
     @Mock
     OrganizationRepository organizationRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(organizationRepository, times(1)).findAll();
         verifyNoMoreInteractions(organizationRepository);
     }
 
     @Test
-    public void shouldInitializeDefaultRoles() throws TechnicalException {
+    public void shouldInitializeDefaultRoles() throws TechnicalException, UpgraderException {
         final Organization organization = mock(Organization.class);
         when(organization.getId()).thenReturn(GraviteeContext.getDefaultOrganization());
         when(organizationRepository.findAll()).thenReturn(Set.of(organization));
@@ -78,7 +78,7 @@ public class DefaultRoleUpgraderTest {
     }
 
     @Test
-    public void shouldCreateApiReviewerRole() throws TechnicalException {
+    public void shouldCreateApiReviewerRole() throws TechnicalException, UpgraderException {
         final Organization organization = mock(Organization.class);
         when(organization.getId()).thenReturn(GraviteeContext.getDefaultOrganization());
         when(organizationRepository.findAll()).thenReturn(Set.of(organization));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSharedPolicyGroupRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSharedPolicyGroupRolesUpgraderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
@@ -58,7 +59,7 @@ public class DefaultSharedPolicyGroupRolesUpgraderTest {
     }
 
     @Test
-    public void upgrade_add_default_shared_policy_groups_roles() throws TechnicalException {
+    public void upgrade_add_default_shared_policy_groups_roles() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenReturn(Set.of(Organization.builder().id("DEFAULT").build()));
 
         when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), any(), eq("DEFAULT")))
@@ -102,7 +103,7 @@ public class DefaultSharedPolicyGroupRolesUpgraderTest {
     }
 
     @Test
-    public void do_nothing_if_role_not_found() throws TechnicalException {
+    public void do_nothing_if_role_not_found() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenReturn(Set.of(Organization.builder().id("DEFAULT").build()));
 
         when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), any(), eq("DEFAULT")))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.DictionaryRepository;
@@ -98,11 +99,11 @@ public class EventsLatestUpgraderTest {
             );
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(apiRepository.searchIds(any(), any(), any())).thenThrow(new RuntimeException());
 
-        assertFalse(cut.upgrade());
+        cut.upgrade();
 
         verify(apiRepository, times(1)).searchIds(any(), any(), any());
         verifyNoMoreInteractions(apiRepository);
@@ -114,13 +115,13 @@ public class EventsLatestUpgraderTest {
     }
 
     @Test
-    public void should_do_nothing_when_nothing_to_migrate() throws TechnicalException {
+    public void should_do_nothing_when_nothing_to_migrate() throws TechnicalException, UpgraderException {
         cut.upgrade();
         verifyNoInteractions(eventLatestRepository);
     }
 
     @Test
-    public void should_create_latest_events_from_existing_apis() throws TechnicalException {
+    public void should_create_latest_events_from_existing_apis() throws TechnicalException, UpgraderException {
         when(apiRepository.searchIds(eq(List.of()), any(), eq(null))).thenReturn(new Page<>(List.of("api1", "api2"), 0, 2, 2));
         Event event1 = new Event();
         when(
@@ -149,7 +150,8 @@ public class EventsLatestUpgraderTest {
     }
 
     @Test
-    public void should_create_latest_events_from_existing_apis_with_valid_and_invalid_payload() throws TechnicalException {
+    public void should_create_latest_events_from_existing_apis_with_valid_and_invalid_payload()
+        throws TechnicalException, UpgraderException {
         when(apiRepository.searchIds(eq(List.of()), any(), eq(null))).thenReturn(new Page<>(List.of("api1", "api2"), 0, 2, 2));
         Event event1 = new Event();
         event1.setId("id1");
@@ -193,7 +195,7 @@ public class EventsLatestUpgraderTest {
     }
 
     @Test
-    public void should_create_latest_events_from_existing_dictionaries() throws TechnicalException {
+    public void should_create_latest_events_from_existing_dictionaries() throws TechnicalException, UpgraderException {
         Dictionary dictionary1 = new Dictionary();
         dictionary1.setId("dictionary1");
         dictionary1.setType(DictionaryType.DYNAMIC);
@@ -260,7 +262,7 @@ public class EventsLatestUpgraderTest {
     }
 
     @Test
-    public void should_create_latest_events_from_existing_organizations() throws TechnicalException {
+    public void should_create_latest_events_from_existing_organizations() throws TechnicalException, UpgraderException {
         Organization organization1 = new Organization();
         organization1.setId("organization1");
         Organization organization2 = new Organization();
@@ -293,7 +295,7 @@ public class EventsLatestUpgraderTest {
     }
 
     @Test
-    public void should_create_latest_events_from_existing_apis_with_multiple_pages() throws TechnicalException {
+    public void should_create_latest_events_from_existing_apis_with_multiple_pages() throws TechnicalException, UpgraderException {
         // Prepare pages
         Map<Integer, List<String>> pageMapping = new HashMap<>();
         int index = 0;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgraderTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
@@ -61,11 +62,11 @@ public class ExecutionModeUpgraderTest {
         cut = new ExecutionModeUpgrader(apiRepository, graviteeMapper);
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(apiRepository.search(any(), any(), any())).thenThrow(new RuntimeException());
 
-        assertFalse(cut.upgrade());
+        cut.upgrade();
 
         verify(apiRepository, times(1)).search(any(), any(), any());
         verify(apiRepository, never()).update(any());
@@ -77,13 +78,13 @@ public class ExecutionModeUpgraderTest {
     }
 
     @Test
-    public void should_do_nothing_when_nothing_to_migrate() throws TechnicalException {
+    public void should_do_nothing_when_nothing_to_migrate() throws TechnicalException, UpgraderException {
         cut.upgrade();
         verify(apiRepository, never()).update(any());
     }
 
     @Test
-    public void should_update_v2_api_with_jupiter_execution_mode() throws TechnicalException {
+    public void should_update_v2_api_with_jupiter_execution_mode() throws TechnicalException, UpgraderException {
         ApiCriteria onlyV2ApiCriteria = new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build();
         Api jupiterApi = new Api();
         jupiterApi.setDefinition("{\"execution_mode\" : \"jupiter\"}");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/GenericNotificationConfigUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/GenericNotificationConfigUpgraderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
@@ -67,7 +68,7 @@ public class GenericNotificationConfigUpgraderTest {
     }
 
     @Test
-    public void should_upgrade_only_portal_default_notification() throws TechnicalException {
+    public void should_upgrade_only_portal_default_notification() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("env#1").build(), Environment.builder().id("env#2").build()));
 
@@ -100,7 +101,7 @@ public class GenericNotificationConfigUpgraderTest {
     }
 
     @Test
-    public void should_not_create_if_not_find_generic_notification() throws TechnicalException {
+    public void should_not_create_if_not_find_generic_notification() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InitializeSharedPolicyGroupUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InitializeSharedPolicyGroupUpgraderTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +22,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.shared_policy_group.use_case.InitializeSharedPolicyGroupUseCase;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.OrganizationEntity;
@@ -54,11 +54,11 @@ public class InitializeSharedPolicyGroupUpgraderTest {
     @InjectMocks
     private final InitializeSharedPolicyGroupUpgrader upgrader = new InitializeSharedPolicyGroupUpgrader();
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(organizationService.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(organizationService, times(1)).findAll();
         verifyNoMoreInteractions(environmentService);
@@ -66,7 +66,7 @@ public class InitializeSharedPolicyGroupUpgraderTest {
     }
 
     @Test
-    public void should_initialize_shared_policy_group() throws TechnicalException {
+    public void should_initialize_shared_policy_group() throws TechnicalException, UpgraderException {
         when(organizationService.findAll()).thenReturn(List.of(new OrganizationEntity()));
         when(environmentService.findByOrganization(any())).thenReturn(List.of(new EnvironmentEntity()));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InstallationKeyStatusUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/InstallationKeyStatusUpgraderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.node.api.upgrader.UpgraderRepository;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
@@ -52,20 +53,19 @@ public class InstallationKeyStatusUpgraderTest {
     @Mock
     private UpgraderRepository upgraderRepository;
 
-    @Test
-    public void should_not_upgrade_when_there_is_exception() {
+    @Test(expected = UpgraderException.class)
+    public void should_not_upgrade_when_there_is_exception() throws UpgraderException {
         when(installationService.get()).thenReturn(new InstallationEntity());
         when(installationService.get().getAdditionalInformation()).thenThrow(new RuntimeException());
 
-        boolean upgraded = cut.upgrade();
-        assertFalse(upgraded);
+        cut.upgrade();
 
         verify(installationService, times(1)).get();
         verify(upgraderRepository, times(0)).create(any());
     }
 
     @Test
-    public void should_upgrade() {
+    public void should_upgrade() throws UpgraderException {
         Map<String, String> additionalInformation = new HashMap<>();
         additionalInformation.put(InstallationKeyStatusUpgrader.ORPHAN_CATEGORY_UPGRADER_STATUS, "SUCCESS");
         additionalInformation.put(InstallationKeyStatusUpgrader.APPLICATION_API_KEY_MODE_UPGRADER_STATUS, "SUCCESS");
@@ -86,7 +86,7 @@ public class InstallationKeyStatusUpgraderTest {
     }
 
     @Test
-    public void should_not_create_record_when_already_exist() {
+    public void should_not_create_record_when_already_exist() throws UpgraderException {
         Map<String, String> additionalInformation = new HashMap<>();
         additionalInformation.put(InstallationKeyStatusUpgrader.ORPHAN_CATEGORY_UPGRADER_STATUS, "SUCCESS");
         additionalInformation.put(InstallationKeyStatusUpgrader.APPLICATION_API_KEY_MODE_UPGRADER_STATUS, "SUCCESS");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationRolesUpgraderTest.java
@@ -17,13 +17,13 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_INTEGRATION_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_INTEGRATION_USER;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
@@ -50,18 +50,18 @@ public class IntegrationRolesUpgraderTest {
     @Mock
     OrganizationRepository organizationRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(organizationRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(organizationRepository, times(1)).findAll();
         verifyNoMoreInteractions(organizationRepository);
     }
 
     @Test
-    public void shouldInitializeIntegrationRoles() throws TechnicalException {
+    public void shouldInitializeIntegrationRoles() throws TechnicalException, UpgraderException {
         final Organization organization = mock(Organization.class);
         when(organization.getId()).thenReturn(GraviteeContext.getDefaultOrganization());
         when(organizationRepository.findAll()).thenReturn(Set.of(organization));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgraderTest.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -63,7 +63,7 @@ public class MetadataDefaultReferenceUpgraderTest {
     }
 
     @Test
-    public void should_upgrade_only_default_metadata() throws TechnicalException {
+    public void should_upgrade_only_default_metadata() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 
@@ -94,7 +94,7 @@ public class MetadataDefaultReferenceUpgraderTest {
     }
 
     @Test
-    public void should_upgrade_if_key_exist() throws TechnicalException {
+    public void should_upgrade_if_key_exist() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 
@@ -128,7 +128,7 @@ public class MetadataDefaultReferenceUpgraderTest {
     }
 
     @Test
-    public void should_not_create_if_not_find_default_metadata() throws TechnicalException {
+    public void should_not_create_if_not_find_default_metadata() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 
@@ -140,18 +140,18 @@ public class MetadataDefaultReferenceUpgraderTest {
         verify(metadataRepository, never()).delete(any(), any(), any());
     }
 
-    @Test
-    public void should_stop_if_cannot_find_all_env() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void should_stop_if_cannot_find_all_env() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll()).thenThrow(new TechnicalException("Cannot find all env"));
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(metadataRepository, never()).create(any());
         verify(metadataRepository, never()).delete(any(), any(), any());
     }
 
-    @Test
-    public void should_stop_if_cannot_create_env() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void should_stop_if_cannot_create_env() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 
@@ -166,7 +166,7 @@ public class MetadataDefaultReferenceUpgraderTest {
         when(metadataRepository.findAll()).thenReturn(metadataList);
         when(metadataRepository.create(any())).thenThrow(new TechnicalException("Cannot create metadata"));
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(metadataRepository).create(any());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OrphanCategoryUpgraderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
@@ -50,18 +51,18 @@ public class OrphanCategoryUpgraderTest {
     @Mock
     private CategoryRepository categoryRepository;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(categoryRepository.findAll()).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(categoryRepository, times(1)).findAll();
         verifyNoMoreInteractions(categoryRepository);
     }
 
     @Test
-    public void upgrade_should_remove_orphan_categories() throws TechnicalException {
+    public void upgrade_should_remove_orphan_categories() throws TechnicalException, UpgraderException {
         final String orphanCategoryId = UuidString.generateRandom();
 
         Category existingCategory = new Category();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlanApiTypeUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlanApiTypeUpgraderTest.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Api;
@@ -92,13 +92,11 @@ public class PlanApiTypeUpgraderTest {
         verify(planRepository, never()).update(any());
     }
 
-    @Test
+    @Test(expected = UpgraderException.class)
     public void shouldHandleExceptionDuringUpgrade() throws Exception {
         when(apiRepository.search(any(), any(), any())).thenThrow(new RuntimeException());
 
-        boolean result = planApiTypeUpgrader.upgrade();
-
-        assertFalse(result);
+        planApiTypeUpgrader.upgrade();
     }
 
     @Test
@@ -115,8 +113,8 @@ public class PlanApiTypeUpgraderTest {
         verify(planRepository, never()).update(any());
     }
 
-    @Test
-    public void shouldLogErrorWhenUpdatingPlanFails() throws Exception {
+    @Test(expected = UpgraderException.class)
+    public void shouldThrowErrorWhenUpdatingPlanFails() throws Exception {
         Api api = new Api();
         api.setId("api1");
         api.setType(ApiType.MESSAGE);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -65,19 +66,19 @@ public class PlansDataFixUpgraderTest {
     @Mock
     private EmailService emailService;
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         when(apiRepository.search(any(), any(), any())).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(apiRepository, times(1)).search(any(), any(), any());
         verifyNoMoreInteractions(apiRepository);
     }
 
     @Test
-    public void upgrade_should_not_run_cause_not_enabled() {
+    public void upgrade_should_not_run_cause_not_enabled() throws UpgraderException {
         ReflectionTestUtils.setField(upgrader, "enabled", false);
 
         boolean success = upgrader.upgrade();
@@ -86,7 +87,7 @@ public class PlansDataFixUpgraderTest {
     }
 
     @Test
-    public void upgrade_should_not_run_cause_already_executed_successfull() {
+    public void upgrade_should_not_run_cause_already_executed_successfull() throws UpgraderException {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
 
         boolean success = upgrader.upgrade();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
@@ -66,11 +66,11 @@ public class PlansFlowsDefinitionUpgraderTest {
         ReflectionTestUtils.setField(upgrader, "objectMapper", new ObjectMapper());
     }
 
-    @Test
-    public void upgrade_should_failed_because_of_exception() throws TechnicalException {
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_failed_because_of_exception() throws TechnicalException, UpgraderException {
         when(apiRepository.search(any(), any(), any())).thenThrow(new RuntimeException());
 
-        assertFalse(upgrader.upgrade());
+        upgrader.upgrade();
 
         verify(apiRepository, times(1)).search(any(), any(), any());
         verifyNoMoreInteractions(apiRepository);
@@ -96,6 +96,7 @@ public class PlansFlowsDefinitionUpgraderTest {
         verify(upgrader).migrateApiFlows(eq("api2"), argThat(api -> api.getId().equals("api2")));
         verify(upgrader).migrateApiFlows(eq("api4"), argThat(api -> api.getId().equals("api4")));
         verify(upgrader).upgrade();
+        verify(upgrader).wrapException(any());
         verifyNoMoreInteractions(upgrader);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigOriginUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigOriginUpgraderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.Origin;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.model.NotificationReferenceType;
@@ -60,7 +61,7 @@ public class PortalNotificationConfigOriginUpgraderTest {
     }
 
     @Test
-    public void should_upgrade_only_portal_with_no_origin() throws TechnicalException {
+    public void should_upgrade_only_portal_with_no_origin() throws TechnicalException, UpgraderException {
         Set<PortalNotificationConfig> portalNotificationConfigs = Set.of(
             // to be upgraded
             aPortalNotificationConfig("api#1", NotificationReferenceType.API, "user#1", null),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgraderTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
@@ -61,7 +62,7 @@ public class PortalNotificationConfigUpgraderTest {
     }
 
     @Test
-    public void should_upgrade_only_portal_default_notification() throws TechnicalException {
+    public void should_upgrade_only_portal_default_notification() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("env#1").build(), Environment.builder().id("env#2").build()));
 
@@ -107,7 +108,7 @@ public class PortalNotificationConfigUpgraderTest {
     }
 
     @Test
-    public void should_not_create_if_not_find_default_notification() throws TechnicalException {
+    public void should_not_create_if_not_find_default_notification() throws TechnicalException, UpgraderException {
         when(environmentRepository.findAll())
             .thenReturn(Set.of(Environment.builder().id("DEFAULT").build(), Environment.builder().id("env#1").build()));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9678

## Description

Introduced an exception wrapper to handle errors in the upgrader, improving error management and maintainability.

**Before:** 
When you call the upgrade method from an Upgrader, if an exception happen, it will be handled by the methode (try catch block).

**Now:**
Exceptions are thrown by the upgrade method. The caller is responsible for handling them.


## Additional context

Linked to this PR on gravitee-node : https://github.com/gravitee-io/gravitee-node/pull/424
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tdjkmymrku.chromatic.com)
<!-- Storybook placeholder end -->
