### PR TITLE
fix: On API groups update, if the groups field is null it should keep its current value

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -86,6 +86,12 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
             sanitizedGroups.add(primaryOwnerEntity.getId());
         }
 
+        // In case groups is null we should still return null if no groups have been added because during the update process a null field
+        // means I want to keep the current value
+        if (sanitizedGroups.isEmpty()) {
+            return groups;
+        }
+
         return sanitizedGroups;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
@@ -406,4 +406,16 @@ public class GroupValidationServiceImplTest {
         Assertions.assertThat(validatedGroups).isEmpty();
         Assertions.assertThat(validatedGroups).isEqualTo(emptyGroups);
     }
+
+    @Test
+    public void shouldReturnNull() {
+        Set<String> validatedGroups = groupValidationService.validateAndSanitize(
+            GraviteeContext.getExecutionContext(),
+            null,
+            null,
+            null,
+            false
+        );
+        assertThat(validatedGroups).isNull();
+    }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-9689

https://github.com/user-attachments/assets/42dc13f4-d171-41e9-9fed-754415f622cb