### PR TITLE
fix(console): email content overlapping in my-account issue

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.component.html
@@ -32,7 +32,7 @@
         ></gio-avatar>
         <span class="gio-user-menu__header__user-info">
           <h5>{{ userShortName }}</h5>
-          <small>{{ currentUser.email }}</small>
+          <small title="{{ currentUser.email }}">{{ currentUser.email | middleEllipsis: 15 : 10 }}</small>
         </span>
       </span>
     </div>

--- a/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.module.ts
+++ b/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.module.ts
@@ -23,6 +23,8 @@ import { MatDividerModule } from '@angular/material/divider';
 
 import { GioUserMenuComponent } from './gio-user-menu.component';
 
+import { MiddleEllipsisPipe } from '../../shared/pipes/middle-ellipsis.pipe';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -35,6 +37,7 @@ import { GioUserMenuComponent } from './gio-user-menu.component';
     GioAvatarModule,
     MatMenuModule,
     MatDividerModule,
+    MiddleEllipsisPipe,
   ],
   declarations: [GioUserMenuComponent],
   exports: [GioUserMenuComponent],

--- a/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.module.ts
+++ b/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+
+import { MiddleEllipsisPipe } from './middle-ellipsis.pipe';
+
+@NgModule({
+  imports: [],
+  declarations: [MiddleEllipsisPipe],
+  exports: [MiddleEllipsisPipe],
+})
+export class GioMiddleEllipsisPipeModule {}

--- a/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MiddleEllipsisPipe } from './middle-ellipsis.pipe';
+
+describe('MiddleEllipsisPipe', () => {
+  it('create an instance', () => {
+    const pipe = new MiddleEllipsisPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return empty string when input is empty', () => {
+    const pipe = new MiddleEllipsisPipe();
+    expect(pipe.transform('')).toEqual('');
+  });
+
+  it('should return empty string when input is null or undefined', () => {
+    const pipe = new MiddleEllipsisPipe();
+    expect(pipe.transform(null)).toEqual('');
+    expect(pipe.transform(undefined)).toEqual('');
+  });
+
+  it('should return the original string when length is less than or equal to frontChars + backChars', () => {
+    const pipe = new MiddleEllipsisPipe();
+    const shortString = 'short@example.com';
+    expect(pipe.transform(shortString)).toEqual(shortString);
+  });
+
+  it('should truncate the string with ellipsis when length exceeds frontChars + backChars', () => {
+    const pipe = new MiddleEllipsisPipe();
+    const longString = 'verylongemailaddress@example.com';
+    expect(pipe.transform(longString)).toEqual('verylongemailad...xample.com');
+  });
+
+  it('should use default values (frontChars=15, backChars=10) when no parameters are provided', () => {
+    const pipe = new MiddleEllipsisPipe();
+    const longString = 'abcdefghijklmnopqrstuvwxyz1234567890';
+    expect(pipe.transform(longString)).toEqual('abcdefghijklmno...1234567890');
+  });
+
+  it('should use custom frontChars and backChars values when provided', () => {
+    const pipe = new MiddleEllipsisPipe();
+    const longString = 'abcdefghijklmnopqrstuvwxyz1234567890';
+    expect(pipe.transform(longString, 5, 5)).toEqual('abcde...67890');
+  });
+
+  it('should handle edge case with very small frontChars and backChars values', () => {
+    const pipe = new MiddleEllipsisPipe();
+    const longString = 'abcdefghijklmnopqrstuvwxyz1234567890';
+    expect(pipe.transform(longString, 1, 1)).toEqual('a...0');
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.ts
+++ b/gravitee-apim-console-webui/src/shared/pipes/middle-ellipsis.pipe.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'middleEllipsis', standalone: true })
+export class MiddleEllipsisPipe implements PipeTransform {
+  transform(value: string, frontChars: number = 15, backChars: number = 10): string {
+    if (!value) return '';
+    if (value.length <= frontChars + backChars) return value;
+    return value.slice(0, frontChars) + '...' + value.slice(value.length - backChars);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10378

## Description

When viewing "My Account" within the APIM Console, the email address is wrapped over itself causing a display issue.

## Additional context

Before fix: 
<img width="719" height="463" alt="image" src="https://github.com/user-attachments/assets/dd29042d-cfaf-4623-8cda-ca000dd08695" />

After fix:
<img width="719" height="463" alt="image" src="https://github.com/user-attachments/assets/9d780e86-e439-4403-ae8f-77a6a1a18054" />

Title for showing the full content on hover: 
<img width="719" height="465" alt="image" src="https://github.com/user-attachments/assets/e1477830-bd5b-4a11-8027-699eee4f0fc3" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ntueowuqbf.chromatic.com)
<!-- Storybook placeholder end -->

**Approach:**

Pipe is now used to hide lengthy content. Also, title attribute is added to provide a glance of the full text hidden through the pipe.
