### PR TITLE
chore: bump up gravitee-policy-ai-prompt-guard-rails version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <gravitee-resource-auth-provider-ldap.version>2.0.0</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>4.0.1</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
-        <gravitee-resource-ai-model-text-classification.version>1.0.0-alpha.1</gravitee-resource-ai-model-text-classification.version>
+        <gravitee-resource-ai-model-text-classification.version>1.0.0-alpha.2</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>
         <gravitee-policy-ai-prompt-token-tracking.version>1.0.0-alpha.3</gravitee-policy-ai-prompt-token-tracking.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9810

## Description

Bumping up Guard Rails policy version
Fix for: Can't create gravitee-io/Llama-Prompt-Guard-2-22M/86M-onnx model resource


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lrnwtdoedu.chromatic.com)
<!-- Storybook placeholder end -->
