### PR TITLE
fix: remove healthcheck probe from dockerfile

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile.debian
+++ b/gravitee-apim-gateway/docker/Dockerfile.debian
@@ -38,7 +38,4 @@ COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082
 ENTRYPOINT ["./bin/gravitee"]
-VOLUME ${GRAVITEEIO_HOME}/logs
-HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18082/_node/health || exit 1
 USER graviteeio

--- a/gravitee-apim-rest-api/docker/Dockerfile.debian
+++ b/gravitee-apim-rest-api/docker/Dockerfile.debian
@@ -33,7 +33,4 @@ COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083
 ENTRYPOINT ["./bin/gravitee"]
-VOLUME ${GRAVITEEIO_HOME}/logs
-HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1
 USER graviteeio


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10103
https://github.com/gravitee-io/issues/issues/10644

## Description

When we applied https://github.com/gravitee-io/gravitee-api-management/pull/12290 we forgot to update the debian Dockerfile

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

