### PR TITLE
chore: remove gravitee-inference service from MAPI distribution

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -170,6 +170,7 @@
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>
                 <exclude>com.graviteesource.service:gravitee-service-secrets:zip</exclude>
+                <exclude>io.gravitee.inference.service:gravitee-inference-service:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>


### PR DESCRIPTION
## Description

Remove `gravitee-inference-service` plugin from MAP distribution as it is only relevant in Gateway distribution.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

