### PR TITLE
fix: prevent group removal on closing the manage groups popup without saving

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
@@ -245,7 +245,7 @@ export class ApiGeneralMembersComponent implements OnInit {
       })
       .afterClosed()
       .pipe(
-        filter(() => !this.isKubernetesOrigin),
+        filter((apiDialogResult): apiDialogResult is ApiGroupsDialogResult => !!apiDialogResult && !this.isKubernetesOrigin),
         switchMap((apiDialogResult) => {
           return combineLatest([of(apiDialogResult), this.apiService.get(this.activatedRoute.snapshot.params.apiId)]);
         }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9768

## Description

Update method should not be called without clicking save button.

Issue -




https://github.com/user-attachments/assets/fc19813d-06ce-4da6-be15-f61ad155306c


Fix -


https://github.com/user-attachments/assets/64f39e96-b011-47d4-a287-c2b00eef1430



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eeygdolpho.chromatic.com)
<!-- Storybook placeholder end -->
