### PR TITLE
Rest-api: avoid error when delete native api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -653,7 +653,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             // Audit
             auditService.createApiAuditLog(executionContext, apiId, Collections.emptyMap(), API_DELETED, new Date(), api, null);
             // remove from search engine
-            searchEngineService.delete(executionContext, apiMapper.toEntity(executionContext, api, false));
+            searchEngineService.delete(executionContext, genericApiMapper.toGenericApi(api, null));
 
             mediaService.deleteAllByApi(apiId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -437,9 +437,10 @@ public class ApiServiceImplTest {
         Api api = new Api();
         api.setId(API_ID);
         api.setLifecycleState(LifecycleState.STOPPED);
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setType(ApiType.NATIVE);
 
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
-        when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.emptySet());
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -447,6 +448,11 @@ public class ApiServiceImplTest {
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
         verify(flowCrudService, times(1)).saveApiFlows(API_ID, null);
+        verify(searchEngineService, times(1))
+            .delete(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(indexableApi -> indexableApi instanceof GenericApiEntity && indexableApi.getId().equals(API_ID))
+            );
     }
 
     @Test(expected = ApiNotDeletableException.class)


### PR DESCRIPTION
## Issue
n/a

## Description


We get an error when we delete a native api. because of a mapping problem. but here for "desindexed" we just need a simple generic mapping because behind it only the class and apiId are used, (i think)

```
18:14:23.630 [gravitee-listener-81] ERROR i.g.r.a.service.v4.mapper.ApiMapper - Unexpected error while generating API definition
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'native' as a subtype of `io.gravitee.definition.model.v4.Api`: Class `io.gravitee.definition.model.v4.nativeapi.NativeApi` not subtype of `io.gravitee.definition.model.v4.Api`
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 71]
	at com.fasterxml.jackson.databind.exc.InvalidTypeIdException.from(InvalidTypeIdException.java:43)
	at com.fasterxml.jackson.databind.DeserializationContext.invalidTypeIdException(DeserializationContext.java:2041)
	at com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase._findDeserializer(TypeDeserializerBase.java:199)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer._deserializeTypedForId(AsPropertyTypeDeserializer.java:151)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer.deserializeTypedFromObject(AsPropertyTypeDeserializer.java:136)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeWithType(BeanDeserializerBase.java:1382)
	at com.fasterxml.jackson.databind.deser.impl.TypeWrappedDeserializer.deserialize(TypeWrappedDeserializer.java:74)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4931)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3868)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3836)
	at io.gravitee.rest.api.service.v4.mapper.ApiMapper.toEntity(ApiMapper.java:118)
	at io.gravitee.rest.api.service.v4.mapper.ApiMapper.toEntity(ApiMapper.java:259)
	at io.gravitee.rest.api.service.v4.mapper.ApiMapper.toEntity(ApiMapper.java:236)
	at io.gravitee.rest.api.service.v4.impl.ApiServiceImpl.delete(ApiServiceImpl.java:656)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

