### PR TITLE
fix: preserve numeric value '1' in custom metrics widgets

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.model.analytics.query.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.AnalyticsCalculateException;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -153,5 +154,33 @@ public class AnalyticsServiceImplTest {
 
         assertNotNull(execute);
         verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
+    }
+
+    @Test
+    public void shouldMapOneToQuestionMarkWhenFieldIsNotCustom() throws Exception {
+        GroupByResponse.Bucket bucket = mock(GroupByResponse.Bucket.class);
+        when(bucket.name()).thenReturn("1");
+        when(bucket.value()).thenReturn(100L);
+        GroupByResponse response = mock(GroupByResponse.class);
+        when(response.getField()).thenReturn("api");
+        when(response.values()).thenReturn(List.of(bucket));
+        when(analyticsRepository.query(any(), any())).thenReturn(response);
+        TopHitsAnalytics result = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
+        assertNotNull(result.getValues());
+        assert result.getValues().containsKey("?");
+    }
+
+    @Test
+    public void shouldKeepOneAsKeyWhenFieldIsCustom() throws Exception {
+        GroupByResponse.Bucket bucket = mock(GroupByResponse.Bucket.class);
+        when(bucket.name()).thenReturn("1");
+        when(bucket.value()).thenReturn(100L);
+        GroupByResponse response = mock(GroupByResponse.class);
+        when(response.getField()).thenReturn("custom.field_name_for_analytics");
+        when(response.values()).thenReturn(List.of(bucket));
+        when(analyticsRepository.query(any(), any())).thenReturn(response);
+        TopHitsAnalytics result = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
+        assertNotNull(result.getValues());
+        assert result.getValues().containsKey("1");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9622

## Description

Fixes a bug where custom metrics with a value of "1" were displayed as "?" in Analytics widgets.  
This occurred because "1" was treated as UNKNOWN_SERVICE, even for custom fields.

Issue:

<img width="1162" alt="Screenshot 2025-05-24 at 8 47 33 PM" src="https://github.com/user-attachments/assets/d4bb0d38-274c-4c14-b74a-2f812485333a" />

Fix:

<img width="1728" alt="Screenshot 2025-05-24 at 8 43 56 PM" src="https://github.com/user-attachments/assets/885def51-abcf-4fff-9a39-2b91306c7b29" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

