### PR TITLE
chore: try to fix flaky e2e

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-create-and-modify-flow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-create-and-modify-flow.spec.ts
@@ -114,7 +114,15 @@ describe('Create and modify a flow in Policy Studio', () => {
 
     it('should show newly added header when calling Gateway', () => {
       const headerCheckFunction = (response: Cypress.Response<any>) => {
-        return response.headers[headerKey] === headerValue;
+        const expected = response.headers[headerKey] === headerValue;
+        if (!expected) {
+          cy.log(
+            'Fail to find header: ' +
+              JSON.stringify({ headerExpected: { [headerKey]: headerValue }, responseHeaders: JSON.stringify(response.headers) }),
+          );
+        }
+
+        return expected;
       };
 
       cy.callGateway(apiPath, headerCheckFunction);

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
@@ -71,6 +71,7 @@ export default class PolicyStudio {
   addOrUpdateHeaders(key: string, value: string) {
     cy.get('textarea[formcontrolname="key"]').first().click().clear().type(key);
     cy.get('textarea[formcontrolname="value"]').first().click().clear().type(value);
+    cy.wait(150);
     return this;
   }
 


### PR DESCRIPTION
## Issue
n/a


## Description

After several go and back, I noticed that sometimes the header value is not set. This is probably because the save button is clicked too quickly.
This pr adds a small invisible wait, but it should stabilize the interaction with the screens.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fptptlsywm.chromatic.com)
<!-- Storybook placeholder end -->
