### PR TITLE
chore: build 2 variants of gateway and mapi Docker images

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -157,6 +157,7 @@ const docker = {
   version: 'default',
 };
 
+export type Variant = 'alpine' | 'debian';
 export const config = {
   aqua,
   artifactoryUrl,

--- a/.circleci/ci/src/jobs/job-build-docker-image.ts
+++ b/.circleci/ci/src/jobs/job-build-docker-image.ts
@@ -16,14 +16,13 @@
 import { commands, Config, parameters, reusable } from '@circleci/circleci-config-sdk';
 import { computeImagesTag, GraviteeioVersion, isBlank, isSupportBranchOrMaster, parse } from '../utils';
 import { CircleCIEnvironment } from '../pipelines';
-import { DockerLoginCommand, DockerLogoutCommand, CreateDockerContextCommand } from '../commands';
-import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
+import { CreateDockerContextCommand, DockerLoginCommand, DockerLogoutCommand } from '../commands';
 import { orbs } from '../orbs';
-import { config } from '../config';
+import { config, Variant } from '../config';
 import { BaseExecutor } from '../executors';
 
-export class BuildDockerImageJob {
-  private static jobName = 'job-build-docker-image';
+export class BuildDockerWebUiImageJob {
+  private static jobName = 'job-build-docker-webui-image';
 
   private static customParametersList = new parameters.CustomParametersList([
     new parameters.CustomParameter('apim-project', 'string', '', 'the name of the project to build'),
@@ -32,6 +31,8 @@ export class BuildDockerImageJob {
   ]);
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment, isProd: boolean): reusable.ParameterizedJob {
+    dynamicConfig.importOrb(orbs.keeper).importOrb(orbs.aquasec);
+
     const createDockerContextCommand = CreateDockerContextCommand.get();
     dynamicConfig.addReusableCommand(createDockerContextCommand);
 
@@ -43,115 +44,210 @@ export class BuildDockerImageJob {
 
     const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
 
-    const dockerTags: string[] = this.dockerTagsArgument(environment, parsedGraviteeioVersion, isProd);
-
-    const steps: Command[] = [
-      new commands.Checkout(),
-      new commands.workspace.Attach({ at: '.' }),
-      new commands.SetupRemoteDocker({ version: config.docker.version }),
-      new reusable.ReusedCommand(createDockerContextCommand),
-      new reusable.ReusedCommand(dockerLoginCommand),
-      new commands.Run({
-        name: 'Build docker image for << parameters.apim-project >>',
-        command: `${this.dockerBuildCommand(environment, dockerTags, isProd)}`,
-        working_directory: '<< parameters.apim-project >>',
-      }),
-    ];
-
-    if (isProd || isSupportBranchOrMaster(environment.branch)) {
-      dynamicConfig.importOrb(orbs.keeper).importOrb(orbs.aquasec);
-      steps.push(
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.aquaKey,
-          'var-name': 'AQUA_KEY',
-        }),
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.aquaSecret,
-          'var-name': 'AQUA_SECRET',
-        }),
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.aquaRegistryUsername,
-          'var-name': 'AQUA_USERNAME',
-        }),
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.aquaRegistryPassword,
-          'var-name': 'AQUA_PASSWORD',
-        }),
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.aquaScannerKey,
-          'var-name': 'SCANNER_TOKEN',
-        }),
-        new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-          'secret-url': config.secrets.githubApiToken,
-          'var-name': 'GITHUB_TOKEN',
-        }),
-        new reusable.ReusedCommand(orbs.aquasec.commands['install_billy']),
-        new reusable.ReusedCommand(orbs.aquasec.commands['pull_aqua_scanner_image']),
-        new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
-          artifact_to_register: `${dockerTags[0]}`,
-        }),
-        new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
-          docker_image_to_scan: `${dockerTags[0]}`,
-          scanner_url: config.aqua.scannerUrl,
-        }),
-      );
-    }
-
-    steps.push(new reusable.ReusedCommand(dockerLogoutCommand));
-
+    const dockerTags: string[] = dockerTagsArgument(environment, parsedGraviteeioVersion, isProd);
     return new reusable.ParameterizedJob(
-      BuildDockerImageJob.jobName,
+      BuildDockerWebUiImageJob.jobName,
       BaseExecutor.create(),
-      BuildDockerImageJob.customParametersList,
-      steps,
+      BuildDockerWebUiImageJob.customParametersList,
+      [
+        new commands.Checkout(),
+        new commands.workspace.Attach({ at: '.' }),
+        new commands.SetupRemoteDocker({ version: config.docker.version }),
+        new reusable.ReusedCommand(createDockerContextCommand),
+        new reusable.ReusedCommand(dockerLoginCommand),
+        new commands.Run({
+          name: 'Build docker image for << parameters.apim-project >>',
+          command: `${dockerBuildCommand(environment, dockerTags, isProd)}`,
+          working_directory: '<< parameters.apim-project >>',
+        }),
+        ...(isProd || isSupportBranchOrMaster(environment.branch)
+          ? [
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.aquaKey,
+                'var-name': 'AQUA_KEY',
+              }),
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.aquaSecret,
+                'var-name': 'AQUA_SECRET',
+              }),
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.aquaRegistryUsername,
+                'var-name': 'AQUA_USERNAME',
+              }),
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.aquaRegistryPassword,
+                'var-name': 'AQUA_PASSWORD',
+              }),
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.aquaScannerKey,
+                'var-name': 'SCANNER_TOKEN',
+              }),
+              new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+                'secret-url': config.secrets.githubApiToken,
+                'var-name': 'GITHUB_TOKEN',
+              }),
+              new reusable.ReusedCommand(orbs.aquasec.commands['install_billy']),
+              new reusable.ReusedCommand(orbs.aquasec.commands['pull_aqua_scanner_image']),
+              new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
+                artifact_to_register: `${dockerTags[0]}`,
+              }),
+              new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
+                docker_image_to_scan: `${dockerTags[0]}`,
+                scanner_url: config.aqua.scannerUrl,
+              }),
+            ]
+          : []),
+        new reusable.ReusedCommand(dockerLogoutCommand),
+      ],
     );
   }
+}
 
-  private static dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string[], isProd: boolean) {
-    let command = 'docker buildx build';
+export class BuildDockerBackendImageJob {
+  private static jobName = 'job-build-docker-backend-image';
 
-    // Only publish if not dry run or not prod
-    if (!isProd || !environment.isDryRun) {
-      command += ' --push';
-    }
+  private static customParametersList = new parameters.CustomParametersList([
+    new parameters.CustomParameter('apim-project', 'string', '', 'the name of the project to build'),
+    new parameters.CustomParameter('docker-context', 'string', '', 'the name of context folder for docker build'),
+    new parameters.CustomParameter('docker-image-name', 'string', '', 'the name of the image'),
+  ]);
 
-    if (isProd) {
-      command += ` --quiet`;
-    }
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment, isProd: boolean): reusable.ParameterizedJob {
+    dynamicConfig.importOrb(orbs.keeper).importOrb(orbs.aquasec);
 
-    command += ` --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \\\n`;
+    const createDockerContextCommand = CreateDockerContextCommand.get();
+    dynamicConfig.addReusableCommand(createDockerContextCommand);
 
-    command += `${dockerTags.map((t) => `-t ${t}`).join(' ')} \\\n`;
-    command += `<< parameters.docker-context >>`;
+    const dockerLoginCommand = DockerLoginCommand.get(dynamicConfig, environment, isProd);
+    dynamicConfig.addReusableCommand(dockerLoginCommand);
 
-    return command;
+    const dockerLogoutCommand = DockerLogoutCommand.get(environment, isProd);
+    dynamicConfig.addReusableCommand(dockerLogoutCommand);
+
+    const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
+
+    const variants: Variant[] = ['alpine', 'debian'];
+    return new reusable.ParameterizedJob(
+      BuildDockerBackendImageJob.jobName,
+      BaseExecutor.create(),
+      BuildDockerBackendImageJob.customParametersList,
+      [
+        new commands.Checkout(),
+        new commands.workspace.Attach({ at: '.' }),
+        new commands.SetupRemoteDocker({ version: config.docker.version }),
+        new reusable.ReusedCommand(createDockerContextCommand),
+        new reusable.ReusedCommand(dockerLoginCommand),
+        ...aquaSetupCommands(),
+        ...variants.flatMap((variant) => {
+          const dockerTags: string[] = dockerTagsArgument(environment, parsedGraviteeioVersion, isProd, variant);
+          return [
+            new commands.Run({
+              name: `Build docker image for << parameters.apim-project >>-${variant}`,
+              command: `${dockerBuildCommand(environment, dockerTags, isProd, variant)}`,
+              working_directory: '<< parameters.apim-project >>',
+            }),
+            ...(isProd || isSupportBranchOrMaster(environment.branch)
+              ? [
+                  new reusable.ReusedCommand(orbs.aquasec.commands['register_artifact'], {
+                    artifact_to_register: `${dockerTags[0]}`,
+                  }),
+                  new reusable.ReusedCommand(orbs.aquasec.commands['scan_docker_image'], {
+                    docker_image_to_scan: `${dockerTags[0]}`,
+                    scanner_url: config.aqua.scannerUrl,
+                  }),
+                ]
+              : []),
+          ];
+        }),
+        new reusable.ReusedCommand(dockerLogoutCommand),
+      ],
+    );
+  }
+}
+
+function aquaSetupCommands() {
+  return [
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.aquaKey,
+      'var-name': 'AQUA_KEY',
+    }),
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.aquaSecret,
+      'var-name': 'AQUA_SECRET',
+    }),
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.aquaRegistryUsername,
+      'var-name': 'AQUA_USERNAME',
+    }),
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.aquaRegistryPassword,
+      'var-name': 'AQUA_PASSWORD',
+    }),
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.aquaScannerKey,
+      'var-name': 'SCANNER_TOKEN',
+    }),
+    new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+      'secret-url': config.secrets.githubApiToken,
+      'var-name': 'GITHUB_TOKEN',
+    }),
+    new reusable.ReusedCommand(orbs.aquasec.commands['install_billy']),
+    new reusable.ReusedCommand(orbs.aquasec.commands['pull_aqua_scanner_image']),
+  ];
+}
+
+function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string[], isProd: boolean, variant?: Variant) {
+  let command = 'docker buildx build';
+
+  const dockerfile = variant === 'debian' ? 'docker/Dockerfile.debian' : 'docker/Dockerfile';
+
+  // Only publish if not dry run or not prod
+  if (!isProd || !environment.isDryRun) {
+    command += ' --push';
   }
 
-  private static dockerTagsArgument(environment: CircleCIEnvironment, graviteeioVersion: GraviteeioVersion, isProd: boolean): string[] {
-    const tags: string[] = [];
-    if (isProd) {
-      const stub = `graviteeio/<< parameters.docker-image-name >>:`;
+  if (isProd) {
+    command += ` --quiet`;
+  }
 
-      // Default tag
-      tags.push(stub + graviteeioVersion.full);
+  command += ` --platform=linux/arm64,linux/amd64 -f ${dockerfile} \\\n`;
 
-      if (isBlank(graviteeioVersion.qualifier.full)) {
-        // Only major and minor for one tag if no qualifier
-        tags.push(stub + graviteeioVersion.version.major + '.' + graviteeioVersion.version.minor);
+  command += `${dockerTags.map((t) => `-t ${t}`).join(' ')} \\\n`;
+  command += `<< parameters.docker-context >>`;
 
-        if (environment.dockerTagAsLatest) {
-          // Add two tags: major and 'latest'
-          tags.push(stub + graviteeioVersion.version.major);
-          tags.push(stub + 'latest');
-        }
-      } else {
-        // Include qualifier name after full version
-        tags.push(stub + graviteeioVersion.version.full + '-' + graviteeioVersion.qualifier.name);
+  return command;
+}
+
+function dockerTagsArgument(
+  environment: CircleCIEnvironment,
+  graviteeioVersion: GraviteeioVersion,
+  isProd: boolean,
+  variant?: Variant,
+): string[] {
+  const tags: string[] = [];
+  const suffix = variant === 'debian' ? '-debian' : '';
+  if (isProd) {
+    const stub = `graviteeio/<< parameters.docker-image-name >>:`;
+
+    // Default tag
+    tags.push(stub + graviteeioVersion.full + suffix);
+
+    if (isBlank(graviteeioVersion.qualifier.full)) {
+      // Only major and minor for one tag if no qualifier
+      tags.push(stub + graviteeioVersion.version.major + '.' + graviteeioVersion.version.minor + suffix);
+
+      if (environment.dockerTagAsLatest) {
+        // Add two tags: major and 'latest'
+        tags.push(stub + graviteeioVersion.version.major + suffix);
+        tags.push(stub + 'latest' + suffix);
       }
     } else {
-      const tag = computeImagesTag(environment.branch);
-      tags.push(`graviteeio.azurecr.io/<< parameters.docker-image-name >>:${tag}`);
+      // Include qualifier name after full version
+      tags.push(stub + graviteeioVersion.version.full + '-' + graviteeioVersion.qualifier.name + suffix);
     }
-    return tags;
+  } else {
+    const tag = computeImagesTag(environment.branch);
+    tags.push(`graviteeio.azurecr.io/<< parameters.docker-image-name >>:${tag}${suffix}`);
   }
+  return tags;
 }

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -238,7 +238,7 @@ jobs:
           paths:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution
             - ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -296,6 +296,76 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
 workflows:
   build-docker-images:
     jobs:
@@ -309,7 +379,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0-alpha.1 - Dry Run
@@ -324,7 +394,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0-alpha.1 - Dry Run
@@ -339,7 +409,7 @@ workflows:
           name: Backend build
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0-alpha.1 - Dry Run
@@ -348,7 +418,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1 - Dry Run

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -238,7 +238,7 @@ jobs:
           paths:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution
             - ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -296,6 +296,76 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
 workflows:
   build-docker-images:
     jobs:
@@ -309,7 +379,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0-alpha.1
@@ -324,7 +394,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0-alpha.1
@@ -339,7 +409,7 @@ workflows:
           name: Backend build
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0-alpha.1
@@ -348,7 +418,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -238,7 +238,7 @@ jobs:
           paths:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution
             - ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -296,6 +296,76 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
 workflows:
   build-docker-images:
     jobs:
@@ -309,7 +379,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0 - Dry Run
@@ -324,7 +394,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0 - Dry Run
@@ -339,7 +409,7 @@ workflows:
           name: Backend build
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0 - Dry Run
@@ -348,7 +418,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0 - Dry Run

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -238,7 +238,7 @@ jobs:
           paths:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution
             - ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -296,6 +296,76 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian -t graviteeio/<< parameters.docker-image-name >>:4-debian -t graviteeio/<< parameters.docker-image-name >>:latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
 workflows:
   build-docker-images:
     jobs:
@@ -309,7 +379,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0
@@ -324,7 +394,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0
@@ -339,7 +409,7 @@ workflows:
           name: Backend build
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0
@@ -348,7 +418,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -238,7 +238,7 @@ jobs:
           paths:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution
             - ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -296,6 +296,76 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
 workflows:
   build-docker-images:
     jobs:
@@ -309,7 +379,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0
@@ -324,7 +394,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0
@@ -339,7 +409,7 @@ workflows:
           name: Backend build
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0
@@ -348,7 +418,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -256,7 +256,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -312,6 +312,76 @@ jobs:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:
@@ -647,7 +717,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0-alpha.1
@@ -662,7 +732,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0-alpha.1
@@ -677,7 +747,7 @@ workflows:
           name: Backend build and publish on download website
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0-alpha.1
@@ -686,7 +756,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -256,7 +256,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -312,6 +312,76 @@ jobs:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:
@@ -681,7 +751,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0 - Dry Run
@@ -696,7 +766,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0 - Dry Run
@@ -711,7 +781,7 @@ workflows:
           name: Backend build and publish on download website
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0 - Dry Run
@@ -720,7 +790,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0 - Dry Run

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -256,7 +256,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -312,6 +312,76 @@ jobs:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian -t graviteeio/<< parameters.docker-image-name >>:4-debian -t graviteeio/<< parameters.docker-image-name >>:latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:
@@ -693,7 +763,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0
@@ -708,7 +778,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0
@@ -723,7 +793,7 @@ workflows:
           name: Backend build and publish on download website
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0
@@ -732,7 +802,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -256,7 +256,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -312,6 +312,76 @@ jobs:
           artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-backend-build-and-publish-on-download-website:
@@ -693,7 +763,7 @@ workflows:
           name: Build APIM Portal
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image for APIM 4.2.0
@@ -708,7 +778,7 @@ workflows:
           name: Build APIM Console
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image for APIM 4.2.0
@@ -723,7 +793,7 @@ workflows:
           name: Backend build and publish on download website
           requires:
             - Setup
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image for APIM 4.2.0
@@ -732,7 +802,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -227,7 +227,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -283,6 +283,76 @@ jobs:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-publish-pr-env-urls:
@@ -344,7 +414,7 @@ workflows:
           requires:
             - Setup
           name: Build backend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -353,7 +423,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image
@@ -368,7 +438,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Console
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -383,7 +453,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -228,7 +228,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -258,6 +258,66 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-latest-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project >>
       - cmd-docker-logout
@@ -320,7 +380,7 @@ workflows:
           requires:
             - Setup
           name: Build backend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -329,7 +389,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image
@@ -344,7 +404,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Console
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -359,7 +419,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image
@@ -380,4 +440,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5
+  aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -227,7 +227,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -283,6 +283,76 @@ jobs:
           artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
       - aquasec/scan_docker_image:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
   job-publish-pr-env-urls:
@@ -344,7 +414,7 @@ workflows:
           requires:
             - Setup
           name: Build backend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -353,7 +423,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image
@@ -368,7 +438,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Console
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -383,7 +453,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -596,7 +596,7 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -692,6 +692,76 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
   job-e2e-generate-sdk:
     docker:
       - image: cimg/openjdk:21.0.5-node
@@ -1135,7 +1205,7 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -1177,7 +1247,7 @@ workflows:
           name: Build APIM Portal
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image
@@ -1202,7 +1272,7 @@ workflows:
             - Lint & test APIM Portal Next
           working_directory: gravitee-apim-portal-webui-next
           cache_type: frontend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -1211,7 +1281,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -596,7 +596,7 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -692,6 +692,76 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - aquasec/register_artifact:
+          artifact_to_register: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
+      - aquasec/scan_docker_image:
+          docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian
+          scanner_url: https://82fb8f75da.cloud.aquasec.com
+      - cmd-docker-logout
   job-e2e-generate-sdk:
     docker:
       - image: cimg/openjdk:21.0.5-node
@@ -1135,7 +1205,7 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -1177,7 +1247,7 @@ workflows:
           name: Build APIM Portal
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image
@@ -1202,7 +1272,7 @@ workflows:
             - Lint & test APIM Portal Next
           working_directory: gravitee-apim-portal-webui-next
           cache_type: frontend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -1211,7 +1281,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -597,7 +597,7 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -676,6 +676,66 @@ jobs:
       - run:
           name: Check workflow jobs
           command: echo "Congratulations! If you can read this, everything is OK"
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-latest-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - cmd-docker-logout
   job-e2e-generate-sdk:
     docker:
       - image: cimg/openjdk:21.0.5-node
@@ -962,7 +1022,7 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -1004,7 +1064,7 @@ workflows:
           name: Build APIM Portal
           context:
             - cicd-orchestrator
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image
@@ -1045,7 +1105,7 @@ workflows:
             - Lint & test APIM Portal Next
             - Build APIM Portal
             - Build APIM Portal docker image
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -1054,7 +1114,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -228,7 +228,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-build-docker-image:
+  job-build-docker-webui-image:
     parameters:
       apim-project:
         type: string
@@ -258,6 +258,66 @@ jobs:
           command: |-
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
+          var-name: AQUA_KEY
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
+          var-name: AQUA_SECRET
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
+          var-name: AQUA_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
+          var-name: AQUA_PASSWORD
+      - keeper/env-export:
+          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
+          var-name: SCANNER_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - aquasec/install_billy
+      - aquasec/pull_aqua_scanner_image
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-latest \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-latest-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project >>
       - cmd-docker-logout
@@ -408,7 +468,7 @@ workflows:
           requires:
             - Setup
           name: Build backend
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Management API docker image
@@ -417,7 +477,7 @@ workflows:
           apim-project: gravitee-apim-rest-api
           docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
           docker-image-name: apim-management-api
-      - job-build-docker-image:
+      - job-build-docker-backend-image:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image
@@ -444,7 +504,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Console
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Console docker image
@@ -459,7 +519,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal
-      - job-build-docker-image:
+      - job-build-docker-webui-image:
           context:
             - cicd-orchestrator
           name: Build APIM Portal docker image
@@ -498,3 +558,4 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5
+  aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/workflows/workflow-build-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-docker-images.ts
@@ -17,7 +17,8 @@ import { Config, Workflow, workflow } from '@circleci/circleci-config-sdk';
 import { CircleCIEnvironment } from '../pipelines';
 import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
-  BuildDockerImageJob,
+  BuildDockerBackendImageJob,
+  BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
   PortalWebuiBuildJob,
   SetupJob,
@@ -34,8 +35,10 @@ export class BuildDockerImagesWorkflow {
     dynamicConfig.addJob(portalWebuiBuildJob);
     const backendBuildJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(backendBuildJob);
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, true);
-    dynamicConfig.addJob(buildDockerImageJob);
+    const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerWebUiImageJob);
+    const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerBackendImageJob);
 
     const jobs = [
       new workflow.WorkflowJob(setupJob, { context: config.jobContext, name: 'Setup' }),
@@ -45,7 +48,7 @@ export class BuildDockerImagesWorkflow {
         name: 'Build APIM Portal',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Portal docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Build APIM Portal'],
@@ -60,7 +63,7 @@ export class BuildDockerImagesWorkflow {
         name: 'Build APIM Console',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Console docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Build APIM Console'],
@@ -75,7 +78,7 @@ export class BuildDockerImagesWorkflow {
         name: 'Backend build',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Management API docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Backend build'],
@@ -83,7 +86,7 @@ export class BuildDockerImagesWorkflow {
         'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
         'docker-image-name': config.components.managementApi.image,
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Gateway docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Backend build'],

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -16,7 +16,8 @@
 import { Config, workflow, Workflow } from '@circleci/circleci-config-sdk';
 import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
-  BuildDockerImageJob,
+  BuildDockerBackendImageJob,
+  BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
   NexusStagingJob,
   PackageBundleJob,
@@ -48,8 +49,10 @@ export class FullReleaseWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, true);
-    dynamicConfig.addJob(buildDockerImageJob);
+    const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerWebUiImageJob);
+    const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerBackendImageJob);
 
     const backendBuildAndPublishOnDownloadWebsiteJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(backendBuildAndPublishOnDownloadWebsiteJob);
@@ -90,7 +93,7 @@ export class FullReleaseWorkflow {
         name: 'Build APIM Portal',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Portal docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Build APIM Portal'],
@@ -105,7 +108,7 @@ export class FullReleaseWorkflow {
         name: 'Build APIM Console',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Console docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Build APIM Console'],
@@ -120,7 +123,7 @@ export class FullReleaseWorkflow {
         name: 'Backend build and publish on download website',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Management API docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Backend build and publish on download website'],
@@ -128,7 +131,7 @@ export class FullReleaseWorkflow {
         'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
         'docker-image-name': config.components.managementApi.image,
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Gateway docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         requires: ['Backend build and publish on download website'],

--- a/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 import { Config, workflow, Workflow } from '@circleci/circleci-config-sdk';
-import { BuildBackendJob, BuildDockerImageJob, ConsoleWebuiBuildJob, PortalWebuiBuildJob, PublishPrEnvUrlsJob, SetupJob } from '../jobs';
+import {
+  BuildBackendJob,
+  BuildDockerBackendImageJob,
+  BuildDockerWebUiImageJob,
+  ConsoleWebuiBuildJob,
+  PortalWebuiBuildJob,
+  PublishPrEnvUrlsJob,
+  SetupJob,
+} from '../jobs';
 import { config } from '../config';
 import { CircleCIEnvironment } from '../pipelines';
 
@@ -32,8 +40,10 @@ export class PublishDockerImagesWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
-    dynamicConfig.addJob(buildDockerImageJob);
+    const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerWebUiImageJob);
+    const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerBackendImageJob);
 
     const publishPrEnvUrlsJob = PublishPrEnvUrlsJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(publishPrEnvUrlsJob);
@@ -42,7 +52,7 @@ export class PublishDockerImagesWorkflow {
       new workflow.WorkflowJob(setupJob, { context: config.jobContext, name: 'Setup' }),
       new workflow.WorkflowJob(buildBackendJob, { context: config.jobContext, requires: ['Setup'], name: 'Build backend' }),
 
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Management API docker image`,
         requires: ['Build backend'],
@@ -50,7 +60,7 @@ export class PublishDockerImagesWorkflow {
         'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
         'docker-image-name': config.components.managementApi.image,
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Gateway docker image`,
         requires: ['Build backend'],
@@ -64,7 +74,7 @@ export class PublishDockerImagesWorkflow {
         requires: ['Setup'],
         name: 'Build APIM Console',
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Console docker image`,
         requires: ['Build APIM Console'],
@@ -78,7 +88,7 @@ export class PublishDockerImagesWorkflow {
         requires: ['Setup'],
         name: 'Build APIM Portal',
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
         context: config.jobContext,
         name: `Build APIM Portal docker image`,
         requires: ['Build APIM Portal'],

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -21,8 +21,11 @@ import { config } from '../config';
 import { BaseExecutor } from '../executors';
 import {
   BuildBackendJob,
+  BuildDockerBackendImageJob,
+  BuildDockerWebUiImageJob,
   ChromaticConsoleJob,
   CommunityBuildBackendJob,
+  ConsoleWebuiBuildJob,
   DangerJsJob,
   DeployOnAzureJob,
   E2ECypressJob,
@@ -30,6 +33,7 @@ import {
   E2ELintBuildJob,
   E2ETestJob,
   PerfLintBuildJob,
+  PortalWebuiBuildJob,
   PublishJob,
   ReleaseHelmJob,
   SetupJob,
@@ -42,12 +46,9 @@ import {
   TestPluginJob,
   TestRepositoryJob,
   TestRestApiJob,
-  ValidateJob,
-  ConsoleWebuiBuildJob,
-  PortalWebuiBuildJob,
-  WebuiLintTestJob,
   TriggerSaasDockerImagesJob,
-  BuildDockerImageJob,
+  ValidateJob,
+  WebuiLintTestJob,
 } from '../jobs';
 import { orbs } from '../orbs';
 
@@ -309,11 +310,11 @@ export class PullRequestsWorkflow {
       requires.push('Lint & test APIM Console', 'Build APIM Console');
 
       if (shouldBuildDockerImages) {
-        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
-        dynamicConfig.addJob(buildDockerImageJob);
+        const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, false);
+        dynamicConfig.addJob(buildDockerWebUiImageJob);
 
         jobs.push(
-          new workflow.WorkflowJob(buildDockerImageJob, {
+          new workflow.WorkflowJob(buildDockerWebUiImageJob, {
             context: config.jobContext,
             name: `Build APIM Console docker image`,
             requires: ['Build APIM Console'],
@@ -375,11 +376,11 @@ export class PullRequestsWorkflow {
       requires.push('Lint & test APIM Portal', 'Lint & test APIM Portal Next', 'Build APIM Portal');
 
       if (shouldBuildDockerImages) {
-        const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
-        dynamicConfig.addJob(buildDockerImageJob);
+        const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, false);
+        dynamicConfig.addJob(buildDockerWebUiImageJob);
 
         jobs.push(
-          new workflow.WorkflowJob(buildDockerImageJob, {
+          new workflow.WorkflowJob(buildDockerWebUiImageJob, {
             context: config.jobContext,
             name: `Build APIM Portal docker image`,
             requires: ['Build APIM Portal'],
@@ -431,8 +432,8 @@ export class PullRequestsWorkflow {
   }
 
   private static getE2EJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {
-    const buildDockerImageJob = BuildDockerImageJob.create(dynamicConfig, environment, false);
-    dynamicConfig.addJob(buildDockerImageJob);
+    const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerBackendImageJob);
 
     const e2eGenerateSdkJob = E2EGenerateSDKJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(e2eGenerateSdkJob);
@@ -450,7 +451,7 @@ export class PullRequestsWorkflow {
     dynamicConfig.addJob(perfLintBuildJob);
 
     return [
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Management API docker image`,
         requires: ['Build backend'],
@@ -458,7 +459,7 @@ export class PullRequestsWorkflow {
         'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
         'docker-image-name': config.components.managementApi.image,
       }),
-      new workflow.WorkflowJob(buildDockerImageJob, {
+      new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Gateway docker image`,
         requires: ['Build backend'],

--- a/gravitee-apim-gateway/docker/Dockerfile.debian
+++ b/gravitee-apim-gateway/docker/Dockerfile.debian
@@ -15,23 +15,24 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21-alpine AS base
+FROM graviteeio/java:21-debian AS base-debian
 ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 USER root
-RUN apk update  \
-    && apk add --no-cache libc6-compat jemalloc \
-    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
+RUN set -eux ;\
+    apt-get update && apt-get install --yes --no-install-recommends libjemalloc2 ;\
+    apt-get clean ;\
+    rm -rf /var/lib/apt/lists/*
 
 
 # Second stage to add the folder and change the permissions and ownership
-FROM base AS builder
-ADD ./distribution ${GRAVITEEIO_HOME}/
+FROM base-debian AS builder
+COPY ./distribution ${GRAVITEEIO_HOME}/
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
-FROM base
+FROM base-debian
 LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,16 +15,14 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21 AS base
+FROM graviteeio/java:21-alpine AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
-
-RUN addgroup -g 1000 graviteeio \
-    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
 
+USER root
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 

--- a/gravitee-apim-rest-api/docker/Dockerfile.debian
+++ b/gravitee-apim-rest-api/docker/Dockerfile.debian
@@ -15,18 +15,14 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:21-alpine AS base
-ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
-
-USER root
-RUN apk update  \
-    && apk add --no-cache libc6-compat jemalloc \
-    && if [ $(apk --print-arch) = "aarch64" ]; then ln -s /lib/libc.musl-aarch64.so.1 /lib/ld-linux-aarch64.so.2; fi
-
+FROM graviteeio/java:21-debian AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
-ADD ./distribution ${GRAVITEEIO_HOME}/
+COPY ./distribution ${GRAVITEEIO_HOME}/
+
+USER root
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
@@ -35,9 +31,9 @@ FROM base
 LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
-EXPOSE 8082
+EXPOSE 8083
 ENTRYPOINT ["./bin/gravitee"]
 VOLUME ${GRAVITEEIO_HOME}/logs
 HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18082/_node/health || exit 1
+            CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1
 USER graviteeio

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -49,3 +49,5 @@ annotations:
           url: https://github.com/gravitee-io/issues/issues/10524
     - kind: fixed
       description: 'The `portal.entrypoint` env var is used to configure the entrypoint used to expose APIs. It is used mainly on the developer portal. The value is automatically set with the ingress of the gateway. Now, if the gateway is configured with  a list of servers (http, tcp...) the `portal.entrypoint` is set accordingly'
+    - kind: changed
+      description: 'Gateway and Management API images are now based on Debian instead of Alpine.'

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -234,6 +234,17 @@ Return the appropriate apiVersion for pod autoscaling.
 {{- end -}}
 
 {{/*
+Gateway API Docker images tag.
+*/}}
+{{- define "gateway.dockerTag" -}}
+{{- if .Values.gateway.image.tag -}}
+{{- .Values.gateway.image.tag -}}
+{{- else -}}
+{{- printf "%s-debian" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns true if an extraVolumes named config is defined
 Usage:
 {{ include "gateway.externalConfig" . }}
@@ -258,6 +269,17 @@ Usage:
 {{- print "config" -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Management API Docker images tag.
+*/}}
+{{- define "api.dockerTag" -}}
+{{- if .Values.api.image.tag -}}
+{{- .Values.api.image.tag -}}
+{{- else -}}
+{{- printf "%s-debian" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Returns true if an extraVolumes named config is defined

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
 {{- $logbackVolumeName := include "api.logbackVolumeName" . -}}
+{{- $dockerImageTag := include "api.dockerTag" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -130,7 +131,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "gravitee.api.fullname" . }}
-          image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext: {{ toYaml .Values.api.deployment.securityContext | nindent 12 }}
           ports:

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -2,6 +2,7 @@
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
 {{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
+{{- $dockerImageTag := include "gateway.dockerTag" . -}}
 apiVersion: apps/v1
 kind: {{ .Values.gateway.type }}
 metadata:
@@ -124,7 +125,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "gravitee.gateway.fullname" . }}
-          image: "{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
+          image: "{{ .Values.gateway.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           securityContext: {{ toYaml .Values.gateway.deployment.securityContext | nindent 12 }}
           ports:

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: apps/v1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-management-api:1.0.0-app
+          value: graviteeio/apim-management-api:1.0.0-app-debian
       - equal:
           path: spec.template.spec.containers[0].env
           value:

--- a/helm/tests/gateway/deployment_additional-plugins_test.yaml
+++ b/helm/tests/gateway/deployment_additional-plugins_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-plugins

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -19,7 +19,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext

--- a/helm/tests/gateway/deployment_test.yaml
+++ b/helm/tests/gateway/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: apps/v1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:1.0.0-app
+          value: graviteeio/apim-gateway:1.0.0-app-debian
       - isEmpty:
           # It should not contain environment variable by default
           path: spec.template.spec.containers[0].env
@@ -80,7 +80,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: graviteeio/apim-gateway:3.15.2
+          value: graviteeio/apim-gateway:3.15.2-debian
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext
@@ -343,4 +343,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
           value: vault-token
-


### PR DESCRIPTION
## Description

This commit introduces a new variants of backend images using `Debian`
instead of `Alpine`.

Why
The new AI policy (Guard Rails) uses ONNX models which require packages
(like PyTorch, NumPy) that depend on glibc.
Gravitee’s current Docker images use Alpine, which uses musl libc, and
is incompatible with many AI-related packages.
Therefore, the policy cannot run on Alpine-based images, making them
unsuitable for future AI features.

Observations
Other teams (e.g., AM) faced similar issues (Cloud HSM plugin) and moved
to Ubuntu Noble base images.
There are no signs that ONNX will support musl in the foreseeable future
(microsoft/onnxruntime#2909).
Building ONNX manually for Alpine is not practical.

To prevent breaking change in 4.8 the usual tags (`4.8.0`, `4.8`) will
keep the Alpine base image and we will provide new tags (`4.8.0-debian`)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vojyssviob.chromatic.com)
<!-- Storybook placeholder end -->
