### PR TITLE
fix: safely handle orphaned gateway events to prevent UI crash

### DIFF
--- a/gravitee-apim-console-webui/src/management/instances/instance-list/instance-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/instances/instance-list/instance-list.component.spec.ts
@@ -124,6 +124,56 @@ describe('InstanceListComponent', () => {
     ]);
   }));
 
+  it('should handle version parsing correctly', fakeAsync(async () => {
+    expectInstancesSearchRequest([
+      fakeInstanceListItem({
+        hostname: 'GW noBuildInfo',
+        state: 'STARTED',
+        ip: '1.1.1.1',
+        port: '8080',
+        last_heartbeat_at: 1700213066567,
+        operating_system_name: 'Linux',
+        version: '5.0.0-SNAPSHOT', // no "(" → should remain the same
+      }),
+      fakeInstanceListItem({
+        hostname: 'GW nullVersion',
+        state: 'STARTED',
+        ip: '2.2.2.2',
+        port: '8080',
+        last_heartbeat_at: 1700213066567,
+        operating_system_name: 'Linux',
+        version: null as any, // null → should be an empty string
+      }),
+    ]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#instancesTable' }));
+    const rows = await table.getRows();
+    const rowCells = await parallel(() => rows.map((row) => row.getCellTextByColumnName()));
+
+    expect(rowCells).toStrictEqual([
+      {
+        hostname: 'GW noBuildInfo',
+        version: '5.0.0-SNAPSHOT', // stays the same
+        state: '',
+        lastHeartbeat: 'Nov 17, 2023, 9:24:26 AM',
+        os: 'Linux',
+        'ip-port': '1.1.1.1:8080',
+        tags: '',
+        tenant: '',
+      },
+      {
+        hostname: 'GW nullVersion',
+        version: '', // empty string
+        state: '',
+        lastHeartbeat: 'Nov 17, 2023, 9:24:26 AM',
+        os: 'Linux',
+        'ip-port': '2.2.2.2:8080',
+        tags: '',
+        tenant: '',
+      },
+    ]);
+  }));
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/management/instances/instance-list/instance-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/instances/instance-list/instance-list.component.ts
@@ -71,7 +71,10 @@ export class InstanceListComponent implements OnInit, OnDestroy {
           state: instance.state,
           // Instance version is like "4.2.0-SNAPSHOT (build: 508664) revision#26c06dbf46547447c420f8683d62ada5c1e15617"
           // so keep only the version number for this screen
-          version: instance.version.substring(0, instance.version.indexOf('(')),
+          version:
+            instance.version && instance.version.includes('(')
+              ? instance.version.substring(0, instance.version.indexOf('(')).trim()
+              : instance.version ?? '',
           ip: instance.ip,
           port: instance.port,
           os: instance.operating_system_name,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10174

## Description

When a gateway is uninstalled improperly or its initial full heartbeat event fails, the console UI may encounter orphaned heartbeat events missing critical fields (e.g., version, tenant, tags). This caused the instance list screen to fail rendering, hiding all other gateways.

- This change is to safely parse version (fallback to empty string when missing or malformed) to ensure that the console UI continues to display all valid gateways even when an orphaned gateway event is present.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aerusidapn.chromatic.com)
<!-- Storybook placeholder end -->
