### PR TITLE
fix(deps): bump gravitee-resource-oauth2-provider-generic to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 
         <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>3.0.0</gravitee-resource-oauth2-provider-am.version>
-        <gravitee-resource-oauth2-provider-generic.version>4.0.2</gravitee-resource-oauth2-provider-generic.version>
+        <gravitee-resource-oauth2-provider-generic.version>4.0.3</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9930

## Description

Updated `<gravitee-resource-oauth2-provider-generic.version>4.0.2</gravitee-resource-oauth2-provider-generic.version> ` to `<gravitee-resource-oauth2-provider-generic.version>4.0.3</gravitee-resource-oauth2-provider-generic.version>   ` 

## Additional context

[mvn_clean_api_mgt.txt](https://github.com/user-attachments/files/20955797/mvn_clean_api_mgt.txt)
[mvn_compile_api_mgt.txt](https://github.com/user-attachments/files/20955799/mvn_compile_api_mgt.txt)
[mvn_dependency_analyze_api_mgt.txt](https://github.com/user-attachments/files/20955800/mvn_dependency_analyze_api_mgt.txt)
[mvn_dependency_tree_api_mgt.txt](https://github.com/user-attachments/files/20955801/mvn_dependency_tree_api_mgt.txt)


