### PR TITLE
fix(portal): include additional_client_metadata in application creation API

### DIFF
--- a/.run/Rest API - MongoDB.run.xml
+++ b/.run/Rest API - MongoDB.run.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Rest API - MongoDB" type="Application" factoryName="Application" folderName="Rest API">
+    <envs>
+      <env name="gravitee_license_key" value="Ic5OXgAAACAAAAACAAAADAAAAAhhbGVydC1lbmdpbmVpbmNsdWRlZAAAACAAAAACAAAABwAAAA1jb21wYW55R3Jhdml0ZWUgRGV2cwAAACkAAAACAAAABQAAABhlbWFpbGFsZWtzQGdyYXZpdGVlc291cmNlLmNvbQAAABoAAAALAAAACmV4cGlyeURhdGUAAAGbdtqn/wAAABQAAAACAAAACAAAAABmZWF0dXJlcwAAACEAAAAMAAAACWxpY2Vuc2VJZJ+3tupzW9emsI8FXUY0SmkAAAEcAAAAAQAAABAAAAEAbGljZW5zZVNpZ25hdHVyZTpNPXjo196BGEpBIbu8OATRMsYMI6jXnwZGUcFhHf/njN7gf6xkGMsStPKBAnCrfshXPAgMlnBJrKjpzzUdi0PbQJk2j4jEY5lti9l/3jYZte6aaWyB9EVA/NU2yV7uC3FHP1EKeEhQ03TMUXczqlqvDVQQqSZBPouTyhRKmuvmGQjbnTlNJPONmF6ykW7/mrEn2O1Loua8GU1VtiKzQmvv73GOvSD6UYNUS5iSWNxdK8R7l6GYm3tr9Tz0EvmpEOHD4yOs2dAW2y/aDnMMvojsnCjNphr948rFjIQ91p/V9sBu7ElcnuUzdfRU5FXz5h5KLtT9qdLrUBVboViY6GQAAAARAAAAAgAAAAUAAAAAcGFja3MAAAAiAAAAAgAAAA8AAAAHc2lnbmF0dXJlRGlnZXN0U0hBLTI1NgAAABgAAAACAAAABAAAAAh0aWVydW5pdmVyc2U=" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
     <module name="gravitee-apim-rest-api-standalone-container" />
     <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
@@ -71,8 +71,8 @@ type ApplicationFormType = FormGroup<{
 
 function mapToApplicationInput(rawValue): ApplicationInput {
   const result = rawValue as ApplicationInput;
-  if (rawValue.oauth !== undefined) {
-    result.settings.oauth.additional_client_metadata = rawValue.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
+  if (rawValue.settings.oauth !== undefined) {
+    result.settings.oauth.additional_client_metadata = rawValue.settings.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
       acc[key] = value;
       return acc;
     }, {});

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.css
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.css
@@ -69,3 +69,12 @@ gv-identity-picture {
   padding: 1px 5px 1px 0;
   opacity: 0.6;
 }
+
+.metadata-table {
+  width: 100%;
+}
+
+.metadata-section {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
@@ -173,6 +173,48 @@
               </gv-confirm>
             </div>
 
+            <!-- Added metadeta on edit application -->
+            <div class="metadata-section">
+              <ng-container>
+                <gv-button link (:gv-button:click)="addMetadata()" icon="code:plus">{{
+                  'applicationType.security.additionalClientMetadata.add' | translate
+                }}</gv-button>
+                <md-table-container *ngIf="additionalClientMetadata.controls.length > 0">
+                  <table md-table class="gv-table-dense metadata-table">
+                    <thead md-head>
+                      <tr md-row>
+                        <th md-column nowrap>Metadata Key</th>
+                        <th md-column nowrap>Metadata Value</th>
+                      </tr>
+                    </thead>
+                    <tbody md-body formArrayName="additionalClientMetadata">
+                      <tr md-row *ngFor="let metadataPair of metadataControls; let i = index" [formGroup]="metadataPair">
+                        <td md-cell>
+                          <gv-input
+                            [placeholder]="'application.settings.oauth.additionalClientMetadata.description' | translate"
+                            formControlName="key"
+                            ngDefaultControl
+                          ></gv-input>
+                        </td>
+                        <td md-cell>
+                          <gv-input
+                            [placeholder]="'applicationType.security.additionalClientMetadata.valueDescription' | translate"
+                            formControlName="value"
+                            ngDefaultControl
+                          ></gv-input>
+                        </td>
+                        <td md-cell>
+                          <gv-button link (:gv-button:click)="removeMetadata(i)" icon="general:close">{{
+                            'applicationType.security.additionalClientMetadata.remove' | translate
+                          }}</gv-button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </md-table-container>
+              </ng-container>
+            </div>
+
             <div class="grid-content">
               <div class="grid-column">
                 <div class="form__control" formArrayName="grant_types">

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
@@ -48,6 +48,7 @@ type OAuthFormType = FormGroup<{
     grant_types: FormArray;
     client_secret: FormControl<string>;
     client_id: FormControl<string>;
+    additionalClientMetadata: FormArray;
   }>;
   tls: FormGroup<{ client_certificate: FormControl<string> }>;
 }>;
@@ -141,6 +142,7 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
             client_id: new FormControl(this.application.settings.oauth.client_id, null),
             redirect_uris: new FormArray([]),
             grant_types: new FormArray([]),
+            additionalClientMetadata: new FormArray([]),
           }),
           tls: this.formBuilder.group({
             client_certificate: new FormControl(this.application.settings?.tls?.client_certificate, null),
@@ -206,6 +208,19 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
       this.application.settings.oauth.redirect_uris.forEach(value => {
         this.redirectURIs.push(new FormControl(value));
       });
+
+      // Populate existing additional client metadata
+      this.additionalClientMetadata.clear();
+      if (this.application.settings.oauth.additional_client_metadata) {
+        Object.keys(this.application.settings.oauth.additional_client_metadata).forEach(key => {
+          this.additionalClientMetadata.push(
+            this.formBuilder.group({
+              key: new FormControl(key, Validators.required),
+              value: new FormControl(this.application.settings.oauth.additional_client_metadata[key], Validators.required),
+            }),
+          );
+        });
+      }
     }
   }
 
@@ -243,10 +258,55 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
     return (this.requiresRedirectUris && this.redirectURIs.length > 0) || !this.requiresRedirectUris;
   }
 
+  addMetadata() {
+    this.additionalClientMetadata.push(
+      this.formBuilder.group({
+        key: new FormControl('', Validators.required),
+        value: new FormControl('', Validators.required),
+      }),
+    );
+    this.applicationForm.markAsDirty();
+  }
+
+  removeMetadata(i: number) {
+    this.additionalClientMetadata.removeAt(i);
+    this.applicationForm.markAsDirty();
+  }
+
+  get metadataControls() {
+    return this.additionalClientMetadata.controls as FormGroup[];
+  }
+
+  get additionalClientMetadata() {
+    return this.applicationForm.get('settings.oauth.additionalClientMetadata') as FormArray;
+  }
+
   submit() {
     this.isSaving = true;
+
+    // Convert form data to the expected format
+    const formValue = this.applicationForm.getRawValue();
+
+    // Convert additionalClientMetadata from FormArray to object format
+    if (this.isOAuth()) {
+      const oauthSettings = (formValue.settings as any).oauth;
+      if (oauthSettings && oauthSettings.additionalClientMetadata) {
+        const metadataArray = oauthSettings.additionalClientMetadata;
+        const metadataObject = {};
+
+        metadataArray.forEach(item => {
+          if (item.key && item.value) {
+            metadataObject[item.key] = item.value;
+          }
+        });
+
+        oauthSettings.additional_client_metadata = metadataObject;
+        delete oauthSettings.additionalClientMetadata;
+      }
+    }
+
     this.applicationService
-      .updateApplicationByApplicationId({ applicationId: this.application.id, application: this.applicationForm.getRawValue() })
+      .updateApplicationByApplicationId({ applicationId: this.application.id, application: formValue })
       .toPromise()
       .then(application => {
         this.application = application;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
@@ -193,6 +193,7 @@ public class ApplicationMapper {
                             .redirectUris(oAuthClientEntitySettings.getRedirectUris())
                             .responseTypes(oAuthClientEntitySettings.getResponseTypes())
                             .renewClientSecretSupported(oAuthClientEntitySettings.isRenewClientSecretSupported())
+                            .additionalClientMetadata(oAuthClientEntitySettings.getAdditionalClientMetadata())
                     );
                     application.setHasClientId(oAuthClientEntitySettings.getClientId() != null);
                 } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -132,6 +132,7 @@ public class ApplicationResource extends AbstractResource {
                 OAuthClientSettings oacs = appEntity.getSettings().getOauth();
                 oacs.setGrantTypes(application.getSettings().getOauth().getGrantTypes());
                 oacs.setRedirectUris(application.getSettings().getOauth().getRedirectUris());
+                oacs.setAdditionalClientMetadata(application.getSettings().getOauth().getAdditionalClientMetadata());
                 settings.setOauth(oacs);
             }
             if (application.getSettings().getTls() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -90,7 +90,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_APPLICATION, acls = RolePermissionAction.CREATE) })
-    public Response createApplication(@Valid @NotNull(message = "Input must not be null.") ApplicationInput applicationInput) {
+        public Response createApplication(@Valid @NotNull(message = "Input must not be null.") ApplicationInput applicationInput) {
         NewApplicationEntity newApplicationEntity = new NewApplicationEntity();
         newApplicationEntity.setDescription(applicationInput.getDescription());
         newApplicationEntity.setDomain(applicationInput.getDomain());
@@ -120,6 +120,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
                 ocs.setApplicationType(oauthAppInput.getApplicationType());
                 ocs.setGrantTypes(oauthAppInput.getGrantTypes());
                 ocs.setRedirectUris(oauthAppInput.getRedirectUris());
+                ocs.setAdditionalClientMetadata(oauthAppInput.getAdditionalClientMetadata());
                 newApplicationEntitySettings.setOauth(ocs);
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5433,6 +5433,10 @@ components:
                     type: string
                 renew_client_secret_supported:
                     type: boolean
+                additional_client_metadata:
+                    type: object
+                    additionalProperties:
+                      type: string
         TlsClientSettings:
             properties:
                 client_certificate:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9616

## Description

- Add missing additional_client_metadata field when creating OAuth client settings in portal API
- Fixes issue where additional client metadata was not passed during application creation in developer portal
- Ensures additional_client_metadata is properly included in mAPI request when DCR is enabled

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

