### PR TITLE
fix: align verticle instances with event loops

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxEmbeddedContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxEmbeddedContainer.java
@@ -64,13 +64,8 @@ public class VertxEmbeddedContainer extends AbstractLifecycleComponent<VertxEmbe
 
     @Override
     protected void doStart() {
-        if (httpInstances < 1 && tcpInstances < 1) {
-            httpInstances = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE / 2;
-            tcpInstances = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE / 2;
-        } else {
-            httpInstances = (httpInstances < 1) ? VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE : httpInstances;
-            tcpInstances = (tcpInstances < 1) ? VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE : tcpInstances;
-        }
+        httpInstances = (httpInstances < 1) ? VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE : httpInstances;
+        tcpInstances = (tcpInstances < 1) ? VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE : tcpInstances;
         startHttpInstances();
         startTcpInstances();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10175

## Description

This PR ensures that TCP and HTTP Verticles are aligned with Vertx event loops.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zmivkwthut.chromatic.com)
<!-- Storybook placeholder end -->
