### PR TITLE
chore(deps): bump gravitee-resource-ai-model-text-classification to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <gravitee-resource-auth-provider-ldap.version>2.0.0</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>4.0.1</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
-        <gravitee-resource-ai-model-text-classification.version>2.0.0</gravitee-resource-ai-model-text-classification.version>
+        <gravitee-resource-ai-model-text-classification.version>2.1.0</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-inference-service.version>1.2.0</gravitee-inference-service.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>


### PR DESCRIPTION
## Description

This PR bumps the gravitee-resource-ai-model-text-classification resource to 2.1.0.
The resource brings 3 tiny models from our huggingface repository

https://github.com/gravitee-io/gravitee-resource-ai-model-text-classification/releases/tag/2.1.0
https://github.com/gravitee-io/gravitee-resource-ai-model-text-classification/commit/107ac684f2df830935fbc723e2adbe4a0d4f71a6
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zhramnryqx.chromatic.com)
<!-- Storybook placeholder end -->
