### PR TITLE
test: fix test configuring transformheader policy

### DIFF
--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
@@ -69,7 +69,7 @@ export default class PolicyStudio {
   }
 
   addOrUpdateHeaders(key: string, value: string) {
-    cy.get('textarea[formcontrolname="key"]').click().clear().type(key);
+    cy.get('textarea[formcontrolname="key"]').first().click().clear().type(key);
     cy.get('textarea[formcontrolname="value"]').first().click().clear().type(value);
     return this;
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Fixes breaking Cypress tests:

Since an update of the transformheader policy, Cypress was not able to configure it because 2 elements were found. Forcing to select the 1st one fix the issue

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mwedakrynj.chromatic.com)
<!-- Storybook placeholder end -->
