### PR TITLE
fix: remove healthcheck prob from dockerfile

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -39,7 +39,4 @@ COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082
 ENTRYPOINT ["./bin/gravitee"]
-VOLUME ${GRAVITEEIO_HOME}/logs
-HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18082/_node/health || exit 1
 USER graviteeio

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -35,7 +35,4 @@ COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083
 ENTRYPOINT ["./bin/gravitee"]
-VOLUME ${GRAVITEEIO_HOME}/logs
-HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1
 USER graviteeio


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10103
https://github.com/gravitee-io/issues/issues/10644

## Description

Remove default hardcoded password. Healthchecks can be defined directly in docker-compose or in kube deployments.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ezzhuiurbp.chromatic.com)
<!-- Storybook placeholder end -->
