### PR TITLE
fix: prevent random config fields from being nulled when associating groups

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
@@ -464,7 +464,6 @@ class ApiHistoryControllerAjs {
     delete payload.picture_url;
     delete payload.background_url;
     delete payload.categories;
-    delete payload.groups;
     delete payload.context_path;
     delete payload.disable_membership_notifications;
     delete payload.labels;
@@ -490,6 +489,9 @@ class ApiHistoryControllerAjs {
     }
     if (payload.tags && isEmpty(payload.tags)) {
       delete payload.tags;
+    }
+    if (payload.groups && isEmpty(payload.groups)) {
+      delete payload.groups;
     }
 
     payload.plans = (payload.plans ?? [])

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
@@ -92,16 +92,24 @@ public interface EndpointMapper {
                 // We need to map the httpProxy, httpClientOptions and httpClientSslOptions to the new configuration
                 var configurationNode = mapper.valueToTree(endpoint);
                 var proxy = configurationNode.get("httpProxy");
-                ((ObjectNode) configurationNode).set("proxy", proxy);
+                if (proxy != null && !proxy.isNull()) {
+                    ((ObjectNode) configurationNode).set("proxy", proxy);
+                }
                 ((ObjectNode) configurationNode).remove("httpProxy");
                 var httpclient = configurationNode.get("httpClientOptions");
-                ((ObjectNode) configurationNode).set("http", httpclient);
+                if (httpclient != null && !httpclient.isNull()) {
+                    ((ObjectNode) configurationNode).set("http", httpclient);
+                }
                 ((ObjectNode) configurationNode).remove("httpClientOptions");
                 var ssl = configurationNode.get("httpClientSslOptions");
-                ((ObjectNode) configurationNode).set("ssl", ssl);
+                if (ssl != null && !ssl.isNull()) {
+                    ((ObjectNode) configurationNode).set("ssl", ssl);
+                }
                 ((ObjectNode) configurationNode).remove("httpClientSslOptions");
                 var healthcheck = configurationNode.get("healthCheck");
-                ((ObjectNode) configurationNode).set("healthcheck", healthcheck);
+                if (healthcheck != null && !healthcheck.isNull()) {
+                    ((ObjectNode) configurationNode).set("healthcheck", healthcheck);
+                }
                 ((ObjectNode) configurationNode).remove("healthCheck");
 
                 configuration = mapper.writeValueAsString(configurationNode);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5666,6 +5666,9 @@ components:
         EndpointStatus:
             type: string
             description: The status of the endpoint.
+            x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonIgnore"
+            x-getter-extra-annotation: "@com.fasterxml.jackson.annotation.JsonIgnore"
+            x-setter-extra-annotation: "@com.fasterxml.jackson.annotation.JsonIgnore"
             example: UP
             enum:
                 - UP

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
@@ -355,15 +355,21 @@ public class EndpointMapperTest {
         var configurationNode = mapper.valueToTree(endpointV2);
 
         var proxy = configurationNode.get("httpProxy");
-        ((ObjectNode) configurationNode).set("proxy", proxy);
+        if (proxy != null && !proxy.isNull()) {
+            ((ObjectNode) configurationNode).set("proxy", proxy);
+        }
         ((ObjectNode) configurationNode).remove("httpProxy");
 
         var httpclient = configurationNode.get("httpClientOptions");
-        ((ObjectNode) configurationNode).set("http", httpclient);
+        if (httpclient != null && !httpclient.isNull()) {
+            ((ObjectNode) configurationNode).set("http", httpclient);
+        }
         ((ObjectNode) configurationNode).remove("httpClientOptions");
 
         var ssl = configurationNode.get("httpClientSslOptions");
-        ((ObjectNode) configurationNode).set("ssl", ssl);
+        if (ssl != null && !ssl.isNull()) {
+            ((ObjectNode) configurationNode).set("ssl", ssl);
+        }
         ((ObjectNode) configurationNode).remove("httpClientSslOptions");
 
         var healthcheck = configurationNode.get("healthCheck");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9980

## Description

When adding or updating groups in a v2 API, unrelated configuration fields 
(`proxy`, `http`, `ssl`, `healthcheck`) were being set to null in the API 
definition. This caused unexpected changes in the deploy history and audit log, 
making it appear as though random configuration fields were updated even when 
only groups were modified.

Root cause:
- Mapping logic in the update path overwrote these fields with null values, 
  unlike the create path where they were ignored as intended.
  
Fix:
- Ensure that update operations only affect the group association, leaving 
  unrelated configuration fields untouched.

Also prevents unnecessary history/audit log entries triggered by these 
unwanted field changes.


https://github.com/user-attachments/assets/e1e9cffc-7509-4a20-99a4-35f7c07a21c4

Issue - 
<img width="813" height="696" alt="Issue_9980" src="https://github.com/user-attachments/assets/ed871f81-713a-493d-aab8-daecf8d553c3" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vidpfhntdo.chromatic.com)
<!-- Storybook placeholder end -->
