### PR TITLE
Apim 10069 highchart font update

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/app.module.ajs.ts
@@ -308,6 +308,74 @@ require('highcharts/modules/map')(Highcharts);
 
 require('@highcharts/map-collection/custom/world');
 
+// Configure Highcharts to use Manrope font
+const PARAGRAPH_FONT_FAMILY = 'Manrope, sans-serif';
+const HEADER_FONT_FAMILY = 'Kanit, Roboto, Helvetica Neue, sans-serif';
+
+Highcharts.setOptions({
+  chart: {
+    style: {
+      fontFamily: PARAGRAPH_FONT_FAMILY,
+    },
+  },
+  title: {
+    style: {
+      fontFamily: HEADER_FONT_FAMILY,
+    },
+  },
+  subtitle: {
+    style: {
+      fontFamily: PARAGRAPH_FONT_FAMILY,
+    },
+  },
+  xAxis: {
+    labels: {
+      style: {
+        fontFamily: PARAGRAPH_FONT_FAMILY,
+      },
+    },
+    title: {
+      style: {
+        fontFamily: PARAGRAPH_FONT_FAMILY,
+      },
+    },
+  },
+  yAxis: {
+    labels: {
+      style: {
+        fontFamily: PARAGRAPH_FONT_FAMILY,
+      },
+    },
+    title: {
+      style: {
+        fontFamily: PARAGRAPH_FONT_FAMILY,
+      },
+    },
+  },
+  legend: {
+    itemStyle: {
+      fontFamily: PARAGRAPH_FONT_FAMILY,
+    },
+    itemHoverStyle: {
+      fontFamily: PARAGRAPH_FONT_FAMILY,
+    },
+  },
+  tooltip: {
+    style: {
+      fontFamily: PARAGRAPH_FONT_FAMILY,
+    },
+  },
+  plotOptions: {
+    series: {
+      dataLabels: {
+        style: {
+          fontFamily: PARAGRAPH_FONT_FAMILY,
+        },
+      },
+    },
+  },
+});
+
 (<any>window).moment = moment;
 require('angular-moment-picker');
 

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard/chart/chart.directive.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard/chart/chart.directive.ts
@@ -136,7 +136,7 @@ class ChartDirective {
               newOptions.title.style = {
                 fontWeight: 'bold',
                 fontSize: '12px',
-                fontFamily: '"Helvetica Neue",Helvetica,Arial,sans-serif',
+                fontFamily: 'Manrope, sans-serif',
               };
               newOptions.title.align = 'left';
             } else {

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
@@ -84,10 +84,46 @@ export class GioChartPieComponent implements OnInit {
         pie: {
           dataLabels: {
             enabled: true,
-            format: '<b>{point.name}</b>: {point.y} ({point.percentage:.1f} %)',
+            distance: 25,
             style: {
+              textAlign: 'center',
+              textOutline: 'none',
+              fontSize: '12px',
               fontFamily: 'Manrope, sans-serif',
             },
+            formatter: function () {
+              const name = this.point.name;
+              const value = this.point.y;
+              const percentage = this.point.percentage;
+
+              // Split long names into multiple lines (max 15 characters per line)
+              const maxCharsPerLine = 15;
+              let formattedName = name;
+
+              if (name.length > maxCharsPerLine) {
+                const words = name.split(' ');
+                const lines = [];
+                let currentLine = '';
+
+                for (const word of words) {
+                  if ((currentLine + word).length <= maxCharsPerLine) {
+                    currentLine += (currentLine ? ' ' : '') + word;
+                  } else {
+                    if (currentLine) lines.push(currentLine);
+                    currentLine = word;
+                  }
+                }
+                if (currentLine) lines.push(currentLine);
+
+                formattedName = lines.join('<br/>');
+              }
+
+              return `<div style="text-align: center;">
+                <div style="font-weight: bold; margin-bottom: 2px;">${formattedName}</div>
+                <div style="font-size: 11px; color: #666;">${value} (${percentage.toFixed(1)}%)</div>
+              </div>`;
+            },
+            useHTML: true,
           },
         },
       },

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
@@ -85,6 +85,9 @@ export class GioChartPieComponent implements OnInit {
           dataLabels: {
             enabled: true,
             format: '<b>{point.name}</b>: {point.y} ({point.percentage:.1f} %)',
+            style: {
+              fontFamily: 'Manrope, sans-serif',
+            },
           },
         },
       },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10069

## Description

- Update font used in highchart components to match the theme.
- Adjust formatting for pie charts on non-AJS pages.

Homepage dashboard:

<img width="1140" height="839" alt="Screenshot 2025-07-17 at 15 35 22" src="https://github.com/user-attachments/assets/7818d82e-cf9d-4e17-92a4-a87df2616184" />
<img width="1168" height="587" alt="Screenshot 2025-07-17 at 15 35 37" src="https://github.com/user-attachments/assets/9f899254-40e8-4bfd-80aa-d9019c981362" />


V2 API Analytics:

<img width="1102" height="716" alt="Screenshot 2025-07-17 at 15 34 34" src="https://github.com/user-attachments/assets/ceb4b6a8-4bf6-4db5-8ade-ba8d1326b175" />
<img width="389" height="381" alt="Screenshot 2025-07-17 at 15 34 41" src="https://github.com/user-attachments/assets/49b0ceca-6a6d-421c-b4ff-73fd65aa592d" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oppahdsmpl.chromatic.com)
<!-- Storybook placeholder end -->
