### PR TITLE
fix(groups): null no longer removes existing groups

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -121,7 +121,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         newApiEntity.setTags(tagsValidationService.validateAndSanitize(executionContext, null, newApiEntity.getTags()));
         // Validate and clean groups
         newApiEntity.setGroups(
-            groupValidationService.validateAndSanitize(executionContext, null, newApiEntity.getGroups(), primaryOwnerEntity, true)
+            groupValidationService.validateAndSanitize(executionContext, null, newApiEntity.getGroups(), null, primaryOwnerEntity, true)
         );
         // Validate and clean listeners
         newApiEntity.setListeners(
@@ -175,6 +175,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
                 executionContext,
                 updateApiEntity.getId(),
                 updateApiEntity.getGroups(),
+                existingApiEntity.getGroups(),
                 primaryOwnerEntity,
                 existingApiEntity.getOriginContext().origin().equals(OriginContext.Origin.KUBERNETES)
             )
@@ -231,7 +232,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         apiEntity.setTags(tagsValidationService.validateAndSanitize(executionContext, null, apiEntity.getTags()));
         // Validate and clean groups
         apiEntity.setGroups(
-            groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), primaryOwnerEntity, true)
+            groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), null, primaryOwnerEntity, true)
         );
         // Validate and clean listeners
         apiEntity.setListeners(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -58,9 +58,14 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
         final ExecutionContext executionContext,
         final String apiId,
         final Set<String> groups,
+        final Set<String> existingGroups,
         final PrimaryOwnerEntity primaryOwnerEntity,
         final boolean addDefaultGroups
     ) {
+        if (existingGroups != null && groups == null) {
+            return existingGroups;
+        }
+
         Set<String> sanitizedGroups = new HashSet<>();
         if (groups != null && !groups.isEmpty()) {
             try {
@@ -84,12 +89,6 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
         // if primary owner is a group, add it as a member of the API
         if (primaryOwnerEntity != null && ApiPrimaryOwnerMode.GROUP.name().equals(primaryOwnerEntity.getType())) {
             sanitizedGroups.add(primaryOwnerEntity.getId());
-        }
-
-        // In case groups is null we should still return null if no groups have been added because during the update process a null field
-        // means I want to keep the current value
-        if (sanitizedGroups.isEmpty()) {
-            return groups;
         }
 
         return sanitizedGroups;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/GroupValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/GroupValidationService.java
@@ -28,6 +28,7 @@ public interface GroupValidationService {
         final ExecutionContext executionContext,
         final String apiId,
         final Set<String> groups,
+        final Set<String> existingGroups,
         final PrimaryOwnerEntity primaryOwnerEntity,
         final boolean addDefaultGroups
     );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -138,7 +138,7 @@ public class ApiValidationServiceImplTest {
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null);
         verify(groupValidationService, times(1))
-            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity, true);
+            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null, primaryOwnerEntity, true);
         verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitizeHttpV4(newApiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), newApiEntity.getType(), null);
@@ -161,7 +161,7 @@ public class ApiValidationServiceImplTest {
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, Set.of());
         verify(groupValidationService, times(1))
-            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity, true);
+            .validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null, primaryOwnerEntity, true);
         verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitizeHttpV4(apiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
@@ -84,6 +84,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -110,6 +111,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             false
         );
@@ -142,6 +144,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
+            null,
             new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL),
             true
         );
@@ -172,6 +175,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             null,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -209,6 +213,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -247,6 +252,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -284,6 +290,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -322,6 +329,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
+            null,
             new PrimaryOwnerEntity(new UserEntity()),
             true
         );
@@ -363,6 +371,7 @@ public class GroupValidationServiceImplTest {
             executionContext,
             apiId,
             groups,
+            null,
             new PrimaryOwnerEntity(currentPrimaryOwner, PO_MAIL),
             true
         );
@@ -387,6 +396,7 @@ public class GroupValidationServiceImplTest {
                     GraviteeContext.getExecutionContext(),
                     null,
                     groups,
+                    null,
                     new PrimaryOwnerEntity(new UserEntity()),
                     true
                 )
@@ -401,6 +411,7 @@ public class GroupValidationServiceImplTest {
             null,
             emptyGroups,
             null,
+            null,
             true
         );
         Assertions.assertThat(validatedGroups).isEmpty();
@@ -408,14 +419,19 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnNull() {
+    public void shouldReturnExistingGroupsWhenGroupsIsNull() {
+        Set<String> existingGroups = Set.of("existing1", "existing2");
+
         Set<String> validatedGroups = groupValidationService.validateAndSanitize(
             GraviteeContext.getExecutionContext(),
             null,
             null,
+            existingGroups,
             null,
             false
         );
-        assertThat(validatedGroups).isNull();
+
+        assertThat(validatedGroups).isNotNull();
+        assertThat(validatedGroups).isEqualTo(existingGroups);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10368

## Description

This PR fixes unintended deletion of groups. When updating APIs if value of groups is provided as null, it clears all non-primary groups. 
As a fix, added null check refering existing group value. And assigning the value.

### Pre video

https://github.com/user-attachments/assets/b3eb6e05-a9b2-4f38-9b5f-1825d9150f81

### Post video

https://github.com/user-attachments/assets/c9e0ce03-eefd-4b9d-a3e4-252015318d19

