### PR TITLE
feat(console): added default sort desc based on order from metadata

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -59,6 +59,7 @@ type WidgetDataConfig = {
   groupByField?: GroupByField;
   statsField?: StatsField;
   ranges?: Range[];
+  orderBy?: string;
 };
 
 export type ApiAnalyticsDashboardWidgetConfig = WidgetDisplayConfig & WidgetDataConfig;
@@ -217,6 +218,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       shouldSortBuckets: false,
       groupByField: 'application-id',
       analyticsType: 'GROUP_BY',
+      orderBy: '-count:_count',
     },
     {
       type: 'table',
@@ -226,6 +228,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       shouldSortBuckets: false,
       groupByField: 'plan-id',
       analyticsType: 'GROUP_BY',
+      orderBy: '-count:_count',
     },
     {
       type: 'table',
@@ -235,6 +238,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       shouldSortBuckets: false,
       groupByField: 'host',
       analyticsType: 'GROUP_BY',
+      orderBy: '-count:_count',
     },
   ];
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
@@ -495,7 +495,8 @@ describe('ApiAnalyticsWidgetService', () => {
             tooltip: 'Applications ranked by total API calls',
             analyticsType: 'GROUP_BY',
             groupByField: 'application-id',
-            shouldSortBuckets: true,
+            shouldSortBuckets: false,
+            orderBy: '-count:_count',
           };
 
           const mockGroupByResponse: GroupByResponse = fakeGroupByResponse({
@@ -505,8 +506,8 @@ describe('ApiAnalyticsWidgetService', () => {
               'app-3': 50,
             },
             metadata: {
-              'app-1': { name: 'Application 1', order: 0 },
-              'app-2': { name: 'Application 2', order: 1 },
+              'app-1': { name: 'Application 1', order: 1 },
+              'app-2': { name: 'Application 2', order: 0 },
               'app-3': { name: 'Application 3', order: 2 },
             },
           });
@@ -541,18 +542,21 @@ describe('ApiAnalyticsWidgetService', () => {
                 count: 200,
                 id: 'app-2',
                 isUnknown: false,
+                order: 0,
               });
               expect(result.widgetData.data[1]).toEqual({
                 name: 'Application 1',
                 count: 100,
                 id: 'app-1',
                 isUnknown: false,
+                order: 1,
               });
               expect(result.widgetData.data[2]).toEqual({
                 name: 'Application 3',
                 count: 50,
                 id: 'app-3',
                 isUnknown: false,
+                order: 2,
               });
             }
             done();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -157,6 +157,10 @@ export class ApiAnalyticsWidgetService {
       urlParamsData.ranges = widgetConfig.ranges.map((range) => `${range.value}`).join(';');
     }
 
+    if (widgetConfig.orderBy) {
+      urlParamsData.order = widgetConfig.orderBy;
+    }
+
     return this.apiAnalyticsV2Service
       .getGroupBy(widgetConfig.apiId, timeRangeParams, urlParamsData)
       .pipe(map((response: GroupByResponse) => this.transformGroupByResponseToApiAnalyticsWidgetConfig(response, widgetConfig)));
@@ -228,12 +232,10 @@ export class ApiAnalyticsWidgetService {
           count: value,
           id: label,
           isUnknown: metadata?.unknown || false,
+          order: Number(metadata?.order ?? Number.MAX_SAFE_INTEGER),
         };
-      });
-
-    if (widgetConfig.shouldSortBuckets) {
-      tableData.sort((a, b) => b.count - a.count);
-    }
+      })
+      .sort((a, b) => a.order - b.order);
 
     const columns: ApiAnalyticsWidgetTableDataColumn[] = [
       { name: 'name', label: 'Name', isSortable: true, dataType: 'string' },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10527

## Description

The right table widgets are sorted on first load as default descending.
<img width="1713" height="884" alt="image" src="https://github.com/user-attachments/assets/3764eea2-c912-4c92-b561-fef17b4320b0" />

match the order to the table at the right top corner

<img width="3426" height="1902" alt="image" src="https://github.com/user-attachments/assets/0ced1569-cff1-49d6-b61a-beb7cc161f4b" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sosikfoylj.chromatic.com)
<!-- Storybook placeholder end -->
