### PR TITLE
feat: prevent rollback with v4 payloads by adding custom deserializer for v2 definitions

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
@@ -428,7 +428,11 @@ class ApiHistoryControllerAjs {
       .then((response) => {
         this.events = response.data;
       })
-      .then(() => this.ngApiV2Service.get(this.api.id).toPromise()); // To update the deploy banner
+      .then(() => this.ngApiV2Service.get(this.api.id).toPromise()) // To update the deploy banner
+      .catch((err) => {
+        const errorMessage = err?.data?.message || 'An unexpected error occurred while rolling back the API';
+        this.NotificationService.showError(errorMessage);
+      });
   }
 
   showRollbackAPIConfirm(ev, api) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/RollbackApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/RollbackApiEntity.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.rest.api.model.api;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.definition.jackson.datatype.api.deser.PropertiesAsListDeserializer;
 import io.gravitee.definition.model.*;
@@ -29,20 +26,20 @@ import io.gravitee.definition.model.services.Services;
 import io.gravitee.rest.api.model.ApiMetadataEntity;
 import io.gravitee.rest.api.model.DeploymentRequired;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.jackson.RollbackApiEntityDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 /**
  * @author GraviteeSource Team
  */
 @Getter
 @Setter
+@JsonDeserialize(using = RollbackApiEntityDeserializer.class)
 public class RollbackApiEntity {
 
     @NotNull

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/jackson/RollbackApiEntityDeserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/jackson/RollbackApiEntityDeserializer.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.jackson;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.gravitee.definition.model.*;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.rest.api.model.ApiMetadataEntity;
+import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.api.RollbackApiEntity;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Custom deserializer for RollbackApiEntity that:
+ * 1. Checks if the payload is a v4 API definition and rejects it early.
+ * 2. Otherwise, deserializes the JSON into a temporary RollbackApiEntityRaw
+ *    (a plain DTO without @JsonDeserialize, to avoid recursion),
+ *    and then maps it to the proper RollbackApiEntity.
+ */
+public class RollbackApiEntityDeserializer extends StdDeserializer<RollbackApiEntity> {
+
+    public RollbackApiEntityDeserializer() {
+        super(RollbackApiEntity.class);
+    }
+
+    @Override
+    public RollbackApiEntity deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        final ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+        final JsonNode node = mapper.readTree(jp);
+
+        if (isV4(text(node.get("definitionVersion")))) {
+            throw JsonMappingException.from(ctxt, "Detected a v4 API definition. Please use the migration tool instead of rollback.");
+        }
+
+        final RollbackApiEntityRaw raw = mapper.treeToValue(node, RollbackApiEntityRaw.class);
+
+        return toEntity(raw);
+    }
+
+    private static RollbackApiEntity toEntity(RollbackApiEntityRaw p) {
+        final RollbackApiEntity out = new RollbackApiEntity();
+        out.setId(p.id);
+        out.setName(p.name);
+        out.setVersion(p.version);
+        out.setDescription(p.description);
+
+        out.setProxy(p.proxy);
+
+        out.setPaths(nullableOr(p.paths, new HashMap<>()));
+        out.setFlows(nullableOr(p.flows, new ArrayList<>()));
+        out.setPlans(nullableOr(p.plans, new ArrayList<>()));
+
+        out.setServices(p.services);
+        out.setResources(nullableOr(p.resources, new ArrayList<>()));
+
+        if (p.propertiesList != null) {
+            Properties props = new Properties();
+            props.setProperties(p.propertiesList);
+            out.setProperties(props);
+        }
+
+        out.setVisibility(p.visibility);
+        out.setTags(p.tags);
+        out.setPicture(p.picture);
+
+        out.setGraviteeDefinitionVersion(p.graviteeDefinitionVersion);
+        out.setFlowMode(p.flowMode);
+        out.setPictureUrl(p.pictureUrl);
+
+        out.setCategories(p.categories);
+        out.setLabels(p.labels);
+        out.setGroups(p.groups);
+        out.setPathMappings(p.pathMappings);
+
+        out.setExecutionMode(p.executionMode);
+        out.setResponseTemplates(p.responseTemplates);
+
+        out.setMetadata(p.metadata);
+        out.setLifecycleState(p.lifecycleState);
+        out.setDisableMembershipNotifications(p.disableMembershipNotifications);
+
+        out.setBackground(p.background);
+        out.setBackgroundUrl(p.backgroundUrl);
+
+        return out;
+    }
+
+    private static String text(JsonNode n) {
+        return (n != null && n.isTextual()) ? n.asText() : null;
+    }
+
+    private static boolean isV4(String v) {
+        if (v == null) return false;
+        for (int i = 0; i < v.length(); i++) {
+            char c = v.charAt(i);
+            if (Character.isDigit(c)) return c == '4';
+        }
+        return false;
+    }
+
+    private static <T> T nullableOr(T value, T fallback) {
+        return value != null ? value : fallback;
+    }
+
+    /**
+     * Raw DTO version of RollbackApiEntity.
+     * Purpose: avoid infinite recursion caused by @JsonDeserialize on the main class.
+     * It has the same fields but no custom annotations, so Jackson can map JSON into it safely.
+     */
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class RollbackApiEntityRaw {
+
+        public String id;
+        public String name;
+        public String version;
+        public String description;
+
+        public Proxy proxy;
+        public Map<String, List<Rule>> paths;
+        public List<Flow> flows;
+        public List<Plan> plans;
+
+        public Services services;
+        public List<Resource> resources;
+
+        @JsonProperty("properties")
+        public List<Property> propertiesList;
+
+        public Visibility visibility;
+        public Set<String> tags;
+        public String picture;
+
+        @JsonProperty("gravitee")
+        public String graviteeDefinitionVersion;
+
+        @JsonProperty("flow_mode")
+        public FlowMode flowMode;
+
+        @JsonProperty("picture_url")
+        public String pictureUrl;
+
+        @JsonProperty("categories")
+        public Set<String> categories;
+
+        public List<String> labels;
+        public Set<String> groups;
+
+        @JsonProperty("path_mappings")
+        public Set<String> pathMappings;
+
+        @JsonProperty("execution_mode")
+        public ExecutionMode executionMode;
+
+        @JsonProperty("response_templates")
+        public Map<String, Map<String, ResponseTemplate>> responseTemplates;
+
+        public List<ApiMetadataEntity> metadata;
+
+        @JsonProperty("lifecycle_state")
+        public ApiLifecycleState lifecycleState;
+
+        @JsonProperty("disable_membership_notifications")
+        public boolean disableMembershipNotifications;
+
+        public String background;
+
+        @JsonProperty("background_url")
+        public String backgroundUrl;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/jackson/RollbackApiEntityDeserializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/jackson/RollbackApiEntityDeserializerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.jackson;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.gravitee.definition.model.Property;
+import io.gravitee.rest.api.model.api.RollbackApiEntity;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RollbackApiEntityDeserializerTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+        SimpleModule m = new SimpleModule();
+        m.addDeserializer(RollbackApiEntity.class, new RollbackApiEntityDeserializer());
+        mapper.registerModule(m);
+    }
+
+    @Test
+    void should_deserialize_v2_payload_and_map_gravitee_and_snake_case_fields() throws Exception {
+        String json =
+            """
+            {
+              "id": "api-123",
+              "name": "Test API",
+              "version": "1.0.0",
+              "description": "desc",
+              "gravitee": "2.0.0",
+              "flow_mode": "DEFAULT",
+              "execution_mode": "v4-emulation-engine",
+              "picture_url": "http://example/logo.png",
+              "path_mappings": ["/a/**"],
+              "categories": ["cat1","cat2"],
+              "labels": ["l1","l2"],
+              "groups": ["g1","g2"],
+              "lifecycle_state": "CREATED",
+              "disable_membership_notifications": true,
+              "background_url": "http://example/bg.png",
+              "response_templates": { "DEFAULT": { "en": { "status": 418 } } },
+              "properties": [
+                { "key": "k1", "value": "v1" },
+                { "key": "k2", "value": "v2" }
+              ]
+            }
+            """;
+
+        RollbackApiEntity e = mapper.readValue(json, RollbackApiEntity.class);
+
+        assertThat(e.getId()).isEqualTo("api-123");
+        assertThat(e.getName()).isEqualTo("Test API");
+        assertThat(e.getVersion()).isEqualTo("1.0.0");
+        assertThat(e.getDescription()).isEqualTo("desc");
+
+        assertThat(e.getGraviteeDefinitionVersion()).isEqualTo("2.0.0");
+
+        assertThat(e.getFlowMode()).hasToString("DEFAULT");
+        assertThat(e.getExecutionMode().name()).isEqualTo("V4_EMULATION_ENGINE");
+        assertThat(e.getPictureUrl()).isEqualTo("http://example/logo.png");
+        assertThat(e.getPathMappings()).containsExactly("/a/**");
+        assertThat(e.getCategories()).containsExactlyInAnyOrder("cat1", "cat2");
+        assertThat(e.getLabels()).containsExactly("l1", "l2");
+        assertThat(e.getGroups()).containsExactlyInAnyOrder("g1", "g2");
+        assertThat(e.getLifecycleState()).hasToString("CREATED");
+        assertThat(e.isDisableMembershipNotifications()).isTrue();
+        assertThat(e.getBackgroundUrl()).isEqualTo("http://example/bg.png");
+
+        assertThat(e.getResponseTemplates()).isInstanceOf(Map.class);
+        assertThat(e.getResponseTemplates()).containsKey("DEFAULT");
+
+        assertThat(e.getProperties()).isNotNull();
+        assertThat(e.getPropertyList()).extracting(Property::getKey).containsExactly("k1", "k2");
+        assertThat(e.getPropertyList()).extracting(Property::getValue).containsExactly("v1", "v2");
+    }
+
+    @Test
+    void should_throw_on_v4_definitionVersion() {
+        String json =
+            """
+            {
+              "id": "api-456",
+              "name": "v4 API",
+              "definitionVersion": "4.0.0"
+            }
+            """;
+
+        assertThatThrownBy(() -> mapper.readValue(json, RollbackApiEntity.class))
+            .isInstanceOf(JsonMappingException.class)
+            .hasMessageContaining("Detected a v4 API definition. Please use the migration tool instead of rollback.");
+    }
+
+    @Test
+    void should_deserialize_minimal_payload_and_apply_fallbacks() throws Exception {
+        String json = """
+            {
+              "id": "api-min",
+              "name": "Minimal API"
+            }
+            """;
+
+        RollbackApiEntity e = mapper.readValue(json, RollbackApiEntity.class);
+
+        assertThat(e.getId()).isEqualTo("api-min");
+        assertThat(e.getName()).isEqualTo("Minimal API");
+
+        assertThat(e.getPlans()).isEmpty();
+        assertThat(e.getPaths()).isEmpty();
+        assertThat(e.getFlows()).isEmpty();
+        assertThat(e.getResources()).isEmpty();
+
+        assertThat(e.getGraviteeDefinitionVersion()).isNull();
+    }
+
+    @Test
+    void should_ignore_unknown_fields_and_allow_non_v4_definitionVersion() throws Exception {
+        String json =
+            """
+            {
+              "id": "api-789",
+              "name": "Unknowns API",
+              "definitionVersion": "3.0.0",
+              "some_unknown_field": "whatever"
+            }
+            """;
+
+        RollbackApiEntity e = mapper.readValue(json, RollbackApiEntity.class);
+
+        assertThat(e.getId()).isEqualTo("api-789");
+        assertThat(e.getName()).isEqualTo("Unknowns API");
+        assertThat(e.getGraviteeDefinitionVersion()).isNull();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10661

## Description

This change introduces a custom deserializer for RollbackApiEntity to correctly handle v2 API definitions while explicitly rejecting v4 payloads. It ensures that once an API has been migrated to v4 and rolled back to v2, it cannot be rolled back to v4 directly. Users should only return to v4 through the migration flow, not via rollback. Unit and resource tests were added to cover both valid v2 and invalid v4 scenarios.

## Additional info

Warning when rollback is impossible:
<img width="2544" height="1241" alt="Zrzut ekranu 2025-08-20 o 17 05 58" src="https://github.com/user-attachments/assets/c08035c1-bce3-48fe-9556-20e4fcdba7ca" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gzvaptirqp.chromatic.com)
<!-- Storybook placeholder end -->
