### PR TITLE
feat: support partial API discovery for integrations

### DIFF
--- a/gravitee-apim-console-webui/src/entities/integrations/preview.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/integrations/preview.fixture.ts
@@ -41,6 +41,7 @@ export function fakeDiscoveryPreview(attribute?: Partial<IntegrationPreview>): I
         state: IntegrationPreviewApisState.NEW,
       },
     ],
+    isPartiallyDiscovered: false,
   };
 
   return {

--- a/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.html
@@ -29,7 +29,7 @@
         color="primary"
         data-testid="proceed-button"
         *gioPermission="{ anyOf: ['environment-integration-c'] }"
-        [disabled]="apiToIngest().length <= 0"
+        [disabled]="apiToIngest().length <= 0 && !this.isPartiallyDiscovered"
         (click)="proceedIngest()"
       >
         Proceed
@@ -42,6 +42,28 @@
   @if (!isLoading && integrationPreview) {
     <div [formGroup]="form" class="preview">
       <section class="preview__toggles">
+        @if (isPartiallyDiscovered) {
+          <gio-banner-warning>
+            Partial API Discovery Warning
+            <span gioBannerBody data-testid="partial-discovery-warning">
+              <p>
+                We were only able to discover <strong>a subset of the APIs</strong> listed below due to an extended discovery time. You can
+                still proceed with ingesting <strong>all available APIs</strong>, but please note the following limitations:
+              </p>
+              <ul>
+                <li>The <strong>preview may not show all APIs</strong>.</li>
+                <li>
+                  <strong>Selective ingestion options</strong> (e.g., “only ingest new” or “update selected”) are currently
+                  <strong>disabled</strong>.
+                </li>
+              </ul>
+              <p>
+                All APIs—both discovered and undiscovered—will be <strong>fully processed</strong>. Existing APIs will be
+                <strong>updated</strong>, and any new ones will be <strong>added</strong>.
+              </p>
+            </span>
+          </gio-banner-warning>
+        }
         <p class="desc">
           {{
             integrationPreview.totalCount === 0
@@ -49,15 +71,17 @@
               : 'The following assets were discovered. You can create or update them in Gravitee:'
           }}
         </p>
-        <gio-form-slide-toggle>
-          <gio-form-label>Create {{ integrationPreview.newCount }} new Federated APIs</gio-form-label>
-          <mat-slide-toggle data-testid="new-items-toggle" gioFormSlideToggle formControlName="NEW"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Update {{ integrationPreview.updateCount }} existing Federated APIs</gio-form-label>
-          Some changes you've made to existing Federated APIs will be overridden when the APIs are updated
-          <mat-slide-toggle data-testid="update-items-toggle" gioFormSlideToggle formControlName="UPDATE"></mat-slide-toggle>
-        </gio-form-slide-toggle>
+        @if (!isPartiallyDiscovered) {
+          <gio-form-slide-toggle>
+            <gio-form-label>Create {{ integrationPreview.newCount }} new Federated APIs</gio-form-label>
+            <mat-slide-toggle data-testid="new-items-toggle" gioFormSlideToggle formControlName="NEW"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Update {{ integrationPreview.updateCount }} existing Federated APIs</gio-form-label>
+            Some changes you've made to existing Federated APIs will be overridden when the APIs are updated
+            <mat-slide-toggle data-testid="update-items-toggle" gioFormSlideToggle formControlName="UPDATE"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        }
       </section>
       @if (integrationPreview.totalCount === 0) {
         <div class="preview__empty">

--- a/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.spec.ts
@@ -119,6 +119,14 @@ describe('DiscoveryPreviewComponent', () => {
     expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], { relativeTo: TestBed.inject(ActivatedRoute) });
   });
 
+  it('should display partial discovery warning banner', async () => {
+    expectIntegrationGetRequest(fakeIntegration({ id: integrationId }));
+    expectPreviewGetRequest(fakeDiscoveryPreview({ isPartiallyDiscovered: true }));
+
+    const bannerContent = await componentHarness.getPartialDiscoveryWarning().then((banner) => banner.getText());
+    expect(bannerContent).toContain('We were only able to discover a subset of the APIs listed below due to an extended discovery time.');
+  });
+
   describe('proceed', () => {
     it('should trigger ingest and return to overview when proceed', async () => {
       expectIntegrationGetRequest(fakeIntegration({ id: integrationId }));
@@ -127,6 +135,18 @@ describe('DiscoveryPreviewComponent', () => {
       await componentHarness.getProceedButton().then((button) => button.click());
 
       expectIngestPostRequest(['testit', 'testit2', 'testit3']);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], { relativeTo: TestBed.inject(ActivatedRoute) });
+    });
+
+    it('should pass an empty list of apis for ingestion in case of partial discovery when proceeding', async () => {
+      expectIntegrationGetRequest(fakeIntegration({ id: integrationId }));
+      const preview = fakeDiscoveryPreview();
+      preview.isPartiallyDiscovered = true;
+      expectPreviewGetRequest(preview);
+
+      await componentHarness.getProceedButton().then((button) => button.click());
+
+      expectIngestPostRequest([]);
       expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], { relativeTo: TestBed.inject(ActivatedRoute) });
     });
 

--- a/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.component.ts
@@ -62,6 +62,7 @@ export class DiscoveryPreviewComponent implements OnInit {
   };
 
   public apisFiltered: IntegrationPreviewApi[] = [];
+  public isPartiallyDiscovered = false;
 
   constructor(
     public readonly integrationsService: IntegrationsService,
@@ -94,6 +95,7 @@ export class DiscoveryPreviewComponent implements OnInit {
           this.nbTotalInstances = integrationPreview.totalCount;
           this.apisFiltered = integrationPreview.apis;
           this.integrationPreview = integrationPreview;
+          this.isPartiallyDiscovered = integrationPreview.isPartiallyDiscovered;
           this.setupForm(IntegrationPreviewApisState.NEW, this.integrationPreview.newCount);
           this.setupForm(IntegrationPreviewApisState.UPDATE, this.integrationPreview.updateCount);
           this.runFilters(this.filters);
@@ -108,10 +110,7 @@ export class DiscoveryPreviewComponent implements OnInit {
 
   public proceedIngest() {
     this.integrationsService
-      .ingest(
-        this.integrationId,
-        this.apiToIngest().map((api) => api.id),
-      )
+      .ingest(this.integrationId, this.isPartiallyDiscovered ? [] : this.apiToIngest().map((api) => api.id))
       .subscribe((response) => {
         switch (response.status) {
           case 'SUCCESS':

--- a/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.harness.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.harness.ts
@@ -17,6 +17,7 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
 export class DiscoveryPreviewHarness extends ComponentHarness {
   public static readonly hostSelector = 'app-discovery-preview';
@@ -28,6 +29,8 @@ export class DiscoveryPreviewHarness extends ComponentHarness {
   private newItemsToggleLocator = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid=new-items-toggle]' }));
 
   private updateItemsToggleLocator = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid=update-items-toggle]' }));
+
+  private partialDiscoveryWarning = this.locatorForOptional(SpanHarness.with({ selector: '[data-testid=partial-discovery-warning]' }));
 
   public getNewItemsToggle = () => {
     return this.newItemsToggleLocator();
@@ -51,5 +54,9 @@ export class DiscoveryPreviewHarness extends ComponentHarness {
     return this.getTable()
       .then((table: MatTableHarness) => table.getRows())
       .then((rows: MatRowHarness[]) => rows.length);
+  };
+
+  public getPartialDiscoveryWarning = () => {
+    return this.partialDiscoveryWarning();
   };
 }

--- a/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.module.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/discovery-preview/discovery-preview.module.ts
@@ -25,7 +25,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { GioCardEmptyStateModule, GioFormSlideToggleModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioCardEmptyStateModule, GioFormSlideToggleModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
 
 import { DiscoveryPreviewComponent } from './discovery-preview.component';
 
@@ -55,6 +55,7 @@ import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrap
     GioPermissionModule,
     GioLoaderModule,
     GioCardEmptyStateModule,
+    GioBannerModule,
   ],
 })
 export class DiscoveryPreviewModule {}

--- a/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
@@ -138,4 +138,5 @@ export interface IntegrationPreview {
   newCount: number;
   updateCount: number;
   apis: IntegrationPreviewApi[];
+  isPartiallyDiscovered: boolean;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
@@ -113,6 +113,7 @@ public interface IntegrationMapper {
                             )
                     )
                     .toList()
-            );
+            )
+            .isPartiallyDiscovered(preview.isPartialDiscovery());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4354,6 +4354,10 @@ components:
                     type: number
                     description: number of update APIs found to ingest
                     example: 4
+                isPartiallyDiscovered:
+                    type: boolean
+                    description: flag to tell if apis where only partially discovered due to timeout
+                    example: false
                 apis:
                     type: array
                     description: number of new APIs found to ingest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResourceTest.java
@@ -672,6 +672,7 @@ public class IntegrationResourceTest extends AbstractResourceTest {
                 .asEntity(IngestionPreviewResponse.class)
                 .isEqualTo(
                     new IngestionPreviewResponse()
+                        .isPartiallyDiscovered(false)
                         .totalCount(1)
                         .newCount(1)
                         .updateCount(0)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/DiscoveredApis.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/DiscoveredApis.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.model;
+
+import java.util.List;
+
+public record DiscoveredApis(List<IntegrationApi> apis, boolean isPartialDiscovery) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
@@ -15,15 +15,14 @@
  */
 package io.gravitee.apim.core.integration.service_provider;
 
+import io.gravitee.apim.core.integration.model.DiscoveredApis;
 import io.gravitee.apim.core.integration.model.IngestStarted;
-import io.gravitee.apim.core.integration.model.IntegrationApi;
 import io.gravitee.apim.core.integration.model.IntegrationSubscription;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.definition.model.federation.FederatedApi;
 import io.gravitee.definition.model.federation.SubscriptionParameter;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.reactivex.rxjava3.core.Completable;
-import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ public interface IntegrationAgent {
      */
     Completable unsubscribe(String integrationId, FederatedApi api, SubscriptionEntity subscription);
 
-    Flowable<IntegrationApi> discoverApis(String integrationId);
+    Single<DiscoveredApis> discoverApis(String integrationId);
 
     enum Status {
         CONNECTED,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/DiscoveryUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/DiscoveryUseCase.java
@@ -60,10 +60,11 @@ public class DiscoveryUseCase {
             .fromOptional(integrationCrudService.findApiIntegrationById(integrationId))
             .filter(integration -> integration.environmentId().equals(input.auditInfo.environmentId()))
             .switchIfEmpty(Single.error(new IntegrationNotFoundException(integrationId)))
-            .flatMapPublisher(integration -> integrationAgent.discoverApis(integration.id()))
-            .map(discoveredApi -> new Output.PreviewApi(discoveredApi, computeState.apply(discoveredApi)))
-            .toList()
-            .map(Output::new)
+            .flatMap(integration -> integrationAgent.discoverApis(integration.id()))
+            .map(discoveredApis -> {
+                var previewApis = discoveredApis.apis().stream().map(api -> new Output.PreviewApi(api, computeState.apply(api))).toList();
+                return new Output(previewApis, discoveredApis.isPartialDiscovery());
+            })
             .doOnError(throwable -> {
                 if (!(throwable instanceof IntegrationNotFoundException)) {
                     log.error("Error during discovery on integration {}", integrationId, throwable);
@@ -89,7 +90,7 @@ public class DiscoveryUseCase {
 
     public record Input(String integrationId, AuditInfo auditInfo) {}
 
-    public record Output(Collection<PreviewApi> apis) {
+    public record Output(Collection<PreviewApi> apis, boolean isPartialDiscovery) {
         public record PreviewApi(String id, String name, String version, State state) {
             public PreviewApi(IntegrationApi api, State state) {
                 this(api.id(), api.name(), api.version(), state);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
@@ -16,6 +16,7 @@
 package inmemory;
 
 import io.gravitee.apim.core.integration.exception.IntegrationIngestionException;
+import io.gravitee.apim.core.integration.model.DiscoveredApis;
 import io.gravitee.apim.core.integration.model.IngestStarted;
 import io.gravitee.apim.core.integration.model.IntegrationApi;
 import io.gravitee.apim.core.integration.model.IntegrationSubscription;
@@ -105,8 +106,12 @@ public class IntegrationAgentInMemory implements IntegrationAgent, InMemoryAlter
     }
 
     @Override
-    public Flowable<IntegrationApi> discoverApis(String integrationId) {
-        return Flowable.fromIterable(storage).filter(asset -> asset.integrationId().equals(integrationId));
+    public Single<DiscoveredApis> discoverApis(String integrationId) {
+        return Flowable
+            .fromIterable(storage)
+            .filter(asset -> asset.integrationId().equals(integrationId))
+            .toList()
+            .map(discoveredApis -> new DiscoveredApis(discoveredApis, false));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-expression-language.version>4.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>4.0.0-alpha.2</gravitee-gateway-api.version>
-        <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
+        <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
         <gravitee-node.version>7.10.0</gravitee-node.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9916

## Description

Added support for handling partial API discoveries due to timeouts. Updated data models, UI, and backend logic to reflect partial discovery status and ensure seamless ingestion of available APIs.

## Additional context

That's the new UI that is displayed when the partial discovery is returned and allows you to ingest all APIs, even those that were not yet discovered 

<img width="5120" height="2488" alt="image" src="https://github.com/user-attachments/assets/e1d54f94-879c-4c04-9b91-3194c8b6c262" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lgsajwmfyf.chromatic.com)
<!-- Storybook placeholder end -->
