### PR TITLE
fix: handle tag removal when the environment contains V4 native APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiTagServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiTagServiceImplTest.java
@@ -117,7 +117,7 @@ public class ApiTagServiceImplTest {
         when(apiRepository.search(any(), isNull(), isA(ApiFieldFilter.class))).thenReturn(Stream.of(api));
         when(apiRepository.update(any())).then(invocation -> invocation.getArgument(0));
 
-        when(objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.v4.Api.class)).thenReturn(apiDefinition);
+        when(objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.v4.AbstractApi.class)).thenReturn(apiDefinition);
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         apiTagService.deleteTagFromAPIs(executionContext, "intranet");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9953

## Description

Issue: Tag deletion fails if a V4 API of type `native` (e.g., Kafka) exists in the environment, even when the tag is not applied to that API.
Root Cause: Tag cleanup logic attempts to deserialize all API definitions using `Api.class`. This fails for native APIs, as they require deserialization via `AbstractApi.class` to correctly resolve subtypes based on the "type" field (e.g., "native", "proxy", "message").
Fix: Switched deserialization to use `AbstractApi.class`, allowing Jackson to handle polymorphic API types correctly and proceed with cleanup.

Issue - 

https://github.com/user-attachments/assets/6e229fa5-5fe8-4761-8634-b1a4199cfc58

Fix -

https://github.com/user-attachments/assets/0dee358e-0917-4778-bb52-f4765acfc61d



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

