### PR TITLE
chore: bump gravitee-node to 7.8.1

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.8.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.8.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.8.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.8.0.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.8.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.8.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.8.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.8.1.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -461,8 +461,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.8.0.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.8.0.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.8.1.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.8.1.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.8.0</gravitee-node.version>
+        <gravitee-node.version>7.8.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.7.0</gravitee-plugin.version>


### PR DESCRIPTION
## Description

Bump gravitee-node to 7.8.1 to embbed the lates fix (see [PR](https://github.com/gravitee-io/gravitee-node/pull/427))
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hdhjpcytzh.chromatic.com)
<!-- Storybook placeholder end -->
