### PR TITLE
fix: safely unwrap response headers when disabled for logging

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -48,10 +48,14 @@ public class LoggingHook implements InvokerHook {
             final AnalyticsContext analyticsContext = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT);
             final LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
-            if (log != null && loggingContext != null && loggingContext.endpointRequest()) {
-                ((LogEndpointRequest) log.getEndpointRequest()).capture();
+            if (log != null && loggingContext != null) {
+                if (loggingContext.endpointRequest()) {
+                    ((LogEndpointRequest) log.getEndpointRequest()).capture();
+                }
 
-                ((MutableExecutionContext) ctx).response().setHeaders(new LogHeadersCaptor(ctx.response().headers()));
+                if (loggingContext.endpointResponseHeaders()) {
+                    ((MutableExecutionContext) ctx).response().setHeaders(new LogHeadersCaptor(ctx.response().headers()));
+                }
             }
         });
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9675

## Description

The updated logic ensures response headers are only unwrapped when they are an instance of LogHeadersCaptor, preventing runtime failures and maintaining compatibility with all logging configurations.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

