### PR TITLE
fix(console): invalidate role caches when updating group default roles

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -401,7 +401,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         Command command = Command
             .builder()
             .id(UUID.random().toString())
-            .environmentId(context.getEnvironmentId())
             .organizationId(context.getOrganizationId())
             .from(this.node.id())
             .to(MessageRecipient.MANAGEMENT_APIS.name())
@@ -409,6 +408,10 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             .createdAt(Date.from(timestamp))
             .updatedAt(Date.from(timestamp))
             .build();
+
+        if (context.hasEnvironmentId()) {
+            command.setEnvironmentId(context.getEnvironmentId());
+        }
         InvalidateRoleCacheCommandEntity eventData = getEventData(reference, member);
 
         try {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9938

## Description

Fixed the problem with creating command event when environment is null.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-egztbyvpsu.chromatic.com)
<!-- Storybook placeholder end -->
