### PR TITLE
fix: fix federation ingest with multiple pages by API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/documentation/PageCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/documentation/PageCrudServiceImpl.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.apim.infra.crud_service.documentation;
 
-import static io.gravitee.apim.core.utils.CollectionUtils.stream;
-
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.exception.ApiPageInvalidReferenceTypeException;
 import io.gravitee.apim.core.documentation.exception.ApiPageNotDeletedException;
@@ -25,11 +23,8 @@ import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.infra.adapter.PageAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
-import io.gravitee.repository.management.api.search.PageCriteria;
-import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9711

## Description

When we ingest an API with multiple pages, keep all of them.
