### PR TITLE
fix: set installation id when publishing health check Alert Event

### DIFF
--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-version: '3.8'
-
 networks:
   frontend:
     name: frontend
@@ -72,7 +70,7 @@ services:
       - storage
 
   alert_engine:
-    image: graviteeio/ae-engine:${AE_VERSION:-2.1.6}
+    image: graviteeio/ae-engine:${AE_VERSION:-2.3.1}
     container_name: gio_ae_engine
     restart: always
     ports:

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -413,6 +413,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                 .property(PROP_MESSAGE, endpointStatus.getSteps().get(0).getMessage())
                 .organization(rule.api().getOrganizationId())
                 .environment(rule.api().getEnvironmentId())
+                .installation((String) node.metadata().get(Node.META_INSTALLATION))
                 .build();
             alertEventProducer.send(event);
         }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-common/src/main/java/io/gravitee/plugin/apiservice/healthcheck/common/HealthCheckManagedEndpoint.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-common/src/main/java/io/gravitee/plugin/apiservice/healthcheck/common/HealthCheckManagedEndpoint.java
@@ -152,6 +152,7 @@ public class HealthCheckManagedEndpoint implements ManagedEndpoint {
                 .property(PROP_MESSAGE, endpointStatus.getSteps().get(0).getMessage())
                 .organization(api.getOrganizationId())
                 .environment(api.getEnvironmentId())
+                .installation((String) node.metadata().get(Node.META_INSTALLATION))
                 .build();
 
             alertEventProducer.send(event);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10523

## Description

The installation ID was set automatically in the AE connector. 
The alert trigger for a health check on an endpoint is filtered based on the installation ID on the AE side. 
We had to add the installation ID to the event to ensure it was properly recognized

## Additional context

<img width="1901" height="779" alt="Screenshot 2025-07-30 at 14 45 23" src="https://github.com/user-attachments/assets/a81aa582-74c6-4a28-8d27-63e323a7f05e" />
