### PR TITLE
chore: bump kafka-reactor - 4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.0.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>7.0.0</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>3.0.0</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>3.0.2</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>7.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
Bump kafka reactor to provide:
 - Change the log level to debug when the Kafka version is greater than the one used by the GW
 - Make sure to load keystore once
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kbpiozfhdz.chromatic.com)
<!-- Storybook placeholder end -->
