### PR TITLE
chore: build 2 variants of gateway and mapi Docker images

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -157,6 +157,7 @@ const docker = {
   version: 'default',
 };
 
+export type Variant = 'alpine' | 'debian';
 export const config = {
   aqua,
   artifactoryUrl,

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -263,13 +263,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -290,10 +283,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
 workflows:

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -263,13 +263,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -290,10 +283,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
 workflows:

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -263,13 +263,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -290,10 +283,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
 workflows:

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -263,13 +263,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -290,10 +283,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian -t graviteeio/<< parameters.docker-image-name >>:4-debian -t graviteeio/<< parameters.docker-image-name >>:latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
 workflows:

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -263,13 +263,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -290,10 +283,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
 workflows:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -281,13 +281,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -308,10 +301,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -281,13 +281,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -308,10 +301,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -281,13 +281,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -308,10 +301,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian -t graviteeio/<< parameters.docker-image-name >>:4-debian -t graviteeio/<< parameters.docker-image-name >>:latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -281,13 +281,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -308,10 +301,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -252,13 +252,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -279,10 +272,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-publish-pr-env-urls:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -254,10 +254,17 @@ jobs:
       - cmd-create-docker-context
       - cmd-docker-login
       - run:
-          name: Build docker image for << parameters.apim-project >>
+          name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project >>
       - cmd-docker-logout
@@ -380,4 +387,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5
+  aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -252,13 +252,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -279,10 +272,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-publish-pr-env-urls:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -621,13 +621,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -648,10 +641,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-portal-webui-build:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -621,13 +621,6 @@ jobs:
           version: default
       - cmd-create-docker-context
       - cmd-docker-login
-      - run:
-          name: Build docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project >>
       - keeper/env-export:
           secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
           var-name: AQUA_KEY
@@ -648,10 +641,29 @@ jobs:
           var-name: GITHUB_TOKEN
       - aquasec/install_billy
       - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
       - aquasec/register_artifact:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-portal-webui-build:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -623,10 +623,17 @@ jobs:
       - cmd-create-docker-context
       - cmd-docker-login
       - run:
-          name: Build docker image for << parameters.apim-project >>
+          name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-latest-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project >>
       - cmd-docker-logout

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -254,7 +254,7 @@ jobs:
       - cmd-create-docker-context
       - cmd-docker-login
       - run:
-          name: Build docker image for << parameters.apim-project >>
+          name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-latest \
@@ -498,3 +498,4 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5
+  aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/workflows/workflow-build-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-docker-images.ts
@@ -34,7 +34,7 @@ export class BuildDockerImagesWorkflow {
     dynamicConfig.addJob(portalWebuiBuildJob);
     const backendBuildJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(backendBuildJob);
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, true);
+    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], true);
     dynamicConfig.addJob(buildDockerImageJob);
 
     const jobs = [

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -48,7 +48,7 @@ export class FullReleaseWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, true);
+    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], true);
     dynamicConfig.addJob(buildDockerImageJob);
 
     const backendBuildAndPublishOnDownloadWebsiteJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, true);

--- a/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
@@ -32,7 +32,7 @@ export class PublishDockerImagesWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
+    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], false);
     dynamicConfig.addJob(buildDockerImageJob);
 
     const publishPrEnvUrlsJob = PublishPrEnvUrlsJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -309,7 +309,7 @@ export class PullRequestsWorkflow {
       requires.push('Lint & test APIM Console', 'Build APIM Console');
 
       if (shouldBuildDockerImages) {
-        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
+        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], false);
         dynamicConfig.addJob(buildDockerImageJob);
 
         jobs.push(
@@ -375,7 +375,7 @@ export class PullRequestsWorkflow {
       requires.push('Lint & test APIM Portal', 'Lint & test APIM Portal Next', 'Build APIM Portal');
 
       if (shouldBuildDockerImages) {
-        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
+        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], false);
         dynamicConfig.addJob(buildDockerImageJob);
 
         jobs.push(
@@ -431,7 +431,7 @@ export class PullRequestsWorkflow {
   }
 
   private static getE2EJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
+    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine', 'debian'], false);
     dynamicConfig.addJob(buildDockerImageJob);
 
     const e2eGenerateSdkJob = E2EGenerateSDKJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-run-e2e-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-run-e2e-tests.ts
@@ -42,7 +42,7 @@ export class RunE2ETestsWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
+    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, ['alpine'], false);
     dynamicConfig.addJob(buildDockerImageJob);
 
     const e2eGenerateSdkJob = E2EGenerateSDKJob.create(dynamicConfig, environment);

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,6 +26,12 @@ tasks:
     cmds:
       - mvn clean install -DskipTests -Dskip.validation -Dbundle=dev -T 1C
 
+  docker-backend-debian:
+    desc: "Build backend 🐳 images using buildx"
+    cmds:
+      - docker buildx build --push -t ${DOCKER_REGISTRY}/apim-gateway:$DOCKER_TAG-debian -f gravitee-apim-gateway/docker/Dockerfile.debian ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+      - docker buildx build --push -t ${DOCKER_REGISTRY}/apim-management-api:$DOCKER_TAG-debian -f gravitee-apim-rest-api/docker/Dockerfile.debian ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+
   docker:
     desc: "Build all 🐳 images"
     cmds:

--- a/gravitee-apim-gateway/docker/Dockerfile.debian
+++ b/gravitee-apim-gateway/docker/Dockerfile.debian
@@ -15,23 +15,25 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21-alpine AS base
+FROM graviteeio/java:21-debian AS base-debian
 ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 USER root
-RUN apk update  \
-    && apk add --no-cache libc6-compat jemalloc \
-    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
+RUN set -eux ;\
+    apt-get update ;\
+    apt-get install --yes libjemalloc2 ;\
+    apt-get clean ;\
+    rm -rf /var/lib/apt/lists/*
 
 
 # Second stage to add the folder and change the permissions and ownership
-FROM base AS builder
+FROM base-debian AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
-FROM base
+FROM base-debian
 LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,16 +15,14 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21 AS base
+FROM graviteeio/java:21-alpine AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
-
-RUN addgroup -g 1000 graviteeio \
-    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
 
+USER root
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 

--- a/gravitee-apim-rest-api/docker/Dockerfile.debian
+++ b/gravitee-apim-rest-api/docker/Dockerfile.debian
@@ -15,18 +15,14 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21-alpine AS base
-ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
-
-USER root
-RUN apk update  \
-    && apk add --no-cache libc6-compat jemalloc \
-    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
-
+FROM graviteeio/java:21-debian AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
+
+USER root
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
@@ -35,9 +31,9 @@ FROM base
 LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
-EXPOSE 8082
+EXPOSE 8083
 ENTRYPOINT ["./bin/gravitee"]
 VOLUME ${GRAVITEEIO_HOME}/logs
 HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18082/_node/health || exit 1
+            CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1
 USER graviteeio

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -49,3 +49,5 @@ annotations:
           url: https://github.com/gravitee-io/issues/issues/10524
     - kind: fixed
       description: 'The `portal.entrypoint` env var is used to configure the entrypoint used to expose APIs. It is used mainly on the developer portal. The value is automatically set with the ingress of the gateway. Now, if the gateway is configured with  a list of servers (http, tcp...) the `portal.entrypoint` is set accordingly'
+    - kind: changed
+      description: 'Gateway and Management API images are now based on Debian instead of Alpine.'

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -234,6 +234,17 @@ Return the appropriate apiVersion for pod autoscaling.
 {{- end -}}
 
 {{/*
+Gateway API Docker images tag.
+*/}}
+{{- define "gateway.dockerTag" -}}
+{{- if .Values.gateway.image.tag -}}
+{{- .Values.gateway.image.tag -}}
+{{- else -}}
+{{- printf "%s-debian" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns true if an extraVolumes named config is defined
 Usage:
 {{ include "gateway.externalConfig" . }}
@@ -258,6 +269,17 @@ Usage:
 {{- print "config" -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Management API Docker images tag.
+*/}}
+{{- define "api.dockerTag" -}}
+{{- if .Values.api.image.tag -}}
+{{- .Values.api.image.tag -}}
+{{- else -}}
+{{- printf "%s-debian" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Returns true if an extraVolumes named config is defined

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
 {{- $logbackVolumeName := include "api.logbackVolumeName" . -}}
+{{- $dockerImageTag := include "api.dockerTag" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -130,7 +131,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "gravitee.api.fullname" . }}
-          image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext: {{ toYaml .Values.api.deployment.securityContext | nindent 12 }}
           ports:

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
 {{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
+{{- $dockerImageTag := include "gateway.dockerTag" . -}}
 apiVersion: apps/v1
 kind: {{ .Values.gateway.type }}
 metadata:
@@ -124,7 +125,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "gravitee.gateway.fullname" . }}
-          image: "{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
+          image: "{{ .Values.gateway.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           securityContext: {{ toYaml .Values.gateway.deployment.securityContext | nindent 12 }}
           ports:

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: apps/v1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-management-api:1.0.0-app
+          value: graviteeio/apim-management-api:1.0.0-app-debian
       - equal:
           path: spec.template.spec.containers[0].env
           value:

--- a/helm/tests/gateway/deployment_additional-plugins_test.yaml
+++ b/helm/tests/gateway/deployment_additional-plugins_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-plugins

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -19,7 +19,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext

--- a/helm/tests/gateway/deployment_test.yaml
+++ b/helm/tests/gateway/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: apps/v1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:1.0.0-app
+          value: graviteeio/apim-gateway:1.0.0-app-debian
       - isEmpty:
           # It should not contain environment variable by default
           path: spec.template.spec.containers[0].env
@@ -80,7 +80,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext
@@ -343,4 +343,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
           value: vault-token
-


### PR DESCRIPTION
## Description

This commit introduces a new variants of backend images using `Debian`
instead of `Alpine`.

Why
The new AI policy (Guard Rails) uses ONNX models which require packages
(like PyTorch, NumPy) that depend on glibc.
Gravitee’s current Docker images use Alpine, which uses musl libc, and
is incompatible with many AI-related packages.
Therefore, the policy cannot run on Alpine-based images, making them
unsuitable for future AI features.

Observations
Other teams (e.g., AM) faced similar issues (Cloud HSM plugin) and moved
to Ubuntu Noble base images.
There are no signs that ONNX will support musl in the foreseeable future
(microsoft/onnxruntime#2909).
Building ONNX manually for Alpine is not practical.

To prevent breaking change in 4.8 the usual tags (`4.8.0`, `4.8`) will
keep the Alpine base image and we will provide new tags (`4.8.0-debian`)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pnpxlabsib.chromatic.com)
<!-- Storybook placeholder end -->
