### PR TITLE
fix(console): revert changes to handle 204 response

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -595,8 +595,6 @@ export class GroupComponent implements OnInit {
               if (response.status === 200) {
                 this.snackBarService.success('Successfully invited user to the group.');
                 this.initializeInvitations();
-              } else if (response.status === 204) {
-                this.snackBarService.success('Successfully added user to the group.');
                 this.initializeGroupMembers();
               } else if (response.status === 202) {
                 this.openTooManyUsersDialog(dialogResult.invitation.email);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
@@ -128,7 +128,6 @@ public class GroupInvitationsResource extends AbstractResource {
                     array = @ArraySchema(schema = @Schema(implementation = UserEntity.class))
                 )
             ),
-            @ApiResponse(responseCode = "204", description = "Only one user with the provided email exists and added to group directly"),
         }
     )
     public Response createGroupInvitation(@Valid @NotNull final NewInvitationEntity invitationEntity) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9492

## Description

The pull request reverts the changes done to handle 204 status code in the response when we invite users by email and they are already in the organization.

<img width="658" alt="Screenshot 2025-06-06 at 4 26 42 PM" src="https://github.com/user-attachments/assets/b4349a3b-2b00-48e4-ae7c-da2aa25a8abc" />
<img width="660" alt="Screenshot 2025-06-06 at 4 27 50 PM" src="https://github.com/user-attachments/assets/468439b7-f49d-444c-a27c-140fbc8f32f5" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qpepdcrgru.chromatic.com)
<!-- Storybook placeholder end -->
