### PR TITLE
fix: allow empty env roles in role mappings of identity-provider

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.html
@@ -234,12 +234,9 @@
                 <td mat-cell *matCellDef="let environment" formGroupName="environments">
                   <mat-form-field>
                     <mat-label>Roles</mat-label>
-                    <mat-select [formControlName]="environment.id" multiple required>
+                    <mat-select [formControlName]="environment.id" multiple>
                       <mat-option *ngFor="let role of environmentRoles$ | async" [value]="role.name">{{ role.name }}</mat-option>
                     </mat-select>
-                    <mat-error *ngIf="roleMappingControl.get('environments').get(environment.id).hasError('required')"
-                      >At least one role is required.</mat-error
-                    >
                   </mat-form-field>
                 </td>
               </ng-container>

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.ts
@@ -239,7 +239,7 @@ export class OrgSettingsIdentityProviderComponent implements OnInit, OnDestroy {
           ...this.allEnvironments.reduce(
             (prev, environment) => ({
               ...prev,
-              [environment.id]: new UntypedFormControl(roleMapping?.environments[environment.id] ?? [], [Validators.required]),
+              [environment.id]: new UntypedFormControl(roleMapping?.environments[environment.id] ?? []),
             }),
             {},
           ),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9393

## Description
This fix ensures that:
- An environment role in the mapping can be empty
- Users can exist without a dedicated role in an environment

Current:


https://github.com/user-attachments/assets/e8114927-d518-43a5-a8ca-375fe44d29b9


Fix:


https://github.com/user-attachments/assets/354740f2-5c6c-4d0e-ba14-fddeb4745d1e


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

