### PR TITLE
chore: bump gravitee-reporter-common version

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -31,7 +31,7 @@
     <name>Gravitee.io APIM - Repository - Elasticsearch</name>
 
     <properties>
-        <gravitee-reporter-common.version>1.7.0-alpha.3</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.7.0-alpha.5</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.3.0-alpha.2</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.1.3</opensearch-testcontainers.version>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10024

## Description

bump `gravitee-reporter-common` version from `1.7.0-alpha.3` to `1.7.0-alpha.5`.

