### PR TITLE
fix: properties migration from v2 to v4

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -35,6 +36,7 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -105,7 +107,7 @@ class ApiMigration {
         api.setApiVersion(apiDefinitionV2.getVersion());
         api.setTags(apiDefinitionV2.getTags());
         api.setType(ApiType.PROXY);
-        api.setProperties(List.of()); // TODO apiDefinitionV2.getProperties())
+        api.setProperties(mapProperties(apiDefinitionV2.getProperties()));
         api.setResources(List.of()); // TODO apiDefinitionV2.getResources());
         return MigrationResult.value(api);
     }
@@ -120,6 +122,13 @@ class ApiMigration {
             .endpoints(endpoints)
             //.services(source.getServices())
             .build();
+    }
+
+    @Nullable
+    private List<Property> mapProperties(@Nullable Properties properties) {
+        return properties == null
+            ? null
+            : stream(properties.getProperties()).map(a -> new Property(a.getKey(), a.getValue(), a.isEncrypted(), a.isDynamic())).toList();
     }
 
     private LoadBalancer mapLoadBalancer(io.gravitee.definition.model.LoadBalancer lb) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -273,7 +273,7 @@ class V2ToV4MigrationOperatorTest {
             assertThat(v4Definition.getApiVersion()).isEqualTo("2.0.1");
             assertThat(v4Definition.getTags()).containsExactlyInAnyOrder("tag1", "tag2", "tag3");
             assertThat(v4Definition.getType()).isEqualTo(ApiType.PROXY);
-            assertThat(v4Definition.getProperties()).isEmpty();
+            assertThat(v4Definition.getProperties()).isNull();
             assertThat(v4Definition.getResources()).isEmpty();
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10248

## Description

The V2 properties and dynamic properties are migrated to V4.
The rollback also takes place successfully.




https://github.com/user-attachments/assets/fb9313b4-4348-4c5b-b1ab-badfe4c9e7b8





<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fbzjeyqbhv.chromatic.com)
<!-- Storybook placeholder end -->
