### PR TITLE
fix: Gracefully handle empty state on the API score tab

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringReportMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringReportMongoRepositoryImpl.java
@@ -33,11 +33,7 @@ import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.internal.model.ScoringReportMongo;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
@@ -119,7 +115,8 @@ public class ScoringReportMongoRepositoryImpl implements ScoringReportMongoRepos
                     })
                     .toList();
 
-            total = result.getList("totalCount", Document.class).get(0).getInteger("count");
+            List<Document> totalCount = result.getList("totalCount", Document.class, Collections.emptyList());
+            total = totalCount.isEmpty() ? 0L : ((Number) totalCount.get(0).getOrDefault("count", 0)).longValue();
         }
 
         return new Page<>(data, pageable != null ? pageable.pageNumber() : 0, pageable != null ? pageable.pageSize() : 0, total);


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-10585

## Description

Resolves an `IndexOutOfBoundsException` that occurred when a user opened the API Score tab in an environment with zero APIs.

The logic now safely handles cases where the API list is empty by providing a default value, ensuring the UI renders a proper empty state without errors.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hvfdcxazjj.chromatic.com)
<!-- Storybook placeholder end -->
