### PR TITLE
fix: reindex API after ownership transfer to prevent stale search results

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -127,7 +127,9 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
                 null,
                 node,
                 objectMapper,
-                commandRepository
+                commandRepository,
+                null,
+                null
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
@@ -122,7 +122,9 @@ public class MembershipService_CreateNewMembershipForApiTest {
                 null,
                 node,
                 objectMapper,
-                commandRepository
+                commandRepository,
+                null,
+                null
             );
 
         mockRole();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -84,6 +84,8 @@ public class MembershipService_DeleteMemberTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -85,6 +85,8 @@ public class MembershipService_EditMemberTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
@@ -96,6 +96,8 @@ public class MembershipService_FindUserMembershipMetadataTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
         USER_MEMBERSHIP = new UserMembership();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
@@ -106,6 +106,8 @@ public class MembershipService_FindUserMembershipTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
@@ -103,6 +103,8 @@ public class MembershipService_GetMemberPermissionsTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
@@ -86,6 +86,8 @@ public class MembershipService_GetMembersTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
@@ -71,6 +71,8 @@ public class MembershipService_GetMembershipsTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
@@ -77,6 +77,8 @@ public class MembershipService_GetUserMemberTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembership.java
@@ -146,7 +146,9 @@ public class MembershipService_IntegrationMembership {
                 integrationRepository,
                 node,
                 objectMapper,
-                commandRepository
+                commandRepository,
+                null,
+                null
             );
     }
 
@@ -288,6 +290,8 @@ public class MembershipService_IntegrationMembership {
             updatedMembership.setReferenceId(INTEGRATION_ID);
             updatedMembership.setMemberId(userId);
             updatedMembership.setMemberType(MembershipMemberType.USER);
+            when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization()))
+                .thenReturn(Optional.of(new RoleEntity()));
             when(
                 membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                     userId,
@@ -383,6 +387,8 @@ public class MembershipService_IntegrationMembership {
             membership.setRoleId(INTEGRATION_PRIMARY_OWNER);
             membership.setReferenceType(MembershipReferenceType.INTEGRATION);
             membership.setReferenceId(INTEGRATION_ID);
+            membership.setMemberType(MembershipMemberType.USER);
+            membership.setMemberId(EXISTING_USER_ID);
 
             when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization()))
                 .thenReturn(Optional.of(new RoleEntity()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
@@ -18,7 +18,9 @@ package io.gravitee.rest.api.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,13 +39,17 @@ import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.ApiOwnershipTransferException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
+import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import java.util.Collections;
@@ -109,6 +115,15 @@ public class MembershipService_TransferOwnershipTest {
     @Mock
     private ObjectMapper objectMapper;
 
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private GroupService groupService;
+
     @BeforeEach
     public void setUp() throws TechnicalException {
         membershipService =
@@ -126,13 +141,15 @@ public class MembershipService_TransferOwnershipTest {
                 apiSearchService,
                 apiGroupService,
                 apiRepository,
-                null,
+                groupService,
                 auditService,
                 null,
                 null,
                 node,
                 objectMapper,
-                commandRepository
+                commandRepository,
+                apiMetadataService,
+                searchEngineService
             );
         newPrimaryOwnerRole.setId(USER_ROLE_ID);
         newPrimaryOwnerRole.setName(USER_ROLE_NAME);
@@ -148,6 +165,7 @@ public class MembershipService_TransferOwnershipTest {
         Api api = new Api();
         api.setId(API_ID);
         lenient().when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+        lenient().when(groupService.findByIds(any())).thenReturn(Set.of());
     }
 
     @Test
@@ -281,5 +299,58 @@ public class MembershipService_TransferOwnershipTest {
         assertThat(createdUserMembership.getRoleId()).isEqualTo(USER_ROLE_ID);
         assertThat(createdUserMembership.getMemberId()).isEqualTo(USER_ID);
         assertThat(createdUserMembership.getReferenceId()).isEqualTo(API_ID);
+    }
+
+    @Test
+    public void shouldReindexApiAfterOwnershipTransfer() throws TechnicalException {
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId(API_PRIMARY_OWNER_ROLE_ID);
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+        newPrimaryOwnerRole.setId(USER_ROLE_ID);
+        newPrimaryOwnerRole.setName(USER_ROLE_NAME);
+        newPrimaryOwnerRole.setScope(RoleScope.API);
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(poRole));
+        when(roleService.findByScopeAndName(RoleScope.API, USER_ROLE_NAME, ORGANIZATION_ID)).thenReturn(Optional.of(newPrimaryOwnerRole));
+        when(roleService.findPrimaryOwnerRoleByOrganization(ORGANIZATION_ID, RoleScope.API)).thenReturn(poRole);
+        when(roleService.findScopeByMembershipReferenceType(any())).thenReturn(RoleScope.API);
+        when(roleService.findById(API_PRIMARY_OWNER_ROLE_ID)).thenReturn(poRole);
+
+        Membership userPoMembership = new Membership();
+        userPoMembership.setReferenceType(MembershipReferenceType.API);
+        userPoMembership.setRoleId(API_PRIMARY_OWNER_ROLE_ID);
+        userPoMembership.setReferenceId(API_ID);
+        userPoMembership.setMemberId(USER_ID);
+        userPoMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+
+        when(membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API, API_ID, API_PRIMARY_OWNER_ROLE_ID))
+            .thenReturn(Set.of(userPoMembership));
+
+        Membership groupPoMembership = new Membership();
+        groupPoMembership.setReferenceType(MembershipReferenceType.GROUP);
+        groupPoMembership.setRoleId(API_PRIMARY_OWNER_ROLE_ID);
+        groupPoMembership.setReferenceId(GROUP_ID);
+        groupPoMembership.setMemberId(GROUP_ID);
+        groupPoMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.GROUP);
+
+        when(membershipRepository.findByReferencesAndRoleId(eq(MembershipReferenceType.GROUP), eq(List.of(GROUP_ID)), any()))
+            .thenReturn(Set.of(groupPoMembership));
+
+        GenericApiEntity mockApi = mock(GenericApiEntity.class);
+        GenericApiEntity mockApiWithMetadata = mock(GenericApiEntity.class);
+
+        when(apiSearchService.findGenericById(EXECUTION_CONTEXT, API_ID)).thenReturn(mockApi);
+        when(apiMetadataService.fetchMetadataForApi(EXECUTION_CONTEXT, mockApi)).thenReturn(mockApiWithMetadata);
+        membershipService.transferApiOwnership(
+            EXECUTION_CONTEXT,
+            API_ID,
+            new MembershipService.MembershipMember(GROUP_ID, null, MembershipMemberType.GROUP),
+            List.of(newPrimaryOwnerRole)
+        );
+
+        verify(apiSearchService).findGenericById(EXECUTION_CONTEXT, API_ID);
+        verify(apiMetadataService).fetchMetadataForApi(EXECUTION_CONTEXT, mockApi);
+        verify(searchEngineService).index(EXECUTION_CONTEXT, mockApiWithMetadata, false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -115,7 +115,9 @@ public class MembershipService_UpdateMembershipForApiTest {
                 null,
                 node,
                 objectMapper,
-                commandRepository
+                commandRepository,
+                null,
+                null
             );
         mockApi();
     }


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-10645

## Description

When API ownership is transferred, the search index was not updated, causing search results to display outdated owner information. This fix ensures that after transferring ownership, the API is reindexed with the latest metadata.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

