### PR TITLE
feat(console): add dedicated plan column to v4 api logs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -146,6 +146,7 @@ describe('ApiRuntimeLogsComponent', () => {
             URI: 'URI',
             actions: '',
             application: 'Application',
+            plan: 'Plan',
             method: 'Method',
             responseTime: 'Response time',
             status: 'Status',
@@ -197,6 +198,7 @@ describe('ApiRuntimeLogsComponent', () => {
               URI: 'URI',
               actions: '',
               application: 'Application',
+              plan: 'Plan',
               endpoint: 'Endpoint reached',
               method: 'Method',
               responseTime: 'Response time',
@@ -204,7 +206,7 @@ describe('ApiRuntimeLogsComponent', () => {
               timestamp: 'Timestamp',
             },
           ],
-          rowCells: [['02/02/2020 20:22:02.000', 'GET', '200', '/api-uri', 'My first application (Default plan)', '42ms', '', '']],
+          rowCells: [['02/02/2020 20:22:02.000', 'GET', '200', '/api-uri', 'My first application', 'Default plan', '42ms', '', '']],
         });
       });
     });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.html
@@ -59,7 +59,14 @@
     <ng-container matColumnDef="application">
       <th mat-header-cell *matHeaderCellDef id="application">Application</th>
       <td mat-cell *matCellDef="let log">
-        {{ log.application.name + ' (' + log.plan.name + ')' }}
+        {{ log.application.name }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="plan">
+      <th mat-header-cell *matHeaderCellDef id="plan">Plan</th>
+      <td mat-cell *matCellDef="let log">
+        {{ log.plan.name }}
       </td>
     </ng-container>
 
@@ -72,7 +79,7 @@
       <th mat-header-cell *matHeaderCellDef id="endpoint">Endpoint reached</th>
       <td mat-cell *matCellDef="let log">
         @if (!!log.endpoint) {
-          <span class="gio-badge-success"><mat-icon svgIcon="gio:check"></mat-icon></span>
+          <span class="gio-badge-neutral"><mat-icon svgIcon="gio:check"></mat-icon></span>
         }
       </td>
     </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.ts
@@ -57,6 +57,7 @@ export class ApiRuntimeLogsListComponent {
     'status',
     'URI',
     'application',
+    'plan',
     'responseTime',
     ...(this.isMessageApi() ? [] : ['endpoint']),
     'actions',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10744

## Description

- Create separate column for Plan in the v4 API Log table
- Change Endpoint Reached badge color to a more neutral color

<img width="1822" height="964" alt="Screenshot 2025-08-12 at 17 24 37" src="https://github.com/user-attachments/assets/474b6845-24ec-452c-8acf-d3da9a87369f" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mfqecfqokp.chromatic.com)
<!-- Storybook placeholder end -->
