### PR TITLE
chore(deps): upgrade policy-jwt to v6.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <gravitee-policy-json-validation.version>2.0.3</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>6.2.0-cj-3061-revocation-list-SNAPSHOT</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>6.2.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>


### PR DESCRIPTION

## Description

This PR upgrades Policy JWT to v6.2.0
Details regarding the added functionality can be found here:

https://github.com/gravitee-io/gravitee-policy-jwt/pull/152

## Additional context

https://github.com/gravitee-io/gravitee-api-management/pull/12769
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ayjneqdpuk.chromatic.com)
<!-- Storybook placeholder end -->
