### PR TITLE
fix(standalone): removed Slf4j usages

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
@@ -21,13 +21,11 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Slf4j
 @SuppressWarnings("java:S4507") // disable printStackTrace warning as we are starting the application
 public class Bootstrap {
 
@@ -73,7 +71,7 @@ public class Bootstrap {
             try {
                 cpList.add(lib.toURI().toURL());
             } catch (java.net.MalformedURLException urlEx) {
-                log.warn("Malformed URL for library file in lib directory: {}", lib, urlEx);
+                urlEx.printStackTrace();
             }
         }
 
@@ -96,7 +94,7 @@ public class Bootstrap {
                     cpList.add(lib.toURI().toURL());
                 }
             } catch (java.net.MalformedURLException urlEx) {
-                log.warn("Malformed URL for library file in ext directory: {}", libDir, urlEx);
+                urlEx.printStackTrace();
             }
         }
 
@@ -179,7 +177,7 @@ public class Bootstrap {
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.start();
         } catch (Exception t) {
-            log.error("Fatal error during Gravitee Standalone bootstrap", t);
+            t.printStackTrace();
             System.exit(1);
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10117

## Description

Removed Slf4j usages in bootstrap standalone

## Additional context

After tests by archi/lead team, this PR could be merged on master.
https://github.com/gravitee-io/gravitee-api-management/pull/12394
