### PR TITLE
fix(api): Multiple methods in common flow is asking for redeploy in v4

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/HttpSelector.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/HttpSelector.java
@@ -16,11 +16,13 @@
 package io.gravitee.definition.model.v4.flow.selector;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.flow.Operator;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -50,6 +52,7 @@ public class HttpSelector extends Selector {
     @Builder.Default
     private Operator pathOperator = DEFAULT_OPERATOR;
 
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<HttpMethod> methods;
 
     public HttpSelector() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -23,11 +23,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -784,5 +787,171 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             );
         verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
         verify(planSearchService, times(1)).findByApi(any(), any());
+    }
+
+    @Test
+    public void should_return_false_for_V4_http_API_with_modified_http_selector() throws JsonProcessingException {
+        io.gravitee.definition.model.v4.Api apiDefinition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id("apiId")
+            .name("Api name")
+            .definitionVersion(DefinitionVersion.V4)
+            .build();
+
+        Api api = new Api();
+        api.setId("apiId");
+        api.setName("Api name");
+        api.setDefinition(objectMapper.writeValueAsString(apiDefinition));
+
+        Event event = new Event();
+        event.setType(io.gravitee.repository.management.model.EventType.PUBLISH_API);
+        event.setPayload(objectMapper.writeValueAsString(api));
+
+        when(
+            eventLatestRepository.search(
+                EventCriteria
+                    .builder()
+                    .types(
+                        List.of(
+                            io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                            io.gravitee.repository.management.model.EventType.STOP_API,
+                            io.gravitee.repository.management.model.EventType.START_API,
+                            io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                        )
+                    )
+                    .properties(Map.of(Event.EventProperties.API_ID.getValue(), "apiId"))
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                1L
+            )
+        )
+            .thenReturn(List.of(event));
+
+        ApiEntity apiEntity = apiMapper.toEntity(GraviteeContext.getExecutionContext(), api, false);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        Flow flow = Flow.builder().build();
+        HttpSelector httpSelector = HttpSelector.builder().path("/api").pathOperator(Operator.STARTS_WITH).build();
+        flow.setSelectors(List.of(httpSelector));
+
+        apiEntity.setFlows(List.of(flow));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isFalse();
+
+        verify(eventLatestRepository, times(1))
+            .search(
+                EventCriteria
+                    .builder()
+                    .types(
+                        List.of(
+                            io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                            io.gravitee.repository.management.model.EventType.STOP_API,
+                            io.gravitee.repository.management.model.EventType.START_API,
+                            io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                        )
+                    )
+                    .properties(Map.of(Event.EventProperties.API_ID.getValue(), "apiId"))
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                1L
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_false_for_V4_http_API_with_changed_http_methods_order() throws JsonProcessingException {
+        Flow flow = Flow.builder().build();
+        Set<HttpMethod> methods = new LinkedHashSet<>();
+        methods.add(HttpMethod.TRACE);
+        methods.add(HttpMethod.CONNECT);
+
+        HttpSelector httpSelector = HttpSelector.builder().path("/api").pathOperator(Operator.STARTS_WITH).methods(methods).build();
+        flow.setSelectors(List.of(httpSelector));
+
+        io.gravitee.definition.model.v4.Api apiDefinition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id("apiId")
+            .name("Api name")
+            .definitionVersion(DefinitionVersion.V4)
+            .flows(List.of(flow))
+            .build();
+
+        Api api = new Api();
+        api.setId("apiId");
+        api.setName("Api name");
+        api.setDefinition(objectMapper.writeValueAsString(apiDefinition));
+
+        Event event = new Event();
+        event.setType(io.gravitee.repository.management.model.EventType.PUBLISH_API);
+        event.setPayload(objectMapper.writeValueAsString(api));
+
+        when(
+            eventLatestRepository.search(
+                EventCriteria
+                    .builder()
+                    .types(
+                        List.of(
+                            io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                            io.gravitee.repository.management.model.EventType.STOP_API,
+                            io.gravitee.repository.management.model.EventType.START_API,
+                            io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                        )
+                    )
+                    .properties(Map.of(Event.EventProperties.API_ID.getValue(), "apiId"))
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                1L
+            )
+        )
+            .thenReturn(List.of(event));
+
+        ApiEntity apiEntity = apiMapper.toEntity(GraviteeContext.getExecutionContext(), api, false);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+        assertThat(isSynchronized).isTrue();
+
+        Flow modifiedFlow = Flow.builder().build();
+        Set<HttpMethod> modifiedMethods = new LinkedHashSet<>();
+        modifiedMethods.add(HttpMethod.CONNECT);
+        modifiedMethods.add(HttpMethod.TRACE);
+
+        HttpSelector modifiedHttpSelector = HttpSelector
+            .builder()
+            .path("/api")
+            .pathOperator(Operator.STARTS_WITH)
+            .methods(modifiedMethods)
+            .build();
+        modifiedFlow.setSelectors(List.of(modifiedHttpSelector));
+
+        apiEntity.setFlows(List.of(modifiedFlow));
+
+        isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+        assertThat(isSynchronized).isFalse();
+
+        verify(eventLatestRepository, times(2))
+            .search(
+                EventCriteria
+                    .builder()
+                    .types(
+                        List.of(
+                            io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                            io.gravitee.repository.management.model.EventType.STOP_API,
+                            io.gravitee.repository.management.model.EventType.START_API,
+                            io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                        )
+                    )
+                    .properties(Map.of(Event.EventProperties.API_ID.getValue(), "apiId"))
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                1L
+            );
+        verify(synchronizationService, times(2)).checkSynchronization(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10220

## Description

Using multiple methods in common flow like GET and POST is not breaking and letting the API deployed. Also, tested on other methods like PUT, HEAD, CONNECT, TRACE, DELETE, etc..

## Additional context

Proofs:

**Before solution video:**


https://github.com/user-attachments/assets/3991c39e-1e41-4699-b0e7-c7630d39cc4b


**After solution video:**


https://github.com/user-attachments/assets/777d807f-5e4b-4e87-842f-c9f2961c7d4a


## Steps to reproduce the behaviour:

1. Create an V4 proxy API.
2. Go to policy and in common flow add GET and POST method or any method except for ALL.
3. Save and deploy.
4. API will be showing out of sync and will ask for redeploy.

