### PR TITLE
fix: es response deserialization of avg aggregation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchHistogramQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchHistogramQueryAdapter.java
@@ -226,8 +226,11 @@ public class SearchHistogramQueryAdapter {
         List<JsonNode> buckets = histogramAgg.getBuckets();
         for (int i = 0; i < buckets.size(); i++) {
             var bucket = buckets.get(i);
-            if (!bucket.has(aggName)) {
-                values.get(aggName).set(i, bucket.get("value").asDouble());
+            if (bucket.has(aggName)) {
+                var aggValue = bucket.get(aggName).get("value");
+                if (!aggValue.isNull()) {
+                    values.get(aggName).set(i, aggValue.asDouble());
+                }
             }
         }
         return new HistogramAggregate<>(aggName, fieldName, values);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10263

## Description

Before change min/max/avg values were taken from a wrong place in es query response. After change it is mapped in the right place.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

