### PR TITLE
fix: ensure debug mode request body wraps correctly to prevent UI break

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-request/debug-mode-request.component.html
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-request/debug-mode-request.component.html
@@ -36,17 +36,12 @@
           <gio-form-headers formControlName="headers"></gio-form-headers>
         </mat-tab>
         <mat-tab label="Request body">
-          <gv-code
+          <gio-monaco-editor
             class="debug-mode-request__content__body"
-            [options]="{
-              placeholder: 'Put request body here',
-              lineWrapping: true,
-              lineNumbers: true,
-              allowDropFileTypes: true,
-              autoCloseTags: true,
-            }"
-            (:gv-code:input)="onBodyChange($any($event).detail)"
-          ></gv-code>
+            gioMonacoEditorFormField
+            [disableMiniMap]="true"
+            formControlName="body"
+          ></gio-monaco-editor>
         </mat-tab>
       </mat-tab-group>
     </div>

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-request/debug-mode-request.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-request/debug-mode-request.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import '@gravitee/ui-components/wc/gv-schema-form';
@@ -27,7 +27,7 @@ import { DebugRequest } from '../../models/DebugRequest';
   styleUrls: ['./debug-mode-request.component.scss'],
   standalone: false,
 })
-export class DebugModeRequestComponent implements OnInit {
+export class DebugModeRequestComponent implements OnInit, OnDestroy {
   @Input()
   public debugInProgress = false;
 
@@ -41,7 +41,7 @@ export class DebugModeRequestComponent implements OnInit {
 
   public requestFormGroup: UntypedFormGroup;
 
-  private unsubscribe$ = new Subject<boolean>();
+  private readonly unsubscribe$ = new Subject<boolean>();
 
   ngOnInit() {
     this.requestFormGroup = new UntypedFormGroup({
@@ -55,10 +55,6 @@ export class DebugModeRequestComponent implements OnInit {
   ngOnDestroy() {
     this.unsubscribe$.next(true);
     this.unsubscribe$.unsubscribe();
-  }
-
-  onBodyChange(value: string) {
-    this.requestFormGroup.get('body').setValue(value ?? '');
   }
 
   onSendRequest() {

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.module.ts
@@ -24,7 +24,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTreeModule } from '@angular/material/tree';
-import { GioClipboardModule, GioFormHeadersModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { GioClipboardModule, GioFormHeadersModule, GioIconsModule, GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCardModule } from '@angular/material/card';
 
@@ -64,6 +64,7 @@ import { GioDiffModule } from '../../../shared/components/gio-diff/gio-diff.modu
     GioFormHeadersModule,
     GioClipboardModule,
     MatCardModule,
+    GioMonacoEditorModule,
   ],
   declarations: [
     DebugModeComponent,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9692

## Description

Changed the old gv-code component used for request body input and used the monaco editor component instead: 
Now everything wraps smoothly:
![image](https://github.com/user-attachments/assets/6fc10341-9c8d-4f70-b9c8-a528b83646ef)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bquxhnauoj.chromatic.com)
<!-- Storybook placeholder end -->
