### PR TITLE
ci: generate pr images and publish message on GH PR

### DIFF
--- a/.circleci/ci/src/jobs/index.ts
+++ b/.circleci/ci/src/jobs/index.ts
@@ -22,7 +22,7 @@ export * from './job-danger-js';
 export * from './job-deploy-on-azure';
 export * from './job-package-bundle';
 export * from './job-perf-lint-build';
-export * from './job-publish-pr-env-urls';
+export * from './job-publish-pr-docker-images';
 export * from './job-publish-prod-docker-images';
 export * from './job-publish-rpm-packages';
 export * from './job-release-commit-and-prepare-next-version';

--- a/.circleci/ci/src/jobs/job-publish-pr-docker-images.ts
+++ b/.circleci/ci/src/jobs/job-publish-pr-docker-images.ts
@@ -19,9 +19,10 @@ import { orbs } from '../orbs';
 import { config } from '../config';
 import { NotifyOnFailureCommand } from '../commands';
 import { CircleCIEnvironment } from '../pipelines';
+import { computeImagesTag } from '../utils';
 
-export class PublishPrEnvUrlsJob {
-  private static jobName = 'job-publish-pr-env-urls';
+export class PublishPrDockerImagesJob {
+  private static jobName = 'job-publish-pr-docker-images';
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     dynamicConfig.importOrb(orbs.keeper);
@@ -30,7 +31,7 @@ export class PublishPrEnvUrlsJob {
     const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig, environment);
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
-    return new Job(PublishPrEnvUrlsJob.jobName, NodeLtsExecutor.create('small'), [
+    return new Job(PublishPrDockerImagesJob.jobName, NodeLtsExecutor.create('small'), [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
@@ -40,6 +41,9 @@ export class PublishPrEnvUrlsJob {
       new reusable.ReusedCommand(orbs.github.commands['setup']),
       new commands.Run({
         name: 'Edit Pull Request Description',
+        environment: {
+          BRANCH_TAG: computeImagesTag(environment.branch),
+        },
         command: `# First check there is an associated pull request, otherwise just stop the job here
 if ! gh pr view --json title;
 then
@@ -54,22 +58,26 @@ then
   exit 0
 fi
 export PR_NUMBER=$(gh pr view --json number --jq .number)
-export PR_BODY_ENV_SECTION="
-<!-- Environment placeholder -->
+export PR_BODY_DOCKER_IMAGES_SECTION="
+<!-- Docker Images placeholder -->
 
-🏗️ Your changes can be tested here and will be available soon:
-      Console: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/console](https://pr.team-apim.gravitee.dev/$PR_NUMBER/console)
-      Portal: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal](https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal)
-      Management-api: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management](https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management)
-      Gateway v4: [https://pr.team-apim.gravitee.dev/$PR_NUMBER](https://pr.team-apim.gravitee.dev/$PR_NUMBER)
-      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER](https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER)
+🏗️ Your changes can be tested using the Docker images listed below, which will be available shortly:
 
-<!-- Environment placeholder end -->
+      Console: graviteeio.azurecr.io/apim-management-ui:$BRANCH_TAG
+      Portal: graviteeio.azurecr.io/apim-portal-ui:$BRANCH_TAG
+      Management-api: graviteeio.azurecr.io/apim-management-api:$BRANCH_TAG
+      Gateway: graviteeio.azurecr.io/apim-gateway:$BRANCH_TAG
+      
+      You can also run any quick-setup docker compose via:
+      1. az acr login -n graviteeio
+      2. APIM_REGISTRY=graviteeio.azurecr.io APIM_VERSION=$BRANCH_TAG docker-compose -f ./docker/quick-setup/mongodb/docker-compose.yml up -d
+
+<!-- Docker Images placeholder end -->
 "
 
-export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Environment placeholder -->/,/Environment placeholder end -->/d')
+export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Docker Images placeholder -->/,/Docker Images placeholder end -->/d')
 
-gh pr edit --body "$CLEAN_BODY$PR_BODY_ENV_SECTION"`,
+gh pr edit --body "$CLEAN_BODY$PR_BODY_DOCKER_IMAGES_SECTION"`,
       }),
       new reusable.ReusedCommand(notifyOnFailureCommand),
     ]);

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -335,7 +335,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-publish-pr-env-urls:
+  job-publish-pr-docker-images:
     docker:
       - image: cimg/node:20.11.1
     resource_class: small
@@ -349,6 +349,8 @@ jobs:
       - gh/setup
       - run:
           name: Edit Pull Request Description
+          environment:
+            BRANCH_TAG: 4.1.x-latest
           command: |-
             # First check there is an associated pull request, otherwise just stop the job here
             if ! gh pr view --json title;
@@ -364,22 +366,26 @@ jobs:
               exit 0
             fi
             export PR_NUMBER=$(gh pr view --json number --jq .number)
-            export PR_BODY_ENV_SECTION="
-            <!-- Environment placeholder -->
+            export PR_BODY_DOCKER_IMAGES_SECTION="
+            <!-- Docker Images placeholder -->
 
-            🏗️ Your changes can be tested here and will be available soon:
-                  Console: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/console](https://pr.team-apim.gravitee.dev/$PR_NUMBER/console)
-                  Portal: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal](https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal)
-                  Management-api: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management](https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management)
-                  Gateway v4: [https://pr.team-apim.gravitee.dev/$PR_NUMBER](https://pr.team-apim.gravitee.dev/$PR_NUMBER)
-                  Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER](https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER)
+            🏗️ Your changes can be tested using the Docker images listed below, which will be available shortly:
 
-            <!-- Environment placeholder end -->
+                  Console: graviteeio.azurecr.io/apim-management-ui:$BRANCH_TAG
+                  Portal: graviteeio.azurecr.io/apim-portal-ui:$BRANCH_TAG
+                  Management-api: graviteeio.azurecr.io/apim-management-api:$BRANCH_TAG
+                  Gateway: graviteeio.azurecr.io/apim-gateway:$BRANCH_TAG
+                  
+                  You can also run any quick-setup docker compose via:
+                  1. az acr login -n graviteeio
+                  2. APIM_REGISTRY=graviteeio.azurecr.io APIM_VERSION=$BRANCH_TAG docker-compose -f ./docker/quick-setup/mongodb/docker-compose.yml up -d
+
+            <!-- Docker Images placeholder end -->
             "
 
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Environment placeholder -->/,/Environment placeholder end -->/d')
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Docker Images placeholder -->/,/Docker Images placeholder end -->/d')
 
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_ENV_SECTION"
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_DOCKER_IMAGES_SECTION"
       - cmd-notify-on-failure
 workflows:
   publish_docker_images:
@@ -412,7 +418,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal and publish image
-      - job-publish-pr-env-urls:
+      - job-publish-pr-docker-images:
           name: Publish environment URLs in Github PR
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -281,7 +281,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-publish-pr-env-urls:
+  job-publish-pr-docker-images:
     docker:
       - image: cimg/node:20.11.1
     resource_class: small
@@ -295,6 +295,8 @@ jobs:
       - gh/setup
       - run:
           name: Edit Pull Request Description
+          environment:
+            BRANCH_TAG: apim-1234-branch-name-latest
           command: |-
             # First check there is an associated pull request, otherwise just stop the job here
             if ! gh pr view --json title;
@@ -310,22 +312,26 @@ jobs:
               exit 0
             fi
             export PR_NUMBER=$(gh pr view --json number --jq .number)
-            export PR_BODY_ENV_SECTION="
-            <!-- Environment placeholder -->
+            export PR_BODY_DOCKER_IMAGES_SECTION="
+            <!-- Docker Images placeholder -->
 
-            🏗️ Your changes can be tested here and will be available soon:
-                  Console: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/console](https://pr.team-apim.gravitee.dev/$PR_NUMBER/console)
-                  Portal: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal](https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal)
-                  Management-api: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management](https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management)
-                  Gateway v4: [https://pr.team-apim.gravitee.dev/$PR_NUMBER](https://pr.team-apim.gravitee.dev/$PR_NUMBER)
-                  Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER](https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER)
+            🏗️ Your changes can be tested using the Docker images listed below, which will be available shortly:
 
-            <!-- Environment placeholder end -->
+                  Console: graviteeio.azurecr.io/apim-management-ui:$BRANCH_TAG
+                  Portal: graviteeio.azurecr.io/apim-portal-ui:$BRANCH_TAG
+                  Management-api: graviteeio.azurecr.io/apim-management-api:$BRANCH_TAG
+                  Gateway: graviteeio.azurecr.io/apim-gateway:$BRANCH_TAG
+                  
+                  You can also run any quick-setup docker compose via:
+                  1. az acr login -n graviteeio
+                  2. APIM_REGISTRY=graviteeio.azurecr.io APIM_VERSION=$BRANCH_TAG docker-compose -f ./docker/quick-setup/mongodb/docker-compose.yml up -d
+
+            <!-- Docker Images placeholder end -->
             "
 
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Environment placeholder -->/,/Environment placeholder end -->/d')
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Docker Images placeholder -->/,/Docker Images placeholder end -->/d')
 
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_ENV_SECTION"
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_DOCKER_IMAGES_SECTION"
       - cmd-notify-on-failure
 workflows:
   publish_docker_images:
@@ -358,7 +364,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal and publish image
-      - job-publish-pr-env-urls:
+      - job-publish-pr-docker-images:
           name: Publish environment URLs in Github PR
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -335,7 +335,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-portal-webui/dist
-  job-publish-pr-env-urls:
+  job-publish-pr-docker-images:
     docker:
       - image: cimg/node:20.11.1
     resource_class: small
@@ -349,6 +349,8 @@ jobs:
       - gh/setup
       - run:
           name: Edit Pull Request Description
+          environment:
+            BRANCH_TAG: master-latest
           command: |-
             # First check there is an associated pull request, otherwise just stop the job here
             if ! gh pr view --json title;
@@ -364,22 +366,26 @@ jobs:
               exit 0
             fi
             export PR_NUMBER=$(gh pr view --json number --jq .number)
-            export PR_BODY_ENV_SECTION="
-            <!-- Environment placeholder -->
+            export PR_BODY_DOCKER_IMAGES_SECTION="
+            <!-- Docker Images placeholder -->
 
-            🏗️ Your changes can be tested here and will be available soon:
-                  Console: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/console](https://pr.team-apim.gravitee.dev/$PR_NUMBER/console)
-                  Portal: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal](https://pr.team-apim.gravitee.dev/$PR_NUMBER/portal)
-                  Management-api: [https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management](https://pr.team-apim.gravitee.dev/$PR_NUMBER/api/management)
-                  Gateway v4: [https://pr.team-apim.gravitee.dev/$PR_NUMBER](https://pr.team-apim.gravitee.dev/$PR_NUMBER)
-                  Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER](https://pr.gateway-v3.team-apim.gravitee.dev/$PR_NUMBER)
+            🏗️ Your changes can be tested using the Docker images listed below, which will be available shortly:
 
-            <!-- Environment placeholder end -->
+                  Console: graviteeio.azurecr.io/apim-management-ui:$BRANCH_TAG
+                  Portal: graviteeio.azurecr.io/apim-portal-ui:$BRANCH_TAG
+                  Management-api: graviteeio.azurecr.io/apim-management-api:$BRANCH_TAG
+                  Gateway: graviteeio.azurecr.io/apim-gateway:$BRANCH_TAG
+                  
+                  You can also run any quick-setup docker compose via:
+                  1. az acr login -n graviteeio
+                  2. APIM_REGISTRY=graviteeio.azurecr.io APIM_VERSION=$BRANCH_TAG docker-compose -f ./docker/quick-setup/mongodb/docker-compose.yml up -d
+
+            <!-- Docker Images placeholder end -->
             "
 
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Environment placeholder -->/,/Environment placeholder end -->/d')
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Docker Images placeholder -->/,/Docker Images placeholder end -->/d')
 
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_ENV_SECTION"
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_DOCKER_IMAGES_SECTION"
       - cmd-notify-on-failure
 workflows:
   publish_docker_images:
@@ -412,7 +418,7 @@ workflows:
           requires:
             - Setup
           name: Build APIM Portal and publish image
-      - job-publish-pr-env-urls:
+      - job-publish-pr-docker-images:
           name: Publish environment URLs in Github PR
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 import { Config, workflow, Workflow } from '@circleci/circleci-config-sdk';
-import { BuildBackendImagesJob, BuildBackendJob, ConsoleWebuiBuildJob, PortalWebuiBuildJob, PublishPrEnvUrlsJob, SetupJob } from '../jobs';
+import {
+  BuildBackendImagesJob,
+  BuildBackendJob,
+  ConsoleWebuiBuildJob,
+  PortalWebuiBuildJob,
+  PublishPrDockerImagesJob,
+  SetupJob,
+} from '../jobs';
 import { config } from '../config';
 import { CircleCIEnvironment } from '../pipelines';
 
@@ -35,7 +42,7 @@ export class PublishDockerImagesWorkflow {
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(portalWebuiBuildJob);
 
-    const publishPrEnvUrlsJob = PublishPrEnvUrlsJob.create(dynamicConfig, environment);
+    const publishPrEnvUrlsJob = PublishPrDockerImagesJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(publishPrEnvUrlsJob);
 
     const jobs = [

--- a/.github/workflows/remove-ready-to-test-labels.yml
+++ b/.github/workflows/remove-ready-to-test-labels.yml
@@ -27,7 +27,7 @@ jobs:
           ORG_NAME: gravitee-io
           REPO_NAME: gravitee-api-management
         run: |
-          PR_NUMBERS=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/gravitee-io/gravitee-api-management/issues?state=open&labels=ready_to_test&type=pr" | jq -r '.[].number')
+          PR_NUMBERS=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/gravitee-io/gravitee-api-management/issues?state=open&labels=ready_to_test&per_page=100" | jq -r '.[] | select(.pull_request) | .number')
           
           for PR_NUMBER in $PR_NUMBERS; do
             # Get all events for the PR


### PR DESCRIPTION
## Description

In this PR we do a quick update on the CI to allow the developers to add the ready_to_test label and have access to the docker image using a docker compose locally

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rcdmmxyidg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Docker Images placeholder -->

🏗️ Your changes can be tested using the Docker images listed below, which will be available shortly:

      Console: graviteeio.azurecr.io/apim-management-ui:ci-generate-pr-images-latest
      Portal: graviteeio.azurecr.io/apim-portal-ui:ci-generate-pr-images-latest
      Management-api: graviteeio.azurecr.io/apim-management-api:ci-generate-pr-images-latest
      Gateway: graviteeio.azurecr.io/apim-gateway:ci-generate-pr-images-latest
      
      You can also run any quick-setup docker compose via:
      1. az acr login -n graviteeio
      2. APIM_REGISTRY=graviteeio.azurecr.io APIM_VERSION=ci-generate-pr-images-latest docker-compose -f ./docker/quick-setup/mongodb/docker-compose.yml up -d

<!-- Docker Images placeholder end -->
