### PR TITLE
fix: map aggregated field values in GroupByQueryAdapter

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -786,7 +786,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 new SearchTermId(SearchTermId.SearchTerm.API, API_ID),
                 "response-time",
                 List.of(new GroupByQuery.Group(0, 100), new GroupByQuery.Group(100, 200)),
-                null,
+                Optional.empty(),
                 new TimeRange(from, to),
                 Optional.empty()
             );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10621

## Description

This PR fixes a bug where, when grouping by a field and ordering by `avg:FIELD`, the analytics response returned the hits count (`doc_count`) instead of the calculated average for the specified field. Now, when the order parameter specifies an average (e.g., `-avg:gateway-response-time-ms`), the response correctly returns the average value for each group.

## Additional context

- Example request:  
  `.../analytics?type=GROUP_BY&from=1751883987653&to=1754475987653&interval=86400000&field=application-id&order=-avg:gateway-response-time-ms`
- Previously, the response values were counts, not averages.
- With this fix, the response values reflect the average of the specified attribute per group, as expected.

<!-- For more details, see the Jira ticket and reproduction steps. -->