### PR TITLE
chore: improve OpenShift compatibility 

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -26,10 +26,9 @@ ADD docker/config/constants.json /usr/share/nginx/html/constants.json
 ADD docker/config/default.conf /etc/nginx/conf.d/default.conf
 COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
-RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
+RUN chmod -R g=u /usr/share/nginx/ /etc/nginx/
 
 COPY docker/config/check_ip_config.sh /check_ip_config.sh
 
-CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]
-
 USER nginx
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]

--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN apk update  \
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
-ADD ./distribution ${GRAVITEEIO_HOME}/
-RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
@@ -36,5 +36,5 @@ LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082
-ENTRYPOINT ["./bin/gravitee"]
 USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]

--- a/gravitee-apim-gateway/docker/Dockerfile.debian
+++ b/gravitee-apim-gateway/docker/Dockerfile.debian
@@ -27,8 +27,8 @@ RUN set -eux ;\
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base-debian AS builder
-COPY ./distribution ${GRAVITEEIO_HOME}/
-RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
@@ -37,5 +37,5 @@ LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082
-ENTRYPOINT ["./bin/gravitee"]
 USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -33,11 +33,10 @@ COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 COPY docker/config/default-next.conf /etc/nginx/conf.d/default-next.conf
 COPY docker/config/default-next.no-ipv6.conf /etc/nginx/conf.d/default-next.no-ipv6.conf
 
-RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/
+RUN chmod -R g=u /usr/share/nginx/ /etc/nginx/
 
 COPY docker/config/portal-next-run.sh /portal-next-run.sh
 COPY docker/config/check_ip_config.sh /check_ip_config.sh
 
-CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /check_ip_config.sh; sh /run.sh"]
-
 USER nginx
+CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /check_ip_config.sh; sh /run.sh"]

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -20,10 +20,9 @@ ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
-COPY ./distribution ${GRAVITEEIO_HOME}/
-
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
 USER root
-RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
@@ -32,5 +31,5 @@ LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083
-ENTRYPOINT ["./bin/gravitee"]
 USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]

--- a/gravitee-apim-rest-api/docker/Dockerfile.debian
+++ b/gravitee-apim-rest-api/docker/Dockerfile.debian
@@ -20,10 +20,9 @@ ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 # Second stage to add the folder and change the permissions and ownership
 FROM base AS builder
-COPY ./distribution ${GRAVITEEIO_HOME}/
-
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
 USER root
-RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
@@ -32,5 +31,5 @@ LABEL maintainer="contact@graviteesource.com"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083
-ENTRYPOINT ["./bin/gravitee"]
 USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/TT-8259

## Description

Change permission of GRAVITEE_HOME for graviteeio:root. OpenShift generates a random USERID but it ensures that user is part of he root group (gid 0). To avoid access error, we need to ensure that the root group has the same permission as the graviteeio user embedded in the image.

The USER needs to be declared before the ENTRYPOINT or CMD to ensure the process does not run with root privileges

⚠️ Prior to this, to run APIM in OpenShift, users needed to override the runAsGroup's securityContext to enforce the GID 1000. After this they need to set it to null to let OpenShift select the root group (GID 0)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ujihqfibxn.chromatic.com)
<!-- Storybook placeholder end -->
