### PR TITLE
fix:  align application template metadata and notification styles

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
@@ -51,96 +51,98 @@
         </div>
       </form>
     </ng-container>
+    <gio-table-wrapper
+      [disableSearchInput]="true"
+      [filters]="filtersStream.value.tableWrapper"
+      [length]="totalResults"
+      (filtersChange)="onFiltersChange($event)"
+    >
+      <table mat-table [dataSource]="dataSource" matSort>
+        <caption style="display: none">
+          {{
+            referenceType
+          }}
+          metadata table
+        </caption>
+
+        <ng-container matColumnDef="key">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by key" data-testid="metadata_key">Key</th>
+          <td mat-cell *matCellDef="let element" data-testid="metadata_key_cell">
+            {{ element.key }}
+            <span
+              *ngIf="!!element.defaultValue"
+              data-testid="metadata_globalBadge"
+              class="gio-badge-neutral"
+              matTooltip="Inherited global metadata"
+              >Global</span
+            >
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name" data-testid="metadata_name">Name</th>
+          <td mat-cell *matCellDef="let element" data-testid="metadata_name_cell">{{ element.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="format">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by format" data-testid="metadata_format">
+            Format
+          </th>
+          <td mat-cell *matCellDef="let element" data-testid="metadata_format_cell">
+            <span class="gio-badge-neutral">{{ element.format | titlecase }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="value">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by value" data-testid="metadata_value">
+            Value
+          </th>
+          <td mat-cell *matCellDef="let element" data-testid="metadata_value_cell">{{ element.value }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef data-testid="metadata_actions">Actions</th>
+          <td mat-cell *matCellDef="let element">
+            <div class="gio-metadata__actions">
+              <div>
+                <button
+                  mat-icon-button
+                  type="button"
+                  class="update-metadata"
+                  (click)="updateMetadata(element)"
+                  *gioPermission="{ anyOf: [permissionPrefix + '-metadata-u'] }"
+                  matTooltip="Edit"
+                  data-testid="metadata_edit_button"
+                >
+                  <mat-icon [svgIcon]="readOnly ? 'gio:eye-empty' : 'gio:edit-pencil'"></mat-icon>
+                </button>
+              </div>
+              <div *ngIf="element.isDeletable">
+                <button
+                  [disabled]="readOnly"
+                  mat-icon-button
+                  type="button"
+                  class="delete-metadata"
+                  (click)="deleteMetadata(element)"
+                  *gioPermission="{ anyOf: [permissionPrefix + '-metadata-d'] }"
+                  matTooltip="{{ element.defaultValue ? 'Reset' : 'Delete' }}"
+                  data-testid="metadata_delete_button"
+                >
+                  <mat-icon *ngIf="element.defaultValue" svgIcon="gio:refresh-cw"></mat-icon>
+                  <mat-icon *ngIf="!element.defaultValue" svgIcon="gio:trash"></mat-icon>
+                </button>
+              </div>
+            </div>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="metadata_table_row"></tr>
+
+        <!-- Row shown when there is no data -->
+        <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No metadata found</td>
+        </tr>
+      </table>
+    </gio-table-wrapper>
   </mat-card-content>
-  <gio-table-wrapper
-    [disableSearchInput]="true"
-    [filters]="filtersStream.value.tableWrapper"
-    [length]="totalResults"
-    (filtersChange)="onFiltersChange($event)"
-  >
-    <table mat-table [dataSource]="dataSource" matSort>
-      <caption style="display: none">
-        {{
-          referenceType
-        }}
-        metadata table
-      </caption>
-
-      <ng-container matColumnDef="key">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by key" data-testid="metadata_key">Key</th>
-        <td mat-cell *matCellDef="let element" data-testid="metadata_key_cell">
-          {{ element.key }}
-          <span
-            *ngIf="!!element.defaultValue"
-            data-testid="metadata_globalBadge"
-            class="gio-badge-neutral"
-            matTooltip="Inherited global metadata"
-            >Global</span
-          >
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name" data-testid="metadata_name">Name</th>
-        <td mat-cell *matCellDef="let element" data-testid="metadata_name_cell">{{ element.name }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="format">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by format" data-testid="metadata_format">
-          Format
-        </th>
-        <td mat-cell *matCellDef="let element" data-testid="metadata_format_cell">
-          <span class="gio-badge-neutral">{{ element.format | titlecase }}</span>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="value">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by value" data-testid="metadata_value">Value</th>
-        <td mat-cell *matCellDef="let element" data-testid="metadata_value_cell">{{ element.value }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef data-testid="metadata_actions">Actions</th>
-        <td mat-cell *matCellDef="let element">
-          <div class="gio-metadata__actions">
-            <div>
-              <button
-                mat-icon-button
-                type="button"
-                class="update-metadata"
-                (click)="updateMetadata(element)"
-                *gioPermission="{ anyOf: [permissionPrefix + '-metadata-u'] }"
-                matTooltip="Edit"
-                data-testid="metadata_edit_button"
-              >
-                <mat-icon [svgIcon]="readOnly ? 'gio:eye-empty' : 'gio:edit-pencil'"></mat-icon>
-              </button>
-            </div>
-            <div *ngIf="element.isDeletable">
-              <button
-                [disabled]="readOnly"
-                mat-icon-button
-                type="button"
-                class="delete-metadata"
-                (click)="deleteMetadata(element)"
-                *gioPermission="{ anyOf: [permissionPrefix + '-metadata-d'] }"
-                matTooltip="{{ element.defaultValue ? 'Reset' : 'Delete' }}"
-                data-testid="metadata_delete_button"
-              >
-                <mat-icon *ngIf="element.defaultValue" svgIcon="gio:refresh-cw"></mat-icon>
-                <mat-icon *ngIf="!element.defaultValue" svgIcon="gio:trash"></mat-icon>
-              </button>
-            </div>
-          </div>
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="metadata_table_row"></tr>
-
-      <!-- Row shown when there is no data -->
-      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No metadata found</td>
-      </tr>
-    </table>
-  </gio-table-wrapper>
 </mat-card>

--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.scss
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.scss
@@ -27,6 +27,6 @@
 }
 
 .mat-column-actions {
-  width: 1%;
-  padding: 0 4px;
+  width: 120px;
+  max-width: 120px;
 }

--- a/gravitee-apim-console-webui/src/components/notification/notification-list/notification-list.component.html
+++ b/gravitee-apim-console-webui/src/components/notification/notification-list/notification-list.component.html
@@ -38,7 +38,7 @@
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef id="actions">Action</th>
+    <th mat-header-cell *matHeaderCellDef id="actions">Actions</th>
     <td mat-cell *matCellDef="let element">
       <div class="notifications__actions">
         @if (element.isReadonly) {

--- a/gravitee-apim-console-webui/src/components/notification/notification-list/notification-list.component.scss
+++ b/gravitee-apim-console-webui/src/components/notification/notification-list/notification-list.component.scss
@@ -17,5 +17,6 @@ $foreground: map.get(gio.$mat-theme, foreground);
 }
 
 .mat-column-actions {
-  width: 100px;
+  width: 120px;
+  max-width: 120px;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9769

## Description

The goal of this PR is to avoid this on actions column
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b4a887fe-a4db-4c9e-a004-16d0ff7664aa" />
 
 and align the style with the card above in the page
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/82e67b31-a9f4-458d-963b-692a0f8cb98e" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/207c80b9-9766-4400-b1d8-d26213c94c68" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ceeqvxmqnn.chromatic.com)
<!-- Storybook placeholder end -->
