### PR TITLE
ci: run dangerjs job all the times

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -116,6 +116,18 @@ commands:
           command: docker logout graviteeio.azurecr.io
     description: Logout from Azure Container Registry
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -172,18 +184,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -1093,6 +1093,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:
@@ -1107,12 +1111,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -164,6 +164,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -174,12 +178,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -279,6 +279,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -289,12 +293,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -323,6 +323,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Test gateway
+            - Integration tests
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -188,6 +188,14 @@ jobs:
       - store_test_results:
           path: ~/test-results
     parallelism: 4
+  job-validate-workflow-status:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - run:
+          name: Check workflow jobs
+          command: echo "Congratulations! If you can read this, everything is OK"
 workflows:
   pull_requests:
     jobs:
@@ -230,6 +238,10 @@ workflows:
             - cicd-orchestrator
           requires:
             - Build backend
+      - job-validate-workflow-status:
+          name: Validate workflow status
+          requires:
+            - Integration tests
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -204,6 +204,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -214,12 +218,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -507,6 +507,7 @@ workflows:
             - Test definition
             - Test gateway
             - Test rest-api
+            - Integration tests
             - Test plugins
             - Test repository
 orbs:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -405,6 +405,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -415,12 +419,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -323,6 +323,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Integration tests
             - Test plugins
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -280,6 +280,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -290,12 +294,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -66,6 +66,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -97,18 +109,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -231,6 +231,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-setup:
           name: Setup
           context:
@@ -241,12 +245,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -92,6 +92,18 @@ commands:
           when: always
     description: Save Maven cache for a dedicated job
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -292,6 +304,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
@@ -37,6 +37,18 @@ commands:
           event: fail
           template: basic_fail_1
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -86,6 +98,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -92,6 +92,18 @@ commands:
           when: always
     description: Save Maven cache for a dedicated job
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -231,6 +243,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -92,6 +92,18 @@ commands:
           paths:
             - ./<< parameters.apim-ui-project >>/node_modules
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -148,18 +160,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -634,6 +634,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:
@@ -648,12 +652,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -800,6 +800,7 @@ workflows:
             - Test definition
             - Test gateway
             - Test rest-api
+            - Integration tests
             - Test plugins
             - Test repository
             - Lint & test APIM Console

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -116,6 +116,18 @@ commands:
           command: docker logout graviteeio.azurecr.io
     description: Logout from Azure Container Registry
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -172,18 +184,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -1093,6 +1093,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:
@@ -1107,12 +1111,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -92,6 +92,18 @@ commands:
           paths:
             - ./<< parameters.apim-ui-project >>/node_modules
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -148,18 +160,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -634,6 +634,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:
@@ -648,12 +652,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -800,6 +800,7 @@ workflows:
             - Test definition
             - Test gateway
             - Test rest-api
+            - Integration tests
             - Test plugins
             - Test repository
             - Lint & test APIM Console

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -117,6 +117,18 @@ commands:
           command: docker logout graviteeio.azurecr.io
     description: Logout from Azure Container Registry
 jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn run danger
   job-test-apim-charts:
     parameters:
       helmClientVersion:
@@ -173,18 +185,6 @@ jobs:
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate
-  job-danger-js:
-    docker:
-      - image: cimg/node:20.11.1
-    resource_class: small
-    steps:
-      - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: Run Danger JS
-          command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
       - image: cimg/openjdk:21.0.5
@@ -910,6 +910,10 @@ workflows:
             - keeper/env-export:
                 secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                 var-name: GITHUB_TOKEN
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
       - job-test-apim-charts:
           name: Helm Chart - Lint & Test
           context:
@@ -924,12 +928,6 @@ workflows:
             - cicd-orchestrator
           requires:
             - Setup
-      - job-danger-js:
-          name: Run Danger JS
-          context:
-            - cicd-orchestrator
-          requires:
-            - Validate backend
       - job-build:
           name: Build backend
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -1094,6 +1094,7 @@ workflows:
             - Test definition
             - Test gateway
             - Test rest-api
+            - Integration tests
             - Test plugins
             - Test repository
             - Lint & test APIM Console

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -222,6 +222,8 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestIntegrationTests(environment.changedFiles)) {
+        // Force validation workflow in case only integration tests have change
+        // addValidationJob = true;
         const testIntegrationJob = TestIntegrationJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testIntegrationJob);
 
@@ -232,6 +234,7 @@ export class PullRequestsWorkflow {
             requires: ['Build backend'],
           }),
         );
+        requires.push('Integration tests');
       }
 
       if (!filterJobs || shouldTestPlugin(environment.changedFiles)) {


### PR DESCRIPTION
## Description

DangerJs being part of the PR's checks it needs to be run all the time## Issue
Trigger validate-workflow-status when integration tests job is run

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pgehthznbz.chromatic.com)
<!-- Storybook placeholder end -->
