### PR TITLE
fix(portal): Correctly parse openapi specs with binary examples in dev portal

### DIFF
--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
@@ -19,23 +19,28 @@ import { Buffer } from 'buffer';
 
 const binaryType = new jsYAML.Type('tag:yaml.org,2002:binary', {
   kind: 'scalar',
-  resolve: (data: any) => {
-    // Validate that the data is valid Base64
-    return typeof data === 'string' && /^[A-Za-z0-9+/=]*$/.test(data);
+  resolve(data: any) {
+    // Ensure data is a valid Base64 string
+    if (typeof data !== 'string') return false;
+    try {
+      Buffer.from(data, 'base64');
+      return true;
+    } catch {
+      return false;
+    }
   },
-  construct: (data: string) => {
-    // Convert Base64 to a Buffer
-    return Buffer.from(data, 'base64').toString('utf-8'); // Convert to UTF-8 string
+  construct(data: string) {
+    return Buffer.from(data, 'base64').toString('utf-8');
   },
   instanceOf: String,
-  represent: (value: any) => {
-    // Encode the value as Base64 for YAML representation
+  represent(value: any) {
     return Buffer.from(String(value), 'utf-8').toString('base64');
   },
 });
 
-const schema = jsYAML.JSON_SCHEMA.extend([binaryType]);
+// Create schema with binary support
+const CUSTOM_SCHEMA = jsYAML.JSON_SCHEMA.extend([binaryType]);
 
 export function readYaml(content: string): any {
-  return jsYAML.load(content, { schema });
+  return jsYAML.load(content, { schema: CUSTOM_SCHEMA });
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10074

## Description

- OpenAPI specs with binary examples for content base64 are read correctly by Dev Portal.
- Replaced the content with binary tags

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
**Before change-**
<img width="1512" height="796" alt="4 5 x_APIM-10074_before" src="https://github.com/user-attachments/assets/f7ed74de-6a79-45d6-8c65-a9b5658ded36" />

**After change-**
<img width="1512" height="796" alt="local_APIM-10074_after" src="https://github.com/user-attachments/assets/8aa68de9-3c5e-4b9e-9079-0bb2350f7587" />


