### PR TITLE
fix: display error msg when deleting a non-empty folder

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ajs.ts
@@ -393,14 +393,19 @@ class DocumentationManagementComponentController implements IController {
       })
       .then((response) => {
         if (response) {
-          this.DocumentationService.remove(page.id, this.apiId).then(() => {
-            this.NotificationService.show('Page ' + page.name + ' has been removed');
-            this.refresh();
-            this.refreshCurrentFolder();
-            if (this.currentTranslation.id === page.id) {
-              delete this.currentTranslation;
-            }
-          });
+          this.DocumentationService.remove(page.id, this.apiId)
+            .then(() => {
+              this.NotificationService.show('Page ' + page.name + ' has been removed');
+              this.refresh();
+              this.refreshCurrentFolder();
+              if (this.currentTranslation?.id === page.id) {
+                delete this.currentTranslation;
+              }
+            })
+            .catch((err) => {
+              const errorMessage = err?.data?.message || 'An unexpected error occurred while removing the page/folder.';
+              this.NotificationService.showError(errorMessage);
+            });
         }
       });
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9867

## Description

fix(documentation): show error message when attempting to delete non-empty folder

Issue: no error message on screen


https://github.com/user-attachments/assets/eabe8d3c-663e-4545-bfc7-4476416130e8

Fix: 


https://github.com/user-attachments/assets/2e01b13c-19a8-4cc8-98a4-2a405db90687



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-emszstjsna.chromatic.com)
<!-- Storybook placeholder end -->
