### PR TITLE
fix(gateway): update SSE status metric before closing

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/logging/MetricsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/logging/MetricsIntegrationTest.java
@@ -102,7 +102,7 @@ class MetricsIntegrationTest extends AbstractGatewayTest {
                     soft.assertThat(metrics.getClientIdentifier()).isEqualTo(CLIENT_ID);
                     soft.assertThat(metrics.getTransactionId()).isEqualTo(TRANSACTION_ID);
                     soft.assertThat(metrics.isRequestEnded()).isFalse();
-                    soft.assertThat(metrics.getStatus()).isZero();
+                    soft.assertThat(metrics.getStatus()).isEqualTo(200);
                     soft.assertThat(metrics.getEndpointResponseTimeMs()).isPositive();
                     soft.assertThat(metrics.getGatewayLatencyMs()).isEqualTo(0);
                     soft.assertThat(metrics.getGatewayResponseTimeMs()).isEqualTo(0);

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <!-- Enterprise plugins -->
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
-        <gravitee-entrypoint-sse.version>5.0.0</gravitee-entrypoint-sse.version>
+        <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>4.0.2</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>4.0.2</gravitee-endpoint-kafka.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9848

Edit 1: 

- Now based on review, changes are implemented at repo` gravitee-entrypoint-sse`.
- PR (approved, released new version 5.0.1): https://github.com/gravitee-io/gravitee-entrypoint-sse/pull/68

200 Status Fix

https://github.com/user-attachments/assets/af9d7ef1-7d81-4219-9276-c4a4974b6fbc

Non 200 Fix video

https://github.com/user-attachments/assets/4e6529e0-6824-48d5-a042-3f9dd954ab0f



------

Edit 0 :
## Description

Fixes SSE metrics: status was left at 0 (zero) until the stream closed because it was set only in the final response-time processor (in file ResponseTimeProcessor.java); the new logic updates status to 200 in the response-logging processor right before the response is sent, so dashboards show the correct code while the connection is open, affecting only SSE traffic and covered by updated tests.

#### Why only 200 response matters ?:

- > [responseTimeProcessor ](https://github.com/gravitee-io/gravitee-api-management/blob/b0373a034eebd7ce3adad1ae9648e1d8c4b699ed/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/responsetime/ResponseTimeProcessor.java#L41) update the final metric status (response phase)
- > For 200 : Its get called, only when connection is closed, till then status as zero (default)
- > For non 200 : Its get executed immediately, in response phase, and update the metric. 
- > So for only 200, we have to wait for connection get closed >>  responseTimeProcessor get called >> update the final metric

## Additional context

PRE Video : 


https://github.com/user-attachments/assets/9471e6df-efc2-4ced-89d0-a242e5d26654

----

Post video 


https://github.com/user-attachments/assets/f0ae09f3-2748-43d5-9c9f-574d0024a716

--
video for non 200 case

https://github.com/user-attachments/assets/5473f65f-9c41-4fc6-8189-e6ac1f4f74ea



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dhtuwearjz.chromatic.com)
<!-- Storybook placeholder end -->
