### PR TITLE
fix: remove commons-lang dependency

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -250,12 +250,6 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.auth0</groupId>
                 <artifactId>java-jwt</artifactId>
                 <version>${java-jwt.version}</version>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/DatabaseHydrator.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/DatabaseHydrator.java
@@ -24,7 +24,7 @@ import io.vertx.core.buffer.Buffer;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class DatabaseHydrator {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
@@ -112,11 +112,6 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-
         <!-- Jackson dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -111,11 +111,6 @@
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-
 		<!-- Jackson dependencies -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
@@ -110,11 +110,6 @@
 			<artifactId>swagger-jaxrs2-jakarta</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-
 		<!-- Jackson dependencies -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -184,10 +184,6 @@
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
 
 		<!-- Jackson dependencies -->
 		<dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/pom.xml
@@ -89,11 +89,6 @@
 			<artifactId>jakarta.annotation-api</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-
 		<!-- Jackson dependencies -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <classgraph.version>4.8.179</classgraph.version>
         <commons-email.version>1.6.0</commons-email.version>
         <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-pool2.version>2.12.1</commons-pool2.version>
         <commons-text.version>1.13.0</commons-text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <classgraph.version>4.8.179</classgraph.version>
         <commons-email.version>1.6.0</commons-email.version>
         <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-pool2.version>2.12.1</commons-pool2.version>
         <commons-text.version>1.13.0</commons-text.version>
         <dozer.version>7.0.0</dozer.version>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-10479

## Description

commons-lang:2.6 is outdated and brings a medium CVE-2025-48924, this PR removes any reference to that library.

I've checked the only usage of `org.apache.commons.lang.` in gravitee's organization and the only remaining item will be in AM plugin https://github.com/gravitee-io/gravitee-am-gateway-handler-saml2-idp


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xipvfcownu.chromatic.com)
<!-- Storybook placeholder end -->
