### PR TITLE
feat: enhance migration dialog with enterprise support instructions

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-migrate-to-v4-dialog/api-general-info-migrate-to-v4-dialog.component.html
@@ -83,7 +83,13 @@
                 }
               </ul>
             }
-            <div>Please remove or update these elements before attempting migration to prevent data loss.</div>
+            <div class="issue-detected__content">
+              Please remove or update these elements before attempting migration to prevent data loss.
+            </div>
+            <div class="issue-detected__content">
+              If you are an enterprise customer, please export your API definition and provide it as part of a support ticket so that the
+              Gravitee team can help you with this migration.
+            </div>
           </div>
         }
         @case ('CAN_BE_FORCED') {


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-10660

## Description


If migration is not possible, I added a note for enterprise customers in the "Migrate to v4" dialog, advising them to export their API definition and contact support for migration assistance.

## Additional context

Agreed with Jonathan on Slack as an alternative to **Contact Support** button 

Preview:
<img width="1310" height="1694" alt="image" src="https://github.com/user-attachments/assets/1647220c-3c68-429e-a018-502fcd0b5c16" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-braoibvlss.chromatic.com)
<!-- Storybook placeholder end -->
