### PR TITLE
fix(portal): include additional_client_metadata in application creation API

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -125,6 +125,61 @@
               >Grant types allowed for the client. Please set only grant types you need for security reasons</mat-hint
             >
           </mat-form-field>
+
+          <!-- Additional Client Metadata Section -->
+          <div class="settings__form__content__integration__metadata">
+            <div class="settings__form__content__integration__metadata__header">
+              <button mat-button type="button" (click)="addMetadata()" data-testId="addMetadata" i18n="@@addMetadataApplicationSettings">
+                <mat-icon>add</mat-icon>
+                Add Metadata
+              </button>
+            </div>
+
+            @if (metadataControls.length > 0) {
+              <div class="settings__form__content__integration__metadata__table">
+                <!-- Table Header -->
+                <div class="metadata-header">
+                  <div class="metadata-header-cell" i18n="@@metadataKeyApplicationSettings">Metadata Key</div>
+                  <div class="metadata-header-cell" i18n="@@metadataValueApplicationSettings">Metadata Value</div>
+                  <div class="metadata-header-cell"></div>
+                </div>
+
+                <!-- Table Rows -->
+                @for (metadataGroup of metadataControls; track i; let i = $index) {
+                  <div class="metadata-row">
+                    <div class="metadata-cell">
+                      <mat-form-field class="settings__form__content__integration__metadata__field">
+                        <input
+                          matInput
+                          [formControl]="getMetadataKeyControl(metadataGroup)"
+                          placeholder="Additional metadata key"
+                          data-testId="metadataKey" />
+                      </mat-form-field>
+                    </div>
+                    <div class="metadata-cell">
+                      <mat-form-field class="settings__form__content__integration__metadata__field">
+                        <input
+                          matInput
+                          [formControl]="getMetadataValueControl(metadataGroup)"
+                          placeholder="Value of metadata key"
+                          data-testId="metadataValue" />
+                      </mat-form-field>
+                    </div>
+                    <div class="metadata-cell">
+                      <button
+                        mat-icon-button
+                        type="button"
+                        (click)="removeMetadata(i)"
+                        data-testId="removeMetadata"
+                        aria-label="Remove metadata">
+                        <mat-icon>delete</mat-icon>
+                      </button>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
         }
       </div>
     </div>

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.scss
@@ -53,6 +53,71 @@
       &__copy-code > * {
         width: 100%;
       }
+
+      &__metadata {
+        margin-top: 16px;
+
+        &__header {
+          margin-bottom: 16px;
+        }
+
+        &__table {
+          overflow: hidden;
+          width: 100%;
+          border: 1px solid #e0e0e0;
+          border-radius: 4px;
+          margin-top: 8px;
+
+          .metadata-header {
+            display: grid;
+            border-bottom: 1px solid #e0e0e0;
+            background-color: #f5f5f5;
+            grid-template-columns: 1fr 1fr 60px;
+
+            .metadata-header-cell {
+              padding: 12px 8px;
+              border-right: 1px solid #e0e0e0;
+              color: rgb(0 0 0 / 87%);
+              font-weight: 500;
+
+              &:last-child {
+                border-right: none;
+              }
+            }
+          }
+
+          .metadata-row {
+            display: grid;
+            border-bottom: 1px solid #e0e0e0;
+            grid-template-columns: 1fr 1fr 60px;
+
+            &:last-child {
+              border-bottom: none;
+            }
+
+            .metadata-cell {
+              display: flex;
+              align-items: center;
+              padding: 8px;
+              border-right: 1px solid #e0e0e0;
+
+              &:last-child {
+                justify-content: center;
+                border-right: none;
+              }
+            }
+          }
+        }
+
+        &__field {
+          width: 100%;
+          margin-bottom: 8px;
+
+          .mat-mdc-form-field {
+            width: 100%;
+          }
+        }
+      }
     }
   }
 

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -76,6 +76,7 @@ export interface ApplicationSettingsOAuth {
   renew_client_secret_supported: boolean;
   response_types: string[];
   grant_types: string[];
+  additional_client_metadata?: Record<string, string>;
 }
 
 export interface ApplicationSettingsTls {

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.spec.ts
@@ -19,9 +19,14 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApiLabelsPipe } from '../../../pipes/api-labels.pipe';
 import { ApiStatesPipe } from '../../../pipes/api-states.pipe';
+import { ApplicationService } from '../../../../../projects/portal-webclient-sdk/src/lib';
+import { NotificationService } from '../../../services/notification.service';
+import { ConfigurationService } from '../../../services/configuration.service';
+import { SubscriptionService } from '../../../../../projects/portal-webclient-sdk/src/lib';
 
 import { ApplicationCreationComponent } from './application-creation.component';
 
@@ -30,12 +35,37 @@ describe('ApplicationCreationComponent', () => {
     { id: 'type1', name: 'type1' },
     { id: 'type2', name: 'type2' },
   ];
+
+  const mockApplicationService = {
+    createApplication: jest.fn(),
+  };
+
+  const mockSubscriptionService = {
+    createSubscription: jest.fn(),
+  };
+
+  const mockNotificationService = {
+    reset: jest.fn(),
+  };
+
+  const mockConfigurationService = {
+    hasFeature: jest.fn(),
+  };
+
   const createComponent = createComponentFactory({
     component: ApplicationCreationComponent,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [HttpClientTestingModule, RouterTestingModule, FormsModule, ReactiveFormsModule],
     declarations: [ApiStatesPipe, ApiLabelsPipe],
-    providers: [ApiStatesPipe, ApiLabelsPipe, { provide: ActivatedRoute, useValue: { snapshot: { data: { enabledApplicationTypes } } } }],
+    providers: [
+      ApiStatesPipe,
+      ApiLabelsPipe,
+      { provide: ActivatedRoute, useValue: { snapshot: { data: { enabledApplicationTypes } } } },
+      { provide: ApplicationService, useValue: mockApplicationService },
+      { provide: SubscriptionService, useValue: mockSubscriptionService },
+      { provide: NotificationService, useValue: mockNotificationService },
+      { provide: ConfigurationService, useValue: mockConfigurationService },
+    ],
   });
 
   let spectator: Spectator<ApplicationCreationComponent>;
@@ -44,9 +74,153 @@ describe('ApplicationCreationComponent', () => {
   beforeEach(() => {
     spectator = createComponent();
     component = spectator.component;
+    jest.clearAllMocks();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('createApp with OAuth metadata', () => {
+    beforeEach(() => {
+      // Setup form with OAuth metadata
+      component.applicationForm.patchValue({
+        name: 'Test App',
+        description: 'Test Description',
+        settings: {
+          oauth: {
+            redirect_uris: ['http://localhost'],
+            grant_types: ['authorization_code'],
+            application_type: 'web',
+            additionalClientMetadata: [
+              { key: 'custom_key1', value: 'custom_value1' },
+              { key: 'custom_key2', value: 'custom_value2' },
+            ],
+          },
+          tls: {
+            client_certificate: '',
+          },
+        },
+      });
+
+      component.subscribeList = [];
+      component.apiKeyMode = 'UNSPECIFIED';
+    });
+
+    it('should convert additionalClientMetadata array to object when creating OAuth application', async () => {
+      const mockApplication = { id: 'app-123', name: 'Test App' };
+      mockApplicationService.createApplication.mockReturnValue(of(mockApplication));
+
+      await component.createApp();
+
+      expect(mockApplicationService.createApplication).toHaveBeenCalledWith({
+        applicationInput: {
+          name: 'Test App',
+          description: 'Test Description',
+          domain: null,
+          picture: null,
+          settings: {
+            oauth: {
+              redirect_uris: ['http://localhost'],
+              grant_types: ['authorization_code'],
+              application_type: 'web',
+              additionalClientMetadata: [
+                { key: 'custom_key1', value: 'custom_value1' },
+                { key: 'custom_key2', value: 'custom_value2' },
+              ],
+              additional_client_metadata: {
+                custom_key1: 'custom_value1',
+                custom_key2: 'custom_value2',
+              },
+            },
+            tls: {
+              client_certificate: '',
+            },
+          },
+          api_key_mode: 'UNSPECIFIED',
+        },
+      });
+    });
+
+    it('should handle empty additionalClientMetadata array', async () => {
+      component.applicationForm.patchValue({
+        settings: {
+          oauth: {
+            redirect_uris: ['http://localhost'],
+            grant_types: ['authorization_code'],
+            application_type: 'web',
+            additionalClientMetadata: [],
+          },
+          tls: {
+            client_certificate: '',
+          },
+        },
+      });
+
+      const mockApplication = { id: 'app-123', name: 'Test App' };
+      mockApplicationService.createApplication.mockReturnValue(of(mockApplication));
+
+      await component.createApp();
+
+      expect(mockApplicationService.createApplication).toHaveBeenCalledWith({
+        applicationInput: {
+          name: 'Test App',
+          description: 'Test Description',
+          domain: null,
+          picture: null,
+          settings: {
+            oauth: {
+              redirect_uris: ['http://localhost'],
+              grant_types: ['authorization_code'],
+              application_type: 'web',
+              additionalClientMetadata: [],
+              additional_client_metadata: {},
+            },
+            tls: {
+              client_certificate: '',
+            },
+          },
+          api_key_mode: 'UNSPECIFIED',
+        },
+      });
+    });
+
+    it('should not modify settings when oauth is undefined', async () => {
+      component.applicationForm.patchValue({
+        settings: {
+          app: {
+            type: 'simple',
+            client_id: 'client123',
+          },
+          tls: {
+            client_certificate: '',
+          },
+        },
+      });
+
+      const mockApplication = { id: 'app-123', name: 'Test App' };
+      mockApplicationService.createApplication.mockReturnValue(of(mockApplication));
+
+      await component.createApp();
+
+      expect(mockApplicationService.createApplication).toHaveBeenCalledWith({
+        applicationInput: {
+          name: 'Test App',
+          description: 'Test Description',
+          domain: null,
+          picture: null,
+          settings: {
+            app: {
+              type: 'simple',
+              client_id: 'client123',
+            },
+            tls: {
+              client_certificate: '',
+            },
+          },
+          api_key_mode: 'UNSPECIFIED',
+        },
+      });
+    });
   });
 });

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
@@ -71,8 +71,8 @@ type ApplicationFormType = FormGroup<{
 
 function mapToApplicationInput(rawValue): ApplicationInput {
   const result = rawValue as ApplicationInput;
-  if (rawValue.oauth !== undefined) {
-    result.settings.oauth.additional_client_metadata = rawValue.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
+  if (rawValue.settings.oauth !== undefined) {
+    result.settings.oauth.additional_client_metadata = rawValue.settings.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
       acc[key] = value;
       return acc;
     }, {});

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.css
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.css
@@ -69,3 +69,12 @@ gv-identity-picture {
   padding: 1px 5px 1px 0;
   opacity: 0.6;
 }
+
+.metadata-table {
+  width: 100%;
+}
+
+.metadata-section {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
@@ -173,6 +173,40 @@
               </gv-confirm>
             </div>
 
+            <!-- Added metadeta on edit application -->
+            <div class="metadata-section">
+              <ng-container>
+                <gv-button link (:gv-button:click)="addMetadata()" icon="code:plus">{{
+                  'applicationType.security.additionalClientMetadata.add' | translate
+                }}</gv-button>
+                <md-table-container *ngIf="additionalClientMetadata.controls.length > 0">
+                  <table md-table class="gv-table-dense metadata-table">
+                    <thead md-head>
+                      <tr md-row>
+                        <th md-column nowrap>Metadata Key</th>
+                        <th md-column nowrap>Metadata Value</th>
+                      </tr>
+                    </thead>
+                    <tbody md-body formArrayName="additionalClientMetadata">
+                      <tr md-row *ngFor="let metadataPair of metadataControls; let i = index" [formGroup]="metadataPair">
+                        <td md-cell>
+                          <gv-input placeholder="Additional metadata key" formControlName="key" ngDefaultControl></gv-input>
+                        </td>
+                        <td md-cell>
+                          <gv-input placeholder="Value of metadata key" formControlName="value" ngDefaultControl></gv-input>
+                        </td>
+                        <td md-cell>
+                          <gv-button link (:gv-button:click)="removeMetadata(i)" icon="general:close">{{
+                            'applicationType.security.additionalClientMetadata.remove' | translate
+                          }}</gv-button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </md-table-container>
+              </ng-container>
+            </div>
+
             <div class="grid-content">
               <div class="grid-column">
                 <div class="form__control" formArrayName="grant_types">

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.spec.ts
@@ -18,25 +18,367 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+
+import { ApplicationService } from '../../../../../projects/portal-webclient-sdk/src/lib';
+import { NotificationService } from '../../../services/notification.service';
+import { EventService } from '../../../services/event.service';
 
 import { ApplicationGeneralComponent } from './application-general.component';
 
 describe('ApplicationGeneralComponent', () => {
+  const mockApplication = {
+    id: 'app-123',
+    name: 'Test Application',
+    description: 'Test Description',
+    domain: 'test.com',
+    picture: 'data:image/png;base64,test',
+    background: 'data:image/png;base64,background',
+    applicationType: 'WEB',
+    owner: {
+      display_name: 'Test Owner',
+    },
+    settings: {
+      oauth: {
+        client_id: 'client123',
+        client_secret: 'secret123',
+        redirect_uris: ['http://localhost'],
+        grant_types: ['authorization_code'],
+        additional_client_metadata: {
+          custom_key: 'custom_value',
+        },
+      },
+      tls: {
+        client_certificate: 'cert123',
+      },
+    },
+    created_at: '2023-01-01T00:00:00Z',
+    updated_at: '2023-01-02T00:00:00Z',
+  };
+
+  const mockApplicationType = {
+    id: 'web',
+    name: 'Web Application',
+    allowed_grant_types: [
+      { type: 'authorization_code', name: 'Authorization Code' },
+      { type: 'refresh_token', name: 'Refresh Token' },
+    ],
+    mandatory_grant_types: [{ type: 'authorization_code' }],
+    requires_redirect_uris: true,
+  };
+
+  const mockPermissions = {
+    DEFINITION: ['U', 'D'],
+  };
+
+  const mockConnectedApis = [
+    { id: 'api-1', name: 'API 1' },
+    { id: 'api-2', name: 'API 2' },
+  ];
+
+  const mockApplicationService = {
+    getSubscriberApisByApplicationId: jest.fn(),
+    updateApplicationByApplicationId: jest.fn(),
+    deleteApplicationByApplicationId: jest.fn(),
+    renewApplicationSecret: jest.fn(),
+  };
+
+  const mockNotificationService = {
+    success: jest.fn(),
+  };
+
+  const mockEventService = {
+    dispatch: jest.fn(),
+  };
+
+  const mockRouter = {
+    navigate: jest.fn(),
+  };
+
+  const mockTranslateService = {
+    currentLang: 'en',
+  };
+
   const createComponent = createComponentFactory({
     component: ApplicationGeneralComponent,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [HttpClientTestingModule, RouterTestingModule, FormsModule, ReactiveFormsModule],
+    providers: [
+      { provide: ApplicationService, useValue: mockApplicationService },
+      { provide: NotificationService, useValue: mockNotificationService },
+      { provide: EventService, useValue: mockEventService },
+      { provide: Router, useValue: mockRouter },
+      { provide: TranslateService, useValue: mockTranslateService },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          snapshot: {
+            data: {
+              application: mockApplication,
+              applicationType: mockApplicationType,
+              permissions: mockPermissions,
+            },
+          },
+        },
+      },
+    ],
   });
 
   let spectator: Spectator<ApplicationGeneralComponent>;
-  let component;
+  let component: ApplicationGeneralComponent;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockApplicationService.getSubscriberApisByApplicationId.mockReturnValue(
+      of({ data: mockConnectedApis.map(api => ({ item: api, type: 'api' })) }),
+    );
     spectator = createComponent();
     component = spectator.component;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('initialization', () => {
+    it('should initialize form with OAuth settings', () => {
+      expect(component.applicationForm).toBeTruthy();
+      expect(component.isOAuth()).toBeTruthy();
+      expect(component.canUpdate).toBeTruthy();
+      expect(component.canDelete).toBeTruthy();
+    });
+
+    it('should load connected APIs', async () => {
+      await component.connectedApis;
+      expect(mockApplicationService.getSubscriberApisByApplicationId).toHaveBeenCalledWith({
+        applicationId: 'app-123',
+        statuses: ['ACCEPTED'],
+      });
+    });
+  });
+
+  describe('form methods', () => {
+    it('should reset form', () => {
+      const resetSpy = jest.spyOn(component.applicationForm, 'reset');
+      component.reset();
+      expect(resetSpy).toHaveBeenCalledWith(mockApplication);
+    });
+
+    it('should check if OAuth is enabled', () => {
+      expect(component.isOAuth()).toBeTruthy();
+    });
+  });
+
+  describe('grant types', () => {
+    it('should update grant types', () => {
+      component.updateGrantTypes();
+      expect(component.allGrantTypes).toBeDefined();
+      expect(component.allGrantTypes.length).toBeGreaterThan(0);
+    });
+
+    it('should add grant type when switched on', () => {
+      const grantType = { type: 'refresh_token', name: 'Refresh Token' };
+      const event = { target: { value: true } };
+      component.onSwitchGrant(event, grantType);
+      expect(component.grantTypes.length).toBeGreaterThan(0);
+    });
+
+    it('should remove grant type when switched off', () => {
+      // First add a grant type
+      const grantType = { type: 'refresh_token', name: 'Refresh Token' };
+      const addEvent = { target: { value: true } };
+      component.onSwitchGrant(addEvent, grantType);
+
+      // Then remove it
+      const removeEvent = { target: { value: false } };
+      component.onSwitchGrant(removeEvent, grantType);
+
+      expect(component.grantTypes.length).toBe(1); // Only the mandatory one should remain
+    });
+  });
+
+  describe('redirect URIs', () => {
+    it('should add redirect URI', () => {
+      const event = { target: { valid: true, value: 'http://new-uri.com' } };
+      component.addRedirectUri(event);
+      expect(component.redirectURIs.length).toBeGreaterThan(1);
+    });
+
+    it('should not add duplicate redirect URI', () => {
+      const event = { target: { valid: true, value: 'http://localhost' } };
+      component.addRedirectUri(event);
+      expect(component.redirectURIs.length).toBe(1); // Should not add duplicate
+    });
+
+    it('should remove redirect URI', () => {
+      const initialLength = component.redirectURIs.length;
+      component.removeRedirectUri(0);
+      expect(component.redirectURIs.length).toBe(initialLength - 1);
+    });
+
+    it('should validate redirect URIs', () => {
+      expect(component.validRedirectUris).toBeTruthy();
+    });
+  });
+
+  describe('metadata management', () => {
+    it('should add metadata', () => {
+      const initialLength = component.additionalClientMetadata.length;
+      component.addMetadata();
+      expect(component.additionalClientMetadata.length).toBe(initialLength + 1);
+    });
+
+    it('should remove metadata', () => {
+      // First add metadata
+      component.addMetadata();
+      const lengthAfterAdd = component.additionalClientMetadata.length;
+
+      // Then remove it
+      component.removeMetadata(0);
+      expect(component.additionalClientMetadata.length).toBe(lengthAfterAdd - 1);
+    });
+
+    it('should get metadata controls', () => {
+      const controls = component.metadataControls;
+      expect(controls).toBeDefined();
+    });
+  });
+
+  describe('form submission', () => {
+    it('should submit form with OAuth metadata conversion', async () => {
+      // Add some metadata
+      component.addMetadata();
+      const metadataControl = component.additionalClientMetadata.at(0) as any;
+      metadataControl.patchValue({ key: 'test_key', value: 'test_value' });
+
+      mockApplicationService.updateApplicationByApplicationId.mockReturnValue(of(mockApplication));
+
+      await component.submit();
+
+      expect(mockApplicationService.updateApplicationByApplicationId).toHaveBeenCalled();
+      const callArg = mockApplicationService.updateApplicationByApplicationId.mock.calls[0][0];
+      expect(callArg.application.settings.oauth.additional_client_metadata).toEqual({
+        test_key: 'test_value',
+      });
+      expect(callArg.application.settings.oauth.additionalClientMetadata).toBeUndefined();
+    });
+
+    it('should handle submission error', async () => {
+      mockApplicationService.updateApplicationByApplicationId.mockReturnValue(throwError(() => new Error('Update failed')));
+
+      await component.submit();
+
+      expect(mockApplicationService.updateApplicationByApplicationId).toHaveBeenCalled();
+    });
+  });
+
+  describe('application deletion', () => {
+    it('should delete application', async () => {
+      mockApplicationService.deleteApplicationByApplicationId.mockReturnValue(of({}));
+
+      await component.delete();
+
+      expect(mockApplicationService.deleteApplicationByApplicationId).toHaveBeenCalledWith({
+        applicationId: 'app-123',
+      });
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['applications']);
+      expect(mockNotificationService.success).toHaveBeenCalledWith('application.success.delete');
+    });
+
+    it('should handle deletion error', async () => {
+      mockApplicationService.deleteApplicationByApplicationId.mockReturnValue(throwError(() => new Error('Delete failed')));
+
+      await component.delete();
+
+      expect(mockApplicationService.deleteApplicationByApplicationId).toHaveBeenCalled();
+    });
+  });
+
+  describe('secret renewal', () => {
+    it('should renew application secret', async () => {
+      mockApplicationService.renewApplicationSecret.mockReturnValue(of(mockApplication));
+
+      await component.renewSecret();
+
+      expect(mockApplicationService.renewApplicationSecret).toHaveBeenCalledWith({
+        applicationId: 'app-123',
+      });
+      expect(mockNotificationService.success).toHaveBeenCalledWith('application.success.renewSecret');
+    });
+
+    it('should handle renewal error', async () => {
+      mockApplicationService.renewApplicationSecret.mockReturnValue(throwError(() => new Error('Renewal failed')));
+
+      await component.renewSecret();
+
+      expect(mockApplicationService.renewApplicationSecret).toHaveBeenCalled();
+    });
+  });
+
+  describe('utility methods', () => {
+    it('should format date to locale string', () => {
+      const result = component.toLocaleDateString('2023-01-01T00:00:00Z');
+      expect(result).toBeDefined();
+    });
+
+    it('should get display name', () => {
+      const displayName = component.displayName;
+      expect(displayName).toBeDefined();
+    });
+
+    it('should handle gv-list click', () => {
+      const detail = { item: { id: 'api-1' } };
+      component.onGvListClick(detail);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/catalog/api/api-1'], {
+        queryParams: { app: 'app-123' },
+      });
+    });
+  });
+
+  describe('non-OAuth application', () => {
+    it('should handle non-OAuth application settings', () => {
+      // Test the isOAuth method with non-OAuth settings
+      const nonOAuthSettings = {
+        app: {
+          type: 'simple',
+          client_id: 'simple-client',
+        },
+        tls: {
+          client_certificate: 'cert123',
+        },
+      };
+
+      // Create a mock application with non-OAuth settings
+      const testApplication = {
+        ...mockApplication,
+        settings: nonOAuthSettings as any,
+      };
+
+      // Test the isOAuth logic directly
+      const isOAuth = testApplication && (testApplication.settings as any).oauth != null;
+      expect(isOAuth).toBeFalsy();
+    });
+
+    it('should handle form submission without OAuth metadata conversion', async () => {
+      // Test the submit method's OAuth metadata conversion logic
+      const formValue = {
+        settings: {
+          app: {
+            type: 'simple',
+            client_id: 'simple-client',
+          },
+        } as any,
+      };
+
+      // Simulate the submit method's logic for non-OAuth applications
+      const isOAuth = formValue.settings.oauth !== undefined;
+      expect(isOAuth).toBeFalsy();
+
+      // Verify that no OAuth metadata conversion occurs
+      expect(formValue.settings.app).toBeDefined();
+      expect(formValue.settings.oauth).toBeUndefined();
+    });
   });
 });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
@@ -193,6 +193,7 @@ public class ApplicationMapper {
                             .redirectUris(oAuthClientEntitySettings.getRedirectUris())
                             .responseTypes(oAuthClientEntitySettings.getResponseTypes())
                             .renewClientSecretSupported(oAuthClientEntitySettings.isRenewClientSecretSupported())
+                            .additionalClientMetadata(oAuthClientEntitySettings.getAdditionalClientMetadata())
                     );
                     application.setHasClientId(oAuthClientEntitySettings.getClientId() != null);
                 } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -132,6 +132,7 @@ public class ApplicationResource extends AbstractResource {
                 OAuthClientSettings oacs = appEntity.getSettings().getOauth();
                 oacs.setGrantTypes(application.getSettings().getOauth().getGrantTypes());
                 oacs.setRedirectUris(application.getSettings().getOauth().getRedirectUris());
+                oacs.setAdditionalClientMetadata(application.getSettings().getOauth().getAdditionalClientMetadata());
                 settings.setOauth(oacs);
             }
             if (application.getSettings().getTls() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -120,6 +120,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
                 ocs.setApplicationType(oauthAppInput.getApplicationType());
                 ocs.setGrantTypes(oauthAppInput.getGrantTypes());
                 ocs.setRedirectUris(oauthAppInput.getRedirectUris());
+                ocs.setAdditionalClientMetadata(oauthAppInput.getAdditionalClientMetadata());
                 newApplicationEntitySettings.setOauth(ocs);
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5432,7 +5432,11 @@ components:
                 application_type:
                     type: string
                 renew_client_secret_supported:
-                    type: boolean
+                  type: boolean
+                additional_client_metadata:
+                    type: object
+                    additionalProperties:
+                      type: string
         TlsClientSettings:
             properties:
                 client_certificate:


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-9616

## Description

- Add missing additional_client_metadata field when creating OAuth client settings in portal API
- Fixes issue where additional client metadata was not passed during application creation in developer portal
- Ensures additional_client_metadata is properly included in mAPI request when DCR is enabled

## Additional conte

https://github.com/user-attachments/assets/333b9426-cdae-48e5-bf95-a127e20739af

https://github.com/user-attachments/assets/26741d1b-c9ba-47b2-8b75-8319d3008e35

