### PR TITLE
helm: fix portal.entrypoint env var if gateway configured with servers

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,3 +29,5 @@ annotations:
       links:
        - name: Github Issue
           url: https://github.com/gravitee-io/issues/issues/10524
+    - kind: fixed
+      description: 'The `portal.entrypoint` env var is used to configure the entrypoint used to expose APIs. It is used mainly on the developer portal. The value is automatically set with the ingress of the gateway. Now, if the gateway is configured with  a list of servers (http, tcp...) the `portal.entrypoint` is set accordingly'

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -194,8 +194,18 @@ spec:
               value: "{{ .Values.cockpit.ssl.verifyHostname }}"
             {{- end }}
             {{- if .Values.gateway.enabled }}
+            {{- if .Values.gateway.servers }}
+            {{- range $i, $server := .Values.gateway.servers }}
+            {{- if and (eq $server.type "http") $server.ingress $server.ingress.enabled }}
+            - name: portal.entrypoint
+              value: "https://{{ index $server.ingress.hosts 0 }}{{ $server.ingress.path }}"
+            {{ break }}
+            {{- end }}
+            {{- end }}
+            {{- else }}
             - name: portal.entrypoint
               value: "https://{{ index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}"
+            {{- end }}
             {{- end }}
 {{- if .Values.api.env | default .Values.api.deployment.extraEnvs }}
 {{ toYaml ( .Values.api.env | default .Values.api.deployment.extraEnvs ) | indent 12 }}

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -301,3 +301,25 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
           value: vault-token
+
+  - it: Auto configure portal entrypoint from servers list
+    template: api/api-deployment.yaml
+    set:
+      gateway:
+        servers:
+          - type: http
+            port: 8082
+            ingress:
+              enabled: true
+              pathType: Prefix
+              path: /
+              hosts:
+                - my.custom.gateway.host
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: portal.entrypoint
+              value: https://my.custom.gateway.host/


### PR DESCRIPTION
## Issue

N/A

## Description

The `portal.entrypoint` env var is used to configure the entrypoint used to expose APIs. It is used mainly on the developer portal. The value is automatically set with the ingress of the gateway. Now, if the gateway is configured with  a list of servers (http, tcp...) the `portal.entrypoint` is set accordingly