### PR TITLE
fix(console): settings and user groups forbidden when creating application

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, Inject, inject, OnInit } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { map, tap } from 'rxjs/operators';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -30,7 +30,7 @@ import { ApplicationTypesService } from '../../../services-ngx/application-types
 import { ApplicationService } from '../../../services-ngx/application.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { toDictionary } from '../../../util/gio-form-header.util';
-import { ConsoleSettingsService } from '../../../services-ngx/console-settings.service';
+import { Constants } from '../../../entities/Constants';
 
 const TYPES_INFOS = {
   SIMPLE: {
@@ -113,7 +113,7 @@ export class ApplicationCreationComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly router: Router,
-    private readonly settingsService: ConsoleSettingsService,
+    @Inject(Constants) private readonly constants: Constants,
   ) {}
 
   ngOnInit(): void {
@@ -168,17 +168,9 @@ export class ApplicationCreationComponent implements OnInit {
   }
 
   private setUserGroupRequiredValidator() {
-    this.settingsService
-      .get()
-      .pipe(
-        tap((consoleSettings) => {
-          if (consoleSettings.userGroup.required.enabled) {
-            this.applicationFormGroup.controls.groups?.setValidators(Validators.required);
-            this.requireUserGroups = true;
-          }
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+    if (this.constants.org.settings.userGroup?.required?.enabled) {
+      this.applicationFormGroup.controls.groups?.setValidators(Validators.required);
+      this.requireUserGroups = true;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/creation/components/application-creation-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/components/application-creation-form.harness.ts
@@ -38,6 +38,9 @@ export class ApplicationCreationFormHarness extends ComponentHarness {
     GioFormTagsInputHarness.with({ selector: '[formControlName="oauthRedirectUris"]' }),
   );
 
+  // Groups
+  private getGroupSelectHarness = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="groups"]' }));
+
   public async setGeneralInformation(name: string, description: string, domain: string) {
     await this.getNameInput().then(async (input) => await input.setValue(name));
     await this.getDescriptionInput().then(async (input) => await input.setValue(description));
@@ -66,5 +69,9 @@ export class ApplicationCreationFormHarness extends ComponentHarness {
 
   public async setApplicationClientCertificate(appClientCertificate: string) {
     await this.getAppClientCertificateInput().then(async (input) => await input.setValue(appClientCertificate));
+  }
+
+  public async selectGroup(groupName: string) {
+    await this.getGroupSelectHarness().then((options) => options.clickOptions({ text: groupName }));
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9985

## Description

Use the existing endpoint to get groups. 
A user can select all the groups in his environment if he has permission. 
Same behavior as in the existing Application group edition page.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cfkglvjvvr.chromatic.com)
<!-- Storybook placeholder end -->
