### PR TITLE
Revert "chore: bump gravitee-gateway-api version to 4.0.0-alpha.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <gravitee-exchange.version>1.8.3</gravitee-exchange.version>
         <gravitee-expression-language.version>4.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>4.0.0-alpha.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.12.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

This reverts commit 5a72e801e4af58219dcb94495834d89f09d6a41d.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mpnjrrljas.chromatic.com)
<!-- Storybook placeholder end -->
