### PR TITLE
chore: bump mcp entrypoint to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <gravitee-entrypoint-webhook.version>4.1.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.0</gravitee-entrypoint-agent-to-agent.version>
-        <gravitee-entrypoint-mcp.version>1.0.1</gravitee-entrypoint-mcp.version>
+        <gravitee-entrypoint-mcp.version>1.0.2</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-kafka.version>4.0.5</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>


### PR DESCRIPTION
## Description

Bump mcp entrypoint to fix an issue with query parameters and an issue with duplicates into the generated path.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xrzlqfilcp.chromatic.com)
<!-- Storybook placeholder end -->
