### PR TITLE
fix: on update revoke previous secrets

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -263,8 +263,23 @@ public class ApiManagerImpl implements ApiManager {
                 SecretDiscoveryEventType.DISCOVER,
                 new SecretDiscoveryEvent(api.getEnvironmentId(), api.getDefinition(), new DefinitionMetadata(api.getRevision()))
             );
+
+            ReactableApi<?> previousApi = apis.get(api.getId());
+
             apis.put(api.getId(), api);
             eventManager.publishEvent(ReactorEvent.UPDATE, api);
+
+            if (previousApi != null) {
+                // Revoke the previous API revision
+                eventManager.publishEvent(
+                    SecretDiscoveryEventType.REVOKE,
+                    new SecretDiscoveryEvent(
+                        previousApi.getEnvironmentId(),
+                        previousApi.getDefinition(),
+                        new DefinitionMetadata(previousApi.getRevision())
+                    )
+                );
+            }
             log.info("{} has been updated", api);
         } else if (plans.isEmpty()) {
             log.warn("There is no published plan associated to this API, undeploy it...");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10199

## Description

Just revoke previous API secrets for previous API revision when update 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

