### PR TITLE
fix: resolve potential memory leak by implementing equals/hashCode on SSL config classes

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/KeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/KeyStore.java
@@ -23,6 +23,7 @@ import io.gravitee.definition.model.v4.ssl.pem.PEMKeyStore;
 import io.gravitee.definition.model.v4.ssl.pkcs12.PKCS12KeyStore;
 import java.io.Serial;
 import java.io.Serializable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -39,6 +40,7 @@ import lombok.Getter;
     }
 )
 @Getter
+@EqualsAndHashCode
 public abstract class KeyStore implements Serializable {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/SslOptions.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/SslOptions.java
@@ -19,6 +19,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -32,6 +33,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class SslOptions implements Serializable {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/TrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/TrustStore.java
@@ -23,6 +23,7 @@ import io.gravitee.definition.model.v4.ssl.pem.PEMTrustStore;
 import io.gravitee.definition.model.v4.ssl.pkcs12.PKCS12TrustStore;
 import java.io.Serial;
 import java.io.Serializable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
@@ -44,6 +45,7 @@ import lombok.Getter;
     }
 )
 @Getter
+@EqualsAndHashCode
 public abstract class TrustStore implements Serializable {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSKeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSKeyStore.java
@@ -21,6 +21,7 @@ import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class JKSKeyStore extends KeyStore {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSTrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSTrustStore.java
@@ -21,6 +21,7 @@ import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class JKSTrustStore extends TrustStore {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMKeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMKeyStore.java
@@ -21,6 +21,7 @@ import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class PEMKeyStore extends KeyStore {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMTrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMTrustStore.java
@@ -20,6 +20,7 @@ import io.gravitee.definition.model.v4.ssl.TrustStoreType;
 import io.gravitee.secrets.api.annotation.Secret;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -30,6 +31,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class PEMTrustStore extends TrustStore {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12KeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12KeyStore.java
@@ -21,6 +21,7 @@ import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class PKCS12KeyStore extends KeyStore {
 
     @Serial

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12TrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12TrustStore.java
@@ -21,6 +21,7 @@ import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class PKCS12TrustStore extends TrustStore {
 
     @Serial


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10477

## Description

We are computing a hash of configuration objects to avoid unnecessarily recreating the sender. However, in our case, a new sender is being created on every HTTP POST, even though the configuration values remain the same. This behavior leads to out-of-memory (OOM) errors due to excessive object creation.

Root Cause -
The issue stems from the SecurityConfiguration, which includes an instance of io.gravitee.definition.model.v4.ssl.SslOptions.
Unfortunately, the SslOptions class does not override equals() and hashCode() methods. As a result, hashing is based on object identity rather than field values, causing different hash codes even when the content is identical.

Reference:
[SslOptions.java](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/SslOptions.java)

To resolve this:
Add Lombok’s @EqualsAndHashCode to SslOptions and any nested/related classes it uses for consistent hash calculation.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

