### PR TITLE
fix: remove api traffic dashboard empty state

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.html
@@ -21,12 +21,6 @@
     <div class="loader">
       <gio-loader></gio-loader>
     </div>
-  } @else if (!apiAnalyticsVM.isAnalyticsEnabled) {
-    <gio-card-empty-state
-      icon="folder-plus"
-      title="Enable Analytics"
-      subtitle="Your metrics live here. Start monitoring your API by enabling the Analytics in the settings."
-    ></gio-card-empty-state>
   } @else {
     <api-analytics-filters-bar></api-analytics-filters-bar>
     <div class="entrypoints">

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.spec.ts
@@ -86,19 +86,6 @@ describe('ApiAnalyticsMessageComponent', () => {
     });
   });
 
-  describe('GIVEN an API with analytics.enabled=false', () => {
-    beforeEach(async () => {
-      await initComponent();
-      expectApiGetRequest(fakeApiV4({ id: API_ID, analytics: { enabled: false } }));
-      expectGetEntrypoints();
-    });
-
-    it('should display empty panel', async () => {
-      expect(await componentHarness.isLoaderDisplayed()).toBeFalsy();
-      expect(await componentHarness.isEmptyPanelDisplayed()).toBeTruthy();
-    });
-  });
-
   describe('GIVEN an API with analytics.enabled=true', () => {
     beforeEach(async () => {
       await initComponent();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.ts
@@ -16,7 +16,7 @@
 import { Component, inject } from '@angular/core';
 import { GioCardEmptyStateModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
 import { MatCardModule } from '@angular/material/card';
-import { combineLatest, Observable, of, switchMap } from 'rxjs';
+import { combineLatest, Observable, switchMap } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { map, startWith } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
@@ -45,7 +45,6 @@ import { AnalyticsResponseStatusRanges } from '../../../../../entities/managemen
 
 type ApiAnalyticsVM = {
   isLoading: boolean;
-  isAnalyticsEnabled?: boolean;
   globalRequestStats?: AnalyticsRequestStats;
   globalResponseStatusRanges?: ApiAnalyticsResponseStatusRanges;
   entrypoints?: {
@@ -112,19 +111,14 @@ export class ApiAnalyticsMessageComponent {
     this.apiAnalyticsV2Service.timeRangeFilter(),
   ]).pipe(
     switchMap(([api, availableEntrypoints]) => {
-      if (api.analytics.enabled) {
-        const apiEntrypointsId = flatten(api.listeners.map((l) => l.entrypoints)).map((e) => e.type);
-        const allEntrypoints: ApiAnalyticsVM['entrypoints'] = availableEntrypoints.map((e) => ({
-          id: e.id,
-          name: e.name,
-          icon: this.iconService.registerSvg(e.id, e.icon),
-        }));
+      const apiEntrypointsId = flatten(api.listeners.map((l) => l.entrypoints)).map((e) => e.type);
+      const allEntrypoints: ApiAnalyticsVM['entrypoints'] = availableEntrypoints.map((e) => ({
+        id: e.id,
+        name: e.name,
+        icon: this.iconService.registerSvg(e.id, e.icon),
+      }));
 
-        return this.analyticsData$(allEntrypoints, apiEntrypointsId).pipe(
-          map((analyticsData) => ({ isAnalyticsEnabled: true, ...analyticsData })),
-        );
-      }
-      return of({ isAnalyticsEnabled: false });
+      return this.analyticsData$(allEntrypoints, apiEntrypointsId);
     }),
     map((analyticsData) => ({ isLoading: false, ...analyticsData })),
     startWith({ isLoading: true }),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.html
@@ -15,21 +15,12 @@
     limitations under the License.
 
 -->
+<div class="api-analytics">
+  <api-analytics-filters-bar></api-analytics-filters-bar>
 
-@if (!isAnalyticsEnabled()) {
-  <gio-card-empty-state
-    icon="folder-plus"
-    title="Enable Analytics"
-    subtitle="Your metrics live here. Start monitoring your API by enabling the Analytics in the settings."
-  ></gio-card-empty-state>
-} @else {
-  <div class="api-analytics">
-    <api-analytics-filters-bar></api-analytics-filters-bar>
-
-    <div class="chart-widgets">
-      @for (widget of chartWidgetConfigs; track widget.title) {
-        <chart-widget [config]="widget" />
-      }
-    </div>
+  <div class="chart-widgets">
+    @for (widget of chartWidgetConfigs; track widget.title) {
+      <chart-widget [config]="widget" />
+    }
   </div>
-}
+</div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
@@ -25,7 +25,6 @@ import { ApiAnalyticsProxyComponent } from './api-analytics-proxy.component';
 import { ApiAnalyticsProxyHarness } from './api-analytics-proxy.component.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
-import { ApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
 import { fakeAnalyticsHistogram } from '../../../../../entities/management-api-v2/analytics/analyticsHistogram.fixture';
 import {
   AggregationFields,
@@ -69,21 +68,9 @@ describe('ApiAnalyticsProxyComponent', () => {
     httpTestingController.verify();
   });
 
-  describe('GIVEN an API with analytics.enabled=false', () => {
-    beforeEach(async () => {
-      await initComponent();
-      expectApiGetRequest(fakeApiV4({ id: API_ID, analytics: { enabled: false } }));
-    });
-
-    it('should display empty panel', async () => {
-      expect(await componentHarness.isEmptyPanelDisplayed()).toBeTruthy();
-    });
-  });
-
   describe('GIVEN an API with analytics.enabled=true', () => {
     beforeEach(async () => {
       await initComponent();
-      expectApiGetRequest(fakeApiV4({ id: API_ID, analytics: { enabled: true } }));
       expectGetHistogramAnalytics(fakeAnalyticsHistogram(), 2);
     });
 
@@ -186,7 +173,6 @@ describe('ApiAnalyticsProxyComponent', () => {
     ].forEach((testParams) => {
       it(`should display "${testParams.expected}" time range if query parameter is ${JSON.stringify(testParams.input)}`, async () => {
         await initComponent(testParams.input);
-        expectApiGetRequest(fakeApiV4({ id: API_ID, analytics: { enabled: true } }));
         expectGetHistogramAnalytics(fakeAnalyticsHistogram(), 2);
 
         const filtersBar = await componentHarness.getFiltersBarHarness();
@@ -198,15 +184,6 @@ describe('ApiAnalyticsProxyComponent', () => {
       });
     });
   });
-
-  function expectApiGetRequest(api: ApiV4) {
-    const res = httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
-      method: 'GET',
-    });
-    res.flush(api);
-    fixture.detectChanges();
-  }
 
   function expectGetHistogramAnalytics(res: HistogramAnalyticsResponse = fakeAnalyticsHistogram(), numberOfRequests: number = 1) {
     const url = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/analytics?type=HISTOGRAM`;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -18,14 +18,9 @@ import { GioCardEmptyStateModule, GioLoaderModule } from '@gravitee/ui-particles
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
 
 import { ChartWidgetComponent, ChartWidgetConfig } from '../components/chart-widget/chart-widget.component';
 import { ApiAnalyticsFiltersBarComponent } from '../components/api-analytics-filters-bar/api-analytics-filters-bar.component';
-import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
-import { onlyApiV4Filter } from '../../../../../util/apiFilter.operator';
 import { AggregationFields, AggregationTypes } from '../../../../../entities/management-api-v2/analytics/analyticsHistogram';
 
 @Component({
@@ -35,15 +30,6 @@ import { AggregationFields, AggregationTypes } from '../../../../../entities/man
   styleUrl: './api-analytics-proxy.component.scss',
 })
 export class ApiAnalyticsProxyComponent {
-  private isAnalyticsEnabled$: Observable<boolean> = this.apiService.getLastApiFetch(this.activatedRoute.snapshot.params.apiId).pipe(
-    onlyApiV4Filter(),
-    map((api) => {
-      return api.analytics.enabled;
-    }),
-  );
-
-  public isAnalyticsEnabled = toSignal(this.isAnalyticsEnabled$, { initialValue: false });
-
   public chartWidgetConfigs: ChartWidgetConfig[] = [
     {
       apiId: this.activatedRoute.snapshot.params.apiId,
@@ -74,8 +60,5 @@ export class ApiAnalyticsProxyComponent {
     },
   ];
 
-  constructor(
-    private readonly apiService: ApiV2Service,
-    private readonly activatedRoute: ActivatedRoute,
-  ) {}
+  constructor(private readonly activatedRoute: ActivatedRoute) {}
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10299

## Description

Currently, when users disabled analytics from the settings page, they could no longer view metrics in the API dashboard, even if traffic data had been recorded before disabling analytics. 

The goal here is simply to change this behaviour. When users disable the analytics, metrics will continue to be displayed in the dashboard for any API traffic that was recorded regardless of the current analytics setting. So that users can now disable analytics without losing access to historical traffic data.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xtnahkzojf.chromatic.com)
<!-- Storybook placeholder end -->
