### PR TITLE
fix: preserve flowExecution.matchRequired when importing V4 API definitions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
@@ -147,6 +147,7 @@ public class ApiExport {
             .failover(failover)
             .flows((List<Flow>) flows)
             .listeners((List<Listener>) listeners)
+            .flowExecution(flowExecution)
             .name(name)
             .properties(properties)
             .resources(resources)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -55,6 +55,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
@@ -924,6 +925,7 @@ class ImportApiDefinitionUseCaseTest {
             .responseTemplates(Map.of("DEFAULT", Map.of("*.*", ResponseTemplate.builder().statusCode(200).build())))
             .tags(TAGS)
             .type(ApiType.PROXY)
+            .flowExecution(new FlowExecution())
             .build();
     }
 
@@ -943,6 +945,7 @@ class ImportApiDefinitionUseCaseTest {
                     .resources(List.of(Resource.builder().name("resource-name").type("resource-type").enabled(true).build()))
                     .responseTemplates(Map.of("DEFAULT", Map.of("*.*", ResponseTemplate.builder().statusCode(200).build())))
                     .tags(Set.of("tag"))
+                    .flowExecution(new FlowExecution())
                     .build()
             )
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-10583

## Description

The flowExecution field was not mapped in ApiExport.toApiDefinitionBuilder(), causing the `matchRequired` flag ("fail on flow mismatch") to be lost during import of V4 APIs. This change ensures flowExecution is properly set so that the expected behaviour is preserved.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

