### PR TITLE
Helm: Disable file logging by default

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -7,7 +7,8 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 4.9.0
 
 - Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)
-- Make embedded MongoDB and Elastic database deployable on OpenShit cluster. BREAKING CHANGE: as we upgrade to newer release of mongo and elastic dependencies
+- Make embedded MongoDB and Elastic database deployable on OpenShift cluster. BREAKING CHANGE: as we upgrade to newer release of mongo and elastic dependencies
+- BREAKING CHANGE: Disable `logging.file.enabled` by default for OpenShift compatibility
 
 ### 4.8.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -43,3 +43,5 @@ annotations:
       description: 'Allow customization on federation ingress. BREAKING CHANGE: now the federation ingress will not inherit anymore some management-api ingress definition (annotation, hosts, and tls)'
     - kind: changed
       description: 'Make embedded MongoDB and Elastic database deployable on OpenShift cluster. BREAKING CHANGE: as we upgrade to newer release of mongo and elastic dependencies'
+    - kind: changed
+      description: 'BREAKING CHANGE: Disable file logging by default for Openshift compatibility'

--- a/helm/tests/api/configmap_logback_yaml_test.yaml
+++ b/helm/tests/api/configmap_logback_yaml_test.yaml
@@ -2,6 +2,56 @@ suite: APIM - API - ConfigMap logback.xml config
 templates:
   - "api/api-configmap.yaml"
 tests:
+  - it: should not write in file by default
+    template: api/api-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      api:
+        logging:
+          debug: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["logback.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!--
+              ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+              ~
+              ~  Licensed under the Apache License, Version 2.0 (the "License");
+              ~  you may not use this file except in compliance with the License.
+              ~  You may obtain a copy of the License at
+              ~
+              ~  http://www.apache.org/licenses/LICENSE-2.0
+              ~
+              ~  Unless required by applicable law or agreed to in writing, software
+              ~  distributed under the License is distributed on an "AS IS" BASIS,
+              ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              ~  See the License for the specific language governing permissions and
+              ~  limitations under the License.
+              -->
+              <configuration>
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <!-- encoders are assigned the type
+                          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                      <encoder>
+                          <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                      </encoder>
+                  </appender>
+
+                  <logger name="io.gravitee" level="DEBUG" />
+                  <logger name="org.eclipse.jetty" level="INFO" />
+
+                  <!-- Strictly speaking, the level attribute is not necessary since -->
+                  <!-- the level of the root level is set to DEBUG by default.       -->
+                  <root level="WARN">
+                      <appender-ref ref="STDOUT" />
+                  </root>
+              </configuration>
+
   - it: should apply default logback configuration
     template: api/api-configmap.yaml
     chart:
@@ -11,6 +61,8 @@ tests:
       api:
         logging:
           debug: true
+          file:
+            enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -77,6 +129,8 @@ tests:
           debug: true
           stdout:
             json: true
+          file:
+            enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -151,6 +205,8 @@ tests:
               level: DEBUG
             - name: io.gravitee.test.infopackage
               level: INFO
+          file:
+            enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm/tests/gateway/configmap_logback_yaml_test.yaml
+++ b/helm/tests/gateway/configmap_logback_yaml_test.yaml
@@ -44,22 +44,6 @@ tests:
                         <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
                     </encoder>
                 </appender>
-                <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                    <file>${gravitee.home}/logs/gravitee.log</file>
-                    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                        <!-- daily rollover -->
-                        <fileNamePattern>${gravitee.home}/logs/gravitee_%d{yyyy-MM-dd}.log</fileNamePattern>
-                        <!-- keep 30 days' worth of history -->
-                        <maxHistory>30</maxHistory>
-                    </rollingPolicy>
-
-                    <encoder>
-                        <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
-                    </encoder>
-                </appender>
-                <appender name="async-file" class="ch.qos.logback.classic.AsyncAppender">
-                    <appender-ref ref="FILE" />
-                </appender>
 
                 <appender name="async-console" class="ch.qos.logback.classic.AsyncAppender">
                     <appender-ref ref="STDOUT" />
@@ -74,11 +58,9 @@ tests:
                 <!-- the level of the root level is set to DEBUG by default.       -->
                 <root level="INFO">
                     <appender-ref ref="async-console" />
-                    <appender-ref ref="async-file" />
                 </root>
             
             </configuration>
-
 
   - it: should apply logback configuration with JSON encoder
     template: gateway/gateway-configmap.yaml
@@ -89,6 +71,8 @@ tests:
       gateway:
         logging:
           debug: true
+          file:
+            enabled: true
           stdout:
             json: true
     asserts:
@@ -172,6 +156,8 @@ tests:
       gateway:
         logging:
           debug: true
+          file:
+            enabled: true
           graviteeLevel: WARN
           additionalLoggers:
             - name: io.gravitee.test.debugpackage

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -488,7 +488,7 @@ api:
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
       contextualLoggingEncoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n"
     file:
-      enabled: true
+      enabled: false
       rollingPolicy: |
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
@@ -1090,7 +1090,7 @@ gateway:
       json: false
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n"
     file:
-      enabled: true
+      enabled: false
       rollingPolicy: |
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/TT-8259

## Description

Disable file logging by default for Openshift compatibility

## Additional context

Writing log file inside a container is a bad practice.
We disabled it by default.
User can still enable it with logging.file.enabled: true

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fqbunfkkoc.chromatic.com)
<!-- Storybook placeholder end -->
