### PR TITLE
Allow to redeploy automatically APIs when a secret has changed 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/ApiV4DefinitionSecretRefsFinder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/ApiV4DefinitionSecretRefsFinder.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 public class ApiV4DefinitionSecretRefsFinder extends AbstractV4APISecretRefFinder<Api> {
 
     public static final String RESPONSE_TEMPLATES_KIND = "response-templates";
+    public static final String API_V4_DEFINITION_KIND = "api-v4";
 
     @Override
     public boolean canHandle(Object definition) {
@@ -49,7 +50,10 @@ public class ApiV4DefinitionSecretRefsFinder extends AbstractV4APISecretRefFinde
 
     @Override
     public DefinitionDescriptor toDefinitionDescriptor(Api definition, DefinitionMetadata metadata) {
-        return new DefinitionDescriptor(new Definition("api-v4", definition.getId()), Optional.ofNullable(metadata.revision()));
+        return new DefinitionDescriptor(
+            new Definition(API_V4_DEFINITION_KIND, definition.getId()),
+            Optional.ofNullable(metadata.revision())
+        );
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/NativeApiV4DefinitionSecretRefsFinder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/NativeApiV4DefinitionSecretRefsFinder.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
  */
 public class NativeApiV4DefinitionSecretRefsFinder extends AbstractV4APISecretRefFinder<NativeApi> {
 
+    public static final String NATIVE_API_V4_DEFINITION_KIND = "native-api-v4";
+
     @Override
     public boolean canHandle(Object definition) {
         return canHandle(definition, NativeApi.class);
@@ -41,7 +43,10 @@ public class NativeApiV4DefinitionSecretRefsFinder extends AbstractV4APISecretRe
 
     @Override
     public DefinitionDescriptor toDefinitionDescriptor(NativeApi definition, DefinitionMetadata metadata) {
-        return new DefinitionDescriptor(new Definition("native-api-v4", definition.getId()), Optional.ofNullable(metadata.revision()));
+        return new DefinitionDescriptor(
+            new Definition(NATIVE_API_V4_DEFINITION_KIND, definition.getId()),
+            Optional.ofNullable(metadata.revision())
+        );
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -880,9 +880,14 @@ api:
 #      maxAttempt: 10
 #    allowGeneratedSpecs: true
 #    renewal:
-#      enable: true
+#      enabled: false
+#      # Retry strategy for secret renewal
 #      check:
-#        delay: 15
+#        delay: 1
+#        unit: MINUTES
+#      # TTL by default for all secrets
+#      defaultSecretTtl:
+#        delay: 1
 #        unit: MINUTES
 
 # Graceful shutdown.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1486,7 +1486,7 @@ gateway:
 #        maxAttempt: 10
 #      allowGeneratedSpecs: true
 #      renewal:
-#        enable: true
+#        enabled: true
 #        check:
 #          delay: 15
 #          unit: MINUTES

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <gravitee-resource-oauth2-provider-api.version>1.4.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>
         <gravitee-scoring-api.version>0.7.0</gravitee-scoring-api.version>
-        <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
+        <gravitee-secret-api.version>2.0.0-alpha.1</gravitee-secret-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
 
@@ -298,7 +298,7 @@
         <gravitee-apim-repository-bridge.version>7.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
-        <gravitee-service-secrets.version>1.0.0</gravitee-service-secrets.version>
+        <gravitee-service-secrets.version>2.0.0-alpha.1</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
 
         <gravitee-policy-kafka-quota.version>1.0.2</gravitee-policy-kafka-quota.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description
Improved Secret Management

The Secret Service now supports two new query parameters to enable more fine-grained secret management.

Ex : `{#secrets.get('/vault/secret/gravitee/tar:foo?renewable=true&reloadOnChange=true')}`


### 1. renewable=true

This parameter automatically assigns a TTL (Time-To-Live) to secrets.

To use this parameter, the renewal mechanism must be enabled in the configuration:

Example configuration with renewal enabled every minute:
```
secrets:
  ...
  renewal:
    enabled: true
    # Retry strategy for secret renewal
    check:
      delay: 1
      unit: MINUTES
    # Default TTL for all secrets
    defaultSecretTtl:
      delay: 1
      unit: MINUTES
```

In this setup, the system checks every minute if the secret value has changed.

### 2. reloadOnChange=true

This parameter automatically reloads the API when a secret value changes. It is useful when the secret is stored in memory (e.g., in an entrypoint or resource configuration).

⚠️ This parameter must be used in combination with renewable=true.

> When to Use renewable=true Only ?

Use renewable=true when the secret is used in a policy that does not cache the secret value in memory (which is the case for most policies).

In this case, the secret will be updated regularly according to the configuration, and each API call will use the latest value automatically.

> When to Use Both renewable=true and reloadOnChange=true ?

Use both parameters when the secret is used in: an endpoint or entrypoint, a resource, or any other component where values are cached or kept in memory (e.g., persistent HTTP connections).

In such cases, reloading the API is necessary to apply the updated secret value.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kdotyktcms.chromatic.com)
<!-- Storybook placeholder end -->
