### PR TITLE
chore(deps): upgrade vertx 4.5.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,14 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2
              in gravitee-apim-gateway-tests-sdk and gravitee-apim-integration-tests
              along with the grpc libs to create test clients and servers -->
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
         <protobuf-java.version>4.28.2</protobuf-java.version>
         <grpc-java.version>1.65.0</grpc-java.version>
         <!-- While waiting fot the new version of lombok-plugin, we use this workaround
              https://github.com/awhitford/lombok.maven/issues/179 -->
         <maven-lombok.version>1.18.36</maven-lombok.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>8.3.14</gravitee-bom.version>
+        <gravitee-bom.version>8.3.30</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.8.2</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.1.1</gravitee-cloud-initializer.version>


### PR DESCRIPTION
## Description

Upgrade the bom to get the latest Vertx 4.5.18.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ctrgbzfdtc.chromatic.com)
<!-- Storybook placeholder end -->
