### PR TITLE
fix: ensure published flag on folders is respected in Management API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -6846,6 +6846,10 @@ components:
                     description: List of access controls.
                     items:
                         $ref: "#/components/schemas/AccessControl"
+                published:
+                  type: boolean
+                  description: Flag to publish the document.
+                  default: false
             required:
                 - name
                 - type

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -1119,6 +1119,51 @@ class ApiPagesResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_create_unpublished_folder_by_default() {
+            var folderToCreate = CreateDocumentationFolder
+                .builder()
+                .name("default unpublished folder")
+                .type(CreateDocumentation.TypeEnum.FOLDER)
+                .parentId(null)
+                .visibility(Visibility.PUBLIC)
+                .build(); // 'published' is not explicitly set
+
+            final Response response = rootTarget().request().post(Entity.json(folderToCreate));
+            var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
+
+            assertThat(createdPage).isNotNull().hasFieldOrPropertyWithValue("published", false);
+
+            assertThat(createdPage.getId()).isNotNull();
+        }
+
+        @Test
+        public void should_create_published_folder() {
+            var folderToCreate = CreateDocumentationFolder
+                .builder()
+                .name("published folder")
+                .type(CreateDocumentation.TypeEnum.FOLDER)
+                .parentId(null)
+                .visibility(Visibility.PUBLIC)
+                .published(true) // 'published' is set to true
+                .build();
+
+            final Response response = rootTarget().request().post(Entity.json(folderToCreate));
+            var createdPage = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Page.class);
+
+            assertThat(createdPage)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("type", PageType.FOLDER)
+                .hasFieldOrPropertyWithValue("name", folderToCreate.getName())
+                .hasFieldOrPropertyWithValue("order", 0)
+                .hasFieldOrPropertyWithValue("parentId", folderToCreate.getParentId())
+                .hasFieldOrPropertyWithValue("visibility", folderToCreate.getVisibility())
+                .hasFieldOrPropertyWithValue("published", true);
+
+            assertThat(createdPage.getId()).isNotNull();
+            assertThat(createdPage.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
         public void should_not_allow_null_name() {
             var request = CreateDocumentationMarkdown
                 .builder()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10457

## Description

Folders created via the Management API were always saved with published: false, even when explicitly set to true in the request. This caused them to remain hidden in the Developer Portal, despite containing published pages.

This fix ensures the published flag is honored, aligning API behavior with the UI.

Sample Request before fix:

<img width="1360" height="703" alt="Screenshot 2025-07-27 at 12 51 07 PM" src="https://github.com/user-attachments/assets/149ea00c-a774-4042-864c-30902c663dfb" />


Sample Request after fix:

<img width="1360" height="703" alt="Screenshot 2025-07-26 at 11 12 58 PM" src="https://github.com/user-attachments/assets/142a979c-a358-438b-8771-c7eddc33c6e4" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

