### PR TITLE
Fix npe when deleting an API. only the Id is filled

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -117,15 +117,15 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
         doc.add(new StringField(FIELD_ID, api.getId(), YES));
         doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, YES));
 
-        doc.add(new StringField(FIELD_STATUS, api.getState().name(), Field.Store.NO));
-        doc.add(new SortedDocValuesField(FIELD_STATUS_SORTED, toSortedValue(api.getState().name())));
-        doc.add(new StringField(FIELD_API_LIFECYCLE_STATE, api.getLifecycleState().name(), Field.Store.NO));
-        doc.add(new SortedDocValuesField(FIELD_VISIBILITY_SORTED, toSortedValue(api.getVisibility().name())));
-
         // If no definition version or name, the api is being deleted. No need for more info in doc.
         if (api.getDefinitionVersion() == null && api.getName() == null) {
             return doc;
         }
+
+        doc.add(new StringField(FIELD_STATUS, api.getState().name(), Field.Store.NO));
+        doc.add(new SortedDocValuesField(FIELD_STATUS_SORTED, toSortedValue(api.getState().name())));
+        doc.add(new StringField(FIELD_API_LIFECYCLE_STATE, api.getLifecycleState().name(), Field.Store.NO));
+        doc.add(new SortedDocValuesField(FIELD_VISIBILITY_SORTED, toSortedValue(api.getVisibility().name())));
 
         if (api.getDefinitionVersion() != null) {
             doc.add(new StringField(FIELD_DEFINITION_VERSION, api.getDefinitionVersion().getLabel(), NO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -84,6 +84,16 @@ class ApiDocumentTransformerTest {
     }
 
     @Test
+    void shouldTransformWithoutError_WithIdOnly() {
+        // When we delete a document only the id is filled in
+        ApiEntity api = new ApiEntity();
+        api.setId("api-uuid");
+        Document doc = cut.transform(api);
+        assertThat(doc.get("id")).isEqualTo(api.getId());
+        assertThat(doc.get("type")).isEqualTo("api");
+    }
+
+    @Test
     void shouldTransformWithoutError_V4ApiOnDeleteMode() {
         var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
         api.setId("api-uuid");


### PR DESCRIPTION
## Issue

n/a

## Description

Fix npe when deleting an API. only the Id is filled

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

