### PR TITLE
fix(console): update stats titles to match designs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -108,7 +108,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
     {
       type: 'stats',
       apiId: this.apiId,
-      title: 'Min Latency',
+      title: 'Min Response Time',
       statsKey: 'min',
       statsUnit: 'ms',
       tooltip: '',
@@ -119,7 +119,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
     {
       type: 'stats',
       apiId: this.apiId,
-      title: 'Max Latency',
+      title: 'Max Response Time',
       statsKey: 'max',
       statsUnit: 'ms',
       tooltip: '',
@@ -130,7 +130,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
     {
       type: 'stats',
       apiId: this.apiId,
-      title: 'Average',
+      title: 'Avg Response Time',
       statsKey: 'avg',
       statsUnit: 'ms',
       tooltip: '',
@@ -141,7 +141,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
     {
       type: 'stats',
       apiId: this.apiId,
-      title: 'RPS',
+      title: 'Requests Per Second',
       statsKey: 'rps',
       statsUnit: '',
       tooltip: '',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10594

## Description

Update labels to match Figma designs and discussions between response time vs latency.

<img width="1517" height="955" alt="Screenshot 2025-08-06 at 15 36 09" src="https://github.com/user-attachments/assets/8b38c693-c2dc-4f0b-9351-61ad65fb324e" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pdmoxrhfqt.chromatic.com)
<!-- Storybook placeholder end -->
