### PR TITLE
fix: set proper form validation when creating new A2A integration and improve error message

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.html
@@ -171,9 +171,12 @@
                           matInput
                           [formControl]="url.controls.url"
                           required="true"
-                          data-testid="create-integration-name-input"
+                          data-testid="create-integration-well-known-url"
                         />
                         <mat-label>Well-known URL</mat-label>
+                        <mat-error *ngIf="url.controls.url.hasError('pattern')"
+                          >Well-known URL should respect URLs pattern (starts with http:// or https://")
+                        </mat-error>
                       </mat-form-field>
                       @if (addInformationForm.controls.wellKnownUrls.length > 1) {
                         <button mat-button type="button" (click)="removeWellKnownUrl(idx)">

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.spec.ts
@@ -209,6 +209,23 @@ describe('CreateIntegrationComponent', () => {
 
       expect(fakeSnackBarService.error).toHaveBeenCalledWith('An error occurred. Integration not created');
     });
+
+    it('should not validate Well Known URl if Url pattern is incorrect', async () => {
+      fakeIntegrationProviderService.getActiveProviders.mockReturnValue([{ icon: 'a2a', value: 'A2A' }]);
+      const radioButtonsGroup: GioFormSelectionInlineHarness = await componentHarness.getRadioButtonsGroup();
+      await radioButtonsGroup.select('A2A');
+      await componentHarness.clickOnAddNewUrl();
+      fixture.detectChanges();
+
+      await componentHarness.setWellKnownUrl('localhost:8082/well-known-url');
+
+      expect(await radioButtonsGroup.getSelectedValue()).toStrictEqual('A2A');
+      const error: MatErrorHarness = await componentHarness.matErrorMessage();
+      expect(await error.getText()).toEqual('Well-known URL should respect URLs pattern (starts with http:// or https://")');
+
+      await componentHarness.clickOnSubmit();
+      httpTestingController.expectNone(`${CONSTANTS_TESTING.env.v2BaseURL}/integrations`);
+    });
   });
 
   function expectIntegrationPostRequest(payload: CreateIntegrationPayload): void {

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.component.ts
@@ -99,7 +99,7 @@ export class CreateIntegrationComponent implements OnInit {
     if (wellKnownUrls.enabled) {
       wellKnownUrls.push(
         this.formBuilder.group({
-          url: ['', [Validators.required, Validators.minLength(1)]],
+          url: ['', [Validators.required, Validators.pattern(/(http|https)?:\/\/(\S+)/)]],
         }),
       );
     }

--- a/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.harness.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/create-integration/create-integration.harness.ts
@@ -40,6 +40,12 @@ export class CreateIntegrationHarness extends ComponentHarness {
   private submitButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorFor(
     MatButtonHarness.with({ selector: '[data-testid=create-integration-submit-button]' }),
   );
+  private addWellKnownUrl: AsyncFactoryFn<MatButtonHarness> = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid=create-integration-add-url]' }),
+  );
+  private wellKnownUrlInputLocator: AsyncFactoryFn<MatInputHarness> = this.locatorFor(
+    MatInputHarness.with({ selector: '[data-testid=create-integration-well-known-url]' }),
+  );
 
   public getSubmitStepFirstButton = async (): Promise<MatButtonHarness> => {
     return await this.submitStepFirstButtonLocator();
@@ -60,8 +66,16 @@ export class CreateIntegrationHarness extends ComponentHarness {
     return this.descriptionTextAreaLocator().then((input: MatInputHarness) => input.setValue(description));
   }
 
+  public async setWellKnownUrl(wellKnownUrl: string): Promise<void> {
+    return this.wellKnownUrlInputLocator().then((input: MatInputHarness) => input.setValue(wellKnownUrl));
+  }
+
   public async clickOnSubmit() {
     return this.submitButtonLocator().then(async (button: MatButtonHarness) => button.click());
+  }
+
+  public async clickOnAddNewUrl() {
+    return this.addWellKnownUrl().then(async (button: MatButtonHarness) => button.click());
   }
 
   public async matErrorMessage(): Promise<MatErrorHarness> {

--- a/gravitee-apim-console-webui/src/management/integrations/integration-configuration/general/integration-general-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-configuration/general/integration-general-configuration.component.html
@@ -77,7 +77,7 @@
                   />
                   <mat-label>Add new well-known URL</mat-label>
                   <mat-error *ngIf="wellKnownUrlsArrayControl()?.controls[i].hasError('pattern')"
-                    >Callback URL should respect URLs patter (starts with http|https://*")
+                    >Well-known URL should respect URLs pattern (starts with http:// or https://")
                   </mat-error>
                 </mat-form-field>
               } @else if (wellKnownUrlsArrayControl().controls.length === 2) {
@@ -105,7 +105,7 @@
                       (keydown)="enterKeyDown($event, i)"
                     ></mat-icon>
                     <mat-error *ngIf="wellKnownUrlsArrayControl()?.controls[i].hasError('pattern')"
-                      >Callback URL should respect URLs patter (starts with http|https://*")
+                      >Well-known URL should respect URLs pattern (starts with http:// or https://")
                     </mat-error>
                   </mat-form-field>
                 </div>

--- a/gravitee-apim-console-webui/src/management/integrations/integration-configuration/general/integration-general-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-configuration/general/integration-general-configuration.component.spec.ts
@@ -122,7 +122,7 @@ describe('IntegrationGeneralConfigurationComponent', (): void => {
       await componentHarness.fillWellKnownUrlInput('wrongURLpattern.com');
 
       const errorToLongName: MatErrorHarness = await componentHarness.matErrorMessage();
-      expect(await errorToLongName.getText()).toEqual('Callback URL should respect URLs patter (starts with http|https://*")');
+      expect(await errorToLongName.getText()).toEqual('Well-known URL should respect URLs pattern (starts with http:// or https://")');
 
       await componentHarness.fillWellKnownUrlInput('http://addValidURL.com');
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10163

## Description

Add well-known URL validation to the integration creation wizard and improve the error message

## Additional context

![image](https://github.com/user-attachments/assets/0578390a-2fec-49c1-85da-1a965d064b22)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ztkhwipcgx.chromatic.com)
<!-- Storybook placeholder end -->
