### PR TITLE
fix: show all accessible applications when subscribing, including group-inherited ones

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -157,7 +157,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
         @QueryParam("order") @DefaultValue("name") final ApplicationsOrderParam applicationsOrderParam
     ) {
         if (!paginationParam.hasPagination()) {
-            return getAllApplications(forSubscription, applicationsOrderParam);
+            return getAllApplications(applicationsOrderParam);
         }
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         Collection<String> applicationIds;
@@ -186,21 +186,13 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
         return createListResponse(executionContext, applicationIds, paginationParam);
     }
 
-    private Response getAllApplications(boolean forSubscription, ApplicationsOrderParam applicationsOrderParam) {
+    private Response getAllApplications(ApplicationsOrderParam applicationsOrderParam) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        Collection<ApplicationListItem> applications;
-        if (forSubscription) {
-            applications =
-                applicationService.findByUserAndPermission(
-                    executionContext,
-                    getAuthenticatedUser(),
-                    applicationsOrderParam.toSortable(),
-                    RolePermission.APPLICATION_SUBSCRIPTION,
-                    RolePermissionAction.CREATE
-                );
-        } else {
-            applications = applicationService.findByUser(executionContext, getAuthenticatedUser(), applicationsOrderParam.toSortable());
-        }
+        Collection<ApplicationListItem> applications = applicationService.findByUser(
+            executionContext,
+            getAuthenticatedUser(),
+            applicationsOrderParam.toSortable()
+        );
         List<Application> applicationList = applications
             .stream()
             .map(applicationListItem -> applicationMapper.convert(executionContext, applicationListItem, uriInfo, false))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
@@ -326,10 +326,8 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
         ApplicationListItem appA = mock(ApplicationListItem.class);
         ApplicationListItem appB = mock(ApplicationListItem.class);
-        Collection<ApplicationListItem> applications = Arrays.asList(appA, appB);
-        doReturn(applications)
-            .when(applicationService)
-            .findByUserAndPermission(any(), any(), any(), eq(RolePermission.APPLICATION_SUBSCRIPTION), eq(RolePermissionAction.CREATE));
+        Collection<ApplicationListItem> applications = Set.of(appA, appB);
+        doReturn(applications).when(applicationService).findByUser(any(), any(), any());
 
         final Response response = target().queryParam("size", -1).queryParam("forSubscription", true).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -55,9 +55,7 @@ public interface ApplicationService {
         return findByUser(executionContext, username, null);
     }
 
-    default Set<ApplicationListItem> findByUser(final ExecutionContext executionContext, String username, Sortable sortable) {
-        return findByUser(executionContext, username, sortable, null);
-    }
+    Set<ApplicationListItem> findByUser(final ExecutionContext executionContext, String username, Sortable sortable);
 
     default Set<String> findIdsByUser(final ExecutionContext executionContext, String username) {
         return findIdsByUser(executionContext, username, null);
@@ -72,16 +70,6 @@ public interface ApplicationService {
         RolePermission rolePermission,
         RolePermissionAction... acl
     );
-
-    List<ApplicationListItem> findByUserAndPermission(
-        ExecutionContext executionContext,
-        String username,
-        Sortable sortable,
-        RolePermission rolePermission,
-        RolePermissionAction... acl
-    );
-
-    Set<ApplicationListItem> findByUser(final ExecutionContext executionContext, String username, Sortable sortable, Pageable pageable);
 
     Set<String> findIdsByOrganization(String organizationId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -317,19 +317,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         return searchIds(executionContext, applicationQuery, sortable);
     }
 
-    @Override
-    public List<ApplicationListItem> findByUserAndPermission(
-        ExecutionContext executionContext,
-        String username,
-        Sortable sortable,
-        RolePermission rolePermission,
-        RolePermissionAction... acl
-    ) {
-        LOGGER.debug("Find applications for user {}, {}, {}", username, rolePermission, acl);
-        ApplicationQuery applicationQuery = ApplicationQuery.builder().user(username).status(ApplicationStatus.ACTIVE.name()).build();
-        return search(executionContext, applicationQuery, sortable, null).getContent();
-    }
-
     @NotNull
     private ApplicationQuery buildApplicationQueryForUserAndPermission(
         ExecutionContext executionContext,
@@ -359,20 +346,10 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByUser(
-        final ExecutionContext executionContext,
-        String username,
-        Sortable sortable,
-        Pageable pageable
-    ) {
+    public Set<ApplicationListItem> findByUser(final ExecutionContext executionContext, String username, Sortable sortable) {
         LOGGER.debug("Find applications for user {}", username);
-
-        ApplicationQuery applicationQuery = new ApplicationQuery();
-        applicationQuery.setUser(username);
-        applicationQuery.setStatus(ApplicationStatus.ACTIVE.name());
-
-        Page<ApplicationListItem> applications = search(executionContext, applicationQuery, sortable, pageable);
-
+        ApplicationQuery applicationQuery = ApplicationQuery.builder().user(username).status(ApplicationStatus.ACTIVE.name()).build();
+        Page<ApplicationListItem> applications = search(executionContext, applicationQuery, sortable, null);
         return new LinkedHashSet<>(applications.getContent());
     }
 


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-9811

## Description
Users who are both individually assigned and group-inherited members of applications
were previously (post-9334) only seeing individually assigned applications when subscribing to an API.

This fix ensures that applications inherited via groups are also included in the
subscription dropdown, allowing full access based on effective membership.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lxorzjmbul.chromatic.com)
<!-- Storybook placeholder end -->
