### PR TITLE
fix: adjust debug mode timeline legend styling to handle text wrapping

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-timeline-legend/debug-mode-timeline-legend.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-timeline-legend/debug-mode-timeline-legend.component.scss
@@ -7,9 +7,12 @@ $typography: map.get(gio.$mat-theme, typography);
 .debug-mode-timeline-legend {
   background-color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
   border-bottom: 2px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
-  height: 40px;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  row-gap: 10px;
 
   &__badge {
     height: 24px;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10484

## Description

Adjust debug mode timeline legend styling to handle text wrapping

## Additional context

**Before:** 
<img width="1046" height="649" alt="image" src="https://github.com/user-attachments/assets/e80a758c-eb7f-47ac-a899-560a6885955f" />

**After:**
<img width="1099" height="622" alt="Zrzut ekranu 2025-07-31 o 17 36 47" src="https://github.com/user-attachments/assets/eac5d45d-5055-4d0b-9d8e-3f2e9c112d1d" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vxmubseibi.chromatic.com)
<!-- Storybook placeholder end -->
