### PR TITLE
prepare migration to allow the different modes

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import io.gravitee.apim.core.api.model.UpdateNativeApi;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
@@ -927,7 +928,7 @@ public class ApiResource extends AbstractResource {
             );
     }
 
-    private static MigrationStateType mapState(MigrateApiUseCase.Output.State state) {
+    private static MigrationStateType mapState(MigrationResult.State state) {
         return switch (state) {
             case MIGRATED -> MigrationStateType.MIGRATED;
             case MIGRATABLE -> MigrationStateType.MIGRATABLE;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -20,6 +20,7 @@ import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
@@ -45,41 +46,24 @@ class ApiMigration {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    Api mapApi(Api source) {
-        return new Api(
-            source.getId(),
-            source.getEnvironmentId(),
-            source.getCrossId(),
-            source.getHrid(),
-            source.getName(),
-            source.getDescription(),
-            source.getVersion(),
-            source.getOriginContext(),
-            DefinitionVersion.V4,
-            apiDefinitionHttpV4(source.getApiDefinition()),
-            null,
-            null,
-            null,
-            null,
-            ApiType.PROXY,
-            source.getDeployedAt(),
-            source.getCreatedAt(),
-            source.getUpdatedAt(),
-            source.getVisibility(),
-            source.getLifecycleState(),
-            source.getPicture(),
-            source.getGroups(),
-            source.getCategories(),
-            source.getLabels(),
-            source.isDisableMembershipNotifications(),
-            source.getApiLifecycleState(),
-            source.getBackground()
-        );
+    MigrationResult<Api> mapApi(Api source) {
+        return apiDefinitionHttpV4(source.getApiDefinition())
+            .map(definition ->
+                source
+                    .toBuilder()
+                    .definitionVersion(DefinitionVersion.V4)
+                    .apiDefinitionHttpV4(definition)
+                    .apiDefinition(null)
+                    .type(ApiType.PROXY)
+                    .build()
+            );
     }
 
-    private io.gravitee.definition.model.v4.Api apiDefinitionHttpV4(io.gravitee.definition.model.Api apiDefinitionV2) {
+    private MigrationResult<io.gravitee.definition.model.v4.Api> apiDefinitionHttpV4(io.gravitee.definition.model.Api apiDefinitionV2) {
         if (apiDefinitionV2 == null) {
-            throw new IllegalArgumentException("apiDefinitionV2 must not be null");
+            return MigrationResult.issues(
+                List.of(new MigrationResult.Issue("apiDefinitionV2 must not be null", MigrationResult.State.IMPOSSIBLE))
+            );
         }
         List<Listener> listeners = List.of(
             HttpListener
@@ -128,7 +112,7 @@ class ApiMigration {
         a.setType(ApiType.PROXY);
         a.setProperties(List.of()); // TODO apiDefinitionV2.getProperties())
         a.setResources(List.of()); // TODO apiDefinitionV2.getResources());
-        return a;
+        return MigrationResult.value(a);
     }
 
     private EndpointGroup mapEndpointGroup(io.gravitee.definition.model.EndpointGroup source) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/V2toV4MigrationOperator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/V2toV4MigrationOperator.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api.model.mapper;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.plan.model.Plan;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,11 +26,11 @@ public class V2toV4MigrationOperator {
     private static final ApiMigration apiMigration = new ApiMigration();
     private static final PlanMigration planMigration = new PlanMigration();
 
-    public Api mapApi(Api source) {
+    public MigrationResult<Api> mapApi(Api source) {
         return apiMigration.mapApi(source);
     }
 
-    public Plan mapPlan(Plan plan) {
+    public MigrationResult<Plan> mapPlan(Plan plan) {
         return planMigration.mapPlan(plan);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationResult.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.utils;
+
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+public class MigrationResult<T> {
+
+    private static final Comparator<State> STATE_COMPARATOR = Comparator.comparing(State::getWeight);
+    private final Collection<Issue> issues = new ArrayList<>();
+    private final T value;
+
+    public MigrationResult(T value, Collection<Issue> issues) {
+        this.value = value;
+        this.issues.addAll(issues);
+    }
+
+    @Nullable
+    public T value() {
+        return state() != State.IMPOSSIBLE ? value : null;
+    }
+
+    public Collection<Issue> issues() {
+        return List.copyOf(issues);
+    }
+
+    public State state() {
+        return value == null ? State.IMPOSSIBLE : stream(issues).map(Issue::state).max(STATE_COMPARATOR).orElse(State.MIGRATABLE);
+    }
+
+    public MigrationResult<T> addIssue(Issue issue) {
+        issues.add(issue);
+        return this;
+    }
+
+    public MigrationResult<T> addIssues(Collection<Issue> issue) {
+        issues.addAll(issue);
+        return this;
+    }
+
+    public <U> MigrationResult<U> map(Function<T, U> mapper) {
+        U newValue = null;
+        Stream<Issue> mappingIssue = Stream.empty();
+        try {
+            newValue = mapper.apply(value);
+        } catch (RuntimeException e) {
+            mappingIssue = Stream.of(new Issue(e.getMessage(), State.IMPOSSIBLE));
+        }
+        return new MigrationResult<>(newValue, Stream.concat(mappingIssue, stream(issues)).toList());
+    }
+
+    public <U> MigrationResult<U> flatMap(Function<T, MigrationResult<U>> mapper) {
+        return mapper.apply(value).addIssues(issues);
+    }
+
+    public <U> MigrationResult<T> foldLeft(MigrationResult<U> result, BiFunction<T, U, T> merger) {
+        return new MigrationResult<>(merger.apply(value(), result.value()), issues).addIssues(result.issues);
+    }
+
+    public static <T> MigrationResult<T> value(T value) {
+        return new MigrationResult<>(value, List.of());
+    }
+
+    public static <T> MigrationResult<T> issues(Collection<Issue> issues) {
+        return new MigrationResult<>(null, issues);
+    }
+
+    public record Issue(String message, State state) {}
+
+    @RequiredArgsConstructor
+    public enum State implements Comparable<State> {
+        MIGRATABLE(0),
+        MIGRATED(1),
+        CAN_BE_FORCED(2),
+        IMPOSSIBLE(3);
+
+        @Getter
+        private final int weight;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.mapper.V2toV4MigrationOperator;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditActor;
@@ -40,7 +41,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import lombok.Getter;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -83,53 +85,81 @@ public class MigrateApiUseCase {
         // Preconditions
         if (api.isEmpty()) {
             throw new ApiNotFoundException(input.apiId());
-        } else if (api.get().getDefinitionVersion() != DefinitionVersion.V2) {
+        }
+        MigrationResult<?> precondition = MigrationResult.value(1);
+        if (api.get().getDefinitionVersion() != DefinitionVersion.V2) {
             return new Output(
                 input.apiId(),
-                List.of(new Output.Issue("Cannot upgrade an API which is not a v2 definition", Output.State.IMPOSSIBLE))
+                List.of(new MigrationResult.Issue("Cannot upgrade an API which is not a v2 definition", MigrationResult.State.IMPOSSIBLE))
             );
         } else if (!apiStateService.isSynchronized(api.get(), input.auditInfo())) {
-            return new Output(
-                input.apiId(),
-                List.of(new Output.Issue("Cannot upgrade an API which is out of sync", Output.State.CAN_BE_FORCED))
-            );
+            precondition =
+                precondition.addIssue(
+                    new MigrationResult.Issue("Cannot upgrade an API which is out of sync", MigrationResult.State.CAN_BE_FORCED)
+                );
         }
 
         // Migration
+        var migrationResult = precondition.flatMap(ignored -> upgradeApiOperator.mapApi(api.get())).map(Migration::new);
+
         var plans = planService.findByApiId(input.apiId());
         for (var plan : plans) {
-            Plan migratedPlan = upgradeApiOperator.mapPlan(plan);
-            if (input.mode() != Input.UpgradeMode.DRY_RUN) {
-                planService.update(migratedPlan);
-            }
+            var migratedPlan = upgradeApiOperator.mapPlan(plan);
+            migrationResult = migrationResult.foldLeft(migratedPlan, Migration::withPlan);
         }
-        Api upgraded = upgradeApiOperator.mapApi(api.get());
 
         // Apply
-        Output.State state = Output.State.MIGRATABLE;
-        if (input.mode() != Input.UpgradeMode.DRY_RUN) {
-            upgraded = apiCrudService.update(upgraded);
-            var apiPrimaryOwner = apiPrimaryOwnerDomainService.getApiPrimaryOwner(input.auditInfo().organizationId(), input.apiId());
+        MigrationResult.State state = applyMigration(
+            migrationResult,
+            input.mode(),
+            migration -> {
+                var upgraded = apiCrudService.update(migration.api());
+                var apiPrimaryOwner = apiPrimaryOwnerDomainService.getApiPrimaryOwner(input.auditInfo().organizationId(), input.apiId());
 
-            auditService.createApiAuditLog(
-                ApiAuditLogEntity
-                    .builder()
-                    .event(ApiAuditEvent.API_UPDATED)
-                    .actor(AuditActor.builder().userId(input.auditInfo().actor().userId()).build())
-                    .apiId(input.apiId())
-                    .environmentId(input.auditInfo().environmentId())
-                    .organizationId(input.auditInfo().organizationId())
-                    .createdAt(TimeProvider.now())
-                    .oldValue(api.get())
-                    .newValue(upgraded)
-                    .properties(Map.of(AuditProperties.API, input.apiId()))
-                    .build()
-            );
-            var auditInfo = new ApiIndexerDomainService.Context(input.auditInfo(), false);
-            apiIndexerDomainService.index(auditInfo, upgraded, apiPrimaryOwner);
-            state = Output.State.MIGRATED;
+                auditService.createApiAuditLog(
+                    ApiAuditLogEntity
+                        .builder()
+                        .event(ApiAuditEvent.API_UPDATED)
+                        .actor(AuditActor.builder().userId(input.auditInfo().actor().userId()).build())
+                        .apiId(input.apiId())
+                        .environmentId(input.auditInfo().environmentId())
+                        .organizationId(input.auditInfo().organizationId())
+                        .createdAt(TimeProvider.now())
+                        .oldValue(api.get())
+                        .newValue(upgraded)
+                        .properties(Map.of(AuditProperties.API, input.apiId()))
+                        .build()
+                );
+                var indexerContext = new ApiIndexerDomainService.Context(input.auditInfo(), false);
+                apiIndexerDomainService.index(indexerContext, upgraded, apiPrimaryOwner);
+                // Plans
+                migration.plans().forEach(planService::update);
+            }
+        );
+        return new Output(input.apiId(), migrationResult.issues(), state);
+    }
+
+    private <T> MigrationResult.State applyMigration(MigrationResult<T> result, Input.UpgradeMode mode, Consumer<T> consumer) {
+        if (mode == Input.UpgradeMode.DRY_RUN) {
+            return result.state();
         }
-        return new Output(upgraded.getId(), List.of(), state);
+        var acceptableLimit = mode == Input.UpgradeMode.FORCE ? MigrationResult.State.CAN_BE_FORCED : MigrationResult.State.MIGRATABLE;
+        if (result.state().getWeight() <= acceptableLimit.getWeight()) {
+            consumer.accept(result.value());
+            return MigrationResult.State.MIGRATED;
+        } else {
+            return result.state();
+        }
+    }
+
+    private record Migration(Api api, Collection<Plan> plans) {
+        public Migration(Api api) {
+            this(api, List.of());
+        }
+
+        public Migration withPlan(Plan plan) {
+            return new Migration(api, Stream.concat(plans.stream(), Stream.of(plan)).toList());
+        }
     }
 
     public record Input(String apiId, UpgradeMode mode, AuditInfo auditInfo) {
@@ -139,24 +169,15 @@ public class MigrateApiUseCase {
         }
     }
 
-    public record Output(String apiId, Collection<Issue> issues, State state) {
-        private static final Comparator<Output.State> STATE_COMPARATOR = Comparator.comparing(Output.State::getWeight);
+    public record Output(String apiId, Collection<MigrationResult.Issue> issues, MigrationResult.State state) {
+        private static final Comparator<MigrationResult.State> STATE_COMPARATOR = Comparator.comparing(MigrationResult.State::getWeight);
 
-        public Output(String apiId, Collection<Issue> issues) {
-            this(apiId, issues, stream(issues).map(Issue::state).max(STATE_COMPARATOR).orElse(State.MIGRATABLE));
-        }
-
-        public record Issue(String message, State state) {}
-
-        @RequiredArgsConstructor
-        public enum State implements Comparable<State> {
-            MIGRATABLE(0),
-            MIGRATED(1),
-            CAN_BE_FORCED(2),
-            IMPOSSIBLE(3);
-
-            @Getter
-            private final int weight;
+        public Output(String apiId, Collection<MigrationResult.Issue> issues) {
+            this(
+                apiId,
+                issues,
+                stream(issues).map(MigrationResult.Issue::state).max(STATE_COMPARATOR).orElse(MigrationResult.State.MIGRATABLE)
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/utils/MigrationResultTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/utils/MigrationResultTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api.model.utils.MigrationResult.Issue;
+import io.gravitee.apim.core.api.model.utils.MigrationResult.State;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MigrationResultTest {
+
+    @Test
+    void should_create_result_with_mapper_that_succeeds() {
+        // Given
+        Function<Integer, String> mapper = Object::toString;
+        Collection<Issue> issues = List.of(new Issue("Test issue", State.MIGRATED));
+        var previousResult = new MigrationResult<>(42, issues);
+
+        // When
+        MigrationResult<String> result = previousResult.map(mapper);
+
+        // Then
+        assertThat(result.value()).isEqualTo("42");
+        assertThat(result.issues()).containsExactlyElementsOf(issues);
+        assertThat(result.state()).isEqualTo(State.MIGRATED);
+    }
+
+    @Test
+    void should_create_result_with_mapper_that_fails() {
+        // Given
+        Function<Integer, String> mapper = i -> {
+            throw new RuntimeException("Mapping failed");
+        };
+        var issues = List.of(new Issue("Test issue", State.CAN_BE_FORCED));
+        var previousResult = new MigrationResult<>(42, issues);
+
+        // When
+        MigrationResult<String> result = previousResult.map(mapper);
+
+        // Then
+        assertThat(result.value()).isNull();
+
+        assertThat(result.issues()).contains(new Issue("Mapping failed", State.IMPOSSIBLE), new Issue("Test issue", State.CAN_BE_FORCED));
+        assertThat(result.state()).isEqualTo(State.IMPOSSIBLE);
+    }
+
+    @Test
+    void should_return_null_when_state_is_impossible() {
+        // Given
+        Collection<Issue> issues = List.of(new Issue("Test issue", State.IMPOSSIBLE));
+        MigrationResult<String> result = new MigrationResult<>("value", issues);
+
+        // When & Then
+        assertThat(result.value()).isNull();
+    }
+
+    @Nested
+    class IssuesMethodTests {
+
+        @Test
+        void should_return_copy_of_issues_collection() {
+            // Given
+            Collection<Issue> originalIssues = new ArrayList<>();
+            originalIssues.add(new Issue("Test issue", State.MIGRATABLE));
+            MigrationResult<String> result = new MigrationResult<>("test", originalIssues);
+
+            // When
+            Collection<Issue> returnedIssues = result.issues();
+            originalIssues.add(new Issue("Another issue", State.MIGRATED));
+
+            // Then
+            assertThat(returnedIssues).hasSize(1);
+            assertThat(returnedIssues).extracting(Issue::message).containsExactly("Test issue");
+        }
+    }
+
+    @Nested
+    class StateMethodTests {
+
+        @Test
+        void should_return_impossible_when_value_is_null() {
+            // Given
+            MigrationResult<String> result = MigrationResult.issues(List.of());
+
+            // When & Then
+            assertThat(result.state()).isEqualTo(State.IMPOSSIBLE);
+        }
+
+        @Test
+        void should_return_migratable_when_no_issues() {
+            // Given
+            MigrationResult<String> result = MigrationResult.value("test");
+
+            // When & Then
+            assertThat(result.state()).isEqualTo(State.MIGRATABLE);
+        }
+
+        @Test
+        void should_return_highest_state_weight_from_issues() {
+            // Given
+            Collection<Issue> issues = List.of(
+                new Issue("Issue 1", State.MIGRATABLE),
+                new Issue("Issue 2", State.CAN_BE_FORCED),
+                new Issue("Issue 3", State.MIGRATED)
+            );
+            MigrationResult<String> result = new MigrationResult<>("test", issues);
+
+            // When & Then
+            assertThat(result.state()).isEqualTo(State.CAN_BE_FORCED);
+        }
+    }
+
+    @Nested
+    class MapMethodTests {
+
+        @Test
+        void should_mapvalue_and_preserve_issues() {
+            // Given
+            String originalValue = "42";
+            Collection<Issue> issues = List.of(new Issue("Test issue", State.MIGRATED));
+            MigrationResult<String> originalResult = new MigrationResult<>(originalValue, issues);
+            Function<String, Integer> mapper = Integer::parseInt;
+
+            // When
+            MigrationResult<Integer> mappedResult = originalResult.map(mapper);
+
+            // Then
+            assertThat(mappedResult.value()).isEqualTo(42);
+            assertThat(mappedResult.issues()).containsExactlyElementsOf(issues);
+            assertThat(mappedResult.state()).isEqualTo(State.MIGRATED);
+        }
+
+        @Test
+        void should_handle_mapping_exceptions() {
+            // Given
+            String originalValue = "not a number";
+            Collection<Issue> issues = List.of(new Issue("Test issue", State.MIGRATABLE));
+            MigrationResult<String> originalResult = new MigrationResult<>(originalValue, issues);
+            Function<String, Integer> mapper = Integer::parseInt;
+
+            // When
+            MigrationResult<Integer> mappedResult = originalResult.map(mapper);
+
+            // Then
+            assertThat(mappedResult.value()).isNull();
+            assertThat(mappedResult.issues()).hasSize(2);
+            assertThat(mappedResult.state()).isEqualTo(State.IMPOSSIBLE);
+        }
+    }
+
+    @Test
+    void should_flat_map_value_and_combine_issues() {
+        // Given
+        String originalValue = "test";
+        var originalIssues = List.of(new Issue("Original issue", State.MIGRATABLE));
+        MigrationResult<String> originalResult = new MigrationResult<>(originalValue, originalIssues);
+
+        var mappedIssues = List.of(new Issue("Mapped issue", State.MIGRATED));
+        Function<String, MigrationResult<Integer>> mapper = s -> new MigrationResult<>(s.length(), mappedIssues);
+
+        // When
+        MigrationResult<Integer> mappedResult = originalResult.flatMap(mapper);
+
+        // Then
+        assertThat(mappedResult.value()).isEqualTo(4);
+        assertThat(mappedResult.issues()).extracting(Issue::message).containsExactlyInAnyOrder("Original issue", "Mapped issue");
+        assertThat(mappedResult.state()).isEqualTo(State.MIGRATED);
+    }
+
+    @Test
+    void should_fold_left_with_another_result_and_combine_issues() {
+        // Given
+        String value1 = "Hello";
+        var issues1 = List.of(new Issue("Issue 1", State.MIGRATABLE));
+        MigrationResult<String> result1 = new MigrationResult<>(value1, issues1);
+
+        int value2 = 12;
+        var issues2 = List.of(new Issue("Issue 2", State.CAN_BE_FORCED));
+        MigrationResult<Integer> result2 = new MigrationResult<>(value2, issues2);
+
+        // When
+        MigrationResult<String> foldedResult = result1.foldLeft(result2, (s1, s2) -> s1 + " " + s2);
+
+        // Then
+        assertThat(foldedResult.value()).isEqualTo("Hello 12");
+        assertThat(foldedResult.issues()).extracting(Issue::message).containsExactlyInAnyOrder("Issue 1", "Issue 2");
+        assertThat(foldedResult.state()).isEqualTo(State.CAN_BE_FORCED);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
@@ -44,6 +44,7 @@ import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -203,14 +204,11 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.IMPOSSIBLE);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.IMPOSSIBLE);
         assertThat(result.apiId()).isEqualTo(API_ID);
         assertThat(result.issues())
             .containsExactly(
-                new MigrateApiUseCase.Output.Issue(
-                    "Cannot upgrade an API which is not a v2 definition",
-                    MigrateApiUseCase.Output.State.IMPOSSIBLE
-                )
+                new MigrationResult.Issue("Cannot upgrade an API which is not a v2 definition", MigrationResult.State.IMPOSSIBLE)
             );
     }
 
@@ -225,15 +223,10 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.CAN_BE_FORCED);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.CAN_BE_FORCED);
         assertThat(result.apiId()).isEqualTo(API_ID);
         assertThat(result.issues())
-            .containsExactly(
-                new MigrateApiUseCase.Output.Issue(
-                    "Cannot upgrade an API which is out of sync",
-                    MigrateApiUseCase.Output.State.CAN_BE_FORCED
-                )
-            );
+            .containsExactly(new MigrationResult.Issue("Cannot upgrade an API which is out of sync", MigrationResult.State.CAN_BE_FORCED));
     }
 
     @Test
@@ -249,7 +242,7 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, DRY_RUN, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.MIGRATABLE);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.MIGRATABLE);
         assertThat(result.apiId()).isEqualTo(API_ID);
 
         var storedApi = apiCrudService.findById(API_ID);
@@ -273,7 +266,7 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.MIGRATED);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.MIGRATED);
         assertThat(result.apiId()).isEqualTo(API_ID);
 
         var upgradedApiOpt = apiCrudService.findById(API_ID);
@@ -312,7 +305,7 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.MIGRATED);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.MIGRATED);
 
         var upgradedApiOpt = apiCrudService.findById(API_ID);
         assertThat(upgradedApiOpt).hasValueSatisfying(MigrateApiUseCaseTest::assertApiV4);
@@ -338,7 +331,7 @@ class MigrateApiUseCaseTest {
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
 
         // Then
-        assertThat(result.state()).isEqualTo(MigrateApiUseCase.Output.State.MIGRATED);
+        assertThat(result.state()).isEqualTo(MigrationResult.State.MIGRATED);
 
         var upgradedApiOpt = apiCrudService.findById(API_ID);
         assertThat(upgradedApiOpt).hasValueSatisfying(MigrateApiUseCaseTest::assertApiV4);


### PR DESCRIPTION
## Description

- don’t store migrated plan if dry run
- save in db only when all is OK or when it’s forced
- help to give maximum information in report
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rkxktflrsq.chromatic.com)
<!-- Storybook placeholder end -->
