### PR TITLE
Fix flaky E2E test exposing a concurrency issue when closing plans

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
@@ -67,4 +67,12 @@ public interface PlanRepository extends CrudRepository<Plan, String> {
     List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException;
 
     boolean exists(String id) throws TechnicalException;
+
+    /**
+     * Update order of a plan identified by its id.
+     * @param planId the plan id
+     * @param order the new order value
+     * @throws TechnicalException in case of error
+     */
+    void updateOrder(String planId, int order) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.lang.String.format;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
@@ -390,6 +391,23 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
         } catch (final Exception ex) {
             LOGGER.error("Failed to check if plan exists", ex);
             throw new TechnicalException("Failed to check if plan exists", ex);
+        }
+    }
+
+    @Override
+    public void updateOrder(String planId, int order) throws TechnicalException {
+        LOGGER.debug("JdbcPlanRepository.updateOrder({}, {})", planId, order);
+        try {
+            jdbcTemplate.update(
+                "update " + tableName + " set " + escapeReservedWord("order") + " = ? where id = ?",
+                ps -> {
+                    ps.setInt(1, order);
+                    ps.setString(2, planId);
+                }
+            );
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to update plan order", ex);
+            throw new TechnicalException("Failed to update plan order", ex);
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
@@ -139,4 +139,15 @@ public class MongoPlanRepository implements PlanRepository {
             throw new TechnicalException("Failed to determine if plan exists by id", e);
         }
     }
+
+    @Override
+    public void updateOrder(String planId, int order) throws TechnicalException {
+        LOGGER.debug("Update plan order for id [{}] to [{}]", planId, order);
+        try {
+            internalPlanRepository.updateOrder(planId, order);
+        } catch (Exception e) {
+            LOGGER.error("Failed to update plan order for id [{}]", planId, e);
+            throw new TechnicalException("Failed to update plan order", e);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/PlanMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/PlanMongoRepositoryCustom.java
@@ -27,4 +27,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PlanMongoRepositoryCustom {
     List<PlanMongo> findByApiInAndEnvironments(List<String> apis, Set<String> environments);
+
+    void updateOrder(String planId, int order);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/PlanMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/PlanMongoRepositoryImpl.java
@@ -28,6 +28,9 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -55,6 +58,13 @@ public class PlanMongoRepositoryImpl implements PlanMongoRepositoryCustom {
             .aggregate(pipeline);
 
         return getListFromAggregate(aggregate);
+    }
+
+    @Override
+    public void updateOrder(String planId, int order) {
+        Query query = Query.query(Criteria.where("_id").is(planId));
+        Update update = new Update().set("order", order);
+        mongoTemplate.updateFirst(query, update, PlanMongo.class);
     }
 
     private List<PlanMongo> getListFromAggregate(AggregateIterable<Document> aggregate) {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
@@ -52,4 +52,9 @@ public class NoOpPlanRepository extends AbstractNoOpManagementRepository<Plan, S
     public boolean exists(String id) throws TechnicalException {
         return false;
     }
+
+    @Override
+    public void updateOrder(String planId, int order) throws TechnicalException {
+        // no-op
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PlanRepositoryTest.java
@@ -504,4 +504,22 @@ public class PlanRepositoryTest extends AbstractManagementRepositoryTest {
     public void plan_should_not_exist() throws Exception {
         assertFalse(planRepository.exists("unknown"));
     }
+
+    @Test
+    public void should_update_order() throws Exception {
+        // Given an existing plan with a known order
+        Optional<Plan> optional = planRepository.findById("my-plan");
+        assertNotNull(optional);
+        assertTrue(optional.isPresent());
+        int initialOrder = optional.get().getOrder();
+
+        // When updating the order
+        int newOrder = initialOrder + 3;
+        planRepository.updateOrder("my-plan", newOrder);
+
+        // Then the plan order is updated
+        Optional<Plan> updated = planRepository.findById("my-plan");
+        assertTrue(updated.isPresent());
+        assertEquals(newOrder, updated.get().getOrder());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -622,8 +622,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             .forEachOrdered(plan -> {
                 try {
                     if (plan.getOrder() > planRemoved.getOrder()) {
-                        plan.setOrder(plan.getOrder() - 1);
-                        planRepository.update(plan);
+                        planRepository.updateOrder(plan.getId(), plan.getOrder() - 1);
                     }
                 } catch (final TechnicalException ex) {
                     logger.error("An error occurs while trying to reorder plan {}", plan.getId(), ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -724,8 +724,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             .forEachOrdered(plan -> {
                 try {
                     if (plan.getOrder() > planRemoved.getOrder()) {
-                        plan.setOrder(plan.getOrder() - 1);
-                        planRepository.update(plan);
+                        planRepository.updateOrder(plan.getId(), plan.getOrder() - 1);
                     }
                 } catch (final TechnicalException ex) {
                     logger.error("An error occurs while trying to reorder plan {}", plan.getId(), ex);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Try to fix this flaky : 
```
FAIL dist/api-test/src/portal/mapi-v1/portal-business-error-subscriptions.spec.js


  ● Test suite failed to run

    ResponseError: Response returned an error code

      432 |     __extends(ResponseError, _super);
      433 |     function ResponseError(response, msg) {
    > 434 |         var _this = _super.call(this, msg) || this;
          |                            ^
      435 |         _this.response = response;
      436 |         _this.name = "ResponseError";
      437 |         return _this;

      at new ResponseError (dist/lib/management-webclient-sdk/src/lib/runtime.js:434:28)
      at APIsApi.<anonymous> (dist/lib/management-webclient-sdk/src/lib/runtime.js:369:31)
      at step (dist/lib/management-webclient-sdk/src/lib/runtime.js:59:23)
      at Object.next (dist/lib/management-webclient-sdk/src/lib/runtime.js:40:53)
      at fulfilled (dist/lib/management-webclient-sdk/src/lib/runtime.js:31:58)

```

As I understand it, we’re trying to close two plans concurrently.
The issue is that, depending on the timing, one plan might already be closed while the other is still reordering the plans from the API, which can inadvertently revert the state to a previous value.

This change ensures that reordering a plan is done atomically, so the order can be updated without interfering with the status, which may be changing at the same time.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzvfpnvxzz.chromatic.com)
<!-- Storybook placeholder end -->
