### PR TITLE
fix: add validation for cron in page source during import to prevent malformed cron expressions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidFetchCronExpressionException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidFetchCronExpressionException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Collections;
+import java.util.Map;
+
+public class InvalidFetchCronExpressionException extends AbstractManagementException {
+
+    private final String fetchCron;
+
+    public InvalidFetchCronExpressionException(String fetchCron, IllegalArgumentException e) {
+        super(e);
+        this.fetchCron = fetchCron;
+    }
+
+    public InvalidFetchCronExpressionException(String message, Throwable cause) {
+        super(message, cause);
+        this.fetchCron = null;
+    }
+
+    public InvalidFetchCronExpressionException(String message) {
+        super(message);
+        this.fetchCron = null;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The fetch cron expression is invalid: " + fetchCron;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "fetch.cron.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return fetchCron != null ? singletonMap("fetchCron", fetchCron) : Collections.emptyMap();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -58,6 +59,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
+import io.gravitee.rest.api.service.exceptions.ApiImportException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
@@ -531,5 +533,17 @@ public class ApiDuplicatorServiceImplTest {
                 ),
                 eq(API_ID)
             );
+    }
+
+    @Test
+    public void shouldThrowExceptionForInvalidFetchCronExpression() throws IOException {
+        ImportApiJsonNode node = loadTestNode(IMPORT_FILES_FOLDER + "import-api.invalid.cron.json");
+        ApiImportException exception = assertThrows(
+            ApiImportException.class,
+            () -> ReflectionTestUtils.invokeMethod(apiDuplicatorService, "checkPagesConsistency", node)
+        );
+
+        assertTrue(exception.getMessage().startsWith("Invalid fetchCron expression in page"));
+        assertTrue(exception.getMessage().contains("Cron expression must consist of 6 fields"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import freemarker.template.TemplateException;
@@ -586,5 +587,15 @@ public class PageService_CreateTest {
         this.pageService.createPage(GraviteeContext.getExecutionContext(), API_ID, newPage);
 
         verify(pageRepository).create(any());
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldFailToCreatePageWithInvalidFetchCron() {
+        PageSourceEntity source = new PageSourceEntity();
+        source.setType("github-fetcher");
+        source.setConfiguration(JsonNodeFactory.instance.objectNode().put("autoFetch", true).put("fetchCron", "15 8,13 * * MON-FRI")); // Invalid cron
+        when(newPage.getSource()).thenReturn(source);
+        when(newPage.getVisibility()).thenReturn(Visibility.PUBLIC);
+        pageService.createPage(GraviteeContext.getExecutionContext(), API_ID, newPage);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.invalid.cron.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.invalid.cron.json
@@ -1,0 +1,165 @@
+{
+  "name" : "Test",
+  "crossId" : "3bb7f9b3-a75b-47cd-b7f9-b3a75bd7cd66",
+  "version" : "1",
+  "execution_mode" : "v4-emulation-engine",
+  "description" : "Test",
+  "visibility" : "PRIVATE",
+  "flows" : [ ],
+  "gravitee" : "2.0.0",
+  "flow_mode" : "DEFAULT",
+  "resources" : [ ],
+  "properties" : [ ],
+  "members" : [ {
+    "source" : "memory",
+    "sourceId" : "admin",
+    "roles" : [ "0716e6d1-dccb-4c16-96e6-d1dccbac1674" ]
+  } ],
+  "pages" : [ {
+    "id" : "8812c075-92ce-41a6-92c0-7592cea1a684",
+    "crossId" : "21c3673a-e29c-4470-8367-3ae29c147099",
+    "name" : "Aside",
+    "type" : "SYSTEM_FOLDER",
+    "order" : 0,
+    "published" : true,
+    "visibility" : "PUBLIC",
+    "lastModificationDate" : 1745480801827,
+    "contentType" : "application/json",
+    "homepage" : false,
+    "parentPath" : "",
+    "excludedAccessControls" : false,
+    "accessControls" : [ ],
+    "api" : "c57c319b-62b6-427c-bc31-9b62b6527c37",
+    "attached_media" : [ ]
+  }, {
+    "id" : "0efebe71-6cb1-43e5-bebe-716cb163e539",
+    "crossId" : "fc3d8a92-b18c-4ba4-bd8a-92b18cfba4ce",
+    "name" : "Test",
+    "type" : "SWAGGER",
+    "content" : "{}",
+    "order" : 1,
+    "lastContributor" : "4407b94b-a747-41d6-87b9-4ba747f1d67c",
+    "published" : false,
+    "visibility" : "PUBLIC",
+    "lastModificationDate" : 1745480801842,
+    "contentType" : "application/json",
+    "source" : {
+      "type" : "gitlab-fetcher",
+      "configuration" : {"gitlabUrl":"https://gitlab.com/api/v4","useSystemProxy":false,"namespace":"t3551","project":"test","branchOrTag":"main","filepath":"/PetStore.json","privateToken":"********","apiVersion":"V4","editLink":null,"fetchCron":"15 8,13 * * MON-FRI","autoFetch":false}
+    },
+    "configuration" : {
+      "viewer" : "Swagger"
+    },
+    "homepage" : false,
+    "parentPath" : "",
+    "excludedAccessControls" : false,
+    "accessControls" : [ ],
+    "api" : "c57c319b-62b6-427c-bc31-9b62b6527c37",
+    "attached_media" : [ ]
+  } ],
+  "plans" : [ {
+    "id" : "ad8e4d1d-7c2c-4036-8e4d-1d7c2c203637",
+    "definitionVersion" : "2.0.0",
+    "crossId" : "5514b581-1083-4ca4-94b5-8110839ca4b1",
+    "name" : "KeylessPlan",
+    "description" : "KeylessPlan",
+    "validation" : "AUTO",
+    "security" : "KEY_LESS",
+    "type" : "API",
+    "status" : "PUBLISHED",
+    "api" : "c57c319b-62b6-427c-bc31-9b62b6527c37",
+    "order" : 0,
+    "characteristics" : [ ],
+    "tags" : [ ],
+    "created_at" : 1742314598986,
+    "updated_at" : 1745480801740,
+    "published_at" : 1742314598996,
+    "paths" : { },
+    "comment_required" : false,
+    "flows" : [ {
+      "id" : "29fef3df-5a55-4e45-bef3-df5a559e4526",
+      "path-operator" : {
+        "path" : "/",
+        "operator" : "STARTS_WITH"
+      },
+      "condition" : "",
+      "consumers" : [ ],
+      "methods" : [ ],
+      "pre" : [ ],
+      "post" : [ ],
+      "enabled" : true
+    } ]
+  } ],
+  "metadata" : [ {
+    "key" : "email-support",
+    "name" : "email-support",
+    "format" : "MAIL",
+    "value" : "${(api.primaryOwner.email)!''}",
+    "defaultValue" : "support@change.me",
+    "apiId" : "c57c319b-62b6-427c-bc31-9b62b6527c37"
+  } ],
+  "id" : "c57c319b-62b6-427c-bc31-9b62b6527c37",
+  "path_mappings" : [ ],
+  "proxy" : {
+    "virtual_hosts" : [ {
+      "path" : "/test/"
+    } ],
+    "strip_context_path" : false,
+    "preserve_host" : false,
+    "logging" : {
+      "mode" : "CLIENT_PROXY",
+      "content" : "HEADERS_PAYLOADS",
+      "scope" : "REQUEST_RESPONSE",
+      "condition" : "{#request.timestamp <= 1688987810835l}"
+    },
+    "groups" : [ {
+      "name" : "default-group",
+      "endpoints" : [ {
+        "name" : "default",
+        "target" : "https://webhook.site/356688cd-27d5-4365-ab40-963a7e945e35",
+        "weight" : 1,
+        "backup" : false,
+        "status" : "UP",
+        "type" : "http",
+        "inherit" : true,
+        "proxy" : null,
+        "http" : null,
+        "ssl" : null,
+        "healthcheck" : {
+          "enabled" : true,
+          "inherit" : true
+        }
+      } ],
+      "load_balancing" : {
+        "type" : "ROUND_ROBIN"
+      },
+      "services" : {
+        "discovery" : {
+          "enabled" : false
+        }
+      },
+      "http" : {
+        "connectTimeout" : 5000,
+        "idleTimeout" : 60000,
+        "keepAliveTimeout" : 300000,
+        "keepAlive" : false,
+        "readTimeout" : 300000,
+        "pipelining" : false,
+        "maxConcurrentConnections" : 100,
+        "useCompression" : true,
+        "followRedirects" : false
+      },
+      "ssl" : {
+        "trustAll" : false,
+        "hostnameVerifier" : false
+      }
+    } ]
+  },
+  "response_templates" : { },
+  "primaryOwner" : {
+    "id" : "4407b94b-a747-41d6-87b9-4ba747f1d67c",
+    "displayName" : "admin",
+    "type" : "USER"
+  },
+  "disable_membership_notifications" : false
+}


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-9446

## Description

This commit adds validation logic for the cron expression field in page sources (e.g., GitHub fetcher). Previously, malformed cron expressions (e.g., with only 5 fields) were silently accepted during import or upgrade, leading to inconsistencies in behavior.

Issue:


https://github.com/user-attachments/assets/9f345419-b752-4d60-9fd9-71b1fd2edf35

Fix:


https://github.com/user-attachments/assets/ec79f6d6-68a7-448a-9830-5e56135d779d


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gbqsjnpgyl.chromatic.com)
<!-- Storybook placeholder end -->
