### PR TITLE
fix: include v4 APIs in label-based search results

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -21,6 +21,8 @@ import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
@@ -319,6 +321,43 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
             .extracting(Api::getApiV4)
             .extracting(ApiV4::getName, ApiV4::getDescription, ApiV4::getApiVersion, ApiV4::getLifecycleState)
             .containsExactly(updatedName, updatedDescription, updatedVersion, updatedLifecycle);
+    }
+
+    @Test
+    public void should_add_label_and_update_api() {
+        String labelToAdd = "new-label";
+        primaryOwnerInit();
+        io.gravitee.rest.api.model.PrimaryOwnerEntity expectedPrimaryOwner = io.gravitee.rest.api.model.PrimaryOwnerEntity
+            .builder()
+            .id(USER_NAME)
+            .type(String.valueOf(Membership.Type.USER))
+            .displayName("John Doe")
+            .build();
+        ApiEntity existingApi = ApiFixtures
+            .aModelHttpApiV4()
+            .toBuilder()
+            .id(API)
+            .labels(List.of())
+            .primaryOwner(expectedPrimaryOwner)
+            .build();
+        UpdateApiV4 updateApiV4 = ApiFixtures.anUpdateApiV4().toBuilder().labels(List.of(labelToAdd)).build();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API)).thenReturn(existingApi);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), eq(existingApi))).thenReturn(true);
+        when(apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME)))
+            .thenAnswer(invocation -> {
+                UpdateApiEntity updateEntity = invocation.getArgument(2);
+                return existingApi.toBuilder().labels(updateEntity.getLabels()).primaryOwner(expectedPrimaryOwner).build();
+            });
+
+        final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
+        assertEquals(OK_200, response.getStatus());
+
+        final ApiV4 apiV4 = response.readEntity(ApiV4.class);
+        assertEquals(API, apiV4.getId());
+        assertTrue(apiV4.getLabels().contains(labelToAdd));
+        assertNotNull(apiV4.getPrimaryOwner());
+        assertEquals("John Doe", apiV4.getPrimaryOwner().getDisplayName());
     }
 
     void primaryOwnerInit() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -388,9 +388,18 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 MembershipReferenceType.API,
                 apiId
             );
+            PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(
+                executionContext,
+                userId,
+                PrimaryOwnerEntity
+                    .builder()
+                    .type(primaryOwnerMembership.getMemberType().name())
+                    .id(primaryOwnerMembership.getMemberId())
+                    .build()
+            );
 
             Api apiToUpdate = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
-            final ApiEntity existingApiEntity = apiMapper.toEntity(executionContext, apiToUpdate, primaryOwnerMembership, false);
+            final ApiEntity existingApiEntity = apiMapper.toEntity(executionContext, apiToUpdate, primaryOwner, false);
 
             apiValidationService.validateAndSanitizeUpdateApi(
                 executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -235,20 +235,6 @@ public class ApiMapper {
     public ApiEntity toEntity(
         final ExecutionContext executionContext,
         final Api api,
-        final MembershipEntity primaryOwnerMembership,
-        final boolean readDatabaseFlows
-    ) {
-        PrimaryOwnerEntity primaryOwner = PrimaryOwnerEntity
-            .builder()
-            .type(primaryOwnerMembership.getMemberType().name())
-            .id(primaryOwnerMembership.getMemberId())
-            .build();
-        return toEntity(executionContext, api, primaryOwner, readDatabaseFlows);
-    }
-
-    public ApiEntity toEntity(
-        final ExecutionContext executionContext,
-        final Api api,
         final PrimaryOwnerEntity primaryOwner,
         final boolean readDatabaseFlows
     ) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -573,25 +573,4 @@ public class ApiMapperTest {
         assertThat(nativeEntity.getFlows()).isNotNull();
         assertThat(nativeEntity.getFlows().size()).isEqualTo(2);
     }
-
-    @Test
-    public void shouldCreateEntity_withMembershipEntity_verifyPrimaryOwner() {
-        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        Api api = Api.builder().build();
-        MembershipEntity primaryOwnerMembership = MembershipEntity
-            .builder()
-            .memberType(MembershipMemberType.GROUP)
-            .memberId("group-1")
-            .build();
-        boolean readDatabaseFlows = false;
-
-        ApiEntity apiEntity = apiMapper.toEntity(executionContext, api, primaryOwnerMembership, readDatabaseFlows);
-
-        assertAll(
-            () -> assertThat(apiEntity.getPrimaryOwner().getId()).isEqualTo(primaryOwnerMembership.getMemberId()),
-            () -> assertThat(apiEntity.getPrimaryOwner().getType()).isEqualTo(primaryOwnerMembership.getMemberType().name()),
-            () -> assertThat(apiEntity.getPrimaryOwner().getEmail()).isNull(),
-            () -> assertThat(apiEntity.getPrimaryOwner().getDisplayName()).isNull()
-        );
-    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10257

## Description

Currently, APIs with definition version V4 are not returned when filtering by labels (e.g., `labels:my-label`). This fix ensures v4 APIs are properly indexed and searchable using the `labels:` filter, aligning the behavior with v2 APIs.

Issue:

<img width="555" height="298" alt="img_10257_1" src="https://github.com/user-attachments/assets/fb6a0159-c03c-457b-8046-6c08686ba5fb" />
<img width="1102" height="498" alt="img_10257" src="https://github.com/user-attachments/assets/6192cd96-fb08-4c15-bd4e-ce029ddb3772" />


Fix:

https://github.com/user-attachments/assets/03630edd-5a99-4199-b750-ea35d6db9fe8


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

