### PR TITLE
fix: prevent changing group role from PO if group owns at least one API

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -237,11 +237,19 @@
             <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
               <mat-form-field>
                 <mat-label>API role</mat-label>
-                <mat-select [id]="group.id" [aria-label]="'API roles for ' + group.id" formControlName="API">
+                <mat-select
+                  [id]="group.id"
+                  [aria-label]="'API roles for ' + group.id"
+                  formControlName="API"
+                  [disabled]="isApiRolePrimaryOwner(group.id)"
+                >
                   <mat-option>-- None --</mat-option>
-                  <mat-option *ngFor="let role of apiRoles$ | async" [disabled]="role.system" [value]="role.name">{{
-                    role.name
-                  }}</mat-option>
+                  <mat-option
+                    *ngFor="let role of apiRoles$ | async"
+                    [disabled]="role.system || isApiRolePrimaryOwner(group.id)"
+                    [value]="role.name"
+                    >{{ role.name }}</mat-option
+                  >
                 </mat-select>
               </mat-form-field>
             </td>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -160,7 +160,7 @@ describe('OrgSettingsUserDetailComponent', () => {
   it('should not reset password if no firstname', async () => {
     const user = fakeUser({
       id: 'userId',
-      source: 'gravitee',
+      source: 'management',
       email: null,
       firstname: null,
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10367

## Description

Prevent users from changing a group's API role from PO if the group is the Product Owner of at least one API.
## Additional context

<img width="1728" height="942" alt="Screenshot 2025-08-07 at 3 59 56 PM" src="https://github.com/user-attachments/assets/4ce5c114-7e0c-4a7f-a4a9-f707eefdd3c2" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-khosreqcpt.chromatic.com)
<!-- Storybook placeholder end -->
