### PR TITLE
refactor: automation target token

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collections;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -122,9 +123,11 @@ public class TargetTokenCommandHandler implements CommandHandler<TargetTokenComm
     }
 
     private boolean assignOrganizationRole(ExecutionContext context, TargetTokenCommandPayload payload, UserEntity user) {
-        String roleName = payload.scope() == TargetTokenCommandPayload.Scope.GKO
-            ? SystemRole.ADMIN.name()
-            : DEFAULT_ROLE_ORGANIZATION_USER.getName();
+        Set<TargetTokenCommandPayload.Scope> adminScopes = Set.of(
+            TargetTokenCommandPayload.Scope.GKO,
+            TargetTokenCommandPayload.Scope.AUTOMATION
+        );
+        String roleName = adminScopes.contains(payload.scope()) ? SystemRole.ADMIN.name() : DEFAULT_ROLE_ORGANIZATION_USER.getName();
         if (roleService.findByScopeAndName(RoleScope.ORGANIZATION, roleName, payload.organizationId()).isEmpty()) {
             log.error("Couldn't find {} role for organization with id [{}]", roleName, payload.organizationId());
             return false;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3382

## Description

Add handling of automation scope for target token creation for cloud token. 

Automation target token has the same permissions as current GKO target token. For now, cockpit still asks apim for a GKO target token but once this is released will move cockpit to ask for automation target token and then can remove depreciated GKO. 

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-odjyghsmed.chromatic.com)
<!-- Storybook placeholder end -->
