### PR TITLE
fix: disable context-path update when gateway_definition-u permission is missing

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
@@ -81,8 +81,13 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
               enabled: false,
             };
           }
+          const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+          const hasUpdatePermission =
+            api.definitionVersion === 'V4'
+              ? this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u'])
+              : this.permissionService.hasAnyMatching(['api-definition-u']);
 
-          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          const isReadOnly = !hasUpdatePermission || isKubernetesOrigin;
           const isCorsDisabled = isReadOnly || !cors.enabled;
 
           this.corsForm = new UntypedFormGroup({

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -80,7 +80,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     }
   };
 
-  const init = async (permissions: string[] = ['api-definition-u', 'api-definition-r']) => {
+  const init = async (permissions: string[] = ['api-definition-u', 'api-definition-r', 'api-gateway_definition-u']) => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiEntrypointsV4Module, MatIconTestingModule, MatAutocompleteModule],
       providers: [
@@ -334,7 +334,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     });
 
     beforeEach(async () => {
-      await createComponent(RESTRICTED_DOMAINS, API, undefined, ['api-definition-u'], false);
+      await createComponent(RESTRICTED_DOMAINS, API, undefined, ['api-definition-u', 'api-gateway_definition-u'], false);
     });
 
     afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
@@ -100,7 +100,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
+    this.canUpdate = this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']);
 
     forkJoin([
       this.restrictedDomainService.get(),

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
@@ -164,7 +164,7 @@ export class ApiEntrypointsComponent implements OnInit, OnDestroy {
     this.formGroup = new UntypedFormGroup({});
 
     this.isReadOnly =
-      !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']) ||
+      !this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']) ||
       api.definitionContext?.origin === 'KUBERNETES' ||
       api.definitionVersion === 'V1';
 

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.spec.ts
@@ -98,4 +98,35 @@ describe('GioPermissionDirective', () => {
       expect(inputEl).toBeNull();
     });
   });
+
+  describe('allOf', () => {
+    it('should display element if all permissions are matching', () => {
+      prepareTestPermissionComponent({ allOf: ['api-rating-r', 'api-rating-c'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeDefined();
+    });
+
+    it('should hide element if only one permission is missing', () => {
+      prepareTestPermissionComponent({ allOf: ['api-rating-r', 'api-rating-u'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeNull();
+    });
+
+    it('should hide element if all permissions are missing', () => {
+      prepareTestPermissionComponent({ allOf: ['api-rating-u', 'api-definition-r'] });
+      fixture.detectChanges();
+
+      const inputEl = fixture.nativeElement.querySelector('div');
+      expect(inputEl).toBeNull();
+    });
+    it('should throw error if allOf and anyOf are both set', () => {
+      expect(() => {
+        prepareTestPermissionComponent({ allOf: ['api-rating-r'], anyOf: ['api-rating-c'] });
+      }).toThrowError('You should only set one of `anyOf`, `noneOf`, or `allOf`, but not more than one.');
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.ts
@@ -20,6 +20,7 @@ import { GioPermissionService } from './gio-permission.service';
 export interface GioPermissionCheckOptions {
   anyOf?: string[];
   noneOf?: string[];
+  allOf?: string[];
 }
 
 @Directive({
@@ -36,16 +37,17 @@ export class GioPermissionDirective implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    if (this.gioPermission.anyOf && this.gioPermission.noneOf) {
-      throw new Error('You should only set `anyOf` or `noneOf` but not both at the same time.');
+    if ([this.gioPermission.anyOf, this.gioPermission.noneOf, this.gioPermission.allOf].filter((val) => !!val).length > 1) {
+      throw new Error('You should only set one of `anyOf`, `noneOf`, or `allOf`, but not more than one.');
     }
 
     this.viewContainer.clear();
-
-    if (
+    const shouldRender =
       (this.gioPermission.anyOf && this.permissionService.hasAnyMatching(this.gioPermission.anyOf)) ||
-      (this.gioPermission.noneOf && !this.permissionService.hasAnyMatching(this.gioPermission.noneOf))
-    ) {
+      (this.gioPermission.noneOf && !this.permissionService.hasAnyMatching(this.gioPermission.noneOf)) ||
+      (this.gioPermission.allOf && this.permissionService.hasAllMatching(this.gioPermission.allOf));
+
+    if (shouldRender) {
       this.viewContainer.createEmbeddedView(this.templateRef);
     }
   }

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { GioPermissionService, GioTestingPermissionProvider } from './gio-permission.service';
+
+import { ApiService } from '../../../services-ngx/api.service';
+import { EnvironmentService } from '../../../services-ngx/environment.service';
+import { ApplicationService } from '../../../services-ngx/application.service';
+
+const mockApiService = {
+  getPermissions: jest.fn().mockReturnValue(of({})),
+};
+const mockEnvironmentService = {
+  getPermissions: jest.fn().mockReturnValue(of({})),
+};
+const mockApplicationService = {
+  getPermissions: jest.fn().mockReturnValue(of({})),
+};
+const mockAjsCurrentUserService = null;
+describe('Permission matching', () => {
+  let service: GioPermissionService;
+
+  function setTestPermissions(permissions: string[]) {
+    (service as any)._setPermissions(permissions);
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        GioPermissionService,
+        { provide: GioTestingPermissionProvider, useValue: [] },
+        { provide: 'CurrentUserService', useValue: mockAjsCurrentUserService },
+        { provide: ApiService, useValue: mockApiService },
+        { provide: EnvironmentService, useValue: mockEnvironmentService },
+        { provide: ApplicationService, useValue: mockApplicationService },
+      ],
+    });
+
+    service = TestBed.inject(GioPermissionService);
+  });
+
+  describe('hasAllMatching', () => {
+    it('should return true when all permissions are present', () => {
+      setTestPermissions(['api-definition-u', 'api-gateway_definition-u']);
+      expect(service.hasAllMatching(['api-definition-u', 'api-gateway_definition-u'])).toBe(true);
+    });
+
+    it('should return false when only one permission is present', () => {
+      setTestPermissions(['api-definition-u']);
+      expect(service.hasAllMatching(['api-definition-u', 'api-gateway_definition-u'])).toBe(false);
+    });
+
+    it('should return false when no permissions match', () => {
+      setTestPermissions(['other-permission']);
+      expect(service.hasAllMatching(['api-definition-u', 'api-gateway_definition-u'])).toBe(false);
+    });
+  });
+
+  describe('hasAnyMatching', () => {
+    it('should return true when the permission is present', () => {
+      setTestPermissions(['api-definition-u']);
+      expect(service.hasAnyMatching(['api-definition-u'])).toBe(true);
+    });
+
+    it('should return false when the permission is not present', () => {
+      setTestPermissions(['api-gateway_definition-u']);
+      expect(service.hasAnyMatching(['api-definition-u'])).toBe(false);
+    });
+
+    it('should return false with empty permissions', () => {
+      setTestPermissions([]);
+      expect(service.hasAnyMatching(['api-definition-u'])).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
@@ -144,4 +144,20 @@ export class GioPermissionService {
   clearApplicationPermissions() {
     this.currentApplicationPermissions = [];
   }
+
+  hasAllMatching(permissions: string[]): boolean {
+    if (!permissions || permissions.length === 0) {
+      return false;
+    }
+
+    const allUserPermissions = [
+      ...this.currentOrganizationPermissions,
+      ...this.currentEnvironmentPermissions,
+      ...this.currentApiPermissions,
+      ...this.currentApplicationPermissions,
+      ...this.permissions,
+    ];
+
+    return permissions.every((permission) => allUserPermissions.includes(permission));
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9784

## Description

disable update/save button for context path (v2/v4 apis) and cors update for v4 apis when api-gateway_definition_u is missing.
need both permissions['api-definition-u', 'api-gateway_definition-u']

**_Doc (note)_** `https://documentation.gravitee.io/apim/configure-v4-apis/cors`

<img width="881" alt="Screenshot 2025-06-18 at 3 34 40 PM" src="https://github.com/user-attachments/assets/09fa4b2b-afd1-44f4-a4f3-8741bd3c577a" />

Current Production:

https://github.com/user-attachments/assets/c383800b-7532-4b86-a6b4-7f195822a369



Post Fix:


https://github.com/user-attachments/assets/f436134c-e51e-4e8b-8b65-83bfd7805352



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dplhqxoicn.chromatic.com)
<!-- Storybook placeholder end -->
