### PR TITLE
ci: updating changelog path

### DIFF
--- a/release/ci-steps/generate-changelog.mjs
+++ b/release/ci-steps/generate-changelog.mjs
@@ -15,7 +15,7 @@ const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
 
 const docRepository = 'gravitee-platform-docs';
 const docRepositoryURL = `https://github.com/gravitee-io/${docRepository}`;
-const docApimChangelogFolder = `docs/apim/${versions.trimmed}/overview/changelog/`;
+const docApimChangelogFolder = `docs/apim/${versions.trimmed}/release-information/changelog/`;
 const docApimChangelogFile = `${docApimChangelogFolder}apim-${versions.branch}.md`;
 const localTmpFolder = '.tmp';
 


### PR DESCRIPTION
## Description

Starting from 4.8, the path of the release note has changed.

`overview/changelog` => `release-information/changelog`