### PR TITLE
fix: handle tag removal

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTagServiceImpl.java
@@ -79,8 +79,13 @@ public class ApiTagServiceImpl implements ApiTagService {
     }
 
     private void removeTag(ExecutionContext executionContext, Api api, String tagId) throws TechnicalManagementException {
-        if (api.getDefinitionVersion() == DefinitionVersion.FEDERATED) {
-            log.debug("skipping tag removal for FEDERATED API: {}", api.getId());
+        // Skip if API is federated or has origin Kubernetes
+        if (api.getDefinitionVersion() == DefinitionVersion.FEDERATED || Api.ORIGIN_KUBERNETES.equals(api.getOrigin())) {
+            log.debug(
+                "Skipping tag removal for API: {}, reason: {}",
+                api.getId(),
+                api.getDefinitionVersion() == DefinitionVersion.FEDERATED ? "FEDERATED" : "KUBERNETES-origin"
+            );
             return;
         }
         log.debug(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9953

## Description

Consolidated the early return checks in removeTag method to a single condition
that skips tag removal for APIs with definition version FEDERATED or origin set to KUBERNETES.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

