### PR TITLE
fix(console): map metadata name when available for histogram data

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsHistogram.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsHistogram.ts
@@ -49,6 +49,13 @@ export interface AggregationHistogramValue {
   buckets: Bucket[];
   field: string;
   name: string;
+  metadata?: AggregationHistogramValueMetadata;
+}
+
+export interface AggregationHistogramValueMetadata {
+  [key: string]: {
+    name?: string;
+  };
 }
 
 export interface HistogramAnalyticsResponse {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -297,7 +297,7 @@ export class ApiAnalyticsWidgetService {
           } else {
             // For single aggregation, use the bucket names as the series names
             return value.buckets.map((bucket) => ({
-              name: bucket.name,
+              name: value.metadata?.[bucket.name]?.name || bucket.name,
               values: bucket.data || [],
             }));
           }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10549

## Description

If metadata exists for a key in a histogram, display the name sent from the backend.

<img width="1179" height="523" alt="Screenshot 2025-08-05 at 10 53 30" src="https://github.com/user-attachments/assets/55dd4f09-f2dc-4073-859f-63578712ca66" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-deocyxzmia.chromatic.com)
<!-- Storybook placeholder end -->
