### PR TITLE
ci: use release version when building frontends [skip ci]

### DIFF
--- a/.circleci/ci/src/jobs/frontend/job-console-webui-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-console-webui-build.ts
@@ -34,7 +34,7 @@ export class ConsoleWebuiBuildJob {
     const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig, environment);
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
-    const apimVersion = ['build_rpm', 'build_docker_images', 'release'].includes(environment.action)
+    const apimVersion = ['build_rpm', 'build_docker_images', 'release', 'full_release'].includes(environment.action)
       ? environment.graviteeioVersion
       : computeApimVersion(environment);
 

--- a/.circleci/ci/src/jobs/frontend/job-portal-webui-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-portal-webui-build.ts
@@ -34,7 +34,7 @@ export class PortalWebuiBuildJob {
     const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig, environment);
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
-    const apimVersion = ['build_rpm', 'build_docker_images', 'release'].includes(environment.action)
+    const apimVersion = ['build_rpm', 'build_docker_images', 'release', 'full_release'].includes(environment.action)
       ? environment.graviteeioVersion
       : computeApimVersion(environment);
 

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -27,7 +27,7 @@ describe('Full release tests', () => {
     'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version $graviteeioVersion',
     ({ baseBranch, branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {
       const result = generateFullReleaseConfig({
-        action: 'release',
+        action: 'full_release',
         sha1: '784ff35ca',
         changedFiles: [],
         buildNum: '1234',


### PR DESCRIPTION
## Description

Using the release version when generating `build.json` file. Otherwise, we use the version in the pom.xml file, which is still "*-SNAPSHOT" at that step of the release.