### PR TITLE
feat(helm): add custom ingress capability for federation

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -4,6 +4,10 @@
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
 
+### 4.9.0
+
+- Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)
+
 ### 4.8.0
 
 - bump elastisearch version to 8.17.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -39,3 +39,5 @@ annotations:
       description: 'The `portal.entrypoint` env var is used to configure the entrypoint used to expose APIs. It is used mainly on the developer portal. The value is automatically set with the ingress of the gateway. Now, if the gateway is configured with  a list of servers (http, tcp...) the `portal.entrypoint` is set accordingly'
     - kind: changed
       description: 'Changed default behavior to enable multi-tenant support in dictionaries'
+    - kind: added
+      description: 'Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)'

--- a/helm/templates/api/api-ingress-federation-controller.yaml
+++ b/helm/templates/api/api-ingress-federation-controller.yaml
@@ -22,9 +22,8 @@ metadata:
     {{- end }}
     {{- end }}
   annotations:
-    {{- $annotations := (merge .Values.api.federation.ingress.annotations .Values.api.ingress.management.annotations ) }}
-    {{- if $annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" $annotations "ingressClassName" .Values.api.federation.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
+    {{- if .Values.api.federation.ingress.annotations }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.federation.ingress.annotations "ingressClassName" .Values.api.federation.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
@@ -36,11 +35,7 @@ spec:
   ingressClassName: {{ .Values.api.federation.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-  {{- $hosts := .Values.api.ingress.management.hosts }}
-  {{- if .Values.api.federation.ingress.hosts -}}
-  {{- $hosts = .Values.api.federation.ingress.hosts }}
-  {{- end -}}
-  {{- range $host := $hosts }}
+  {{- range $host := .Values.api.federation.ingress.hosts }}
   - host: {{ $host | quote }}
     http:
       paths:
@@ -57,13 +52,9 @@ spec:
             servicePort: {{ $serviceAPIPort }}
           {{- end -}}
   {{- end -}}
-  {{- $tls := .Values.api.ingress.management.tls }}
-  {{- if .Values.api.federation.ingress.tls -}}
-  {{- $tls = .Values.api.federation.ingress.tls }}
-  {{- end -}}
-  {{- if $tls }}
+  {{- if .Values.api.federation.ingress.tls }}
   tls:
-{{ toYaml $tls | indent 4 }}
+{{ toYaml .Values.api.federation.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/tests/api/ingress_federationcontroller_test.yaml
+++ b/helm/tests/api/ingress_federationcontroller_test.yaml
@@ -135,7 +135,7 @@ tests:
           path: spec.rules[0].http.paths[0].path
           value: /test-federation-controller
 
-  - it: Check overridden hosts federation ingress
+  - it: Check hosts federation ingress
     set:
       api:
         federation:
@@ -157,13 +157,12 @@ tests:
           path: spec.rules[0].http.paths[0].path
           value: /integration-controller(/.*)?
 
-  - it: Check management tls configuration by default
+  - it: Check tls federation ingress
     set:
       api:
         federation:
           enabled: true
-        ingress:
-          management:
+          ingress:
             tls:
               - hosts:
                   - tls.example.com
@@ -181,33 +180,3 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: api-custom-cert
-
-  - it: Check overridden tls configuration
-    set:
-      api:
-        ingress:
-          management:
-            tls:
-              - hosts:
-                  - tls.example.com
-                secretName: api-custom-cert
-        federation:
-          enabled: true
-          ingress:
-            tls:
-              - hosts:
-                  - federation.example.com
-                secretName: federation-custom-cert
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: networking.k8s.io/v1
-      - equal:
-          path: spec.tls[0].hosts[0]
-          value: federation.example.com
-      - equal:
-          path: spec.tls[0].secretName
-          value: federation-custom-cert

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -869,8 +869,8 @@ api:
       ingressClassName: ""
       path: /integration-controller(/.*)?
       pathType: Prefix
-#      hosts:
-#        - apim.example.com
+      hosts:
+        - apim.example.com
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/proxy-read-timeout: 3600                                                                                                                                              │


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9766

## Description

The default federation ingress contain also some definition from
`api.ingress.management`. Which sometime is not relevant.

The issue is that we can not define a specific federation ingress.

So we indroduce here a breaking change to not include
`api.ingress.management` properties in federation ingress anymore.

Then, like for the bridge endpoint, we will be able to keep by default,
same configuration of ingress (from `values.yaml` default value) or to
define a specific federation ingress.

