### PR TITLE
fix: use existing plan's validation value when 'validation' is null in update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -406,6 +406,7 @@ public class ApiPlansResource extends AbstractResource {
         filtered.setCommentRequired(entity.isCommentRequired());
         filtered.setCommentMessage(entity.getCommentMessage());
         filtered.setGeneralConditions(entity.getGeneralConditions());
+        filtered.setStatus(entity.getPlanStatus());
 
         return filtered;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/UpdatePlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/UpdatePlanUseCase.java
@@ -48,6 +48,9 @@ public class UpdatePlanUseCase {
         if (!planEntity.getApiId().equals(input.apiId)) {
             throw new PlanNotFoundException(input.planToUpdate.getId());
         }
+        if (input.planToUpdate.getValidation() == null) {
+            input.planToUpdate.setValidation(planEntity.getValidation());
+        }
 
         var updatedEntity = input.planToUpdate.applyTo(planEntity);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10190

## Description

When updating a v4 API plan, the 'validation' field is now used from the existing validation field if it is null or missed.
Previously, updating a v4 API plan without the 'validation' field succeeded silently, potentially corrupting the plan and blocking access to the API. This fix enforces that the 'validation' field must be present in plan update requests. 

Issue:

https://github.com/user-attachments/assets/2864cb90-6fe5-4a31-a5fa-a5ce1bae17ea



Fix:


https://github.com/user-attachments/assets/899cb77a-86cb-42e1-a2fe-eb6a6fad2ab4


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pucnzvffrr.chromatic.com)
<!-- Storybook placeholder end -->
