### PR TITLE
ci: add validation workflow job for distribution

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -143,6 +143,14 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./rest-api-docker-context
             - ./gateway-docker-context
+  job-validate-workflow-status:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - run:
+          name: Check workflow jobs
+          command: echo "Congratulations! If you can read this, everything is OK"
 workflows:
   pull_requests:
     jobs:
@@ -181,6 +189,10 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-validate-workflow-status:
+          name: Validate workflow status
+          requires:
+            - Build backend
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -370,6 +370,12 @@ export class PullRequestsWorkflow {
       requires.push('Lint & test APIM Portal', 'Lint & test APIM Portal Next', 'Build APIM Portal and publish image');
     }
 
+    // Force validation workflow in case only distribution pom.xml has changed
+    if (environment.changedFiles.some((file) => file.includes('gravitee-apim-distribution'))) {
+      addValidationJob = true;
+      requires.push('Build backend');
+    }
+
     // compute check-workflow job
     if (addValidationJob && requires.length > 0) {
       const checkWorkflowJob = new Job('job-validate-workflow-status', BaseExecutor.create('small'), [


### PR DESCRIPTION
## Issue

N/A

## Description

In case only the pom.xml file from the distribution has changed, we need to add the validation status job so the github PR can be merged (due to requirements)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hqtuvykajr.chromatic.com)
<!-- Storybook placeholder end -->
