### PR TITLE
fix(portal): include additional_client_metadata in application creati…

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
@@ -71,8 +71,8 @@ type ApplicationFormType = FormGroup<{
 
 function mapToApplicationInput(rawValue): ApplicationInput {
   const result = rawValue as ApplicationInput;
-  if (rawValue.oauth !== undefined) {
-    result.settings.oauth.additional_client_metadata = rawValue.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
+  if (rawValue.settings.oauth) {
+    result.settings.oauth.additional_client_metadata = rawValue.settings.oauth.additionalClientMetadata.reduce((acc, { key, value }) => {
       acc[key] = value;
       return acc;
     }, {});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -120,6 +120,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
                 ocs.setApplicationType(oauthAppInput.getApplicationType());
                 ocs.setGrantTypes(oauthAppInput.getGrantTypes());
                 ocs.setRedirectUris(oauthAppInput.getRedirectUris());
+                ocs.setAdditionalClientMetadata(oauthAppInput.getAdditionalClientMetadata());
                 newApplicationEntitySettings.setOauth(ocs);
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5433,6 +5433,10 @@ components:
                     type: string
                 renew_client_secret_supported:
                     type: boolean
+                additional_client_metadata:
+                    type: object
+                    additionalProperties:
+                      type: string
         TlsClientSettings:
             properties:
                 client_certificate:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9616

## Description

- Add missing additional_client_metadata field when creating OAuth client settings in portal API
- Fixes issue where additional client metadata was not passed during application creation in developer portal
- Ensures additional_client_metadata is properly included in mAPI request when DCR is enabled


## Additional context
### Before Fix
https://github.com/user-attachments/assets/55366bed-6604-4076-95ca-c007e9362156


### After Fix
https://github.com/user-attachments/assets/5c7720b2-75af-4c36-8229-daa21bbc6b1f



