### PR TITLE
fix: allow an ADMIN environment role to view newly created documentation pages

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.spec.ts
@@ -82,4 +82,42 @@ describe('SettingsNavigationService', () => {
 
     expect(menuSearchItems).toStrictEqual([]);
   });
+
+  it('should include Documentation when permission is granted', () => {
+    init();
+    const menuSearchItems = service.getSettingsNavigationSearchItems(envId);
+    const documentationItem = menuSearchItems.find((i) => i.name === 'Documentation');
+    expect(documentationItem).toBeDefined();
+    expect(documentationItem?.routerLink).toContain(`${envId}/settings/documentation`);
+  });
+
+  it('should exclude Documentation when permission is not granted', () => {
+    init(false);
+    const menuSearchItems = service.getSettingsNavigationSearchItems(envId);
+    const documentationItem = menuSearchItems.find((i) => i.name === 'Documentation');
+    expect(documentationItem).toBeUndefined();
+  });
+
+  it('should exclude Documentation when permission is not granted', () => {
+    // Mock hasAnyMatching to deny only "environment-documentation-r"
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+      providers: [
+        {
+          provide: GioPermissionService,
+          useValue: {
+            hasAnyMatching: (permissions: string[]) => !permissions.includes('environment-documentation-r'),
+          },
+        },
+      ],
+    });
+    service = TestBed.inject(SettingsNavigationService);
+    const menuSearchItems = service.getSettingsNavigationSearchItems(envId);
+    // Documentation should NOT exist
+    const documentationItem = menuSearchItems.find((i) => i.name === 'Documentation');
+    expect(documentationItem).toBeUndefined();
+    // Now we expect 16 items (17-1)
+    expect(menuSearchItems).toHaveLength(16);
+    expect(menuSearchItems.some((i) => i.routerLink.includes('/documentation'))).toBe(false);
+  });
 });

--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.ts
@@ -73,7 +73,7 @@ export class SettingsNavigationService {
           {
             displayName: 'Documentation',
             routerLink: './documentation',
-            permissions: ['environment-documentation-c', 'environment-documentation-u', 'environment-documentation-d'],
+            permissions: ['environment-documentation-r'],
           },
           {
             displayName: 'Metadata',

--- a/gravitee-apim-console-webui/src/management/settings/settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings-routing.module.ts
@@ -250,7 +250,7 @@ export const settingsRoutes: Routes = [
             page: 'management-configuration-portal-pages',
           },
           permissions: {
-            anyOf: ['environment-documentation-c', 'environment-documentation-u', 'environment-documentation-d'],
+            anyOf: ['environment-documentation-r'],
             unauthorizedFallbackTo: '../shared-policy-groups',
           },
         },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10839

## Description

Users with an ADMIN environment role were unable to view documentation pages they had just created in the Admin Console, receiving 401 Unauthorised errors when the page was unpublished. 

This fix ensures Console access control distinguishes between Portal and Console contexts, allowing ADMIN users (or users with documentation management rights) to immediately view pages they create, regardless of publication status.

Issue:

https://github.com/user-attachments/assets/48c4d7d2-d34a-422e-be1f-fe5228d761eb

Fix:

https://github.com/user-attachments/assets/5105b37f-91b8-4d2b-8e59-b69b2e9b339d



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bdyqckupov.chromatic.com)
<!-- Storybook placeholder end -->
