### PR TITLE
fix(console): Prevent timeout on API v2 creation by paginating groups scroller

### DIFF
--- a/gravitee-apim-console-webui/jest.config.js
+++ b/gravitee-apim-console-webui/jest.config.js
@@ -6,4 +6,7 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!(.*\\.mjs$)|(@gravitee/ui-components/.*?\\.js)|lit|@lit/reactive-element|(lit-element/.*?\\.js)|(lit-html/.*?\\.js)|(resize-observer-polyfill/.*?\\.js)|(date-fns/.*?\\.js)$)',
   ],
+  moduleNameMapper: {
+    '^html-loader!.*\\.html$': '<rootDir>/src/__mocks__/htmlLoaderMock.js',
+  },
 };

--- a/gravitee-apim-console-webui/src/__mocks__/htmlLoaderMock.js
+++ b/gravitee-apim-console-webui/src/__mocks__/htmlLoaderMock.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = {
+  default: '<div></div>',
+};

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1-component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1-component.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ApiCreationStep1Component from './api-creation-step1.component';
+
+// Extract the controller class from the component definition
+const ControllerClass = ApiCreationStep1Component.controller[1];
+
+describe('ApiCreationStep1Component Scroll Events', () => {
+  let instance: any;
+  let mockParent: any;
+
+  beforeEach(() => {
+    mockParent = {
+      hasMoreGroups: true,
+      loadMoreGroups: jest.fn(),
+    };
+
+    instance = new ControllerClass({ isHybrid: () => true });
+    instance.parent = mockParent;
+    instance.hasLoadedOnce = false;
+    instance.isLoading = false;
+  });
+
+  it('should call loadMoreGroups on first scroll when threshold is met', () => {
+    const fakeTarget = {
+      scrollTop: 700,
+      clientHeight: 300,
+      scrollHeight: 1000,
+    };
+
+    const event = { target: fakeTarget } as unknown as Event;
+
+    instance.onScroll(event);
+
+    expect(mockParent.loadMoreGroups).toHaveBeenCalled();
+    expect(instance.hasLoadedOnce).toBe(true);
+  });
+
+  it('should throttle subsequent scrolls with delay', () => {
+    jest.useFakeTimers();
+
+    instance.hasLoadedOnce = true;
+    instance.isLoading = false;
+
+    const fakeTarget = {
+      scrollTop: 700,
+      clientHeight: 300,
+      scrollHeight: 1000,
+    };
+
+    const event = { target: fakeTarget } as unknown as Event;
+
+    instance.onScroll(event);
+    expect(instance.isLoading).toBe(true);
+    expect(mockParent.loadMoreGroups).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    expect(mockParent.loadMoreGroups).toHaveBeenCalled();
+    expect(instance.isLoading).toBe(false);
+
+    jest.useRealTimers();
+  });
+
+  it('should not call loadMoreGroups if threshold not met', () => {
+    const fakeTarget = {
+      scrollTop: 100,
+      clientHeight: 300,
+      scrollHeight: 1000,
+    };
+
+    const event = { target: fakeTarget } as unknown as Event;
+
+    instance.onScroll(event);
+    expect(mockParent.loadMoreGroups).not.toHaveBeenCalled();
+  });
+
+  it('should clean up scroll listener on destroy', () => {
+    const removeListener = jest.fn();
+    instance.scrollListener = removeListener;
+    instance.scrollContainer = {} as HTMLElement;
+
+    instance.$onDestroy();
+
+    expect(removeListener).toHaveBeenCalled();
+    expect(instance.scrollListener).toBeNull();
+    expect(instance.scrollContainer).toBeNull();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.html
@@ -112,8 +112,9 @@
 
         <div layout-gt-sm="row" ng-if="$ctrl.advancedMode && $ctrl.parent.attachableGroups && $ctrl.parent.attachableGroups.length > 0">
           <md-input-container class="md-block" flex-gt-sm>
+            <!-- Note: Before making any changes in the label or its text please also check onSelectOpen() function -->
             <label>Groups</label>
-            <md-select ng-model="$ctrl.parent.api.groups" multiple>
+            <md-select ng-model="$ctrl.parent.api.groups" md-on-open="$ctrl.onSelectOpen()" md-on-close="$ctrl.onSelectClose()" multiple>
               <md-option ng-repeat="group in $ctrl.parent.attachableGroups" ng-value="group">{{group.name}}</md-option>
             </md-select>
             <div class="hint">Groups that will be able to access the API.</div>

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.component.ts
@@ -35,6 +35,8 @@ export class ApiCreationV2Component extends UpgradeComponent implements OnDestro
   @Input() groups;
   @Input() tenants;
   @Input() tags;
+  private page = 1;
+  private pageSize = 50;
 
   private unsubscribe$ = new Subject<void>();
 
@@ -50,10 +52,10 @@ export class ApiCreationV2Component extends UpgradeComponent implements OnDestro
   }
 
   override ngOnInit() {
-    combineLatest([this.groupService.list(), this.tenantService.list(), this.tagService.list()])
+    combineLatest([this.groupService.listPaginated(this.page, this.pageSize), this.tenantService.list(), this.tagService.list()])
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(([groups, tenants, tags]) => {
-        this.groups = groups;
+        this.groups = groups.data;
         this.tenants = tenants;
         this.tags = tags;
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.spec.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ApiCreationV2ControllerAjs from './api-creation-v2.controller.ajs';
+
+describe('ApiCreationV2ControllerAjs', () => {
+  let ctrl;
+  let GroupService;
+  let $scope;
+  let $timeout;
+  let $mdDialog;
+  let $window;
+  let ApiService;
+  let ngApiV2Service;
+  let NotificationService;
+  let UserService;
+  let Constants;
+  let $rootScope;
+  let ngIfMatchEtagInterceptor;
+  let ngRouter;
+
+  beforeEach(() => {
+    $scope = { $watch: jest.fn() };
+    $timeout = jest.fn().mockImplementation((fn) => fn());
+    $mdDialog = { show: jest.fn() };
+    $window = {};
+
+    ApiService = {
+      import: jest.fn(),
+      askForReview: jest.fn(),
+      deploy: jest.fn(),
+      start: jest.fn(),
+    };
+
+    ngApiV2Service = {
+      get: jest.fn(),
+      verifyPath: jest.fn(),
+    };
+
+    NotificationService = {
+      show: jest.fn(),
+      showError: jest.fn(),
+    };
+
+    UserService = {
+      getCurrentUserGroups: jest.fn().mockReturnValue(['group1', 'group2']),
+    };
+
+    Constants = {
+      env: {
+        settings: {
+          plan: {
+            security: {
+              apikey: { enabled: true },
+              keyless: { enabled: true },
+            },
+          },
+        },
+      },
+      org: {
+        settings: {
+          v4EmulationEngine: {
+            defaultValue: 'no',
+          },
+        },
+      },
+    };
+
+    $rootScope = {};
+    ngIfMatchEtagInterceptor = {};
+    ngRouter = { navigate: jest.fn() };
+
+    GroupService = {
+      listPaginated: jest.fn().mockResolvedValue({
+        data: {
+          data: Array.from({ length: 50 }, (_, i) => ({ id: `id-${i}`, name: `Group ${i}` })),
+          page: { current: 1, total_pages: 2 },
+        },
+      }),
+    };
+
+    ctrl = new ApiCreationV2ControllerAjs(
+      $scope,
+      $timeout,
+      $mdDialog,
+      $window,
+      ApiService,
+      ngApiV2Service,
+      NotificationService,
+      UserService,
+      Constants,
+      $rootScope,
+      ngIfMatchEtagInterceptor,
+      ngRouter,
+      GroupService,
+    );
+  });
+
+  describe('loadMoreGroups', () => {
+    it('should fetch and append groups from GroupService and increment page if data length equals pageSize', async () => {
+      ctrl.pageSize = 50;
+      ctrl.currentPage = 1;
+      ctrl.loadedGroups = [];
+      ctrl.hasMoreGroups = true;
+      ctrl.isFetchingGroups = false;
+
+      await ctrl.loadMoreGroups();
+
+      expect(GroupService.listPaginated).toHaveBeenCalledWith(1, 50);
+      expect(ctrl.loadedGroups.length).toBe(50);
+      expect(ctrl.loadedGroups[0].name).toBe('Group 0');
+      expect(ctrl.loadedGroups[49].name).toBe('Group 49');
+      expect(ctrl.currentPage).toBe(2);
+      expect(ctrl.hasMoreGroups).toBe(true);
+    });
+
+    it('should stop fetching when group list is less than pageSize', async () => {
+      GroupService.listPaginated.mockResolvedValue({
+        data: {
+          data: [{ id: 'xyz789', name: 'Small Group' }],
+          page: { current: 1, total_pages: 1 },
+        },
+      });
+
+      ctrl.loadedGroups = [];
+      ctrl.pageSize = 50;
+      ctrl.currentPage = 1;
+      ctrl.hasMoreGroups = true;
+      ctrl.isFetchingGroups = false;
+
+      await ctrl.loadMoreGroups();
+
+      expect(ctrl.hasMoreGroups).toBe(false);
+      expect(ctrl.currentPage).toBe(1);
+    });
+
+    it('should not fetch if already fetching or no more groups', async () => {
+      ctrl.isFetchingGroups = true;
+      await ctrl.loadMoreGroups();
+      expect(GroupService.listPaginated).not.toHaveBeenCalled();
+
+      ctrl.isFetchingGroups = false;
+      ctrl.hasMoreGroups = false;
+      await ctrl.loadMoreGroups();
+      expect(GroupService.listPaginated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('$onChanges', () => {
+    it('should categorize groups correctly when changes received', () => {
+      const groupList = [
+        { name: 'group1', apiPrimaryOwner: null },
+        { name: 'group2', apiPrimaryOwner: 'user1' },
+        { name: 'group3', apiPrimaryOwner: null },
+      ];
+
+      ctrl.$onChanges({
+        groups: { currentValue: groupList },
+      });
+
+      expect(ctrl.attachableGroups.length).toBe(2);
+      expect(ctrl.poGroups.length).toBe(1);
+    });
+
+    it('should set hasMoreGroups correctly when group count is multiple of pageSize', () => {
+      ctrl.pageSize = 2;
+
+      ctrl.$onChanges({
+        groups: { currentValue: [{}, {}] },
+      });
+
+      expect(ctrl.hasMoreGroups).toBe(true);
+    });
+
+    it('should not change anything if no groups change', () => {
+      ctrl.groups = [{ name: 'group1' }];
+      ctrl.attachableGroups = [{ name: 'group1' }];
+      ctrl.poGroups = [];
+
+      ctrl.$onChanges({});
+
+      expect(ctrl.groups.length).toBe(1);
+      expect(ctrl.attachableGroups.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Calls made to the groups endpoint on v2 API creation page fail due to a timeout when there are a large number of groups.

## Issue

https://gravitee.atlassian.net/browse/APIM-9836

## Description

Achieved Goal:
The Groups endpoint on the v2 API creation page now loads successfully without timing out.

How This Was Achieved:
Group data is now fetched in paginated form. Instead of retrieving all groups at once, additional groups are loaded dynamically as the user scrolls through the dropdown. This improves performance and prevents request timeouts.

## Additional context

Test case results:
yarn test results before the code:
[Before Running_Web-console-ui-yarn-test-Output.txt](https://github.com/user-attachments/files/21142841/Before.Running_Web-console-ui-yarn-test-Output.txt)

yarn test results after the code:
[After Running yarn-test-357 passed cases.txt](https://github.com/user-attachments/files/21142849/After.Running.yarn-test-357.passed.cases.txt)

Before change, video proof:

https://github.com/user-attachments/assets/bdd226d7-bfe5-4305-8675-342fe95a580c


After change, video proof:

https://github.com/user-attachments/assets/70961555-c924-43a7-82fb-0c8a045f5a38

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lkxrbiqmqe.chromatic.com)
<!-- Storybook placeholder end -->
