### PR TITLE
fix: show all accessible applications when subscribing, including group-inherited ones

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -325,8 +325,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         RolePermission rolePermission,
         RolePermissionAction... acl
     ) {
-        LOGGER.debug("Find applications for user and permission {}, {}, {}", username, rolePermission, acl);
-        ApplicationQuery applicationQuery = buildApplicationQueryForUserAndPermission(executionContext, rolePermission, acl, username);
+        LOGGER.debug("Find applications for user {}, {}, {}", username, rolePermission, acl);
+        ApplicationQuery applicationQuery = ApplicationQuery.builder().user(username).status(ApplicationStatus.ACTIVE.name()).build();
         return search(executionContext, applicationQuery, sortable, null).getContent();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationServiceImplTest.java
@@ -19,31 +19,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApplicationServiceImplTest {
 
     @InjectMocks
+    @Spy
     private final ApplicationServiceImpl applicationService = new ApplicationServiceImpl();
 
     @Mock
     private MembershipService membershipService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
 
     @Test
     public void buildSearchCriteria() {
@@ -101,5 +117,25 @@ public class ApplicationServiceImplTest {
             .thenReturn(Set.of());
         ApplicationCriteria criteria = applicationService.buildSearchCriteria(executionContext, query);
         assertNull(criteria);
+    }
+
+    @Test
+    public void buildSearchCriteria_userAndStatus() throws TechnicalException {
+        ExecutionContext executionContext = new ExecutionContext("org1", "env1");
+        ApplicationQuery query = ApplicationQuery.builder().user("user1").status(ApplicationStatus.ACTIVE.name()).build();
+        when(membershipService.getReferenceIdsByMemberAndReference(MembershipMemberType.USER, "user1", MembershipReferenceType.APPLICATION))
+            .thenReturn(new HashSet<>(Set.of("app1", "app2")));
+        MembershipEntity groupMembership = MembershipEntity.builder().referenceId("group1").roleId("role-app").build();
+        when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, "user1", MembershipReferenceType.GROUP))
+            .thenReturn(Set.of(groupMembership));
+        RoleEntity mockedRole = new RoleEntity();
+        mockedRole.setScope(RoleScope.APPLICATION);
+        when(roleService.findById("role-app")).thenReturn(mockedRole);
+        when(applicationRepository.searchIds(any(), any())).thenReturn(Set.of("app-group-1"));
+        ApplicationCriteria criteria = applicationService.buildSearchCriteria(executionContext, query);
+        assertThat(criteria).isNotNull();
+        assertThat(criteria.getEnvironmentIds()).containsExactly("env1");
+        assertThat(criteria.getStatus()).isEqualTo(ApplicationStatus.ACTIVE);
+        assertThat(criteria.getRestrictedToIds()).containsExactlyInAnyOrder("app1", "app2", "app-group-1");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9811

## Description

Users who are both individually assigned and group-inherited members of applications
were previously (post-9334) only seeing individually assigned applications when subscribing to an API.

This fix ensures that applications inherited via groups are also included in the
subscription dropdown, allowing full access based on effective membership.

Fix:

https://github.com/user-attachments/assets/f6730337-0c8e-42d2-bc7a-2f4c421db126




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

