### PR TITLE
fix(console): correctly handle group assignment across environments in multi-tenant setup

### DIFF
--- a/gravitee-apim-console-webui/src/entities/group/group.ts
+++ b/gravitee-apim-console-webui/src/entities/group/group.ts
@@ -32,4 +32,6 @@ export interface Group {
   email_invitation?: boolean;
   disable_membership_notifications?: boolean;
   apiPrimaryOwner?: boolean;
+  environmentName?: string;
+  environmentId?: string;
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.html
@@ -23,7 +23,9 @@
       <mat-form-field>
         <mat-label>Group</mat-label>
         <mat-select formControlName="groupId" aria-label="Groups selection" required>
-          <mat-option *ngFor="let group of groups" [value]="group.id">{{ group.name }}</mat-option>
+          <mat-option *ngFor="let group of groups" [value]="group.id"
+            >{{ group.name }}{{ group.environmentName ? ' (Environment: ' + group.environmentName + ')' : '' }}</mat-option
+          >
         </mat-select>
         <mat-error *ngIf="addGroupForm.get('groupId').hasError('required')">Group is required.</mat-error>
       </mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail-add-group-dialog.component.spec.ts
@@ -68,7 +68,11 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
 
   it('should fill and submit form', async () => {
     fixture.detectChanges();
-    expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+    expectGroupListByOrganizationRequest([
+      fakeGroup({ id: 'group-a', name: 'Group A', environmentId: 'roleEnvApiId', environmentName: 'Role Env API' }),
+    ]);
+
+    await fixture.whenStable(); // wait for async tasks like HTTP & `valueChanges` subscriptions
     fixture.detectChanges();
     expectRolesListRequest('API', [
       fakeRole({ id: 'roleOrgUserId', name: 'ROLE_API_USER' }),
@@ -83,7 +87,7 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
     expect(await submitButton.isDisabled()).toBeTruthy();
 
     const groupIdSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=groupId' }));
-    await groupIdSelect.clickOptions({ text: 'Group A' });
+    await groupIdSelect.clickOptions({ text: 'Group A (Environment: Role Env API)' });
 
     const apiRoleSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=apiRole' }));
     await apiRoleSelect.clickOptions({ text: 'ROLE_API_USER' });
@@ -98,6 +102,7 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
       applicationRole: 'ROLE_APPLICATION_ADMIN',
       groupId: 'group-a',
       isAdmin: null,
+      environmentId: 'roleEnvApiId',
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -104,6 +104,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       ],
       customFields,
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -133,6 +134,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       id: 'userId',
       source: 'gravitee',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -161,6 +163,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       email: null,
       firstname: null,
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -179,6 +182,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'PENDING',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -209,6 +213,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'PENDING',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -239,6 +244,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'PENDING',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -259,6 +265,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -278,6 +285,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
       roles: [{ id: 'roleOrgUserId', name: 'ROLE_ORG_USER', scope: 'ORGANIZATION' }],
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -309,6 +317,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
       envRoles: { environmentAlphaId: [{ id: 'roleEnvApiId' }], environmentBetaId: [] },
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectUserGroupsGetRequest(user.id);
@@ -343,6 +352,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -391,6 +401,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'PENDING',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -423,6 +434,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -455,6 +467,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -484,6 +497,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -520,6 +534,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -574,6 +589,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
       status: 'ACTIVE',
     });
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -609,7 +625,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     const tokenResponse: Token = fakeUserToken({ name: 'My token', created_at: 1630373735403, last_use_at: 1631017105654 });
-
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user, [tokenResponse]);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -647,6 +663,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     expect(reqDelete.request.method).toEqual('DELETE');
     reqDelete.flush(null);
 
+    expectGroupListByOrganizationRequest();
     expectUserTokensGetRequest(user, []);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -65,6 +65,8 @@ interface EnvironmentDS {
 interface GroupDS {
   id: string;
   name: string;
+  environmentId?: string;
+  environmentName?: string;
 }
 
 interface ApiDS {
@@ -154,9 +156,10 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
       this.usersService.get(this.activatedRoute.snapshot.params.userId),
       this.environmentService.list(),
       this.usersService.getUserGroups(this.activatedRoute.snapshot.params.userId),
+      this.groupService.listByOrganization().pipe(shareReplay(1)), // Fetch groups only once
     ])
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(([user, environments, groups]) => {
+      .subscribe(([user, environments, groups, allGroups]) => {
         const organizationRoles = user.roles.filter((r) => r.scope === 'ORGANIZATION');
         this.user = {
           ...user,
@@ -176,10 +179,15 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
 
         this.initEnvironmentsRolesForm(environments);
 
-        this.groupsTableDS = groups.map((g) => ({
-          id: g.id,
-          name: g.name,
-        }));
+        this.groupsTableDS = groups.map((g) => {
+          const fullGroup = allGroups.find((ag) => ag.id === g.id);
+          return {
+            id: g.id,
+            name: g.name,
+            environmentId: fullGroup?.environmentId ?? this.constants.org.currentEnv.id,
+            environmentName: fullGroup?.environmentName ?? this.constants.org.currentEnv.name,
+          };
+        });
         this.initialTableDS['groupsTableDS'] = this.groupsTableDS;
         this.tablesUnpaginatedLength['groupsTableDS'] = this.groupsTableDS.length;
         this.initGroupsRolesForm(groups);
@@ -414,7 +422,7 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
       .afterClosed()
       .pipe(
         filter((confirm) => confirm === true),
-        switchMap(() => this.groupService.deleteMember(group.id, this.user.id)),
+        switchMap(() => this.groupService.deleteMember(group.id, this.user.id, group.environmentId)),
         tap(() => this.snackBarService.success(`"${this.user.displayName}" has been deleted from the group "${group.name}"`)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
@@ -443,16 +451,20 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
       .pipe(
         filter((groupeAdded) => !isEmpty(groupeAdded)),
         switchMap((groupeAdded) =>
-          this.groupService.addOrUpdateMemberships(groupeAdded.groupId, [
-            {
-              id: this.user.id,
-              roles: [
-                { scope: 'GROUP' as const, name: groupeAdded.isAdmin ? 'ADMIN' : '' },
-                { scope: 'API' as const, name: groupeAdded.apiRole },
-                { scope: 'APPLICATION' as const, name: groupeAdded.applicationRole },
-              ],
-            },
-          ]),
+          this.groupService.addOrUpdateMemberships(
+            groupeAdded.groupId,
+            [
+              {
+                id: this.user.id,
+                roles: [
+                  { scope: 'GROUP' as const, name: groupeAdded.isAdmin ? 'ADMIN' : '' },
+                  { scope: 'API' as const, name: groupeAdded.apiRole },
+                  { scope: 'APPLICATION' as const, name: groupeAdded.applicationRole },
+                ],
+              },
+            ],
+            groupeAdded.environmentId ?? this.constants.org.currentEnv.name,
+          ),
         ),
         tap(() => {
           this.snackBarService.success('Roles successfully updated');

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.ts
@@ -47,7 +47,7 @@ export class GroupService {
     return this.http.get<Group[]>(`${this.constants.org.baseURL}/groups`);
   }
 
-  addOrUpdateMemberships(groupId: string, groupMemberships: GroupMembership[]): Observable<void> {
+  addOrUpdateMemberships(groupId: string, groupMemberships: GroupMembership[], environmentId?: string): Observable<void> {
     // Remove Membership with empty roles
     const filterEmptyMembershipRoles = (groupMembership: GroupMembership[]) => groupMembership.filter((m) => !isEmpty(m.roles));
 
@@ -55,11 +55,12 @@ export class GroupService {
     if (isEmpty(groupMembershipToSend)) {
       return of(void 0);
     }
-
-    return this.http.post<void>(`${this.constants.env.baseURL}/configuration/groups/${groupId}/members`, groupMembershipToSend);
+    const environmentUrl = environmentId ? `${this.constants.org.baseURL}/environments/${environmentId}` : this.constants.env.baseURL;
+    return this.http.post<void>(`${environmentUrl}/configuration/groups/${groupId}/members`, groupMembershipToSend);
   }
 
-  deleteMember(groupId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(`${this.constants.env.baseURL}/configuration/groups/${groupId}/members/${memberId}`);
+  deleteMember(groupId: string, memberId: string, environmentId?: string): Observable<void> {
+    const environmentUrl = environmentId ? `${this.constants.org.baseURL}/environments/${environmentId}` : this.constants.env.baseURL;
+    return this.http.delete<void>(`${environmentUrl}/configuration/groups/${groupId}/members/${memberId}`);
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupSimpleEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupSimpleEntity.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Objects;
 
 /**
@@ -25,6 +26,8 @@ public class GroupSimpleEntity {
 
     private String id;
     private String name;
+    private String environmentName;
+    private String environmentId;
 
     public String getId() {
         return id;
@@ -42,6 +45,22 @@ public class GroupSimpleEntity {
         this.name = name;
     }
 
+    public String getEnvironmentName() {
+        return environmentName;
+    }
+
+    public void setEnvironmentName(String environmentName) {
+        this.environmentName = environmentName;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,6 +76,21 @@ public class GroupSimpleEntity {
 
     @Override
     public String toString() {
-        return "GroupSimpleEntity{" + "id='" + id + '\'' + ", name='" + name + '\'' + '}';
+        return (
+            "GroupSimpleEntity{" +
+            "id='" +
+            id +
+            '\'' +
+            ", name='" +
+            name +
+            '\'' +
+            ", environmentName='" +
+            environmentName +
+            '\'' +
+            ", environmentId='" +
+            environmentId +
+            '\'' +
+            '}'
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -52,6 +52,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.InvitationService;
 import io.gravitee.rest.api.service.MembershipService;
@@ -139,6 +140,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
     @Autowired
     private ApiConverter apiConverter;
+
+    @Autowired
+    private EnvironmentService environmentService;
 
     @Override
     public List<GroupEntity> findAll(ExecutionContext executionContext) {
@@ -246,7 +250,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             logger.debug("Find all groups for organization {} - DONE", organizationId);
             return groups
                 .stream()
-                .map(this::mapToSimple)
+                .map(group -> mapToSimple(group, organizationId))
                 .sorted(Comparator.comparing(GroupSimpleEntity::getName))
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
@@ -954,15 +958,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         return group;
     }
 
-    private GroupSimpleEntity mapToSimple(Group group) {
+    private GroupSimpleEntity mapToSimple(Group group, String organizationId) {
         if (group == null) {
             return null;
         }
-
+        EnvironmentEntity environment = environmentService.findByOrgAndIdOrHrid(organizationId, group.getEnvironmentId());
         GroupSimpleEntity entity = new GroupSimpleEntity();
         entity.setId(group.getId());
         entity.setName(group.getName());
-
+        entity.setEnvironmentId(group.getEnvironmentId());
+        entity.setEnvironmentName(environment.getName());
         return entity;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindAllTest.java
@@ -19,9 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.model.Group;
+import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.GroupSimpleEntity;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Collections;
@@ -43,6 +46,9 @@ public class GroupService_FindAllTest extends TestCase {
 
     @InjectMocks
     private final GroupService groupService = new GroupServiceImpl();
+
+    @Mock
+    private EnvironmentService environmentService;
 
     @Mock
     private GroupRepository groupRepository;
@@ -84,18 +90,27 @@ public class GroupService_FindAllTest extends TestCase {
         Group group1 = new Group();
         group1.setId("group-1");
         group1.setName("Alpha");
+        group1.setEnvironmentId(ENVIRONMENT_ID);
         Group group2 = new Group();
         group2.setId("group-2");
         group2.setName("Beta");
+        group2.setEnvironmentId(ENVIRONMENT_ID);
         groups.add(group1);
         groups.add(group2);
 
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT_ID);
+        environmentEntity.setName("env-name");
+
         when(groupRepository.findAllByOrganization(ORGANIZATION_ID)).thenReturn(groups);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(environmentEntity);
 
         List<GroupSimpleEntity> result = groupService.findAllByOrganization(ORGANIZATION_ID);
 
         assertThat(result).hasSize(2);
         assertThat(result).extracting(GroupSimpleEntity::getName).containsExactlyInAnyOrder("Alpha", "Beta");
+        assertThat(result).extracting(GroupSimpleEntity::getEnvironmentId).containsOnly(ENVIRONMENT_ID);
+        assertThat(result).extracting(GroupSimpleEntity::getEnvironmentName).containsOnly("env-name");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8844

## Description
Fixed issue where group deletion failed with "group not found" due to filtering by current environment ID instead of the group's actual environment ID. Now, deletion uses the correct environment ID associated with the group.

Also updated group addition logic to use the target group's environment ID, ensuring correct environment scoping during both add and delete operations.

## Additional context
<img width="1723" alt="Screenshot 2025-06-19 at 3 02 55 PM" src="https://github.com/user-attachments/assets/9e6498a5-e442-4a99-afb9-f5cf66a5517f" />
<img width="1723" alt="Screenshot 2025-06-19 at 3 34 43 PM" src="https://github.com/user-attachments/assets/941fdb3f-cf9a-4deb-a9de-11da0aacd412" />
<img width="1723" alt="Screenshot 2025-06-19 at 3 48 51 PM" src="https://github.com/user-attachments/assets/2b92f760-0bd1-417c-8686-ee7bd4a97226" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cpukddbvxw.chromatic.com)
<!-- Storybook placeholder end -->
