### PR TITLE
fix(console): import `tinycolor` directly from package

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/app.module.ajs.ts
@@ -25,7 +25,7 @@ import * as hljs from 'highlight.js';
 // Codemirror
 import * as CodeMirror from 'codemirror';
 import moment from 'moment';
-import * as tinycolor from 'tinycolor2';
+import tinycolor from 'tinycolor2';
 import AutofocusDirective from './components/autofocus/autofocus.directive';
 import GvModelDirective from './libraries/gv-model.directive';
 import { ApiService } from './services/api.service';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9593

## Description

The color picker was blank and errors logged in console as "o is undefined". 
After the `tinycolor2` upgrade to 1.6.0, the module needed to be imported differently.

Fixed:

https://github.com/user-attachments/assets/5dc196c1-7d68-4237-8c9b-9863bfc97320



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-egehmqjgdi.chromatic.com)
<!-- Storybook placeholder end -->
