### PR TITLE
feat(console): add multiple aggregations for chart-widget

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsHistogram.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsHistogram.ts
@@ -24,6 +24,7 @@ export enum AggregationTypes {
 export enum AggregationFields {
   STATUS = 'status',
   GATEWAY_RESPONSE_TIME_MS = 'gateway-response-time-ms',
+  ENDPOINT_RESPONSE_TIME_MS = 'endpoint-response-time-ms',
 }
 
 export interface AnalyticsHistogramAggregation {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -47,18 +47,30 @@ export class ApiAnalyticsProxyComponent {
   public chartWidgetConfigs: ChartWidgetConfig[] = [
     {
       apiId: this.activatedRoute.snapshot.params.apiId,
-      aggregationType: AggregationTypes.FIELD,
-      aggregationField: AggregationFields.STATUS,
+      aggregations: [
+        {
+          type: AggregationTypes.FIELD,
+          field: AggregationFields.STATUS,
+        },
+      ],
       title: 'Response Status Over Time',
       tooltip: 'Visualizes the breakdown of HTTP status codes (2xx, 4xx, 5xx) across time',
       shouldSortBuckets: true,
     },
     {
       apiId: this.activatedRoute.snapshot.params.apiId,
-      aggregationType: AggregationTypes.AVG,
-      aggregationField: AggregationFields.GATEWAY_RESPONSE_TIME_MS,
+      aggregations: [
+        {
+          type: AggregationTypes.AVG,
+          field: AggregationFields.GATEWAY_RESPONSE_TIME_MS,
+        },
+        {
+          type: AggregationTypes.AVG,
+          field: AggregationFields.ENDPOINT_RESPONSE_TIME_MS,
+        },
+      ],
       title: 'Response Time Over Time',
-      tooltip: 'Measures latency trend for gateway and downstream systems (API) ',
+      tooltip: 'Measures response time for gateway and endpoint',
     },
   ];
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/chart-widget/chart-widget.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/chart-widget/chart-widget.component.ts
@@ -25,16 +25,24 @@ import { GioChartLineModule } from '../../../../../../shared/components/gio-char
 import { GioChartLineData, GioChartLineOptions } from '../../../../../../shared/components/gio-chart-line/gio-chart-line.component';
 import { ApiAnalyticsV2Service } from '../../../../../../services-ngx/api-analytics-v2.service';
 import { SnackBarService } from '../../../../../../services-ngx/snack-bar.service';
-import { AggregationFields, AggregationTypes } from '../../../../../../entities/management-api-v2/analytics/analyticsHistogram';
+import {
+  AnalyticsHistogramAggregation,
+  Bucket,
+  HistogramAnalyticsResponse,
+} from '../../../../../../entities/management-api-v2/analytics/analyticsHistogram';
 
 export interface ChartWidgetConfig {
   apiId: string;
-  aggregationType: AggregationTypes;
-  aggregationField: AggregationFields;
+  aggregations: AnalyticsHistogramAggregation[];
   title: string;
   tooltip: string;
   shouldSortBuckets?: boolean;
 }
+
+const namesFormatted = {
+  'avg_gateway-response-time-ms': 'Gateway Response Time',
+  'avg_endpoint-response-time-ms': 'Endpoint Response Time',
+};
 
 @Component({
   selector: 'chart-widget',
@@ -54,25 +62,35 @@ export class ChartWidgetComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
   ) {}
 
+  private buildAggregationsParams(aggregations: AnalyticsHistogramAggregation[]): string {
+    return aggregations.reduce((acc, aggregation, index) => {
+      return acc + `${aggregation.type}:${aggregation.field}${index !== aggregations.length - 1 ? ',' : ''}`;
+    }, '');
+  }
+
+  private mapResponseToChartData(res: HistogramAnalyticsResponse): GioChartLineData[] {
+    return res.values
+      .reduce((acc: Bucket[], value): Bucket[] => {
+        return [...acc, ...value.buckets];
+      }, [])
+      .map(({ name, data }) => ({ name: namesFormatted[name] || name, values: data }));
+  }
+
   ngOnInit() {
     this.apiAnalyticsV2Service
       .timeRangeFilter()
       .pipe(
-        switchMap(() => {
+        switchMap((timeRangeParams) => {
           this.isLoading = true;
-          return this.apiAnalyticsV2Service.getHistogramAnalytics(this.config().apiId, {
-            type: this.config().aggregationType,
-            field: this.config().aggregationField,
-          });
+          const aggregationsParams = this.buildAggregationsParams(this.config().aggregations);
+          return this.apiAnalyticsV2Service.getHistogramAnalytics(this.config().apiId, aggregationsParams, timeRangeParams);
         }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: (res) => {
           this.isLoading = false;
-          this.chartInput = res.values
-            .find((value) => value.name === this.config().aggregationField)
-            .buckets.map(({ name, data }) => ({ name, values: data }));
+          this.chartInput = this.mapResponseToChartData(res);
 
           if (this.config().shouldSortBuckets) {
             this.chartInput = this.chartInput.sort((a, b) => +a.name - +b.name);

--- a/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.ts
@@ -26,7 +26,7 @@ import { AnalyticsResponseStatusRanges } from '../entities/management-api-v2/ana
 import { AnalyticsResponseTimeOverTime } from '../entities/management-api-v2/analytics/analyticsResponseTimeOverTime';
 import { TimeRangeParams } from '../shared/utils/timeFrameRanges';
 import { ApiAnalyticsFilters } from '../management/api/api-traffic-v4/analytics/components/api-analytics-filters-bar/api-analytics-filters-bar.configuration';
-import { HistogramAnalyticsResponse, AnalyticsHistogramAggregation } from '../entities/management-api-v2/analytics/analyticsHistogram';
+import { HistogramAnalyticsResponse } from '../entities/management-api-v2/analytics/analyticsHistogram';
 
 @Injectable({
   providedIn: 'root',
@@ -97,13 +97,8 @@ export class ApiAnalyticsV2Service {
     );
   }
 
-  getHistogramAnalytics(apiId: string, aggregation: AnalyticsHistogramAggregation) {
-    return this.timeRangeFilter().pipe(
-      filter((data) => !!data),
-      switchMap(({ from, to, interval }) => {
-        const url = `${this.constants.env.v2BaseURL}/apis/${apiId}/analytics?type=HISTOGRAM&from=${from}&to=${to}&interval=${interval}&aggregations=${aggregation.type}:${aggregation.field}`;
-        return this.http.get<HistogramAnalyticsResponse>(url);
-      }),
-    );
+  getHistogramAnalytics(apiId: string, aggregations: string, { from, to, interval }: TimeRangeParams) {
+    const url = `${this.constants.env.v2BaseURL}/apis/${apiId}/analytics?type=HISTOGRAM&from=${from}&to=${to}&interval=${interval}&aggregations=${aggregations}`;
+    return this.http.get<HistogramAnalyticsResponse>(url);
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
@@ -32,14 +32,6 @@ export const defineLineColors = (code: string) => {
   return colors[Math.floor(+code / 100) - 1];
 };
 
-export const names = {
-  'avg_gateway-response-time-ms': 'Gateway Response Time',
-};
-
-export const formatName = (name: string) => {
-  return names[name] || name;
-};
-
 @Component({
   selector: 'gio-chart-line',
   templateUrl: './gio-chart-line.component.html',
@@ -101,7 +93,7 @@ export class GioChartLineComponent implements OnInit {
       },
 
       series: this.data?.map((item) => ({
-        name: formatName(item.name),
+        name: item.name,
         data: item.values,
         type: 'spline',
         color: defineLineColors(item.name),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10069

## Description

- added multiple aggregations option for widgets
- added **endpoint** aggregation for response time
- clean ups

<img width="899" height="443" alt="image" src="https://github.com/user-attachments/assets/485b9ff0-5168-4cff-a62d-4f3e1beff2e7" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dqbhvfkcxu.chromatic.com)
<!-- Storybook placeholder end -->
