### PR TITLE
chore: bump gravitee-reporter-elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>6.2.0-alpha.3</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>6.2.0-alpha.4</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.5.3</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.6.2</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.5.2</gravitee-reporter-cloud.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10024

## Description

Bump `gravitee-reporter-elasticsearch` version from `6.2.0-alpha.3` to `6.2.0-alpha.4`.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ylkgyeamzu.chromatic.com)
<!-- Storybook placeholder end -->
