### PR TITLE
fix: remove URL length limit and fix SSL handling for A2A agents discovery

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
@@ -99,7 +99,7 @@ export class CreateIntegrationComponent implements OnInit {
     if (wellKnownUrls.enabled) {
       wellKnownUrls.push(
         this.formBuilder.group({
-          url: ['', [Validators.required, Validators.maxLength(50), Validators.minLength(1)]],
+          url: ['', [Validators.required, Validators.minLength(1)]],
         }),
       );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/federation/A2aAgentFetcherImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/federation/A2aAgentFetcherImpl.java
@@ -66,7 +66,8 @@ public class A2aAgentFetcherImpl implements A2aAgentFetcher {
                         default -> throw new IllegalArgumentException("Invalid port " + uri.getPort());
                     };
             }
-            return webClient.get(port, uri.getHost(), uri.getFile()).rxSend();
+            boolean ssl = "https".equalsIgnoreCase(uri.getProtocol());
+            return webClient.get(port, uri.getHost(), uri.getFile()).ssl(ssl).rxSend();
         } catch (Exception e) {
             return Single.error(e);
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9782

## Description

1. Increased URL length limit for Well-known URLs
The previous implementation restricted Well-known URLs to a maximum length of 50 characters, which was insufficient for many valid test cases. This limit has now been removed to allow longer URLs to be used during discovery and validation.

2. Fixed HTTPS handling in discovery logic
The discovery mechanism failed when using HTTPS URLs due to missing SSL configuration. This has been addressed by ensuring that SSL is correctly enabled when the discovered URL uses the https scheme.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mhouosqrft.chromatic.com)
<!-- Storybook placeholder end -->
