### PR TITLE
fix: default API lifecycle state to STOPPED to allow IndexableApi deletion from SearchEngineIndexer

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -115,7 +115,8 @@ public class Api {
     /**
      * The current runtime life cycle state.
      */
-    private LifecycleState lifecycleState;
+    @Builder.Default
+    private LifecycleState lifecycleState = LifecycleState.STOPPED;
 
     /**
      * The api picture

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
@@ -469,6 +469,7 @@ class StartIngestIntegrationApisUseCaseTest {
                         .definitionVersion(DefinitionVersion.FEDERATED_AGENT)
                         .groups(Set.of())
                         .federatedAgent(federatedAgent)
+                        .lifecycleState(null)
                         .build()
                 );
             assertThat(planCrudService.storage())
@@ -559,6 +560,7 @@ class StartIngestIntegrationApisUseCaseTest {
                         .createdAt(ZonedDateTime.parse("2023-10-22T12:15:30+02:00[Europe/Paris]"))
                         .updatedAt(ZonedDateTime.parse("2023-10-22T12:15:30+02:00[Europe/Paris]"))
                         .federatedAgent(federatedAgent1)
+                        .lifecycleState(null)
                         .build(),
                     Api
                         .builder()
@@ -573,6 +575,7 @@ class StartIngestIntegrationApisUseCaseTest {
                         .definitionVersion(DefinitionVersion.FEDERATED_AGENT)
                         .groups(Set.of())
                         .federatedAgent(federatedAgent2)
+                        .lifecycleState(null)
                         .build()
                 );
             assertThat(planCrudService.storage())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10771

## Description

Fix for the issue occurring when the IndexibleApi is deleted during api migration from v2 -> v4


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pdegzykwhe.chromatic.com)
<!-- Storybook placeholder end -->
