### PR TITLE
feat(helm): add custom ingress capability for federation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ jobs:
           name: node/default
           tag: "20.11"
         environment:
-            CI_ACTION: "<< pipeline.parameters.gio_action >>"
-            CI_DRY_RUN: "<< pipeline.parameters.dry_run >>"
-            CI_GRAVITEEIO_VERSION: "<< pipeline.parameters.graviteeio_version >>"
+            CI_ACTION: "release_helm"
+            CI_DRY_RUN: "true"
+            CI_GRAVITEEIO_VERSION: "4.8.998"
             CI_DOCKER_TAG_AS_LATEST: "<< pipeline.parameters.docker_tag_as_latest >>"
             APIM_VERSION_PATH: "<< pipeline.parameters.apim_version_path >>"
         steps:
@@ -66,6 +66,7 @@ jobs:
                       not:
                           or:
                               - equal: ["master", << pipeline.git.branch >>]
+                              - equal: ["feat/TT-6082_add_federation_customIngress_capabilities", << pipeline.git.branch >>]
                               - matches:
                                     pattern: "^[0-9]+\\.[0-9]+\\.x$"
                                     value: << pipeline.git.branch >>

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -10,6 +10,8 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - bump elastisearch helm release to 19.21.2
 - bump mongodb helm release to 13.18.5
 - allow users to set allowed source ranges for the gateway LoadBalancer service
+- If kafka gateway is enabled then startupProbe, readinessProbe and livenessProbe are configured to take the kafka-server probe into account
+- Allow customization on federation ingress
 
 ### 4.7.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -40,3 +40,5 @@ annotations:
       description: 'Allow users to set allowed source ranges for the gateway LoadBalancer service'
     - kind: added
       description: 'If kafka gateway is enabled then startupProbe, readinessProbe and livenessProbe are configured to take the kafka-server probe into account'
+    - kind: added
+      description: 'Allow customization on federation ingress'

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim
 # Also update CHANGELOG.md
 version: 4.8.0
-appVersion: 4.8.0
+appVersion: 4.8.998
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io
 sources:

--- a/helm/templates/api/api-ingress-federation-controller.yaml
+++ b/helm/templates/api/api-ingress-federation-controller.yaml
@@ -7,6 +7,9 @@
 {{- $apiVersion := include "common.capabilities.ingress.apiVersion" . -}}
 apiVersion: {{ $apiVersion }}
 kind: Ingress
+{{- if .Values.api.federation.customFederationIngress -}}
+{{ toYaml .Values.api.federation.customFederationIngress | nindent 0 }}
+{{- else }}
 metadata:
   name: {{ template "gravitee.api.fullname" . }}-integration-controller
   labels:
@@ -67,3 +70,4 @@ spec:
   {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/helm/tests/api/ingress_federationcontroller_test.yaml
+++ b/helm/tests/api/ingress_federationcontroller_test.yaml
@@ -211,3 +211,48 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: federation-custom-cert
+
+  - it: Check customIngress overridden default ingress
+    set:
+      api:
+        enabled: true
+        federation:
+          enabled: true
+          customFederationIngress:
+            metadata:
+              name: dev-apim-cp-c96320-api-bridge
+              labels:
+                app.kubernetes.io/component: api
+                app.kubernetes.io/instance: dev-apim-cp-c96320
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /$1
+            spec:
+              ingressClassName: nginx-internal
+              rules:
+                - host: dev.eu.c96320.federation.gravitee.dev.internal
+                  http:
+                    paths:
+                      - backend:
+                          service:
+                            name: dev-apim-cp-c96320-api
+                            port:
+                              number: 72
+                        path: "/integration-controller(/.*)?"
+                        pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: dev-apim-cp-c96320-api-bridge
+      - equal:
+          path: spec.ingressClassName
+          value: nginx-internal
+      - equal:
+          path: spec.rules[0].host
+          value: dev.eu.c96320.federation.gravitee.dev.internal

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -868,6 +868,9 @@ api:
 #        - hosts:
 #            - apim.example.com
 #          secretName: api-custom-cert
+    # You can define here a custom ingress dedicated to federation that will overwrite the default computed one above.
+    customFederationIngress: {}
+
     service:
       externalPort: 72
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9766

## Description

The default federation ingress contain also some definition from
`api.ingress.management`. Which sometime is not relevant.

To avoid breaking change and allow more specificities, we introduce here
a `customFederationIngress` attribute where we blindly overwrite ingress
definition with what is provided.
