### PR TITLE
feat: add provider metadata to subscription command to support multi-account, multi-region agent subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
@@ -26,6 +26,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
+import java.util.Map;
 
 public interface IntegrationAgent {
     /**
@@ -58,7 +59,8 @@ public interface IntegrationAgent {
         FederatedApi api,
         SubscriptionParameter subscriptionParameter,
         String subscriptionId,
-        BaseApplicationEntity application
+        BaseApplicationEntity application,
+        Map<String, String> providerMetadata
     );
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/integration/IntegrationAgentImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/integration/IntegrationAgentImpl.java
@@ -97,9 +97,11 @@ public class IntegrationAgentImpl implements IntegrationAgent {
         FederatedApi api,
         SubscriptionParameter subscriptionParameter,
         String subscriptionId,
-        BaseApplicationEntity application
+        BaseApplicationEntity application,
+        Map<String, String> providerMetadata
     ) {
         Map<String, String> metadata = api.getServer() != null ? new HashMap<>(api.getServer()) : new HashMap<>();
+        metadata.putAll(providerMetadata);
         SubscriptionType type;
         if (subscriptionParameter instanceof SubscriptionParameter.ApiKey apiKeyParams) {
             type = SubscriptionType.API_KEY;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
@@ -61,7 +61,8 @@ public class IntegrationAgentInMemory implements IntegrationAgent, InMemoryAlter
         FederatedApi api,
         SubscriptionParameter subscriptionParameter,
         String subscriptionId,
-        BaseApplicationEntity application
+        BaseApplicationEntity application,
+        Map<String, String> providerMetadata
     ) {
         subscriptions.compute(
             integrationId,
@@ -81,12 +82,16 @@ public class IntegrationAgentInMemory implements IntegrationAgent, InMemoryAlter
         } else {
             throw new IntegrationIngestionException("Unsupported subscription parameter: " + subscriptionParameter);
         }
+        var metadata = new HashMap<>(Map.of("key", "value"));
+        if (!providerMetadata.isEmpty()) {
+            metadata.putAll(providerMetadata);
+        }
         return Single.just(
             new IntegrationSubscription(
                 integrationId,
                 type,
                 String.join("-", type.name(), subscriptionId, application.getId(), application.getName()),
-                Map.of("key", "value")
+                metadata
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
@@ -21,22 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.ApplicationModelFixtures;
 import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.IntegrationFixture;
 import fixtures.core.model.PlanFixtures;
 import fixtures.core.model.SubscriptionFixtures;
-import inmemory.ApiCrudServiceInMemory;
-import inmemory.ApiKeyCrudServiceInMemory;
-import inmemory.ApiKeyQueryServiceInMemory;
-import inmemory.ApplicationCrudServiceInMemory;
-import inmemory.AuditCrudServiceInMemory;
-import inmemory.GroupQueryServiceInMemory;
-import inmemory.InMemoryAlternative;
-import inmemory.IntegrationAgentInMemory;
-import inmemory.MembershipQueryServiceInMemory;
-import inmemory.PlanCrudServiceInMemory;
-import inmemory.RoleQueryServiceInMemory;
-import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
-import inmemory.UserCrudServiceInMemory;
+import inmemory.*;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.domain_service.GenerateApiKeyDomainService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
@@ -124,6 +112,8 @@ class AcceptSubscriptionDomainServiceTest {
     GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
     MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
     AcceptSubscriptionDomainService cut;
 
     @BeforeAll
@@ -161,7 +151,9 @@ class AcceptSubscriptionDomainServiceTest {
                 integrationAgent,
                 triggerNotificationDomainService,
                 userCrudService,
-                applicationPrimaryOwnerDomainService
+                applicationPrimaryOwnerDomainService,
+                metadataCrudService,
+                integrationCrudService
             );
 
         planCrudService.initWith(List.of(PLAN_CLOSED, PLAN_PUBLISHED, PUSH_PLAN));
@@ -405,6 +397,7 @@ class AcceptSubscriptionDomainServiceTest {
             apiCrudService.create(
                 Api.builder().id(subscription.getApiId()).originContext(new OriginContext.Integration("integration-id")).build()
             );
+            integrationCrudService.initWith(List.of(IntegrationFixture.anApiIntegration()));
 
             // When
             accept(subscription, plan);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.infra.domain_service.subscription;
 
-import static fixtures.core.model.MembershipFixtures.anApiPrimaryOwnerUserMembership;
 import static fixtures.core.model.MembershipFixtures.anApplicationPrimaryOwnerUserMembership;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,19 +24,7 @@ import static org.mockito.Mockito.when;
 
 import fixtures.ApplicationModelFixtures;
 import fixtures.core.model.AuditInfoFixtures;
-import inmemory.ApiCrudServiceInMemory;
-import inmemory.ApiKeyCrudServiceInMemory;
-import inmemory.ApiKeyQueryServiceInMemory;
-import inmemory.ApplicationCrudServiceInMemory;
-import inmemory.AuditCrudServiceInMemory;
-import inmemory.GroupQueryServiceInMemory;
-import inmemory.IntegrationAgentInMemory;
-import inmemory.MembershipQueryServiceInMemory;
-import inmemory.PlanCrudServiceInMemory;
-import inmemory.RoleQueryServiceInMemory;
-import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
-import inmemory.UserCrudServiceInMemory;
+import inmemory.*;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.domain_service.GenerateApiKeyDomainService;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
@@ -122,6 +109,8 @@ class SubscriptionCRDSpecDomainServiceImplTest {
         roleQueryService,
         userCrudService
     );
+    private final MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    private final IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
 
     private final SubscriptionService subscriptionService = Mockito.mock(SubscriptionService.class);
 
@@ -288,7 +277,9 @@ class SubscriptionCRDSpecDomainServiceImplTest {
             integrationAgent,
             notificationService,
             userCrudService,
-            applicationPrimaryOwnerDomainService
+            applicationPrimaryOwnerDomainService,
+            metadataCrudService,
+            integrationCrudService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
@@ -61,6 +61,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -237,7 +238,8 @@ class IntegrationAgentImplTest {
                     ApiDefinitionFixtures.aFederatedApi().toBuilder().id("gravitee-api-id").providerId("api-provider-id").build(),
                     subscriptionParameter,
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS);
@@ -286,7 +288,8 @@ class IntegrationAgentImplTest {
                         .build(),
                     subscriptionParameter,
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS);
@@ -323,7 +326,8 @@ class IntegrationAgentImplTest {
                     ApiDefinitionFixtures.aFederatedApi(),
                     PlanFixtures.subscriptionParameter(),
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
@@ -344,13 +348,38 @@ class IntegrationAgentImplTest {
                     ApiDefinitionFixtures.aFederatedApi().toBuilder().server(Map.of("k1", "v1")).build(),
                     PlanFixtures.subscriptionParameter(),
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
                 .values();
 
             assertThat(subscribeCommandCaptor.getValue().getPayload().subscription().metadata()).containsEntry("k1", "v1");
+            assertThat(result)
+                .hasSize(1)
+                .containsExactly(
+                    new IntegrationSubscription(INTEGRATION_ID, IntegrationSubscription.Type.API_KEY, "my-api-key", Map.of("key", "value"))
+                );
+        }
+
+        @Test
+        void should_send_providers_metadata() {
+            var result = agent
+                .subscribe(
+                    INTEGRATION_ID,
+                    ApiDefinitionFixtures.aFederatedApi().toBuilder().server(Map.of()).build(),
+                    PlanFixtures.subscriptionParameter(),
+                    SUBSCRIPTION_ID,
+                    APPLICATION,
+                    Map.of("provider-metadata-key", "provider-metadata-value")
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .values();
+
+            assertThat(subscribeCommandCaptor.getValue().getPayload().subscription().metadata())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("planId", "provider-id", "provider-metadata-key", "provider-metadata-value"));
             assertThat(result)
                 .hasSize(1)
                 .containsExactly(
@@ -368,7 +397,8 @@ class IntegrationAgentImplTest {
                     ApiDefinitionFixtures.aFederatedApi(),
                     PlanFixtures.subscriptionParameter(),
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)
@@ -387,7 +417,8 @@ class IntegrationAgentImplTest {
                     ApiDefinitionFixtures.aFederatedApi(),
                     PlanFixtures.subscriptionParameter(),
                     SUBSCRIPTION_ID,
-                    APPLICATION
+                    APPLICATION,
+                    Map.of()
                 )
                 .test()
                 .awaitDone(10, TimeUnit.SECONDS)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9917

## Description

This feature is required to enable multi-account, multi-region subscriptions for AWS accounts.
It introduces provider metadata support in the subscription command.

Thanks to this change, the agent will now receive all the necessary information to correctly select the appropriate AWS account and create the subscription on the provider's side.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jlyxagqblw.chromatic.com)
<!-- Storybook placeholder end -->
