### PR TITLE
fix: Prevent timeout on API v2 History page due to groups API data

### DIFF
--- a/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
@@ -19,6 +19,7 @@ import { UbuntuExecutor } from '../../executors';
 import { Executor } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Executors';
 import { AnyParameterLiteral } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Parameters/types/CustomParameterLiterals.types';
 import { CircleCIEnvironment } from '../../pipelines';
+import { config } from '../../config';
 
 export abstract class AbstractTestContainerJob {
   protected static create(
@@ -40,6 +41,9 @@ export abstract class AbstractTestContainerJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName }),
+      new commands.cache.Restore({
+        keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
+      }),
       testStep,
       new commands.Run({
         name: 'Save test results',

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -130,6 +130,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-jdbc-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Management repository tests with database << parameters.jdbcType >>
           command: |-
@@ -162,6 +165,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-mongo-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Management repository tests with MongoDB << parameters.mongoVersion >>
           command: |-
@@ -201,6 +207,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-elastic-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Analytics repository tests with engine << parameters.engineType >> and version << parameters.engineVersion >>
           command: |-
@@ -233,6 +242,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-redis-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rate-limit repository tests with Redis << parameters.redisVersion >>
           command: |-

--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { of } from 'rxjs';
+
+import ApiHistoryControllerAjs from './apiHistory.controller.ajs';
+
+describe('ApiHistoryControllerAjs', () => {
+  let controller: ApiHistoryControllerAjs;
+  let mockNgGroupV2Service: any;
+
+  beforeEach(() => {
+    mockNgGroupV2Service = {
+      listById: jest.fn(),
+    };
+
+    controller = new ApiHistoryControllerAjs(
+      {} as any, // $mdDialog
+      {} as any, // ApiService
+      {} as any, // NotificationService
+      {} as any, // PolicyService
+      {} as any, // ResourceService
+      {} as any, // FlowService
+      {} as any, // ngApiV2Service
+      mockNgGroupV2Service,
+    );
+  });
+
+  describe('fetchGroupsConsumed', () => {
+    it('should fetch and set groups correctly when payloads are valid', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"groups":["group1","group2"]}' }, { payload: '{"groups":["group2","group3"]}' }],
+        },
+      };
+      const mockGroups = ['group1', 'group2', 'group3'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1', 'group2', 'group3'], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should set groups to empty array if no groups are found', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"somethingElse":["value1"]}' }, { payload: '{"anotherKey":["value2"]}' }],
+        },
+      };
+      mockNgGroupV2Service.listById = jest.fn(() => of([]));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith([], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toEqual([]);
+      });
+    });
+
+    it('should handle empty content array', () => {
+      const mockResponse = {
+        data: {
+          content: [],
+        },
+      };
+      mockNgGroupV2Service.listById = jest.fn(() => of([]));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith([], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toEqual([]);
+      });
+    });
+
+    it('should handle null groups in payload', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"groups":null}' }, { payload: '{"groups":["group1"]}' }],
+        },
+      };
+      const mockGroups = ['group1'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1'], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should handle undefined groups in payload', () => {
+      const mockResponse = {
+        data: {
+          content: [
+            { payload: '{}' }, // undefined groups
+            { payload: '{"groups":["group1"]}' },
+          ],
+        },
+      };
+      const mockGroups = ['group1'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1'], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should deduplicate group IDs', () => {
+      const mockResponse = {
+        data: {
+          content: [
+            { payload: '{"groups":["group1","group2"]}' },
+            { payload: '{"groups":["group2","group1"]}' }, // duplicate IDs
+            { payload: '{"groups":["group3","group2"]}' }, // more duplicates
+          ],
+        },
+      };
+      const mockGroups = ['group1', 'group2', 'group3'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      // Should only contain unique IDs
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1', 'group2', 'group3'], 1, 10, false);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.html
@@ -112,7 +112,6 @@
 
         <div layout-gt-sm="row" ng-if="$ctrl.advancedMode && $ctrl.parent.attachableGroups && $ctrl.parent.attachableGroups.length > 0">
           <md-input-container class="md-block" flex-gt-sm>
-            <!-- Note: Before making any changes in the label or its text please also check onSelectOpen() function -->
             <label>Groups</label>
             <md-select ng-model="$ctrl.parent.api.groups" md-on-open="$ctrl.onSelectOpen()" md-on-close="$ctrl.onSelectClose()" multiple>
               <md-option ng-repeat="group in $ctrl.parent.attachableGroups" ng-value="group">{{group.name}}</md-option>

--- a/gravitee-apim-console-webui/src/services-ngx/group-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group-v2.service.spec.ts
@@ -118,6 +118,87 @@ describe('GroupV2Service', () => {
     });
   });
 
+  describe('listById', () => {
+    it('should call API with a valid idList', (done) => {
+      const validIdList = ['id1', 'id2'];
+      const groupsResponse: GroupsResponse = fakeGroupsResponse();
+
+      groupService.listById(validIdList).subscribe((groups) => {
+        expect(groups).toMatchObject(groupsResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=10`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ ids: validIdList, paginated: true });
+
+      req.flush(groupsResponse);
+    });
+
+    it('should call API with an empty idList', (done) => {
+      const groupsResponse: GroupsResponse = fakeGroupsResponse();
+
+      groupService.listById([]).subscribe((groups) => {
+        expect(groups).toMatchObject(groupsResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=10`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ ids: [], paginated: true });
+
+      req.flush(groupsResponse);
+    });
+
+    it('should call API with default empty idList when no parameter is provided', (done) => {
+      const groupsResponse: GroupsResponse = fakeGroupsResponse();
+
+      groupService.listById().subscribe((groups) => {
+        expect(groups).toMatchObject(groupsResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=10`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ ids: [], paginated: true });
+
+      req.flush(groupsResponse);
+    });
+
+    it('should allow custom pagination', (done) => {
+      const validIdList = ['id1', 'id2'];
+      const groupsResponse: GroupsResponse = fakeGroupsResponse({ pagination: { page: 2, perPage: 5 } });
+
+      groupService.listById(validIdList, 2, 5).subscribe((groups) => {
+        expect(groups).toMatchObject(groupsResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=2&perPage=5`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ ids: validIdList, paginated: true });
+
+      req.flush(groupsResponse);
+    });
+
+    it('should handle error response', (done) => {
+      const validIdList = ['id1', 'id2'];
+      const errorMessage = 'Error occurred while fetching groups by ID';
+      const emptyGroupResponse: GroupsResponse = { data: [] };
+
+      groupService.listById(validIdList).subscribe({
+        next: (groups) => {
+          expect(groups).toEqual(emptyGroupResponse);
+          done();
+        },
+        error: () => done(),
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=10`);
+      req.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
@@ -47,6 +47,22 @@ export class GroupV2Service {
     });
   }
 
+  listById(ids: string[] = [], page = 1, perPage = 10, paginated = true): Observable<GroupsResponse> {
+    return this.http.post<GroupsResponse>(
+      `${this.constants.env.v2BaseURL}/groups/_search`,
+      {
+        ids,
+        paginated,
+      },
+      {
+        params: {
+          page,
+          perPage,
+        },
+      },
+    );
+  }
+
   public getPermissions(groupId: string): Observable<Record<string, string>> {
     return this.http.get<Record<string, string>>(`${this.constants.env.v2BaseURL}/groups/${groupId}/permissions`);
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/param/GroupSearchParams.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/param/GroupSearchParams.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.group.param;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupSearchParams {
+
+    @Valid
+    @NotNull
+    @JsonProperty("ids")
+    private Set<String> ids;
+
+    @Valid
+    @NotNull
+    @JsonProperty("paginated")
+    private boolean paginated;
+
+    /**
+     * Constructor with only ids parameter, setting paginated to true by default.
+     * @param ids The set of group IDs to search for
+     */
+    public GroupSearchParams(Set<String> ids) {
+        this.ids = ids;
+        this.paginated = true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1124,6 +1124,45 @@ paths:
                     $ref: "#/components/responses/GroupsResponse"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/groups/_search:
+      post:
+        tags:
+          - Groups
+        summary: Search for groups using id set
+        description:
+          Search for groups using a list of group IDs.
+          User must have the ENVIRONMENT_GROUP[READ] permission.
+        operationId: searchGroupsByIds
+        parameters:
+          - $ref: "#/components/parameters/pageParam"
+          - $ref: "#/components/parameters/perPageParam"
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ids
+                  - paginated
+                properties:
+                  ids:
+                    type: array
+                    description: List of group IDs to fetch
+                    minItems: 1
+                    items:
+                      type: string
+                    example:
+                      - "6881cdb8-7b87-4c5c-81cd-b87d1o3c5c03"
+                      - "bf25fa4b-6e75-4315-a5fa-4b31n21156b"
+                  paginated:
+                    type: boolean
+                    description: Whether the results should be paginated
+                    default: false
+        responses:
+          "200":
+            $ref: "#/components/responses/GroupsResponse"
+          default:
+            $ref: "#/components/responses/Error"
     /environments/{envId}/groups/{groupId}/members:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -45,6 +45,7 @@ public interface GroupService {
     List<GroupSimpleEntity> findAllByOrganization(String organizationId);
     GroupEntity findById(ExecutionContext executionContext, String groupId);
     Set<GroupEntity> findByIds(Set<String> groupIds);
+    Set<GroupEntity> findByIdsAndEnv(ExecutionContext executionContext, Set<String> groupIds);
     void associate(final ExecutionContext executionContext, String groupId, String associationType);
     Set<GroupEntity> findByEvent(final String environmentId, GroupEvent event);
     List<GroupEntity> findByName(final String environmentId, String name);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10310

## Description

Replaced Group paginated API on the history page with Groups/by-id API. Only needed groups are fetched one the basis of ids.

## Additional context

Before change network request change:

<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/8d726f86-e6d2-4dbe-b395-d8c0fafa2548" />


<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/8899b2f2-b2c7-4141-8786-0b421ea4b0ce" />


After change network request change:
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/218bcebb-7759-4b46-9205-2b01f65379e2" />

<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/04783a4c-7f72-4867-bb92-47a8e0fafb42" />



After change, video proof:


Part1 : 

https://github.com/user-attachments/assets/2b601c76-45de-4fea-aafb-396271b06f95



Part2: 

https://github.com/user-attachments/assets/d5f2fbe1-6401-4ef7-9777-c69e6543ffb0



Part3: 

https://github.com/user-attachments/assets/e17be63a-e474-4232-b8f1-c230600739a9



Part4: 

https://github.com/user-attachments/assets/01b3493b-f4ad-4ac9-84b0-ef4c18d8ebb3




<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zuqqcmevjy.chromatic.com)
<!-- Storybook placeholder end -->
