### PR TITLE
fix(console): use picture_url to display category picture in list

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
@@ -44,7 +44,7 @@
         <ng-container matColumnDef="picture">
           <th mat-header-cell *matHeaderCellDef id="picture"></th>
           <td mat-cell *matCellDef="let element">
-            <gio-avatar [src]="element.picture" [name]="element.name" [size]="32" [roundedBorder]="true"></gio-avatar>
+            <gio-avatar [src]="element.picture_url" [name]="element.name" [size]="32" [roundedBorder]="true"></gio-avatar>
           </td>
         </ng-container>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9464

## Description

Display custom category image in category list

https://github.com/user-attachments/assets/d847bc7a-b402-4592-9c39-e5d5388b0483


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

