### PR TITLE
fix(federation): map jwt plan type

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
@@ -37,6 +37,7 @@ public record IntegrationApi(
     public record Plan(String id, String name, String description, PlanType type, List<String> characteristics) {}
     public enum PlanType {
         API_KEY,
+        JWT,
         OAUTH2,
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
@@ -53,7 +53,7 @@ public interface IntegrationAdapter {
     IntegrationApi.Plan map(io.gravitee.integration.api.model.Plan source);
 
     @ValueMapping(source = "API_KEY", target = "API_KEY")
-    @ValueMapping(source = "JWT", target = MappingConstants.NULL)
+    @ValueMapping(source = "JWT", target = "JWT")
     @ValueMapping(source = "OAUTH2", target = "OAUTH2")
     IntegrationApi.PlanType map(PlanSecurityType source);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

When working on the Edge Stack Federation Agent, it was discovered that plans with JWT PlanSecurityType were not being created on ingest.  After debugging, the reason that they were not being created was due to the mapping being set to `null` when trying to create the plan for the federate API.  This change provides a mapping for the JWT PlanSecurityType when ingesting APIs with JWT plans associated.

## Additional context

