### PR TITLE
fix(console): handle multiple users with same email in group invitation

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
@@ -51,6 +51,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-raised-button color="warn" [disabled]="disableSubmit()" (click)="submit()">Delete</button>
+  <button mat-raised-button color="primary" [disabled]="disableSubmit" (click)="submit()">Delete</button>
   <button mat-raised-button mat-dialog-close>Cancel</button>
 </mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, OnInit, signal } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -64,7 +64,7 @@ export class DeleteMemberDialogComponent implements OnInit {
     searchTerm: FormControl<string>;
   }>;
   ownershipTransferMessage: string = null;
-  disableSubmit = signal<boolean>(false);
+  disableSubmit = false;
 
   private members: Member[] = [];
   private primaryOwnerMembership: GroupMembership = null;
@@ -95,7 +95,7 @@ export class DeleteMemberDialogComponent implements OnInit {
     if (isPrimaryOwner) {
       this.deleteMemberForm.controls.searchTerm.enable();
       this.deleteMemberForm.controls.searchTerm.addValidators(Validators.required);
-      this.disableSubmit.set(true);
+      this.disableSubmit = true;
     }
   }
 
@@ -128,7 +128,7 @@ export class DeleteMemberDialogComponent implements OnInit {
     this.deleteMemberForm.controls.searchTerm.removeValidators(Validators.required);
     this.ownershipTransferMessage = `${this.member.displayName} is the API primary owner. Primary ownership of the group will be transferred from ${this.member.displayName} to ${this.newPrimaryOwner.displayName}.`;
     this.mapGroupMembership();
-    this.disableSubmit.set(false);
+    this.disableSubmit = false;
   }
 
   deselectPrimaryOwner() {
@@ -138,7 +138,7 @@ export class DeleteMemberDialogComponent implements OnInit {
     this.deleteMemberForm.controls.searchTerm.setValue('');
     this.deleteMemberForm.controls.searchTerm.enable();
     this.deleteMemberForm.controls.searchTerm.addValidators(Validators.required);
-    this.disableSubmit.set(true);
+    this.disableSubmit = true;
   }
 
   private mapGroupMembership() {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SearchableUser } from 'src/entities/user/searchableUser';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -45,6 +44,7 @@ import { Role } from '../../../../entities/role/role';
 import { EnvironmentSettingsService } from '../../../../services-ngx/environment-settings.service';
 import { UsersService } from '../../../../services-ngx/users.service';
 import { GroupMembership, GroupMembershipMemberRoleEntity } from '../../../../entities/group/groupMember';
+import { SearchableUser } from '../../../../entities/user/searchableUser';
 
 describe('GroupComponent', () => {
   let fixture: ComponentFixture<GroupComponent>;
@@ -307,7 +307,7 @@ describe('GroupComponent', () => {
       const buttonHarness = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Add Group To Existing APIs' }));
       await buttonHarness.click();
       const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
-      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Add' }));
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Continue' }));
       await confirmButtonHarness.click();
       const req = httpTestingController.expectOne({
         url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/memberships?type=api`,
@@ -325,7 +325,7 @@ describe('GroupComponent', () => {
       const buttonHarness = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Add Group To Existing Applications' }));
       await buttonHarness.click();
       const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
-      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Add' }));
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Continue' }));
       await confirmButtonHarness.click();
       const req = httpTestingController.expectOne({
         url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/memberships?type=application`,
@@ -449,7 +449,7 @@ describe('GroupComponent', () => {
       const deleteButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Delete invitation"]' }));
       await deleteButton.click();
       const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
-      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Continue' }));
       await confirmButtonHarness.click();
       expectDeleteInvitation('1');
     });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -616,9 +616,9 @@ export class GroupComponent implements OnInit {
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         data: {
           title: 'Delete Invitation',
-          content: `Are you sure you want to delete an invitation sent to ${email}?`,
-          confirmButton: 'Delete',
-          cancelButton: 'No',
+          content: `You are trying to delete an invitation sent to ${email}. Do you want to continue?`,
+          confirmButton: 'Continue',
+          cancelButton: 'Cancel',
         },
         role: 'alertdialog',
         id: 'deleteInvitationDialog',
@@ -651,9 +651,9 @@ export class GroupComponent implements OnInit {
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         data: {
           title: 'Add group to existing APIs',
-          content: `Are you sure you want to add the group to all existing APIs?`,
-          confirmButton: 'Add',
-          cancelButton: 'No',
+          content: `You are trying to add the group to all the existing APIs. Do you want to continue?`,
+          confirmButton: 'Continue',
+          cancelButton: 'Cancel',
         },
         role: 'alertdialog',
         id: 'confirmDialog',
@@ -683,9 +683,9 @@ export class GroupComponent implements OnInit {
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         data: {
           title: 'Add group to existing applications',
-          content: `Are you sure you want to add the group to all existing applications?`,
-          confirmButton: 'Add',
-          cancelButton: 'No',
+          content: `You are trying to add the group to all the existing applications. Do you want to continue?`,
+          confirmButton: 'Continue',
+          cancelButton: 'Cancel',
         },
         role: 'alertdialog',
         id: 'confirmDialog',

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,10 @@
     limitations under the License.
 
 -->
-<h2 mat-dialog-title>Remove Member</h2>
+<h2 mat-dialog-title>Many Users Found</h2>
 <mat-dialog-content>
   <gio-banner-info>
-    More than one user already exist with the email id {{ email }} in the organization. You can select and add add a specific user using add
+    More than one user already exist with the email id {{ email }} in the organization. You can select and add a specific user using add
     member function.
   </gio-banner-info>
   <span> Do you want to continue? </span>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title>Remove Member</h2>
+<mat-dialog-content>
+  <gio-banner-info>
+    More than one user already exist with the email id {{ email }} in the organization. You can select and add add a specific user using add
+    member function.
+  </gio-banner-info>
+  <span> Do you want to continue? </span>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-raised-button color="primary" (click)="submit()">Continue</button>
+  <button mat-raised-button mat-dialog-close>Cancel</button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.scss
@@ -1,0 +1,6 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/too-many-users-dialog/too-many-users-dialog.component.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+
+import { TooManyUsersDialogData } from '../group.component';
+
+@Component({
+  selector: 'too-many-users-dialog',
+  imports: [MatCardModule, MatDialogModule, MatButtonModule, GioBannerModule],
+  templateUrl: './too-many-users-dialog.component.html',
+  styleUrl: './too-many-users-dialog.component.scss',
+})
+export class TooManyUsersDialogComponent implements OnInit {
+  email: string;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: TooManyUsersDialogData,
+    private matDialogRef: MatDialogRef<TooManyUsersDialogComponent>,
+  ) {}
+
+  ngOnInit(): void {
+    this.email = this.data.email;
+  }
+
+  submit() {
+    this.matDialogRef.close(true);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
@@ -17,7 +17,7 @@
 -->
 <mat-card>
   <mat-card-header class="groups__card-header-with-btn">
-    <mat-card-title>Groups</mat-card-title>
+    <mat-card-title><h2>Groups</h2></mat-card-title>
     <button
       mat-raised-button
       [routerLink]="['.', 'new']"
@@ -54,14 +54,17 @@
           <td mat-cell *matCellDef="let row">
             <div>
               {{ row.name }}
+              @if (row.apiPrimaryOwner) {
+                <span class="gio-badge-primary" tooltip="Group has a member with API role primary owner">Primary Owner</span>
+              }
               @if (row.shouldAddToNewAPIs) {
-                <span class="gio-badge-primary" tooltip="Group will be automatically added to new applications"
+                <span class="gio-badge-warning" tooltip="Group will be automatically added to new applications"
                   >Automatically associated to APIs</span
                 >
               }
 
               @if (row.shouldAddToNewApplications) {
-                <span tooltip="Group will be automatically added to new APIs" class="gio-badge-primary"
+                <span tooltip="Group will be automatically added to new APIs" class="gio-badge-warning"
                   >Automatically associated to Applications</span
                 >
               }
@@ -78,7 +81,7 @@
             <button
               mat-button
               (click)="deleteGroup(row)"
-              [disabled]="deleteGroupDisabled"
+              [disabled]="protectedGroups.has(row.id)"
               matTooltip="Delete group"
               aria-hidden="false"
               aria-label="Click to delete group"

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -147,7 +146,7 @@ describe('GroupsComponent', () => {
 
     it('should not delete when API role is primary owner', async () => {
       expectGetGroupsList(
-        fakePagedResult([{ id: '1', name: 'Group 1', manageable: true, roles: { API: 'PRIMARY_OWNER' } }], {
+        fakePagedResult([{ id: '1', name: 'Group 1', manageable: true, roles: { API: 'PRIMARY_OWNER' }, apiPrimaryOwner: true }], {
           current: 1,
           per_page: 10,
           size: 2,

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.ts
@@ -85,8 +85,10 @@ export class GroupService {
     return this.http.get<Member[]>(`${this.constants.env.baseURL}/configuration/groups/${groupId}/members`);
   }
 
-  inviteMember(groupId: string, invitation: Invitation) {
-    return this.http.post<Invitation>(`${this.constants.env.baseURL}/configuration/groups/${groupId}/invitations`, invitation);
+  inviteMember(groupId: string, invitation: Invitation): Observable<any> {
+    return this.http.post<Invitation>(`${this.constants.env.baseURL}/configuration/groups/${groupId}/invitations`, invitation, {
+      observe: 'response',
+    });
   }
 
   deleteMember(groupId: string, memberId: string): Observable<void> {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/UserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/UserRepository.java
@@ -49,7 +49,7 @@ public interface UserRepository extends CrudRepository<User, String> {
      * @return
      * @throws TechnicalException
      */
-    Optional<User> findByEmail(String email, String organizationId) throws TechnicalException;
+    List<User> findByEmail(String email, String organizationId) throws TechnicalException;
 
     /**
      * Find a list of {@link User} by IDs

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
@@ -94,16 +94,15 @@ public class JdbcUserRepository extends JdbcAbstractCrudRepository<User, String>
     }
 
     @Override
-    public Optional<User> findByEmail(String email, String organizationId) throws TechnicalException {
+    public List<User> findByEmail(String email, String organizationId) throws TechnicalException {
         LOGGER.debug("JdbcUserRepository.findByEmail({})", email);
         try {
-            List<User> users = jdbcTemplate.query(
+            return jdbcTemplate.query(
                 getOrm().getSelectAllSql() + " u where UPPER(u.email) = UPPER(?) and organization_id = ?",
                 getOrm().getRowMapper(),
                 email,
                 organizationId
             );
-            return users.stream().findFirst();
         } catch (final Exception ex) {
             LOGGER.error("Failed to find user by email", ex);
             throw new TechnicalException("Failed to find user by email", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
@@ -78,22 +78,21 @@ public class MongoUserRepository implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByEmail(String email, String organizationId) {
+    public List<User> findByEmail(String email, String organizationId) {
         logger.debug("Find user by email [{}]", email);
 
         if (email == null) {
-            return Optional.empty();
+            return List.of();
         }
 
-        UserMongo user;
+        List<UserMongo> users;
         if (isEncryptionEnabled) {
-            user = internalUserRepo.findByEmail(email.toLowerCase(), organizationId);
+            users = internalUserRepo.findByEmail(email.toLowerCase(), organizationId);
         } else {
-            user = internalUserRepo.findByEmailIgnoreCase(email, organizationId);
+            users = internalUserRepo.findByEmailIgnoreCase(email, organizationId);
         }
-        User res = mapper.map(user);
 
-        return Optional.ofNullable(res);
+        return users.stream().map(mapper::map).toList();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepository.java
@@ -37,13 +37,13 @@ public interface UserMongoRepository extends MongoRepository<UserMongo, String>,
     UserMongo findBySourceAndSourceIdIgnoreCase(String source, String sourceId, String organizationId);
 
     @Query(value = "{ 'email': {$regex: '^?0$', $options: 'i'}, 'organizationId': ?1 }")
-    UserMongo findByEmailIgnoreCase(String email, String organizationId);
+    List<UserMongo> findByEmailIgnoreCase(String email, String organizationId);
 
     @Query(value = "{ 'source': ?0, 'sourceId': ?1, 'organizationId': ?2 }")
     UserMongo findBySourceAndSourceId(String source, String sourceId, String organizationId);
 
     @Query(value = "{ 'email':?0, 'organizationId': ?1 }")
-    UserMongo findByEmail(String email, String organizationId);
+    List<UserMongo> findByEmail(String email, String organizationId);
 
     @Query(value = "{ 'organizationId': ?0 }", fields = "{ _id : 1 }", delete = true)
     List<UserMongo> deleteByOrganizationId(String organizationId);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
@@ -17,8 +17,11 @@ package io.gravitee.repository.management;
 
 import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.UserCriteria;
@@ -70,7 +73,7 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("Invalid saved user status.", user.getStatus(), userFound.getStatus());
         assertEquals("Invalid saved user login count.", user.getLoginCount(), userFound.getLoginCount());
         assertEquals("Invalid saved user first connection at.", user.getFirstConnectionAt(), userFound.getFirstConnectionAt());
-        assertEquals("Invalid saved user newsletter.", false, user.getNewsletterSubscribed());
+        assertEquals("Invalid saved user newsletter.", user.getNewsletterSubscribed(), false);
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
@@ -70,7 +70,7 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("Invalid saved user status.", user.getStatus(), userFound.getStatus());
         assertEquals("Invalid saved user login count.", user.getLoginCount(), userFound.getLoginCount());
         assertEquals("Invalid saved user first connection at.", user.getFirstConnectionAt(), userFound.getFirstConnectionAt());
-        assertEquals("Invalid saved user newsletter.", user.getNewsletterSubscribed(), false);
+        assertEquals("Invalid saved user newsletter.", false, user.getNewsletterSubscribed());
     }
 
     @Test
@@ -137,7 +137,7 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull(users);
         assertEquals("Invalid user numbers in search", 1, users.size());
-        assertEquals("user0", users.get(0).getId());
+        assertEquals("user0", users.getFirst().getId());
     }
 
     @Test
@@ -192,11 +192,11 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void findUserByEmail() throws Exception {
-        Optional<User> user1 = userRepository.findByEmail("user0@gravitee.io", "DEFAULT");
-        Optional<User> user1Upper = userRepository.findByEmail("usER0@gravitee.io", "DEFAULT");
-        assertTrue(user1.isPresent());
-        assertTrue(user1Upper.isPresent());
-        assertEquals(user1.get().getId(), user1Upper.get().getId());
+        List<User> user1 = userRepository.findByEmail("user0@gravitee.io", "DEFAULT");
+        List<User> user1Upper = userRepository.findByEmail("usER0@gravitee.io", "DEFAULT");
+        assertFalse(user1.isEmpty());
+        assertFalse(user1Upper.isEmpty());
+        assertEquals(user1.getFirst().getId(), user1Upper.getFirst().getId());
     }
 
     @Test
@@ -262,7 +262,7 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull(users);
         assertEquals(2, users.size());
-        assertTrue(users.stream().map(User::getId).collect(toList()).containsAll(asList("user1", "user5")));
+        assertTrue(users.stream().map(User::getId).toList().containsAll(asList("user1", "user5")));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
@@ -155,7 +155,9 @@ public class GroupInvitationsResource extends AbstractResource {
             }
         }
 
-        // If there are multiple users holding the same email id, we send back the list of users to select one and send an invitation
+        /*If there is more than one user holding the same email id, we send back the list of users.
+        We can do the same for the case when one user is found with the given email. This will keep POST invitation dedicated to sending
+        invitations for external emails, and we can get rid of adding members in invitation service - looks clean.*/
         List<UserEntity> userEntities = userService.findByEmail(executionContext, invitationEntity.getEmail());
 
         if (CollectionUtils.isNotEmpty(userEntities) && userEntities.size() > 1) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResourceTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.InvitationEntity;
+import io.gravitee.rest.api.model.InvitationReferenceType;
+import io.gravitee.rest.api.model.NewInvitationEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.InvitationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class GroupInvitationsResourceTest extends AbstractResourceTest {
+
+    private GroupEntity group;
+
+    @Autowired
+    private InvitationService invitationService;
+
+    @Override
+    protected String contextPath() {
+        return "configuration/groups/b72c4ad7-10aa-4331-ac4a-d710aad331ab/invitations/";
+    }
+
+    @Before
+    public void init() {
+        group = new GroupEntity();
+        group.setId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        group.setName("group1");
+        group.setMaxInvitation(5);
+
+        when(groupService.findById(GraviteeContext.getExecutionContext(), "b72c4ad7-10aa-4331-ac4a-d710aad331ab")).thenReturn(group);
+    }
+
+    @Test
+    public void should_throw_when_max_invitations_reached() {
+        NewInvitationEntity newInvitation = new NewInvitationEntity();
+        newInvitation.setReferenceId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        newInvitation.setEmail("test@test.com");
+        newInvitation.setReferenceType(InvitationReferenceType.GROUP);
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_GROUP,
+                GraviteeContext.getCurrentEnvironment(),
+                RolePermissionAction.CREATE,
+                RolePermissionAction.UPDATE,
+                RolePermissionAction.DELETE
+            )
+        )
+            .thenReturn(false);
+        when(groupService.getNumberOfMembers(GraviteeContext.getExecutionContext(), "b72c4ad7-10aa-4331-ac4a-d710aad331ab")).thenReturn(5);
+
+        final Response response = envTarget().request().post(Entity.json(newInvitation));
+
+        assertEquals(400, response.getStatus());
+
+        assertThat(response.readEntity(String.class), containsString("Limitation of 5 members exceeded"));
+    }
+
+    @Test
+    public void should_throw_when_email_invitation_is_not_allowed() {
+        group.setEmailInvitation(false);
+        NewInvitationEntity newInvitation = new NewInvitationEntity();
+        newInvitation.setReferenceId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        newInvitation.setEmail("test@test.com");
+        newInvitation.setReferenceType(InvitationReferenceType.GROUP);
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_GROUP,
+                GraviteeContext.getCurrentEnvironment(),
+                RolePermissionAction.CREATE,
+                RolePermissionAction.UPDATE,
+                RolePermissionAction.DELETE
+            )
+        )
+            .thenReturn(false);
+        when(groupService.getNumberOfMembers(GraviteeContext.getExecutionContext(), "b72c4ad7-10aa-4331-ac4a-d710aad331ab")).thenReturn(2);
+
+        final Response response = envTarget().request().post(Entity.json(newInvitation));
+
+        // We have returned 404 in case of forbidden. Probably, needs to change.
+        assertEquals(404, response.getStatus());
+
+        assertThat(
+            response.readEntity(String.class),
+            containsString("Invitation email is forbidden for group [b72c4ad7-10aa-4331-ac4a-d710aad331ab]")
+        );
+    }
+
+    @Test
+    public void should_return_list_of_users_holding_same_email_id() {
+        group.setEmailInvitation(true);
+        NewInvitationEntity newInvitation = new NewInvitationEntity();
+        newInvitation.setReferenceId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        newInvitation.setEmail("test@test.com");
+        newInvitation.setReferenceType(InvitationReferenceType.GROUP);
+        UserEntity user1 = new UserEntity();
+        user1.setEmail("test@test.com");
+        UserEntity user2 = new UserEntity();
+        user2.setEmail("test@test.com");
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_GROUP,
+                GraviteeContext.getCurrentEnvironment(),
+                RolePermissionAction.CREATE,
+                RolePermissionAction.UPDATE,
+                RolePermissionAction.DELETE
+            )
+        )
+            .thenReturn(true);
+        when(userService.findByEmail(GraviteeContext.getExecutionContext(), "test@test.com")).thenReturn(List.of(user1, user2));
+
+        final Response response = envTarget().request().post(Entity.json(newInvitation));
+
+        assertEquals(202, response.getStatus());
+        List<UserEntity> users = response.readEntity(new GenericType<>() {});
+        assertEquals(2, users.size());
+    }
+
+    @Test
+    public void should_create_invitation() {
+        group.setEmailInvitation(true);
+        NewInvitationEntity newInvitation = new NewInvitationEntity();
+        newInvitation.setReferenceId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        newInvitation.setEmail("test@test.com");
+        newInvitation.setReferenceType(InvitationReferenceType.GROUP);
+        InvitationEntity invitationEntity = new InvitationEntity();
+        invitationEntity.setId("e98ede5e-ee8d-4469-8ede-5eee8d14693a");
+        invitationEntity.setEmail("test@test.com");
+        invitationEntity.setReferenceId("b72c4ad7-10aa-4331-ac4a-d710aad331ab");
+        invitationEntity.setReferenceType(InvitationReferenceType.GROUP);
+        UserEntity user = new UserEntity();
+        user.setEmail("test@test.com");
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_GROUP,
+                GraviteeContext.getCurrentEnvironment(),
+                RolePermissionAction.CREATE,
+                RolePermissionAction.UPDATE,
+                RolePermissionAction.DELETE
+            )
+        )
+            .thenReturn(true);
+        when(userService.findByEmail(GraviteeContext.getExecutionContext(), "test@test.com")).thenReturn(List.of(user));
+        when(invitationService.create(GraviteeContext.getExecutionContext(), newInvitation)).thenReturn(invitationEntity);
+        final Response response = envTarget().request().post(Entity.json(newInvitation));
+
+        assertEquals(200, response.getStatus());
+        InvitationEntity invitation = response.readEntity(new GenericType<>() {});
+        assertEquals("e98ede5e-ee8d-4469-8ede-5eee8d14693a", invitation.getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -130,6 +130,7 @@ import io.gravitee.rest.api.service.FetcherService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.InstanceService;
+import io.gravitee.rest.api.service.InvitationService;
 import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.LogsService;
 import io.gravitee.rest.api.service.MediaService;
@@ -883,5 +884,10 @@ public class ResourceContextConfiguration {
         ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainServiceInMemory
     ) {
         return new GetExposedEntrypointsUseCase(apiCrudServiceInMemory, apiExposedEntrypointDomainServiceInMemory);
+    }
+
+    @Bean
+    public InvitationService invitationService() {
+        return mock(InvitationService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -40,7 +40,7 @@ public interface UserService {
         return findById(executionContext, id, false);
     }
 
-    Optional<UserEntity> findByEmail(ExecutionContext executionContext, String email);
+    List<UserEntity> findByEmail(ExecutionContext executionContext, String email);
 
     UserEntity findByIdWithRoles(ExecutionContext executionContext, String id);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailRecipientsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailRecipientsServiceImpl.java
@@ -19,6 +19,7 @@ import static java.util.function.Predicate.not;
 
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
+import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.EmailRecipientsService;
 import io.gravitee.rest.api.service.UserService;
@@ -74,10 +75,10 @@ public class EmailRecipientsServiceImpl implements EmailRecipientsService {
     public Set<String> filterRegisteredUser(ExecutionContext executionContext, Collection<String> recipientsEmail) {
         return recipientsEmail
             .stream()
-            .map(email -> userService.findByEmail(executionContext, email))
-            .flatMap(Optional::stream)
-            .filter(UserEntity::optedIn)
-            .map(UserEntity::getEmail)
+            .filter(email -> {
+                List<UserEntity> users = userService.findByEmail(executionContext, email);
+                return CollectionUtils.isNotEmpty(users) && users.size() == 1 && users.getFirst().optedIn();
+            })
             .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.service.notification.NotificationParamsBuilde
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
+import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
 import io.gravitee.repository.management.model.Invitation;
@@ -86,9 +87,9 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
         }
         try {
             // First check if user exists
-            final Optional<UserEntity> existingUser = userService.findByEmail(executionContext, invitation.getEmail());
-            if (existingUser.isPresent()) {
-                final UserEntity user = existingUser.get();
+            final List<UserEntity> existingUsers = userService.findByEmail(executionContext, invitation.getEmail());
+            if (CollectionUtils.isNotEmpty(existingUsers)) {
+                final UserEntity user = existingUsers.getFirst();
 
                 Set<String> groupUsers = membershipService
                     .getMembershipsByReference(MembershipReferenceType.GROUP, invitation.getReferenceId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -416,11 +416,11 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     }
 
     @Override
-    public Optional<UserEntity> findByEmail(ExecutionContext executionContext, String email) {
+    public List<UserEntity> findByEmail(ExecutionContext executionContext, String email) {
         try {
             LOGGER.debug("Find user by Email: {}", email);
-            Optional<User> optionalUser = userRepository.findByEmail(email, executionContext.getOrganizationId());
-            return optionalUser.map(user -> convert(optionalUser.get(), false));
+            List<User> users = userRepository.findByEmail(email, executionContext.getOrganizationId());
+            return users.stream().map(user -> convert(user, false)).toList();
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find user using its email", ex);
             throw new TechnicalManagementException("An error occurs while trying to find user using its email", ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailRecipientsServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailRecipientsServiceImplTest.java
@@ -152,7 +152,7 @@ class EmailRecipientsServiceImplTest {
 
         @Test
         void should_return_empty_collection_if_no_user_found_for_a_mail() {
-            when(userService.findByEmail(executionContext, "no-user@mail.gio")).thenReturn(Optional.empty());
+            when(userService.findByEmail(executionContext, "no-user@mail.gio")).thenReturn(List.of());
             final Set<String> result = cut.filterRegisteredUser(executionContext, List.of("no-user@mail.gio"));
             assertThat(result).isEmpty();
         }
@@ -160,7 +160,7 @@ class EmailRecipientsServiceImplTest {
         @Test
         void should_return_empty_collection_if_no_user_has_not_opted_in() {
             final UserEntity userEntity = UserEntity.builder().source("gravitee").email("user@mail.gio").build();
-            when(userService.findByEmail(executionContext, "user@mail.gio")).thenReturn(Optional.of(userEntity));
+            when(userService.findByEmail(executionContext, "user@mail.gio")).thenReturn(List.of(userEntity));
             final Set<String> result = cut.filterRegisteredUser(executionContext, List.of("user@mail.gio"));
             assertThat(result).isEmpty();
         }
@@ -168,7 +168,7 @@ class EmailRecipientsServiceImplTest {
         @ParameterizedTest
         @MethodSource("provideOptedInUser")
         void should_return_opted_in_user_email(UserEntity optedInUser) {
-            when(userService.findByEmail(executionContext, optedInUser.getEmail())).thenReturn(Optional.of(optedInUser));
+            when(userService.findByEmail(executionContext, optedInUser.getEmail())).thenReturn(List.of(optedInUser));
             final Set<String> result = cut.filterRegisteredUser(executionContext, List.of(optedInUser.getEmail()));
             assertThat(result).containsExactly(optedInUser.getEmail());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -230,11 +230,11 @@ public class UserServiceTest {
         when(user.getFirstname()).thenReturn(FIRST_NAME);
         when(user.getLastname()).thenReturn(LAST_NAME);
         when(user.getPassword()).thenReturn(PASSWORD);
-        when(userRepository.findByEmail(EMAIL, ORGANIZATION)).thenReturn(of(user));
+        when(userRepository.findByEmail(EMAIL, ORGANIZATION)).thenReturn(List.of(user));
 
-        final Optional<UserEntity> optUserEntity = userService.findByEmail(EXECUTION_CONTEXT, EMAIL);
+        final List<UserEntity> optUserEntity = userService.findByEmail(EXECUTION_CONTEXT, EMAIL);
 
-        UserEntity userEntity = optUserEntity.get();
+        UserEntity userEntity = optUserEntity.getFirst();
         assertNotNull(userEntity);
 
         assertEquals(USER_NAME, userEntity.getId());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9492

## Description
* **Problem**
  - Email invitations could be ambiguous when multiple users share the same email address
  - No clear way to select specific user when duplicate emails exist

* **Solution**
  - Added warning dialog when duplicate email addresses are detected
  - Provided guidance to use member search for precise user selection
  - Improved user experience with clear action options

* **Secondary Changes**
  - Display primary owner badge and disable delete action on PO groups.

* **Demo**
  - It is uploaded [here](https://drive.google.com/file/d/1DMB7u_ZhSG4NYOEP2j2LQey-35OzMW60/view?usp=drive_link) because the file size was more than 100Mb.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-codzoejhso.chromatic.com)
<!-- Storybook placeholder end -->
