### PR TITLE
Add UI for v2 to v4 migration

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v2/migrateToV4Response.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v2/migrateToV4Response.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class MigrateToV4Response {
+  state: MigrateToV4State;
+  issues: MigrateToV4Issue[];
+}
+
+export class MigrateToV4Issue {
+  message: string;
+  state: MigrateToV4State;
+}
+
+export type MigrateToV4State = 'MIGRATED' | 'MIGRATABLE' | 'CAN_BE_FORCED' | 'IMPOSSIBLE';

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.html
@@ -1,0 +1,158 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<ng-container>
+  <h2 mat-dialog-title class="title">Migrate API to v4</h2>
+
+  @if (migrationResponse$ | async; as response) {
+    <mat-dialog-content>
+      @switch (response.state) {
+        @case ('MIGRATABLE') {
+          @switch (migrationStep) {
+            @case ('INITIAL_CHECK') {
+              <div class="icon-container">
+                <mat-icon class="icon-container--success" svgIcon="gio:check-circled-outline"></mat-icon>
+              </div>
+              <div class="migratable-state">
+                <h3 class="migratable-state__header">Migration ready</h3>
+                <div>Your API is compatible with v4 and can be migrated safely</div>
+              </div>
+            }
+            @case ('CONFIRMATION') {
+              <div class="confirmation-state">
+                <div class="confirmation-state__header">Ready to migrate API to v4</div>
+                <gio-banner-warning class="confirmation-state__warning">
+                  Analytics history will not be preserved
+                  <div gioBannerBody>
+                    Historical analytics data from v2 will not be available in the v4 API. Currently analytics will reset after migration.
+                  </div>
+                </gio-banner-warning>
+                <mat-checkbox (change)="isConfirmed = $event.checked">
+                  <b>I understand that analytics history will be lost</b>
+                </mat-checkbox>
+              </div>
+            }
+          }
+        }
+        @case ('IMPOSSIBLE') {
+          <div class="icon-container">
+            <mat-icon class="icon-container--error" svgIcon="gio:error"></mat-icon>
+          </div>
+          <div class="issue-detected">
+            <h3 class="issue-detected__header">Migration blocked: Incompatible elements detected</h3>
+            <div class="issue-detected__subtitle">Your API cannot be migrated to v4 at this time.</div>
+            <div class="issue-detected__content">
+              We've detected incompatible elements in your v2 API definition that cannot be migrated to v4. To ensure your API works
+              reliably and without data loss, we've blocked the migration process.
+            </div>
+            @let impossibleIssues = impossibleIssues$ | async;
+            @if (impossibleIssues?.length) {
+              <div class="issue-detected__issue_warning">
+                <mat-icon class="issue-detected__issue_warning__error-icon" svgIcon="gio:error"></mat-icon>
+                To proceed, you'll need to remove or replace the following unsupported features before attempting migration:
+              </div>
+              <ul class="issue-detected__issues-list">
+                @for (issue of impossibleIssues || []; track issue.message) {
+                  <li>{{ issue.message }}</li>
+                }
+              </ul>
+            }
+            @let forcibleIssues = forcibleIssues$ | async;
+            @if (forcibleIssues?.length) {
+              <div class="issue-detected__issue_warning">
+                <mat-icon class="issue-detected__issue_warning__alert-icon" svgIcon="gio:alert-circle"></mat-icon>
+                These settings might need attention:
+              </div>
+              <ul class="issue-detected__issues-list">
+                @for (issue of forcibleIssues || []; track issue.message) {
+                  <li>{{ issue.message }}</li>
+                }
+              </ul>
+            }
+            <div>Please remove or update these elements before attempting migration to prevent data loss.</div>
+          </div>
+        }
+        @case ('CAN_BE_FORCED') {
+          @switch (migrationStep) {
+            @case ('INITIAL_CHECK') {
+              <div class="icon-container">
+                <mat-icon class="icon-container--alert" svgIcon="gio:alert-circle"></mat-icon>
+              </div>
+              <div class="issue-detected">
+                <h3 class="issue-detected__header">Migration allowed - Some settings may not migrate correctly</h3>
+                <div class="issue-detected__content">
+                  While most configuration will be preserved, some settings might be partially incompatible and require manual review after
+                  migration.
+                </div>
+                @if (forcibleIssues$ | async; as forcibleIssues) {
+                  <div class="issue-detected__issue_warning">
+                    <mat-icon class="issue-detected__issue_warning__alert-icon" svgIcon="gio:alert-circle"></mat-icon>
+                    These settings might need attention:
+                  </div>
+                  <ul class="issue-detected__issues-list">
+                    @for (issue of forcibleIssues; track issue.message) {
+                      <li>{{ issue.message }}</li>
+                    }
+                  </ul>
+                }
+              </div>
+            }
+            @case ('CONFIRMATION') {
+              <div class="confirmation-state">
+                <div class="confirmation-state__header">Ready to migrate API to v4</div>
+                <gio-banner-warning class="confirmation-state__warning">
+                  Analytics history will not be preserved
+                  <div gioBannerBody>
+                    Historical analytics data from v2 will not be available in the v4 API. Currently analytics will reset after migration.
+                  </div>
+                </gio-banner-warning>
+                <mat-checkbox (change)="isConfirmed = $event.checked">
+                  <b>I understand that analytics history will be lost</b>
+                </mat-checkbox>
+              </div>
+            }
+          }
+        }
+      }
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end" class="actions">
+      @if (migrationStep === 'INITIAL_CHECK') {
+        <button mat-flat-button [mat-dialog-close]="false">Cancel</button>
+      }
+      @if (migrationStep === 'CONFIRMATION') {
+        <button mat-flat-button (click)="onBack()">Back</button>
+      }
+      @if ((response.state === 'MIGRATABLE' || response.state === 'CAN_BE_FORCED') && migrationStep === 'INITIAL_CHECK') {
+        <button color="primary" mat-raised-button (click)="onContinue()">Continue</button>
+      }
+      @if ((response.state === 'MIGRATABLE' || response.state === 'CAN_BE_FORCED') && migrationStep === 'CONFIRMATION') {
+        <button color="primary" mat-raised-button (click)="onStartMigration(response)" [disabled]="!isConfirmed">Start Migration</button>
+      }
+    </mat-dialog-actions>
+  } @else {
+    <mat-dialog-content>
+      <div class="loader" data-testid="loader-spinner">
+        <gio-loader />
+        <div class="loader__content">Checking API compatibility...</div>
+      </div>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end" class="actions">
+      <button mat-flat-button [mat-dialog-close]="false">Cancel</button>
+    </mat-dialog-actions>
+  }
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.scss
@@ -1,0 +1,110 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  mat-dialog-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+}
+
+// --- Component Blocks ---
+
+.icon-container {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 96px;
+    width: 96px;
+    height: 96px;
+  }
+}
+
+.icon-container--success {
+  color: mat.m2-get-color-from-palette(gio.$mat-success-palette, 'default');
+}
+
+.icon-container--error {
+  color: mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+}
+
+.icon-container--alert {
+  color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
+}
+
+.loader {
+  &__content {
+    margin-top: 8px;
+  }
+}
+
+.migratable-state {
+  &__header {
+    font-size: 1.5em;
+    margin-bottom: 8px;
+  }
+}
+
+.issue-detected {
+  width: 100%;
+  text-align: left;
+
+  &__header {
+    font-size: 1.1em;
+    margin-bottom: 8px;
+  }
+  &__subtitle {
+    margin-bottom: 16px;
+  }
+  &__content {
+    margin-bottom: 16px;
+  }
+  &__issues-list {
+    padding-left: 20px;
+    margin: 0 0 24px;
+  }
+  &__issue_warning {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+    @include mat.m2-typography-level($typography, subtitle-2);
+
+    &__error-icon {
+      color: mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+      flex: 0 0 auto;
+      width: 24px;
+      height: 24px;
+    }
+    &__alert-icon {
+      color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
+      flex: 0 0 auto;
+    }
+  }
+}
+
+.confirmation-state {
+  width: 100%;
+  text-align: left;
+
+  &__header {
+    font-size: 1.1em;
+    margin-bottom: 20px;
+  }
+  &__warning {
+    margin-bottom: 16px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { GioBannerModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { MatButton } from '@angular/material/button';
+import { map, Observable, shareReplay } from 'rxjs';
+import { MatIcon } from '@angular/material/icon';
+import { AsyncPipe } from '@angular/common';
+import { MatCheckbox } from '@angular/material/checkbox';
+
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { MigrateToV4Issue, MigrateToV4Response } from '../../../../entities/management-api-v2/api/v2/migrateToV4Response';
+import { MigrateDialogResult } from '../api-general-info.component';
+
+@Component({
+  selector: 'api-general-info-migrate-to-v4-dialog',
+  imports: [
+    GioLoaderModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatButton,
+    MatDialogActions,
+    MatDialogClose,
+    AsyncPipe,
+    MatIcon,
+    GioBannerModule,
+    MatCheckbox,
+  ],
+  templateUrl: './api-general-info-migrate-to-v4-dialog.component.html',
+  styleUrl: './api-general-info-migrate-to-v4-dialog.component.scss',
+})
+export class ApiGeneralInfoMigrateToV4DialogComponent implements OnInit {
+  public migrationStep: 'INITIAL_CHECK' | 'CONFIRMATION' = 'INITIAL_CHECK';
+  public isConfirmed = false;
+
+  migrationResponse$: Observable<MigrateToV4Response>;
+  impossibleIssues$: Observable<MigrateToV4Issue[]>;
+  forcibleIssues$: Observable<MigrateToV4Issue[]>;
+
+  constructor(
+    public dialogRef: MatDialogRef<ApiGeneralInfoMigrateToV4DialogComponent, MigrateDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: { apiId: string },
+    private readonly apiService: ApiV2Service,
+  ) {}
+
+  ngOnInit(): void {
+    this.migrationResponse$ = this.apiService.migrateToV4(this.data.apiId, 'DRY_RUN').pipe(shareReplay(1));
+    this.impossibleIssues$ = this.migrationResponse$.pipe(
+      map((response) => response.issues?.filter((issue) => issue.state === 'IMPOSSIBLE') ?? []),
+    );
+    this.forcibleIssues$ = this.migrationResponse$.pipe(
+      map((response) => response.issues?.filter((issue) => issue.state === 'CAN_BE_FORCED') ?? []),
+    );
+  }
+
+  onContinue(): void {
+    this.migrationStep = 'CONFIRMATION';
+  }
+
+  onBack(): void {
+    this.migrationStep = 'INITIAL_CHECK';
+    this.isConfirmed = false;
+  }
+
+  onStartMigration(migrationResponse: MigrateToV4Response): void {
+    this.dialogRef.close({
+      confirmed: true,
+      state: migrationResponse.state,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -193,6 +193,18 @@
           <mat-icon svgIcon="gio:language" />
           Promote
         </button>
+        @if (api.definitionVersion === 'V2') {
+          <button
+            *gioPermission="{ anyOf: ['api-definition-u'] }"
+            mat-raised-button
+            color="primary"
+            class="details-card__actions__btn_align_right"
+            data-testid="api_info_migrate_menu"
+            (click)="migrateToV4()"
+          >
+            Migrate to v4
+          </button>
+        }
       </mat-card-actions>
     }
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.scss
@@ -131,6 +131,10 @@ $typography: map.get(gio.$mat-theme, typography);
     &_btn {
       margin-right: 8px;
     }
+
+    &__btn_align_right {
+      margin-left: auto;
+    }
   }
 
   &__update-banner {

--- a/gravitee-apim-console-webui/src/management/api/history-v4/api-history-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/history-v4/api-history-v4.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, Signal } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { isEqual, isNil } from 'lodash';
@@ -87,6 +87,7 @@ export class ApiHistoryV4Component {
     private readonly activatedRoute: ActivatedRoute,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
+    private readonly router: Router,
   ) {}
 
   protected paginationChange(searchParam: SearchApiEventParam) {
@@ -238,6 +239,7 @@ export class ApiHistoryV4Component {
       .subscribe({
         next: () => {
           this.snackBarService.success('API deployment has been rolled back successfully');
+          this.router.navigate(['../..'], { relativeTo: this.activatedRoute });
         },
         error: (error) => {
           this.snackBarService.error(error?.error?.message ?? 'An error occurred while rolling back the API deployment!');

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -641,4 +641,52 @@ describe('ApiV2Service', () => {
       httpTestingController.expectNone(`${CONSTANTS_TESTING.env.v2BaseURL}/apis`);
     });
   });
+
+  describe('migrateToV4', () => {
+    it('should POST to migrate endpoint without mode', (done) => {
+      const apiId = 'my-api-id';
+
+      apiV2Service.migrateToV4(apiId).subscribe((res) => {
+        expect(res).toEqual({ state: 'MIGRATABLE', issues: [] });
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_migrate`,
+        method: 'POST',
+      });
+      expect(req.request.params.keys().length).toBe(0);
+      req.flush({ state: 'MIGRATABLE', issues: [] });
+    });
+
+    it('should POST to migrate endpoint with mode=DRY_RUN', (done) => {
+      const apiId = 'my-api-id';
+
+      apiV2Service.migrateToV4(apiId, 'DRY_RUN').subscribe((res) => {
+        expect(res).toEqual({ state: 'MIGRATABLE', issues: [] });
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_migrate?mode=DRY_RUN`,
+        method: 'POST',
+      });
+      req.flush({ state: 'MIGRATABLE', issues: [] });
+    });
+
+    it('should POST to migrate endpoint with mode=FORCE', (done) => {
+      const apiId = 'my-api-id';
+
+      apiV2Service.migrateToV4(apiId, 'FORCE').subscribe((res) => {
+        expect(res).toEqual({ state: 'MIGRATED', issues: [] });
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_migrate?mode=FORCE`,
+        method: 'POST',
+      });
+      req.flush({ state: 'MIGRATED', issues: [] });
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { BehaviorSubject, from, mergeMap, Observable, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
@@ -26,18 +26,19 @@ import {
   ApiSortByParam,
   ApisResponse,
   ApiSubscribersResponse,
+  ApiTransferOwnership,
   ApiV4,
   CreateApi,
   DuplicateApiOptions,
-  UpdateApi,
-  ApiTransferOwnership,
-  VerifyApiDeployResponse,
   ListenerType,
   Member,
+  UpdateApi,
+  VerifyApiDeployResponse,
 } from '../entities/management-api-v2';
 import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 import { VerifyApiHostsResponse } from '../entities/management-api-v2/api/verifyApiHosts';
 import { ImportSwaggerDescriptor } from '../entities/management-api-v2/api/v4/importSwaggerDescriptor';
+import { MigrateToV4Response } from '../entities/management-api-v2/api/v2/migrateToV4Response';
 
 export interface HostValidatorParams {
   currentHost?: string;
@@ -215,17 +216,40 @@ export class ApiV2Service {
   }
 
   verifyPath(apiId: string, paths: PathToVerify[]): Observable<VerifyApiPathResponse> {
-    return this.http.post<VerifyApiPathResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/paths`, { apiId, paths });
+    return this.http.post<VerifyApiPathResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/paths`, {
+      apiId,
+      paths,
+    });
   }
 
   verifyHosts(apiId: string, listenerType: ListenerType, hosts: string[]): Observable<VerifyApiHostsResponse> {
-    return this.http.post<VerifyApiHostsResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/hosts`, { apiId, listenerType, hosts });
+    return this.http.post<VerifyApiHostsResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/hosts`, {
+      apiId,
+      listenerType,
+      hosts,
+    });
   }
 
   rollback(apiId: string, eventId: string): Observable<void> {
     return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_rollback`, { eventId }).pipe(
       switchMap(() => this.get(apiId)),
       map(() => {}),
+    );
+  }
+
+  migrateToV4(apiId: string, mode?: 'DRY_RUN' | 'FORCE'): Observable<MigrateToV4Response> {
+    let httpParams = new HttpParams();
+
+    if (mode) {
+      httpParams = httpParams.set('mode', mode);
+    }
+
+    return this.http.post<MigrateToV4Response>(
+      `${this.constants.env.v2BaseURL}/apis/${apiId}/_migrate`,
+      {},
+      {
+        params: httpParams,
+      },
     );
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9842

## Description

- UI for v2 -> v4 migration
- Handling redirect after v4 -> v2 rollback

## Additional context

**Screens:** 

1. Migrate button: 
<img width="2294" height="1640" alt="image" src="https://github.com/user-attachments/assets/20e7679b-81b7-4b86-a382-922e211e5f11" />

2. Migratable scenario: 
<img width="1100" height="832" alt="image" src="https://github.com/user-attachments/assets/e944f308-43cf-4f94-bc24-fceddac0fc1d" />

3. Can be forced Scneario: 
<img width="1008" height="1068" alt="image" src="https://github.com/user-attachments/assets/29b73c7f-91f6-4ceb-ae73-807655772a8f" />

4. Impossible migration scenario: 
<img width="1028" height="1480" alt="image" src="https://github.com/user-attachments/assets/5c262702-d905-4510-84fe-18df9fa78677" />

5. Confirmation window: 
<img width="1030" height="846" alt="image" src="https://github.com/user-attachments/assets/745e6e31-4ac8-44a2-8d1a-5779b5aff086" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vmwfippmnh.chromatic.com)
<!-- Storybook placeholder end -->
