### PR TITLE
Add name to automation maven module

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>gravitee-apim-rest-api-automation-rest</artifactId>
+    <name>Gravitee.io APIM - Management API - Automation - Rest API</name>
 
     <properties>
         <openapi-generator.version>7.12.0</openapi-generator.version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>gravitee-apim-rest-api-automation-security</artifactId>
+    <name>Gravitee.io APIM - Management API - Automation - Security</name>
 
     <dependencies>
         <!-- Gravitee Management dependencies -->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/pom.xml
@@ -30,6 +30,8 @@
     <artifactId>gravitee-apim-rest-api-automation</artifactId>
     <packaging>pom</packaging>
 
+    <name>Gravitee.io APIM - Management API - Automation</name>
+
     <modules>
         <module>gravitee-apim-rest-api-automation-rest</module>
         <module>gravitee-apim-rest-api-automation-security</module>


### PR DESCRIPTION
## Description

To publish on Central Sonatype (replacement for OSSRH Sonatype Nexus), every maven modules MUST define a name.
https://central.sonatype.org/publish/requirements/#project-name-description-and-url