### PR TITLE
fix: safely unwrap response headers when disabled for logging

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -53,7 +53,7 @@ public class LoggingHook implements InvokerHook {
                     ((LogEndpointRequest) log.getEndpointRequest()).capture();
                 }
 
-                if (loggingContext.endpointResponseHeaders()) {
+                if (loggingContext.endpointResponseHeaders() || loggingContext.endpointResponse()) {
                     ((MutableExecutionContext) ctx).response().setHeaders(new LogHeadersCaptor(ctx.response().headers()));
                 }
             }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9675

## Description
fix: safely unwrap response headers when disabled for logging

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

