### PR TITLE
test(e2e): ensure api and app user are properly initialized before using them in tests

### DIFF
--- a/gravitee-apim-e2e/api-test/jest.setup.ts
+++ b/gravitee-apim-e2e/api-test/jest.setup.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { beforeAll } from '@jest/globals';
+import { CurrentUserApi } from '../lib/management-webclient-sdk/src/lib/apis/CurrentUserApi';
+import { forManagementAsApiUser, forManagementAsAppUser } from '../lib/utils/configuration';
+
+let initialized = false;
+
+beforeAll(async () => {
+  if (initialized) {
+    return;
+  }
+
+  const orgId = 'DEFAULT';
+  const currentUserResourceAsApiUser = new CurrentUserApi(forManagementAsApiUser());
+  const currentUserResourceAsAppUser = new CurrentUserApi(forManagementAsAppUser());
+
+  console.log('Initializing API and App users for tests.');
+  // Ensure that API user and App User are properly initialized before using them in tests.
+  // APIM should create these two users automatically
+  const apiResponse = await currentUserResourceAsApiUser.getCurrentUserRaw({
+    orgId,
+  });
+  if (apiResponse.raw.status !== 200) {
+    throw new Error(`Failed to initialize API user: ${apiResponse.raw.statusText}`);
+  }
+
+  const appResponse = await currentUserResourceAsAppUser.getCurrentUserRaw({
+    orgId,
+  });
+  if (appResponse.raw.status !== 200) {
+    throw new Error(`Failed to initialize App user: ${appResponse.raw.statusText}`);
+  }
+
+  // Wait for 1 second to ensure APIM is ready for the next tests
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  initialized = true;
+});

--- a/gravitee-apim-e2e/api-test/src/apis/settings/mapi-v1/notification-setting.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/settings/mapi-v1/notification-setting.spec.ts
@@ -33,7 +33,7 @@ describe('Notification settings tests', () => {
 
   describe('Create', () => {
     it('should create a notification setting', async () => {
-      const users = await managementUserResourceAsAdminUser.getAllUsers({ orgId, envId });
+      const users = await managementUserResourceAsAdminUser.getAllUsers({ orgId, envId, size: 200 });
       apiUser = users.data.find((user) => user.displayName === API_USER.username);
 
       const userOrganizationRole = await succeed(

--- a/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/token.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/token.spec.ts
@@ -36,7 +36,7 @@ describe('User tokens crud tests', () => {
   let apiUser: UserEntity;
 
   beforeAll(async () => {
-    const users = await managementUserResourceAsAdminUser.getAllUsers({ orgId, envId });
+    const users = await managementUserResourceAsAdminUser.getAllUsers({ orgId, envId, size: 200 });
     apiUser = users.data.find((user) => user.displayName === API_USER.username);
   });
 

--- a/gravitee-apim-e2e/jest.config.ci.js
+++ b/gravitee-apim-e2e/jest.config.ci.js
@@ -26,5 +26,7 @@ module.exports = {
     '^.+\\.xml$': '<rootDir>/lib/jest-raw-loader.js',
   },
 
+  setupFilesAfterEnv: ['<rootDir>/dist/api-test/jest.setup.js'],
+
   reporters: ['default', ['jest-junit', { outputDirectory: '.tmp', outputName: 'e2e-test-report.xml' }]],
 };

--- a/gravitee-apim-e2e/jest.config.js
+++ b/gravitee-apim-e2e/jest.config.js
@@ -132,7 +132,7 @@ module.exports = {
   // setupFiles: ['./jest.setup.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['<rootDir>/api-test/jest.setup.ts'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -21,7 +21,7 @@
         "test:report:dev": "ENV=dev ant -f jacoco/build.xml",
         "test:report:merge": "ant -f jacoco/merge.xml",
         "lint": "yarn prettier && yarn lint:license",
-        "lint:fix": "yarn prettier:fix && yarn lint:license:fix && tsc --noEmit",
+        "lint:fix": "yarn lint:license:fix && yarn prettier:fix && tsc --noEmit",
         "lint:license": "license-check-and-add check -f license-check-config.json",
         "lint:license:fix": "license-check-and-add add -f license-check-config.json -r",
         "prettier": "prettier --check \"**/*.{js,ts,html,css,scss,json}\"",

--- a/gravitee-apim-e2e/tsconfig.json
+++ b/gravitee-apim-e2e/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "dom"],
     "types": ["./types", "cypress", "node", "node-fetch", "jsonwebtoken"],
     "baseUrl": ".",
+    "allowJs": true,
     "resolveJsonModule": true,
     "module": "Node16",
     "moduleResolution": "Node16",
@@ -18,7 +19,8 @@
       "@api-test-resources/*": ["<rootDir>/api-test/resources/$1"],
       "@lib/jest-utils": ["lib/jest-utils"],
       "@gravitee/utils/*": ["<rootDir>/lib/utils/$1"]
-    }
+    },
+    "isolatedModules": true
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Issue
n/a

## Description

Based on the mysterious order of the tests, I think that user Api1 exists or does not exist 🤷‍♂️ 

Add a "before all" to the jest so that it is correctly initialised before all tests are executed.
And ... the other issue i see is that there are too many users to find the user api1 on the first page.

Try to Fix this flaky error : 

```

FAIL dist/api-test/src/apis/settings/mapi-v1/notification-setting.spec.js
  ● Notification settings tests › Create › should create a notification setting

    TypeError: Cannot read properties of undefined (reading 'id')

      69 |                         userOrganizationRole = _c.sent();
      70 |                         return [4, (0, jest_utils_1.succeed)(managementUserResourceAsAdminUser.updateUserRolesRaw({
    > 71 |                                 userId: apiUser.id,
         |                                                 ^
      72 |                                 userReferenceRoleEntity: {
      73 |                                     referenceId: orgId,
      74 |                                     referenceType: 'ORGANIZATION',

      at dist/api-test/src/apis/settings/mapi-v1/notification-setting.spec.js:71:49
      at step (dist/api-test/src/apis/settings/mapi-v1/notification-setting.spec.js:33:23)
      at Object.next (dist/api-test/src/apis/settings/mapi-v1/notification-setting.spec.js:14:53)
      at fulfilled (dist/api-test/src/apis/settings/mapi-v1/notification-setting.spec.js:5:58)

```


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vuhfbswceg.chromatic.com)
<!-- Storybook placeholder end -->
