### PR TITLE
fix: ensure deployment number increments across all lifecycle events

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -224,7 +224,14 @@ public class ApiStateServiceImpl implements ApiStateService {
     ) {
         EventCriteria criteria = EventCriteria
             .builder()
-            .types(Set.of(io.gravitee.repository.management.model.EventType.PUBLISH_API))
+            .types(
+                Set.of(
+                    io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                    io.gravitee.repository.management.model.EventType.STOP_API,
+                    io.gravitee.repository.management.model.EventType.START_API,
+                    io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                )
+            )
             .property(Event.EventProperties.API_ID.getValue(), apiId)
             .build();
 
@@ -362,7 +369,13 @@ public class ApiStateServiceImpl implements ApiStateService {
                 lastPublishedAPI.setDeployedAt(new Date());
                 Map<String, String> properties = new HashMap<>();
                 properties.put(Event.EventProperties.USER.getValue(), userId);
-
+                properties.put(
+                    Event.EventProperties.DEPLOYMENT_NUMBER.getValue(),
+                    Optional
+                        .ofNullable(event.getProperties())
+                        .map(p -> p.get(Event.EventProperties.DEPLOYMENT_NUMBER.getValue()))
+                        .orElse("0")
+                );
                 // Clear useless field for history
                 lastPublishedAPI.setPicture(null);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -288,6 +288,7 @@ public class ApiStateServiceImplTest {
 
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+        properties.put(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "0");
 
         verify(eventService)
             .createApiEvent(
@@ -372,6 +373,7 @@ public class ApiStateServiceImplTest {
 
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+        properties.put(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "0");
 
         verify(eventService)
             .createApiEvent(
@@ -413,6 +415,7 @@ public class ApiStateServiceImplTest {
 
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+        properties.put(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "0");
 
         verify(eventService)
             .createApiEvent(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9634

## Description
Issue:
In v2  & V4 APIs, the audit history displays repeated deployment numbers (e.g., PUBLISH_API #1 appears twice) before the sequence begins incrementing correctly. This occurs when the API is started or redeployed early in its lifecycle. Also, deployment numbers start from 1 again if lifecycle is changes from START to STOP or vice versa.

Fix: 
Deployment number is now incremented across all lifecycle-related events (START_API, STOP_API, PUBLISH_API, UNPUBLISH_API), ensuring consistent versioning in audit history.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

