### PR TITLE
chore: move gravitee-policy-ai-prompt-token-tracking in OSS profile

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -919,6 +919,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.policy</groupId>
+            <artifactId>gravitee-policy-ai-prompt-token-tracking</artifactId>
+            <version>${gravitee-policy-ai-prompt-token-tracking.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Reporters -->
         <dependency>
@@ -1621,19 +1634,6 @@
                     <groupId>io.gravitee.secretprovider</groupId>
                     <artifactId>gravitee-secret-provider-kubernetes</artifactId>
                     <version>${gravitee-secretprovider-kubernetes.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>io.gravitee.policy</groupId>
-                    <artifactId>gravitee-policy-ai-prompt-token-tracking</artifactId>
-                    <version>${gravitee-policy-ai-prompt-token-tracking.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>


### PR DESCRIPTION
## Description

Move gravitee-policy-ai-prompt-token-tracking in the OSS profile next to the other AI policy

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

