### PR TITLE
fix(console): Stats analytics - zero requests status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.spec.ts
@@ -681,4 +681,96 @@ describe('ApiAnalyticsWidgetComponent', () => {
       }
     });
   });
+
+  describe('Stats Widget', () => {
+    beforeEach(async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'loading',
+        widgetType: 'stats',
+        widgetData: [],
+      });
+      fixture.detectChanges();
+      harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+      harness = await harnessLoader.getHarness(ApiAnalyticsWidgetHarness);
+    });
+
+    it('should show formatted zero value', async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'success',
+        widgetType: 'stats',
+        widgetData: { stats: 0, statsUnit: 'ms' },
+      });
+      fixture.detectChanges();
+
+      expect(await harness.isLoading()).toBe(false);
+      expect(await harness.getTitleText()).toBe('Test Stats Widget');
+      const statsHarness = await harness.getStatsComponentHarness();
+      expect(await statsHarness.getDisplayedValue()).toBe('0ms');
+    });
+
+    it('should show defined value formatted to number without unit', async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'success',
+        widgetType: 'stats',
+        widgetData: { stats: 1000000 },
+      });
+
+      fixture.detectChanges();
+
+      expect(await harness.isLoading()).toBe(false);
+      expect(await harness.getTitleText()).toBe('Test Stats Widget');
+      const statsHarness = await harness.getStatsComponentHarness();
+      expect(await statsHarness.getDisplayedValue()).toBe('1,000,000');
+    });
+
+    it('should show defined value with the unit', async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'success',
+        widgetType: 'stats',
+        widgetData: { stats: 100, statsUnit: 'candies' },
+      });
+
+      fixture.detectChanges();
+
+      expect(await harness.isLoading()).toBe(false);
+      expect(await harness.getTitleText()).toBe('Test Stats Widget');
+      const statsHarness = await harness.getStatsComponentHarness();
+      expect(await statsHarness.getDisplayedValue()).toBe('100candies');
+    });
+
+    it('should display empty state for undefined stats', async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'success',
+        widgetType: 'stats',
+        widgetData: { stats: undefined, statsUnit: 'ms' },
+      });
+
+      fixture.detectChanges();
+
+      expect(await harness.isLoading()).toBe(false);
+      expect(await harness.getTitleText()).toBe('Test Stats Widget');
+      const statsHarness = await harness.getStatsComponentHarness();
+      expect(await statsHarness.getDisplayedValue()).toBe('-');
+    });
+
+    it('should display empty state for null stats', async () => {
+      fixture.componentRef.setInput('config', {
+        title: 'Test Stats Widget',
+        state: 'success',
+        widgetType: 'stats',
+        widgetData: { stats: null, statsUnit: 'ms' },
+      });
+      fixture.detectChanges();
+
+      expect(await harness.isLoading()).toBe(false);
+      expect(await harness.getTitleText()).toBe('Test Stats Widget');
+      const statsHarness = await harness.getStatsComponentHarness();
+      expect(await statsHarness.getDisplayedValue()).toBe('-');
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.harness.ts
@@ -18,13 +18,19 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { GioWidgetLayoutHarness } from '../../../../../../shared/components/gio-widget-layout/gio-widget-layout.harness';
 import { ApiAnalyticsWidgetTableHarness } from '../api-analytics-widget-table/api-analytics-widget-table.harness';
 import { GioChartPieHarness } from '../../../../../../shared/components/gio-chart-pie/gio-chart-pie.harness';
+import { AnalyticsStatsComponentHarness } from '../../../../../../shared/components/analytics-stats/analytics-stats.component.harness';
 
 export class ApiAnalyticsWidgetHarness extends ComponentHarness {
   static hostSelector = 'api-analytics-widget';
 
+  protected getStatsWidget = this.locatorFor(AnalyticsStatsComponentHarness);
   protected getWidgetLayout = this.locatorFor(GioWidgetLayoutHarness);
   protected getTableWidget = this.locatorForOptional(ApiAnalyticsWidgetTableHarness);
   protected getPieChart = this.locatorForOptional(GioChartPieHarness);
+
+  async getStatsComponentHarness(): Promise<AnalyticsStatsComponentHarness> {
+    return this.getStatsWidget();
+  }
 
   /**
    * Gets the widget layout harness

--- a/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.harness.ts
+++ b/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.harness.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class AnalyticsStatsComponentHarness extends ComponentHarness {
+  public static hostSelector = 'analytics-stats';
+
+  private getRecord = this.locatorFor('.analytics-stats__record');
+
+  async getDisplayedValue(): Promise<string> {
+    const record = await this.getRecord();
+    return record.text();
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.html
@@ -16,5 +16,7 @@
 
 -->
 <div class="analytics-stats">
-  <p class="analytics-stats__record">{{ input().stats | number }}{{ input().statsUnit }}</p>
+  <p class="analytics-stats__record">
+    {{ input().stats != null ? (input().stats | number) + (input().statsUnit ?? '') : '-' }}
+  </p>
 </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10843

## Description

- handle zero requests for stats widget
- add tests for stats 


<img width="1413" height="419" alt="image" src="https://github.com/user-attachments/assets/4833d726-a1b9-4bc7-bdf6-3041e29852a1" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-szddtbluzw.chromatic.com)
<!-- Storybook placeholder end -->
