### PR TITLE
feat(helm): upgrade MongoDB and Elastic dependencies to make it work on Openshift

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 4.9.0
 
 - Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)
+- Make embedded MongoDB and Elastic database deployable on OpenShit cluster. BREAKING CHANGE: as we upgrade to newer release of mongo and elastic dependencies
 
 ### 4.8.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -41,3 +41,5 @@ annotations:
       description: 'Changed default behavior to enable multi-tenant support in dictionaries'
     - kind: changed
       description: 'Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)'
+    - kind: changed
+      description: 'Make embedded MongoDB and Elastic database deployable on OpenShift cluster. BREAKING CHANGE: as we upgrade to newer release of mongo and elastic dependencies'

--- a/helm/requirements.lock
+++ b/helm/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 19.21.2
+  version: 22.0.13
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.18.5
-digest: sha256:57e9c877c85ae3678e55bc28374379bd7d69d6d26449093af0513a0e8d37ad98
-generated: "2025-03-03T08:42:14.379136+01:00"
+  version: 16.5.32
+digest: sha256:9bd9e3e7f218d94b9d309dd458dfed15287e1ef70190803c092f1df0b7d77dcd
+generated: "2025-07-17T16:09:16.835382218+02:00"

--- a/helm/requirements.yaml
+++ b/helm/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: elasticsearch
-    version: 19.21.2
+    version: 22.0.13
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled
   - name: mongodb
-    version: 13.18.5
+    version: 16.5.32
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -307,6 +307,11 @@ mongodb:
     accessModes:
       - ReadWriteOnce
     size: 1Gi
+  # For Openshift user, you can enforce the compatibility (default: auto)
+#  global:
+#    compatibility:
+#      openshift:
+#        adaptSecurityContext: force
 
 es:
   enabled: true
@@ -393,6 +398,13 @@ elasticsearch:
         memory: 1024Mi
     persistence:
       size: 20Gi
+  # For Openshift user, you can enforce the compatibility (default: auto) and need to disable sysctlImage
+#  global:
+#    compatibility:
+#      openshift:
+#        adaptSecurityContext: force
+#  sysctlImage:
+#    enabled: false
 
 alerts:
   enabled: false


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10388

## Description

Currently we can deploy APIM with specific configuration to make it works on OpenShift Cluster.

However APIM provide also configuration to deploy via helm dependencies elastic and
mongo databases which is not working in an Openshift cluster.

I see that newer version of our dependencies seems to be designed to work with OpenShift too.

Bitnami provide an attribute 'global.compatibility.openshift.adaptSecurityContext'
to 'auto' (default) or 'force'.

This for both MongoDB and Elastic helm chart.

This implies to upgrade helm chart dependencies:
* MongoDB from 13.18.5 to 16.5.32
* Elastic from 19.21.2 to 22.0.13

That mean a potential breaking change because of the major dependencies
upgrade.

