### PR TITLE
fix: Prevent history page timeout when groups are loaded

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { jest } from '@jest/globals';
+
+import ApiHistoryControllerAjs from './apiHistory.controller.ajs';
+
+describe('ApiHistoryControllerAjs - fetchGroupsConsumed', () => {
+  let controller: ApiHistoryControllerAjs;
+  let mockGroupService: any;
+
+  beforeEach(() => {
+    mockGroupService = {
+      searchPaginated: jest.fn(),
+    };
+
+    controller = new ApiHistoryControllerAjs(null, null, null, null, null, null, null, null, mockGroupService);
+    controller.groups = [];
+  });
+
+  it('should populate `groups` when groupService.searchPaginated resolves successfully', async () => {
+    const mockResponse = { data: { data: [{ id: 'group1' }, { id: 'group2' }] } };
+    mockGroupService.searchPaginated.mockResolvedValue(mockResponse);
+
+    const testPayload = JSON.stringify({
+      groups: ['group1', 'group2'],
+    });
+    const mockData = {
+      data: {
+        content: [{ payload: testPayload }],
+      },
+    };
+
+    await controller.fetchGroupsConsumed(mockData);
+
+    expect(mockGroupService.searchPaginated).toHaveBeenCalledWith(1, 200, 'ASC', '', ['group1', 'group2']);
+    expect(controller.groups).toEqual(mockResponse.data.data);
+  });
+
+  it('should handle an empty `groups` list in payload gracefully', async () => {
+    const mockResponse = { data: { data: [] } };
+    mockGroupService.searchPaginated.mockResolvedValue(mockResponse);
+
+    const testPayload = JSON.stringify({});
+    const mockData = {
+      data: {
+        content: [{ payload: testPayload }],
+      },
+    };
+
+    await controller.fetchGroupsConsumed(mockData);
+
+    expect(mockGroupService.searchPaginated).toHaveBeenCalledWith(1, 200, 'ASC', '', []);
+    expect(controller.groups).toEqual(mockResponse.data.data);
+  });
+
+  it('should handle an error from groupService.searchPaginated', async () => {
+    mockGroupService.searchPaginated.mockRejectedValue(new Error('Error fetching groups'));
+
+    const testPayload = JSON.stringify({
+      groups: ['group1', 'group2'],
+    });
+    const mockData = {
+      data: {
+        content: [{ payload: testPayload }],
+      },
+    };
+
+    await expect(controller.fetchGroupsConsumed(mockData)).resolves.not.toThrow();
+    expect(mockGroupService.searchPaginated).toHaveBeenCalledWith(1, 200, 'ASC', '', ['group1', 'group2']);
+    expect(controller.groups).toEqual([]);
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.spec.ts
@@ -68,6 +68,94 @@ describe('GroupService', () => {
     });
   });
 
+  describe('listPaginated', () => {
+    it('should call the API with default parameters', (done) => {
+      const fakePagedGroups = {
+        data: [fakeGroup()],
+        page: { current: 1, total_pages: 1, total_elements: 1, size: 20 },
+      };
+
+      groupService.listPaginated().subscribe((pagedGroups) => {
+        expect(pagedGroups).toMatchObject(fakePagedGroups);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/_paged?page=1&size=20&query=`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakePagedGroups);
+    });
+
+    it('should call the API with custom parameters', (done) => {
+      const page = 2;
+      const size = 10;
+      const query = 'test';
+      const fakePagedGroups = {
+        data: [fakeGroup()],
+        page: { current: page, total_pages: 2, total_elements: 15, size: size },
+      };
+
+      groupService.listPaginated(page, size, query).subscribe((pagedGroups) => {
+        expect(pagedGroups).toMatchObject(fakePagedGroups);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/_paged?page=${page}&size=${size}&query=${query}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakePagedGroups);
+    });
+  });
+
+  describe('searchPaginated', () => {
+    it('should call the API with default parameters', (done) => {
+      const fakePagedGroups = {
+        data: [fakeGroup()],
+        page: { current: 1, total_pages: 1, total_elements: 1, size: 20 },
+      };
+
+      groupService.searchPaginated().subscribe((pagedGroups) => {
+        expect(pagedGroups).toMatchObject(fakePagedGroups);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/_paged?page=1&size=20&sortOrder=ASC`,
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ query: '', ids: [] });
+
+      req.flush(fakePagedGroups);
+    });
+
+    it('should call the API with custom parameters', (done) => {
+      const page = 2;
+      const size = 10;
+      const sortOrder = 'DESC';
+      const query = 'test';
+      const ids = ['group1', 'group2'];
+      const fakePagedGroups = {
+        data: [fakeGroup()],
+        page: { current: page, total_pages: 2, total_elements: 15, size: size },
+      };
+
+      groupService.searchPaginated(page, size, sortOrder, query, ids).subscribe((pagedGroups) => {
+        expect(pagedGroups).toMatchObject(fakePagedGroups);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/_paged?page=${page}&size=${size}&sortOrder=${sortOrder}`,
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({ query: query, ids: ids });
+
+      req.flush(fakePagedGroups);
+    });
+  });
+
   describe('addOrUpdateMemberships', () => {
     it('should call the API', (done) => {
       const groupId = 'GROUP_ID';

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.ts
@@ -43,6 +43,22 @@ export class GroupService {
     );
   }
 
+  searchPaginated(
+    page: number = 1,
+    size: number = 20,
+    sortOrder: string = 'ASC',
+    query: string = '',
+    ids: string[] = [],
+  ): Observable<PagedResult<Group>> {
+    return this.http.post<PagedResult<Group>>(
+      `${this.constants.env.baseURL}/configuration/groups/_paged?page=${page}&size=${size}&sortOrder=${sortOrder}`,
+      {
+        query,
+        ids,
+      },
+    );
+  }
+
   listByOrganization(): Observable<Group[]> {
     return this.http.get<Group[]>(`${this.constants.org.baseURL}/groups`);
   }

--- a/gravitee-apim-console-webui/src/services/group.service.ts
+++ b/gravitee-apim-console-webui/src/services/group.service.ts
@@ -49,6 +49,19 @@ class GroupService {
     );
   }
 
+  searchPaginated(
+    page: number = 1,
+    size: number = 20,
+    sortOrder: string = 'ASC',
+    query: string = '',
+    ids: string[] = [],
+  ): ng.IPromise<any> {
+    return this.$http.post(`${this.Constants.env.baseURL}/configuration/groups/_paged?page=${page}&size=${size}&sortOrder=${sortOrder}`, {
+      query,
+      ids,
+    });
+  }
+
   listByOrganization(): ng.IPromise<any> {
     return this.$http.get(`${this.Constants.org.baseURL}/groups`);
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1124,6 +1124,7 @@ paths:
                     $ref: "#/components/responses/GroupsResponse"
                 default:
                     $ref: "#/components/responses/Error"
+
     /environments/{envId}/groups/{groupId}/members:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -5184,6 +5185,7 @@ components:
             enum:
                 - API_CREATE
                 - APPLICATION_CREATE
+
         Member:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupSearchParams.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupSearchParams.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Implementation of GroupSearchParams for searching groups by query and IDs
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupSearchParams implements io.gravitee.rest.api.model.common.GroupSearchCriteria {
+
+    @Valid
+    @NotNull
+    @JsonProperty("query")
+    private String query;
+
+    @Valid
+    @NotNull
+    @JsonProperty("ids")
+    private Set<String> ids;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
@@ -99,7 +99,40 @@ public class GroupsResource extends AbstractResource {
         @QueryParam("query") String query,
         @QueryParam("sortOrder") Order.Direction sortOrder
     ) {
-        Page<GroupEntity> page = groupService.search(GraviteeContext.getExecutionContext(), pageable.toPageable(), sortOrder, query);
+        Page<GroupEntity> page = groupService.search(GraviteeContext.getExecutionContext(), pageable.toPageable(), sortOrder, query, null);
+        PagedResult<GroupEntity> pagedResult = new PagedResult<>(page, pageable.getSize());
+        return Response.ok(pagedResult).build();
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Find paginated searched groups",
+        description = "Find paginated groups based on size and GroupSearchParams. Results can be filtered based on GroupSearchParams object." +
+        "Only administrators could see all groups." +
+        "Only users with MANAGE_API permissions could see API groups."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Page containing the list of searched groups",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PagedResult.class))
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
+    @Path("/_paged")
+    public Response getSearchedGroupsPaged(
+        @Valid @BeanParam Pageable pageable,
+        @QueryParam("sortOrder") Order.Direction sortOrder,
+        @Valid GroupSearchParams searchData
+    ) {
+        Page<GroupEntity> page = groupService.search(
+            GraviteeContext.getExecutionContext(),
+            pageable.toPageable(),
+            sortOrder,
+            searchData.getQuery(),
+            searchData
+        );
         PagedResult<GroupEntity> pagedResult = new PagedResult<>(page, pageable.getSize());
         return Response.ok(pagedResult).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/GroupSearchCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/GroupSearchCriteria.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.common;
+
+import java.util.Set;
+
+/**
+ * Interface for group search parameters
+ *
+ * @author GraviteeSource Team
+ */
+public interface GroupSearchCriteria {
+    String getQuery();
+    Set<String> getIds();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.GroupSimpleEntity;
 import io.gravitee.rest.api.model.NewGroupEntity;
 import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.common.GroupSearchCriteria;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -41,7 +42,13 @@ public interface GroupService {
     void delete(ExecutionContext executionContext, String groupId);
     void deleteUserFromGroup(ExecutionContext executionContext, String groupId, String username);
     List<GroupEntity> findAll(ExecutionContext executionContext);
-    Page<GroupEntity> search(ExecutionContext executionContext, Pageable pageable, Order.Direction orderDirection, String query);
+    Page<GroupEntity> search(
+        ExecutionContext executionContext,
+        Pageable pageable,
+        Order.Direction orderDirection,
+        String query,
+        GroupSearchCriteria searchData
+    );
     List<GroupSimpleEntity> findAllByOrganization(String organizationId);
     GroupEntity findById(ExecutionContext executionContext, String groupId);
     Set<GroupEntity> findByIds(Set<String> groupIds);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -63,6 +63,7 @@ import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
 import io.gravitee.rest.api.model.alert.ApplicationAlertMembershipEvent;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.common.GroupSearchCriteria;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -244,10 +245,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         ExecutionContext executionContext,
         Pageable pageable,
         Order.Direction orderDirection,
-        String query
+        String query,
+        GroupSearchCriteria groupSearchCriteria
     ) {
         String environmentId = executionContext.getEnvironmentId();
         GroupCriteria.GroupCriteriaBuilder groupCriteriaBuilder = GroupCriteria.builder().environmentId(environmentId).query(query);
+
+        if (groupSearchCriteria != null && groupSearchCriteria.getIds() != null && !groupSearchCriteria.getIds().isEmpty()) {
+            groupCriteriaBuilder.idIn(new HashSet<>(groupSearchCriteria.getIds()));
+        }
+
         if (
             !permissionService.hasPermission(
                 executionContext,
@@ -274,6 +281,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     .stream()
                     .map(MembershipEntity::getReferenceId)
                     .collect(Collectors.toSet());
+                if (groupSearchCriteria != null && groupSearchCriteria.getIds() != null && !groupSearchCriteria.getIds().isEmpty()) {
+                    groupIds.retainAll(groupSearchCriteria.getIds());
+                }
                 groupCriteriaBuilder.idIn(groupIds);
             }
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10310

## Description

History page timeout issue when a large number of groups exist and loaded. So, only required groups are fetched on the history page.

## Additional context
Video proofs are attached below:


https://github.com/user-attachments/assets/aa436b54-7a21-404f-b972-a131771c672a


https://github.com/user-attachments/assets/3a171f79-cba4-47df-98e7-8122754633f0


https://github.com/user-attachments/assets/92262143-9005-4572-8c26-d4131a60c0d4


https://github.com/user-attachments/assets/b1575a6e-ee86-4fe8-84bb-defeee0e5da1







<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eoftmitani.chromatic.com)
<!-- Storybook placeholder end -->
