### PR TITLE
fix: error handling for discovery of A2A agents

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.ts
@@ -97,7 +97,12 @@ export class IntegrationOverviewComponent implements OnInit {
   }
 
   public a2aDiscover(): void {
-    this.integrationsService.ingest(this.integration.id).subscribe({ complete: () => this.ngOnInit() });
+    this.integrationsService.ingest(this.integrationId).subscribe((response) => {
+      if (response.status === 'ERROR') {
+        this.snackBarService.error(`Ingestion failed. Please check your settings and try again: ${response.message}`);
+      }
+      this.ngOnInit();
+    });
   }
 
   private getIntegration() {

--- a/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
@@ -59,7 +59,7 @@ export class IntegrationsService {
       catchError((error) => {
         return of({
           status: AsyncJobStatus.ERROR,
-          message: `Fail to ingest APIs: ${error.message}`,
+          message: `${error.error.message}`,
         });
       }),
     );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/exception/FederatedAgentIngestionException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/exception/FederatedAgentIngestionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.exception;
+
+import java.util.List;
+
+public class FederatedAgentIngestionException extends RuntimeException {
+
+    public FederatedAgentIngestionException(List<String> failedUrls) {
+        super("Failed to ingest data from the following URLs: " + String.join(", ", failedUrls));
+    }
+
+    public FederatedAgentIngestionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9894

## Description

This PR provides better handling for failed A2A Integration discovery. 
In cases where multiple known URLs fail to be discovered, we display a list of all broken links.
For those A2A agents that successfully ingested, we create Federated APIs  

## Additional context

![image](https://github.com/user-attachments/assets/cea0c6cd-25b1-470f-a167-2b1a362a727c)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iswglppiho.chromatic.com)
<!-- Storybook placeholder end -->
