### PR TITLE
ci: use local maven repository [skip ci]

### DIFF
--- a/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
@@ -19,6 +19,7 @@ import { UbuntuExecutor } from '../../executors';
 import { Executor } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Executors';
 import { AnyParameterLiteral } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Parameters/types/CustomParameterLiterals.types';
 import { CircleCIEnvironment } from '../../pipelines';
+import { config } from '../../config';
 
 export abstract class AbstractTestContainerJob {
   protected static create(
@@ -40,6 +41,9 @@ export abstract class AbstractTestContainerJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName }),
+      new commands.cache.Restore({
+        keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
+      }),
       testStep,
       new commands.Run({
         name: 'Save test results',

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -130,6 +130,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-jdbc-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Management repository tests with database << parameters.jdbcType >>
           command: |-
@@ -162,6 +165,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-mongo-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Management repository tests with MongoDB << parameters.mongoVersion >>
           command: |-
@@ -201,6 +207,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-elastic-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Analytics repository tests with engine << parameters.engineType >> and version << parameters.engineVersion >>
           command: |-
@@ -233,6 +242,9 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-redis-test-container
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rate-limit repository tests with Redis << parameters.redisVersion >>
           command: |-


### PR DESCRIPTION
## Description
when building APIM in the build job, artefacts are stored locally, but they are lost in the next jobs. In the pullRequest workflow, we use a job cache, but we wasn't using it in the repositories test workflow. Hence the need to publish a SNAPSHOT version after a release so repo tests are green.

With this commit, we now use the local maven repository, with the freshly built artefacts.