### PR TITLE
fix(upgrader): use the initial apiv4categoriesupgrader behavior

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
@@ -25,7 +25,6 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Category;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +39,6 @@ import org.springframework.stereotype.Component;
 /**
  * Before this upgrader runs :
  *  - categories attached to V4 APIs are not ids but keys
- *
  * For each V4 APIS, this upgrader will :
  *  - update its categories list to store ids instead of keys
  *
@@ -81,7 +79,7 @@ public class ApiV4CategoriesUpgrader implements Upgrader {
 
         // If there are no categories, then upgrade is not necessary
         if (Objects.isNull(categories) || categories.isEmpty()) {
-            return false;
+            return true;
         }
 
         // Two different maps so that we can look up the key or the id of a category

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgraderTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
@@ -187,5 +186,16 @@ public class ApiV4CategoriesUpgraderTest {
         apiV4CategoriesUpgrader.upgrade();
 
         verify(apiRepository, times(1)).update(argThat(currentApi -> currentApi.getCategories().containsAll(List.of("id1", "id2"))));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenNoCategoriesExist() throws Exception {
+        when(categoryRepository.findAll()).thenReturn(null);
+
+        boolean result = apiV4CategoriesUpgrader.upgrade();
+
+        verify(apiRepository, never()).search(any(), any(), any());
+        verify(apiRepository, never()).update(any());
+        assert (result);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9780

## Description

Use initial behavior (return true when there are no categories).

## Additional context

https://gravitee.atlassian.net/browse/APIM-9678

https://github.com/gravitee-io/gravitee-api-management/pull/11902/files#diff-283383113572d650e77175adbc566557975be951a5e94c230b4df4aac64fae22

