### PR TITLE
fix: discard port when matching host header in overlapping http acceptor

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactor.handler;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OverlappingHttpAcceptorTest {
+
+    @Test
+    void match_host_should_remove_port_for_matching() {
+        var acceptor = new OverlappingHttpAcceptor("very.specific.com", "/s1", Set.of());
+        assertThat(acceptor.matchHost("very.specific.com:1234")).isTrue();
+    }
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1241

This is to comply with the following Gateway API specification rule

```
// Port value within the Host header MUST not be considered while
// performing match against hostname.