### PR TITLE
feat: add new LogGuardService and use it in reactor to disable

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
@@ -63,6 +63,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-reporting</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-opentelemetry</artifactId>
         </dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContext.java
@@ -16,10 +16,7 @@
 package io.gravitee.gateway.reactive.core.v4.analytics;
 
 import io.gravitee.definition.model.v4.analytics.Analytics;
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
-import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.gateway.opentelemetry.TracingContext;
-import io.gravitee.node.api.configuration.Configuration;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,24 +32,17 @@ public class AnalyticsContext {
     protected LoggingContext loggingContext;
     protected TracingContext tracingContext;
 
-    public AnalyticsContext(
-        final Analytics analytics,
-        final String loggingMaxsize,
-        final String loggingExcludedResponseType,
-        final TracingContext tracingContext
-    ) {
+    public AnalyticsContext(final Analytics analytics, final LoggingContext loggingContext, final TracingContext tracingContext) {
         this.analytics = analytics;
         if (isEnabled()) {
-            initLoggingContext(loggingMaxsize, loggingExcludedResponseType);
+            initLoggingContext(loggingContext);
             initTracingContext(tracingContext);
         }
     }
 
-    private void initLoggingContext(final String loggingMaxsize, final String loggingExcludedResponseType) {
+    private void initLoggingContext(final LoggingContext loggingContext) {
         if (AnalyticsUtils.isLoggingEnabled(analytics)) {
-            this.loggingContext = loggingContext(analytics.getLogging());
-            this.loggingContext.setMaxSizeLogMessage(loggingMaxsize);
-            this.loggingContext.setExcludedResponseTypes(loggingExcludedResponseType);
+            this.loggingContext = loggingContext;
         }
     }
 
@@ -60,10 +50,6 @@ public class AnalyticsContext {
         if (tracingContext.isEnabled()) {
             this.tracingContext = tracingContext;
         }
-    }
-
-    protected LoggingContext loggingContext(Logging logging) {
-        return new LoggingContext(logging);
     }
 
     public boolean isEnabled() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
@@ -20,6 +20,7 @@ import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import jakarta.annotation.Nonnull;
 import lombok.AccessLevel;
@@ -36,7 +37,8 @@ public class AnalyticsUtils {
         @Nonnull final io.gravitee.definition.model.Api apiV2,
         final String loggingMaxsize,
         final String loggingExcludedResponseType,
-        final TracingContext tracingContext
+        final TracingContext tracingContext,
+        final LogGuardService logGuardService
     ) {
         io.gravitee.definition.model.Logging loggingV2 = apiV2.getProxy().getLogging();
 
@@ -61,12 +63,12 @@ public class AnalyticsUtils {
                 logging.getContent().setPayload(loggingV2.getContent().isPayloads());
             }
             analytics.setLogging(logging);
-
-            LoggingContext loggingContext = new LoggingContext(analytics.getLogging());
-            loggingContext.setMaxSizeLogMessage(loggingMaxsize);
-            loggingContext.setExcludedResponseTypes(loggingExcludedResponseType);
         }
-        return new AnalyticsContext(analytics, loggingMaxsize, loggingExcludedResponseType, tracingContext);
+        LoggingContext loggingContext = new LoggingContext(analytics.getLogging());
+        loggingContext.setMaxSizeLogMessage(loggingMaxsize);
+        loggingContext.setExcludedResponseTypes(loggingExcludedResponseType);
+        loggingContext.setLogGuardService(logGuardService);
+        return new AnalyticsContext(analytics, loggingContext, tracingContext);
     }
 
     public static boolean isEnabled(final Analytics analytics) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -17,8 +17,8 @@ package io.gravitee.gateway.reactive.core.v4.analytics;
 
 import io.gravitee.common.utils.SizeUtils;
 import io.gravitee.definition.model.ConditionSupplier;
-import io.gravitee.definition.model.MessageConditionSupplier;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +38,7 @@ public class LoggingContext implements ConditionSupplier {
     private int maxSizeLogMessage = -1;
     private String excludedResponseTypes;
     private Pattern excludedContentTypesPattern;
+    private LogGuardService logGuardService;
 
     @Override
     public String getCondition() {
@@ -133,5 +134,19 @@ public class LoggingContext implements ConditionSupplier {
         }
 
         return contentType == null || !excludedContentTypesPattern.matcher(contentType).find();
+    }
+
+    /**
+     * Determines if body can be logged by asking the logGuardService
+     * if the guard is activated (if logGuardService not available, always
+     * return true)
+     * @return true if the body can be logged
+     */
+    public boolean isBodyLoggable() {
+        return logGuardService == null || !logGuardService.isLogGuardActive();
+    }
+
+    public void setLogGuardService(LogGuardService logGuardService) {
+        this.logGuardService = logGuardService;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContextTest.java
@@ -39,7 +39,7 @@ class AnalyticsContextTest {
 
     @Test
     void should_not_be_enabled_if_analytics_is_null() {
-        AnalyticsContext analyticsContext = new AnalyticsContext(null, "100MB", null, TracingContext.noop());
+        AnalyticsContext analyticsContext = new AnalyticsContext(null, null, TracingContext.noop());
         assertThat(analyticsContext.isEnabled()).isFalse();
     }
 
@@ -47,7 +47,7 @@ class AnalyticsContextTest {
     void should_be_enabled_if_analytics_is_enabled() {
         Analytics analytics = new Analytics();
         analytics.setEnabled(true);
-        AnalyticsContext analyticsContext = new AnalyticsContext(analytics, "100MB", null, TracingContext.noop());
+        AnalyticsContext analyticsContext = new AnalyticsContext(analytics, null, TracingContext.noop());
         assertThat(analyticsContext.isEnabled()).isTrue();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -78,6 +78,7 @@ import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.context.DefaultV3ExecutionContextFactory;
 import io.gravitee.gateway.reactor.handler.context.V3ExecutionContextFactory;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.gateway.resource.internal.ResourceConfigurationFactoryImpl;
@@ -141,6 +142,7 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
     private final List<InstrumenterTracerFactory> instrumenterTracerFactories;
     private final DictionaryManager dictionaryManager;
     private ApplicationContext applicationContext;
+    private final LogGuardService logGuardService;
 
     public ApiReactorHandlerFactory(
         ApplicationContext applicationContext,
@@ -160,7 +162,8 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
         OpenTelemetryConfiguration openTelemetryConfiguration,
         OpenTelemetryFactory openTelemetryFactory,
         List<InstrumenterTracerFactory> instrumenterTracerFactories,
-        DictionaryManager dictionaryManager
+        DictionaryManager dictionaryManager,
+        LogGuardService logGuardService
     ) {
         this.applicationContext = applicationContext;
         this.configuration = configuration;
@@ -181,6 +184,7 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
         this.instrumenterTracerFactories = instrumenterTracerFactories;
         this.dictionaryManager = dictionaryManager;
         this.contentTemplateVariableProvider = new ContentTemplateVariableProvider();
+        this.logGuardService = logGuardService;
     }
 
     @Override
@@ -374,7 +378,8 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
             accessPointManager,
             eventManager,
             httpAcceptorFactory,
-            createTracingContext(api, "API_V2_EMULATED")
+            createTracingContext(api, "API_V2_EMULATED"),
+            logGuardService
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -55,6 +55,7 @@ import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.license.LicenseManager;
@@ -189,7 +190,8 @@ public class ApiHandlerConfiguration {
         OpenTelemetryConfiguration openTelemetryConfiguration,
         OpenTelemetryFactory openTelemetryFactory,
         @Autowired(required = false) List<InstrumenterTracerFactory> instrumenterTracerFactories,
-        DictionaryManager dictionaryManager
+        DictionaryManager dictionaryManager,
+        LogGuardService logGuardService
     ) {
         return new ApiReactorHandlerFactory(
             applicationContext,
@@ -209,7 +211,8 @@ public class ApiHandlerConfiguration {
             openTelemetryConfiguration,
             openTelemetryFactory,
             instrumenterTracerFactories,
-            dictionaryManager
+            dictionaryManager,
+            logGuardService
         );
     }
 
@@ -262,7 +265,8 @@ public class ApiHandlerConfiguration {
         OpenTelemetryFactory openTelemetryFactory,
         @Autowired(required = false) List<InstrumenterTracerFactory> instrumenterTracerFactories,
         GatewayConfiguration gatewayConfiguration,
-        DictionaryManager dictionaryManager
+        DictionaryManager dictionaryManager,
+        LogGuardService logGuardService
     ) {
         return new DefaultApiReactorFactory(
             applicationContext,
@@ -284,7 +288,8 @@ public class ApiHandlerConfiguration {
             openTelemetryFactory,
             instrumenterTracerFactories,
             gatewayConfiguration,
-            dictionaryManager
+            dictionaryManager,
+            logGuardService
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -62,10 +62,10 @@ import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LoggingHoo
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactor.handler.Acceptor;
-import io.gravitee.gateway.reactor.handler.DefaultHttpAcceptor;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.http.AccessPointHttpAcceptor;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -128,6 +128,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     protected AnalyticsContext analyticsContext;
     protected HttpSecurityChain httpSecurityChain;
     protected List<Acceptor<?>> acceptors;
+    private final LogGuardService logGuardService;
 
     public SyncApiReactor(
         final Api api,
@@ -145,7 +146,8 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         final AccessPointManager accessPointManager,
         final EventManager eventManager,
         final HttpAcceptorFactory httpAcceptorFactory,
-        final TracingContext tracingContext
+        final TracingContext tracingContext,
+        final LogGuardService logGuardService
     ) {
         this.api = api;
         this.componentProvider = componentProvider;
@@ -159,6 +161,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         this.eventManager = eventManager;
         this.httpAcceptorFactory = httpAcceptorFactory;
         this.tracingContext = tracingContext;
+        this.logGuardService = logGuardService;
 
         this.beforeHandleProcessors = apiProcessorChainFactory.beforeHandle(api, tracingContext);
         this.afterHandleProcessors = apiProcessorChainFactory.afterHandle(api, tracingContext);
@@ -451,7 +454,13 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
 
         tracingContext.start();
         this.analyticsContext =
-            AnalyticsUtils.createAnalyticsContext(api.getDefinition(), loggingMaxSize, loggingExcludedResponseType, tracingContext);
+            AnalyticsUtils.createAnalyticsContext(
+                api.getDefinition(),
+                loggingMaxSize,
+                loggingExcludedResponseType,
+                tracingContext,
+                logGuardService
+            );
         if (analyticsContext.isLoggingEnabled()) {
             invokerHooks.add(new LoggingHook());
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -53,6 +53,7 @@ import io.gravitee.gateway.reactive.v4.flow.selection.HttpSelectorConditionFilte
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -97,6 +98,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
     protected final ReporterService reporterService;
     protected final GatewayConfiguration gatewayConfiguration;
     protected final HttpAcceptorFactory httpAcceptorFactory;
+    protected final LogGuardService logGuardService;
     private final Logger logger = LoggerFactory.getLogger(DefaultApiReactorFactory.class);
 
     public DefaultApiReactorFactory(
@@ -119,7 +121,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         final OpenTelemetryFactory openTelemetryFactory,
         final List<InstrumenterTracerFactory> instrumenterTracerFactories,
         final GatewayConfiguration gatewayConfiguration,
-        final DictionaryManager dictionaryManager
+        final DictionaryManager dictionaryManager,
+        final LogGuardService logGuardService
     ) {
         super(applicationContext, policyFactoryManager, configuration, dictionaryManager);
         this.node = node;
@@ -140,6 +143,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         this.reporterService = reporterService;
         this.openTelemetryFactory = openTelemetryFactory;
         this.instrumenterTracerFactories = instrumenterTracerFactories;
+        this.logGuardService = logGuardService;
     }
 
     // FIXME: this constructor is here to keep compatibility with Message Reactor plugin. it will be deleted when Message Reactor has been updated
@@ -163,7 +167,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         final OpenTelemetryFactory openTelemetryFactory,
         final List<InstrumenterTracerFactory> instrumenterTracerFactories,
         final GatewayConfiguration gatewayConfiguration,
-        final DictionaryManager dictionaryManager
+        final DictionaryManager dictionaryManager,
+        final LogGuardService logGuardService
     ) {
         super(applicationContext, new PolicyFactoryManager(new HashSet<>(Set.of(policyFactory))), configuration, dictionaryManager);
         this.node = node;
@@ -184,6 +189,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         this.reporterService = reporterService;
         this.openTelemetryFactory = openTelemetryFactory;
         this.instrumenterTracerFactories = instrumenterTracerFactories;
+        this.logGuardService = logGuardService;
     }
 
     @SuppressWarnings("java:S1845")
@@ -285,7 +291,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
             endpointManager,
             resourceLifecycleManager,
             flowChainFactory,
-            v4FlowChainFactory
+            v4FlowChainFactory,
+            logGuardService
         );
     }
 
@@ -302,7 +309,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         DefaultEndpointManager endpointManager,
         ResourceLifecycleManager resourceLifecycleManager,
         FlowChainFactory flowChainFactory,
-        io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory
+        io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory,
+        LogGuardService logGuardService
     ) {
         return new DefaultApiReactor(
             api,
@@ -324,7 +332,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
             accessPointManager,
             eventManager,
             httpAcceptorFactory,
-            createTracingContext(api, "API_V4")
+            createTracingContext(api, "API_V4"),
+            logGuardService
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
@@ -25,13 +25,11 @@ import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
-import io.gravitee.gateway.reactive.api.context.tcp.TcpExecutionContext;
-import io.gravitee.gateway.reactive.api.invoker.BaseInvoker;
 import io.gravitee.gateway.reactive.api.invoker.TcpInvoker;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
+import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
 import io.gravitee.gateway.reactive.core.v4.invoker.TcpEndpointInvoker;
@@ -43,7 +41,6 @@ import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -198,7 +195,10 @@ public class TcpApiReactor extends AbstractApiReactor {
     }
 
     protected AnalyticsContext analyticsContext() {
-        return new AnalyticsContext(api.getDefinition().getAnalytics(), loggingMaxSize, loggingExcludedResponseType, tracingContext);
+        LoggingContext loggingContext = new LoggingContext(api.getDefinition().getAnalytics().getLogging());
+        loggingContext.setMaxSizeLogMessage(loggingMaxSize);
+        loggingContext.setExcludedResponseTypes(loggingExcludedResponseType);
+        return new AnalyticsContext(api.getDefinition().getAnalytics(), loggingContext, tracingContext);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
@@ -33,7 +33,6 @@ import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
-import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import java.util.List;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
@@ -42,12 +42,16 @@ abstract class LogRequest extends io.gravitee.reporter.api.common.Request {
         if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE))) {
             final Buffer buffer = Buffer.buffer();
 
-            request.chunks(
-                request
-                    .chunks()
-                    .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                    .doOnComplete(() -> this.setBody(buffer.toString()))
-            );
+            if (loggingContext.isBodyLoggable()) {
+                request.chunks(
+                    request
+                        .chunks()
+                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
+                        .doOnComplete(() -> this.setBody(buffer.toString()))
+                );
+            } else {
+                this.setBody("BODY NOT CAPTURED");
+            }
         }
 
         if (isLogHeaders()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
 
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
-import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
 
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
-import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactoryTest.java
@@ -39,6 +39,7 @@ import io.gravitee.gateway.reactive.platform.organization.policy.OrganizationPol
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
@@ -104,6 +105,9 @@ public class ApiReactorHandlerFactoryTest {
     @Mock
     private OpenTelemetryFactory openTelemetryFactory;
 
+    @Mock
+    private LogGuardService logGuardService;
+
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -135,7 +139,8 @@ public class ApiReactorHandlerFactoryTest {
                 openTelemetryConfiguration,
                 openTelemetryFactory,
                 List.of(),
-                dictionaryManager
+                dictionaryManager,
+                logGuardService
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -66,6 +66,7 @@ import io.gravitee.gateway.reactive.handlers.api.security.HttpSecurityChain;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LoggingHook;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -244,6 +245,9 @@ class SyncApiReactorTest {
 
     private TracingContext tracingContext = TracingContext.noop();
 
+    @Mock
+    private LogGuardService logGuardService;
+
     @BeforeEach
     void init() {
         lenient().when(apiDefinition.getProxy()).thenReturn(mock(Proxy.class));
@@ -296,7 +300,8 @@ class SyncApiReactorTest {
                 accessPointManager,
                 eventManager,
                 new HttpAcceptorFactory(false),
-                tracingContext
+                tracingContext,
+                logGuardService
             );
 
         lenient().when(ctx.getInternalAttribute(ATTR_INTERNAL_INVOKER)).thenReturn(invokerAdapter);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -54,6 +54,7 @@ import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.internal.v4.DefaultResourceManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -69,7 +70,6 @@ import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.resource.api.ResourceManager;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -152,6 +152,9 @@ class DefaultApiReactorFactoryTest {
     @Mock
     private GatewayConfiguration gatewayConfiguration;
 
+    @Mock
+    private LogGuardService logGuardService;
+
     @BeforeEach
     void init() {
         lenient().when(applicationContext.getBeanFactory()).thenReturn(applicationContextListable);
@@ -177,7 +180,8 @@ class DefaultApiReactorFactoryTest {
                 openTelemetryFactory,
                 List.of(),
                 gatewayConfiguration,
-                dictionaryManager
+                dictionaryManager,
+                logGuardService
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -57,8 +57,6 @@ import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.apiservice.ApiService;
 import io.gravitee.gateway.reactive.api.apiservice.ApiServiceFactory;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.BaseEntrypointConnector;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.async.EntrypointAsyncConnector;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.async.HttpEntrypointAsyncConnector;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
@@ -83,6 +81,7 @@ import io.gravitee.gateway.reactor.handler.HttpAcceptor;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.reactor.handler.http.AccessPointHttpAcceptor;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -289,6 +288,9 @@ class DefaultApiReactorTest {
     private DefaultApiReactor cut;
     private TracingContext tracingContext = TracingContext.noop();
 
+    @Mock
+    private LogGuardService logGuardService;
+
     @BeforeEach
     public void init() throws Exception {
         lenient().when(ctx.request()).thenReturn(request);
@@ -404,7 +406,8 @@ class DefaultApiReactorTest {
                     accessPointManager,
                     eventManager,
                     new HttpAcceptorFactory(false),
-                    tracingContext
+                    tracingContext,
+                    logGuardService
                 );
             ReflectionTestUtils.setField(defaultApiReactor, "entrypointConnectorResolver", entrypointConnectorResolver);
             ReflectionTestUtils.setField(defaultApiReactor, "defaultInvoker", defaultInvoker);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -102,6 +102,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
         when(loggingContext.entrypointRequestPayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
@@ -143,6 +144,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
         when(loggingContext.entrypointRequestPayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(maxPayloadSize);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
@@ -154,5 +156,21 @@ class LogEntrypointRequestTest {
 
         assertNull(logRequest.getHeaders());
         assertThat(logRequest.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+    }
+
+    @Test
+    void shouldLogBodyNotCaptureWhenBodyNotLoggable() {
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+        when(loggingContext.entrypointRequestPayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(false);
+        when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
+
+        final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture();
+        verify(request, times(0)).chunks(any(Flowable.class));
+
+        assertNull(logRequest.getHeaders());
+        assertThat(logRequest.getBody()).isEqualTo("BODY NOT CAPTURED");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -123,6 +123,7 @@ class LogEndpointResponseTest {
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
@@ -165,6 +166,7 @@ class LogEndpointResponseTest {
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(maxPayloadSize);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
@@ -176,5 +178,21 @@ class LogEndpointResponseTest {
 
         assertNull(logResponse.getHeaders());
         assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+    }
+
+    @Test
+    void shouldLogBodyNotCapturedWhenBodyIsNotLoggable() {
+        when(response.headers()).thenReturn(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(false);
+        when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
+
+        final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
+        verify(response, times(0)).chunks(any(Flowable.class));
+
+        assertNull(logResponse.getHeaders());
+        assertThat(logResponse.getBody()).isEqualTo("BODY NOT CAPTURED");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -99,6 +99,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
@@ -141,6 +142,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(maxPayloadSize);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
@@ -152,5 +154,21 @@ class LogEntrypointResponseTest {
 
         assertNull(logResponse.getHeaders());
         assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+    }
+
+    @Test
+    void shouldLogBodyNotCapturedWhenBodyIsNotLoggable() {
+        when(response.headers()).thenReturn(HttpHeaders.create());
+        when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+        when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(false);
+        when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
+
+        final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture();
+        verify(response, times(0)).chunks(any(Flowable.class));
+
+        assertNull(logResponse.getHeaders());
+        assertThat(logResponse.getBody()).isEqualTo("BODY NOT CAPTURED");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
@@ -67,5 +67,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/LogGuardService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/LogGuardService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.gateway.report.guard;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.gateway.report.guard.strategy.CoolDownLogGuardStrategy;
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class LogGuardService extends AbstractService<LogGuardService> {
+
+    private final boolean isLogGuardEnabled;
+
+    private final String strategy;
+
+    private final int cooldownDurationInSeconds;
+
+    private final NodeHealthCheckService nodeHealthCheckService;
+
+    private LogGuardStrategy logGuardStrategy;
+
+    @Override
+    public void doStart() throws Exception {
+        if (isLogGuardEnabled) {
+            if (!strategy.isEmpty() && strategy.equals("cooldown")) {
+                logGuardStrategy = new CoolDownLogGuardStrategy(nodeHealthCheckService, Duration.ofSeconds(cooldownDurationInSeconds));
+            } else {
+                throw new IllegalStateException("Log guard strategy unknown: " + strategy);
+            }
+        }
+    }
+
+    /**
+     *
+     * @return the current state of the log guard
+     */
+    public boolean isLogGuardActive() {
+        if (logGuardStrategy != null) {
+            return logGuardStrategy.execute();
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/LogGuardStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/LogGuardStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.gateway.report.guard;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface LogGuardStrategy {
+    String getName();
+
+    boolean execute();
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/strategy/CoolDownLogGuardStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/guard/strategy/CoolDownLogGuardStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.gateway.report.guard.strategy;
+
+import io.gravitee.gateway.report.guard.LogGuardStrategy;
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Basic strategy that check the memory pressure and activate the guard for
+ * a defined period if the threshold is reached before checking the pressure again.
+ * This strategy prevents an oscillation effect if the memory is near the threshold.
+ *
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CoolDownLogGuardStrategy implements LogGuardStrategy {
+
+    private final NodeHealthCheckService nodeHealthCheckService;
+    private final Duration cooldownDuration;
+
+    private Instant cooldownStartTime;
+    private final AtomicBoolean guardState = new AtomicBoolean(false);
+
+    @Override
+    public String getName() {
+        return "cooldown";
+    }
+
+    @Override
+    public boolean execute() {
+        // Check if pressure is too high and guard is not activated
+        if (nodeHealthCheckService.isGcPressureTooHigh() && !guardState.get()) {
+            //Initialize cooldownStartTime
+            cooldownStartTime = Instant.now();
+            guardState.set(true);
+            log.debug("Cooldown started for {}seconds", cooldownDuration.toSeconds());
+        } else if (guardState.get()) {
+            //Check if cooldown period is finished
+            if (Instant.now().isAfter(cooldownStartTime.plus(cooldownDuration))) {
+                if (nodeHealthCheckService.isGcPressureTooHigh()) {
+                    // Reset cooldown start time if memory pressure is still too high
+                    cooldownStartTime = Instant.now();
+                    guardState.set(true);
+                    log.debug("Cooldown restarted");
+                } else {
+                    guardState.set(false);
+                    log.debug("Cooldown finished");
+                }
+            }
+        }
+
+        return guardState.get();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/spring/ReporterConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/main/java/io/gravitee/gateway/report/spring/ReporterConfiguration.java
@@ -16,8 +16,11 @@
 package io.gravitee.gateway.report.spring;
 
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.report.impl.NodeMonitoringReporterService;
 import io.gravitee.gateway.report.impl.ReporterServiceImpl;
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,5 +39,15 @@ public class ReporterConfiguration {
     @Bean
     public NodeMonitoringReporterService nodeMonitoringReporterService() {
         return new NodeMonitoringReporterService();
+    }
+
+    @Bean
+    public LogGuardService logGuardService(
+        @Value("${reporters.logging.memory_pressure_guard.enabled:true}") boolean enabled,
+        @Value("${reporters.logging.memory_pressure_guard.strategy.type:cooldown}") String strategy,
+        @Value("${reporters.logging.memory_pressure_guard.strategy.cooldown.duration:60}") int cooldownDurationInSeconds,
+        NodeHealthCheckService nodeHealthCheckService
+    ) {
+        return new LogGuardService(enabled, strategy, cooldownDurationInSeconds, nodeHealthCheckService);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/test/java/io/gravitee/gateway/report/guard/LogGuardServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/test/java/io/gravitee/gateway/report/guard/LogGuardServiceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.gateway.report.guard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class LogGuardServiceTest {
+
+    @Mock
+    private NodeHealthCheckService nodeHealthCheckService;
+
+    private LogGuardService cut;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cut = new LogGuardService(true, "cooldown", 30, nodeHealthCheckService);
+
+        cut.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        cut.stop();
+    }
+
+    @Test
+    void should_be_active_when_gc_pressure_too_high() {
+        when(nodeHealthCheckService.isGcPressureTooHigh()).thenReturn(true);
+
+        assertThat(cut.isLogGuardActive()).isTrue();
+    }
+
+    @Test
+    void should_be_inactive_when_gc_pressure_not_too_high() {
+        when(nodeHealthCheckService.isGcPressureTooHigh()).thenReturn(false);
+
+        assertThat(cut.isLogGuardActive()).isFalse();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/test/java/io/gravitee/gateway/report/guard/strategy/CoolDownLogGuardStrategyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/src/test/java/io/gravitee/gateway/report/guard/strategy/CoolDownLogGuardStrategyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.gateway.report.guard.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class CoolDownLogGuardStrategyTest {
+
+    @Mock
+    private NodeHealthCheckService nodeHealthCheckService;
+
+    private CoolDownLogGuardStrategy cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new CoolDownLogGuardStrategy(nodeHealthCheckService, Duration.ofSeconds(3));
+    }
+
+    @AfterEach
+    void tearDown() {}
+
+    @Test
+    void should_return_true_when_gc_pressure_too_high() {
+        when(nodeHealthCheckService.isGcPressureTooHigh()).thenReturn(true);
+
+        assertThat(cut.execute()).isTrue();
+    }
+
+    @Test
+    void should_return_false_when_gc_pressure_not_too_high() {
+        when(nodeHealthCheckService.isGcPressureTooHigh()).thenReturn(false);
+
+        assertThat(cut.execute()).isFalse();
+    }
+
+    @Test
+    void should_return_true_during_cooldown_period_once_started_and_false_after_if_gc_pressure_dropped() {
+        when(nodeHealthCheckService.isGcPressureTooHigh()).thenReturn(true).thenReturn(false);
+
+        assertThat(cut.execute()).isTrue();
+
+        //Check if result is true during cooldown period and false once cooldown period has ended
+        await().atLeast(Duration.ofSeconds(2)).atMost(Duration.ofSeconds(4)).untilAsserted(() -> assertThat(cut.execute()).isFalse());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandlerFactory.java
@@ -102,7 +102,8 @@ public class DebugApiReactorHandlerFactory extends ApiReactorHandlerFactory {
             null,
             null,
             null,
-            dictionaryManager
+            dictionaryManager,
+            null
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactor.java
@@ -93,7 +93,8 @@ public class DebugSyncApiReactor extends SyncApiReactor {
             accessPointManager,
             eventManager,
             httpAcceptorFactory,
-            tracingContext
+            tracingContext,
+            null
         );
         invokerHooks.add(new DebugInvokerHook());
     }
@@ -163,7 +164,8 @@ public class DebugSyncApiReactor extends SyncApiReactor {
             pendingRequestsTimeout,
             analyticsContext,
             httpSecurityChain,
-            acceptors
+            acceptors,
+            null
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugV4ApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugV4ApiReactor.java
@@ -92,7 +92,8 @@ public class DebugV4ApiReactor extends DefaultApiReactor {
             accessPointManager,
             eventManager,
             httpAcceptorFactory,
-            tracingContext
+            tracingContext,
+            null
         );
         invokerHooks.add(new DebugInvokerHook());
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
@@ -90,7 +90,8 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
             null,
             null,
             gatewayConfiguration,
-            dictionaryManager
+            dictionaryManager,
+            null
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
@@ -18,10 +18,10 @@ package io.gravitee.gateway.standalone.node;
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactor.handler.ReactorEventListener;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.report.impl.NodeMonitoringReporterService;
 import io.gravitee.gateway.standalone.vertx.VertxEmbeddedContainer;
 import io.gravitee.node.api.NodeMetadataResolver;
-import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.container.AbstractNode;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import java.util.ArrayList;
@@ -65,6 +65,7 @@ public class GatewayNode extends AbstractNode {
         final List<Class<? extends LifecycleComponent>> components = new ArrayList<>();
 
         components.add(NodeMonitoringReporterService.class);
+        components.add(LogGuardService.class);
         components.add(ReactorEventListener.class);
         components.addAll(super.components());
         // at this stage secret providers are loaded if any, so TLS can be resolved.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
@@ -26,6 +26,7 @@ import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.node.container.NodeFactory;
+import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
 import io.gravitee.node.monitoring.spring.NodeMonitoringConfiguration;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
@@ -121,6 +122,11 @@ public class GatewayTestContainer extends GatewayContainer {
         @Bean
         public LicenseManager licenseManager() {
             return new PermissiveLicenseManager();
+        }
+
+        @Bean
+        public NodeHealthCheckService nodeHealthCheckService() {
+            return Mockito.mock(NodeHealthCheckService.class);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestNode.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.standalone.container;
 
 import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.report.impl.NodeMonitoringReporterService;
 import io.gravitee.gateway.standalone.node.GatewayNode;
 import io.gravitee.node.management.http.ManagementService;
@@ -24,7 +25,6 @@ import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
 import io.gravitee.node.monitoring.infos.NodeInfosService;
 import io.gravitee.node.monitoring.monitor.NodeMonitorService;
 import io.gravitee.node.plugins.service.ServiceManager;
-import io.gravitee.node.reporter.ReporterManager;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import java.util.List;
 
@@ -44,6 +44,7 @@ public class GatewayTestNode extends GatewayNode {
         components.remove(ServiceManager.class);
         components.remove(ManagementService.class);
         components.remove(NodeMonitoringReporterService.class);
+        components.remove(LogGuardService.class);
         components.remove(NodeHealthCheckService.class);
         components.remove(NodeInfosService.class);
         components.remove(NodeMonitorService.class);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -504,10 +504,16 @@ ratelimit:
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:
-  # logging configuration
+# logging configuration
 #  logging:
 #    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
 #    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+#    memory_pressure_guard:
+#      enabled: true (default is false)
+#      strategy:
+#        type: cooldown #type of strategy (default is cooldown)
+#        cooldown:
+#          duration: 60 #duration in seconds (default is 60 seconds)
   # Elasticsearch reporter
   elasticsearch:
     # enabled: true # Is the reporter enabled or not (default to true)
@@ -633,10 +639,12 @@ services:
 #    enabled: true
 #    delay: 5000
 #    unit: MILLISECONDS
-  # The thresholds to determine if a probe is healthy or not
+##   The thresholds to determine if a probe is healthy or not
 #    threshold:
-#      cpu: # Default is 80%
-#      memory: # Default is 80%
+#      cpu: 80 # Default is 80%
+#      memory: 80 # Default is 80%
+#      gc-pressure: 1 # Default is 15%
+
 
   # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
   # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestNode.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.gateway.tests.sdk.container;
 
 import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.report.impl.NodeMonitoringReporterService;
 import io.gravitee.gateway.standalone.node.GatewayNode;
 import io.gravitee.node.management.http.ManagementService;
@@ -41,6 +42,7 @@ public class GatewayTestNode extends GatewayNode {
         components.remove(AlertEventProducerManager.class);
         components.remove(ManagementService.class);
         components.remove(NodeMonitoringReporterService.class);
+        components.remove(LogGuardService.class);
         components.remove(NodeHealthCheckService.class);
         components.remove(NodeInfosService.class);
         components.remove(NodeMonitorService.class);

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.9.1</gravitee-node.version>
+        <gravitee-node.version>7.10.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.8.0</gravitee-plugin.version>


### PR DESCRIPTION
logging of the body to protect the gateway from OOM

## Issue

https://gravitee.atlassian.net/browse/ARCHI-493

## Description

This PR adds a new Service `LogGuardService` that can monitor the GcPressure and when triggered, the guard is used to disable the logging of the request/response body to prevent the Gateway from a potential OOM kill.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dsdhlknshw.chromatic.com)
<!-- Storybook placeholder end -->
