### PR TITLE
chore: bump kafka to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <json-smart.version>2.5.2</json-smart.version>
         <json-unit.version>4.1.1</json-unit.version>
         <jsoup.version>1.19.1</jsoup.version>
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
         <lucene.version>10.1.0</lucene.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.3</mapstruct.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9963


## Description

Just bump kafka client

📝 After merging this PR, kafka is broken. We therefore need a SNAPSHOT version to be able to merge these next PRs : 


Reactor : https://github.com/gravitee-io/gravitee-reactor-native-kafka/pull/194
ACL : https://github.com/gravitee-io/gravitee-policy-kafka-acl/pull/28
TopicMapping : https://github.com/gravitee-io/gravitee-policy-kafka-topic-mapping/pull/18

And Bump agin APIM to make everything rework.



## Additional context
Link to https://github.com/gravitee-io/gravitee-reactor-native-kafka/pull/194

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bhhevdfpnr.chromatic.com)
<!-- Storybook placeholder end -->
