### PR TITLE
fix: ensure deployment number increments across all lifecycle events

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1803,7 +1803,14 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         if (EventType.PUBLISH_API.equals(eventType)) {
             EventCriteria criteria = EventCriteria
                 .builder()
-                .types(Set.of(io.gravitee.repository.management.model.EventType.PUBLISH_API))
+                .types(
+                    Set.of(
+                        io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                        io.gravitee.repository.management.model.EventType.STOP_API,
+                        io.gravitee.repository.management.model.EventType.START_API,
+                        io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                    )
+                )
                 .property(Event.EventProperties.API_ID.getValue(), apiId)
                 .build();
 
@@ -1860,6 +1867,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 lastPublishedAPI.setDeployedAt(new Date());
                 Map<String, String> properties = new HashMap<>();
                 properties.put(Event.EventProperties.USER.getValue(), userId);
+                properties.put(
+                    Event.EventProperties.DEPLOYMENT_NUMBER.getValue(),
+                    event.getProperties().getOrDefault(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "0")
+                );
 
                 // Clear useless field for history
                 lastPublishedAPI.setPicture(null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
@@ -165,7 +165,7 @@ public class ApiService_StartTest {
                 eq(GraviteeContext.getCurrentOrganization()),
                 eq(EventType.START_API),
                 argThat((ArgumentMatcher<Api>) argApi -> argApi.getId().equals(API_ID)),
-                eq(event.getProperties())
+                argThat((Map<String, String> props) -> "myUser".equals(props.get("user")) && props.containsKey("deployment_number"))
             );
         verify(notifierService, times(1)).trigger(eq(executionContext), eq(ApiHook.API_STARTED), eq(API_ID), any());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
@@ -165,7 +165,7 @@ public class ApiService_StopTest {
                 eq(GraviteeContext.getCurrentOrganization()),
                 eq(EventType.STOP_API),
                 argThat((ArgumentMatcher<Api>) apiArg -> apiArg.getId().equals(API_ID)),
-                eq(event.getProperties())
+                argThat((Map<String, String> props) -> USER_NAME.equals(props.get("user")) && props.containsKey("deployment_number"))
             );
         verify(notifierService, times(1)).trigger(eq(executionContext), eq(ApiHook.API_STOPPED), eq(API_ID), any());
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9634

## Description

Issue:
In v2 & V4 APIs, the audit history displays repeated deployment numbers (e.g., PUBLISH_API https://github.com/gravitee-io/gravitee-api-management/pull/1 appears twice) before the sequence begins incrementing correctly. This occurs when the API is started or redeployed early in its lifecycle. Also, deployment numbers start from 1 again if lifecycle is changes from START to STOP or vice versa.

Fix:
Deployment number is now incremented across all lifecycle-related events (START_API, STOP_API, PUBLISH_API, UNPUBLISH_API), ensuring consistent versioning in audit history.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

