### PR TITLE
GKO-1317: Disable application edition in the portal if application is managed by GKO

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
@@ -101,8 +101,13 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
     this.permissions = this.route.snapshot.data.permissions;
     if (this.application) {
       this.applicationTypeEntity = this.route.snapshot.data.applicationType;
-      this.canDelete = this.permissions.DEFINITION && this.permissions.DEFINITION.includes('D');
-      this.canUpdate = this.permissions.DEFINITION && this.permissions.DEFINITION.includes('U');
+
+      const isAppEditable = this.application?.origin !== 'KUBERNETES';
+      const canDeleteApp = this.permissions?.DEFINITION?.includes('D');
+      const canUpdateApp = this.permissions?.DEFINITION?.includes('U');
+
+      this.canDelete = canDeleteApp && isAppEditable;
+      this.canUpdate = canUpdateApp && isAppEditable;
 
       this.initForm();
       this.updateGrantTypes();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1317

## Description

If an application is managed by GKO, the portal will disable edition/deletion of the application.

Screenshots show an application that can be edited (left) vs. one that can't (right).

<img width="5112" height="3185" alt="image" src="https://github.com/user-attachments/assets/884284ea-57ac-4127-a8e8-ccc1a31815be" />

The fix was to update the `canDelete` and `canUpdate` fields in the `ApplicationGeneralComponent` class based on the application's `origin`.
This way, the existing display logic will take care of making the app read-only.

Applications are made read-only if `origin` is `KUBERNETES`.

Notes:
- This change is for the old portal. I'm looking at the next portal and will update it in another PR if necessary.
- This PR depends on [12783.](https://github.com/gravitee-io/gravitee-api-management/pull/12783)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

