### PR TITLE
fix: migrate healthcheck from endpoint and endpointgroups

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ServiceMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ServiceMapper.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
+import io.gravitee.apim.core.utils.StringUtils;
+import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
+import io.gravitee.definition.model.v4.service.Service;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class ServiceMapper {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String TYPE_ENDPOINT = "ENDPOINT";
+
+    private ServiceMapper() {}
+
+    public static MigrationResult<io.gravitee.definition.model.v4.service.Service> convert(
+        io.gravitee.definition.model.Service v2Service,
+        String type,
+        String name
+    ) {
+        return switch (v2Service) {
+            case io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService v2dynamicPropertyService -> null;
+            case io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService vEP2HealthCheckService -> convertEPHealthCheckService(
+                vEP2HealthCheckService,
+                type,
+                name
+            );
+            case io.gravitee.definition.model.services.healthcheck.HealthCheckService v2HealthCheckService -> convertHealthCheckService(
+                v2HealthCheckService,
+                type,
+                name
+            );
+            case io.gravitee.definition.model.services.schedule.ScheduledService v2ScheduledService -> null;
+            case io.gravitee.definition.model.services.discovery.EndpointDiscoveryService v2EndpointDiscoveryService -> null;
+            case null -> null;
+            default -> MigrationResult.issue("Unsupported Service", MigrationResult.State.IMPOSSIBLE);
+        };
+    }
+
+    private static MigrationResult<Service> convertHealthCheckService(HealthCheckService v2HealthCheckService, String type, String name) {
+        ObjectNode config = MAPPER.createObjectNode();
+        MigrationResult<Service> migrationResult = MigrationResult.value(
+            Service.builder().enabled(v2HealthCheckService.isEnabled()).overrideConfiguration(false).type("http-health-check").build()
+        );
+        String endpointReferenceForMessage = String.format("%s : %s", type.equals(TYPE_ENDPOINT) ? "endpoint" : "endpointgroup", name);
+        if (v2HealthCheckService.getSchedule() != null) {
+            config.put("schedule", v2HealthCheckService.getSchedule());
+        } else {
+            config.putNull("schedule");
+        }
+
+        config.put("failureThreshold", 2);
+        config.put("successThreshold", 2);
+
+        // If steps exist, derive config from the first step
+        List<HealthCheckStep> steps = v2HealthCheckService.getSteps();
+        if (steps != null && !steps.isEmpty()) {
+            if (steps.size() > 1) {
+                log.error("Health check for {} cannot have more than one step ", endpointReferenceForMessage);
+                migrationResult.addIssue(
+                    new MigrationResult.Issue(
+                        "Health check for " + endpointReferenceForMessage + " cannot have more than one step",
+                        MigrationResult.State.IMPOSSIBLE
+                    )
+                );
+            }
+            HealthCheckStep step = steps.get(0);
+            if (step.getResponse().getAssertions() != null && step.getResponse().getAssertions().size() > 1) {
+                log.error("Health check for {} cannot have more than one assertion", endpointReferenceForMessage);
+                migrationResult.addIssue(
+                    new MigrationResult.Issue(
+                        "Health check for " + endpointReferenceForMessage + " cannot have more than one assertion",
+                        MigrationResult.State.IMPOSSIBLE
+                    )
+                );
+            }
+            try {
+                config.set(
+                    "headers",
+                    (step.getRequest().getHeaders() == null ? MAPPER.createArrayNode() : MAPPER.valueToTree(step.getRequest().getHeaders()))
+                );
+                config.set("method", MAPPER.valueToTree(step.getRequest().getMethod()));
+                config.set("target", MAPPER.valueToTree(step.getRequest().getPath()));
+                config.set("assertion", MAPPER.valueToTree(StringUtils.appendCurlyBraces(step.getResponse().getAssertions().get(0))));
+                config.set("overrideEndpointPath", MAPPER.valueToTree(step.getRequest().isFromRoot()));
+            } catch (Exception e) {
+                log.error("Unable to map configuration for Health check ", e);
+                return migrationResult.addIssue(
+                    new MigrationResult.Issue("Unable to map configuration for Health check", MigrationResult.State.IMPOSSIBLE)
+                );
+            }
+        }
+
+        // Build the v4 Service
+        return migrationResult.map(ser -> {
+            ser.setConfiguration(config.toString());
+            return ser;
+        });
+    }
+
+    private static MigrationResult<Service> convertEPHealthCheckService(
+        EndpointHealthCheckService v2EPHealthCheckService,
+        String type,
+        String name
+    ) {
+        return convertHealthCheckService(v2EPHealthCheckService, type, name)
+            .map(plainHealthCheckService -> {
+                plainHealthCheckService.setOverrideConfiguration(!v2EPHealthCheckService.isInherit());
+                return plainHealthCheckService;
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/StringUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/StringUtils.java
@@ -33,4 +33,15 @@ public final class StringUtils {
     public static boolean isNotEmpty(@Nullable CharSequence cs) {
         return !isEmpty(cs);
     }
+
+    public static String appendCurlyBraces(String selectionRule) {
+        if (selectionRule == null) {
+            return null;
+        }
+        if (selectionRule.startsWith("#")) {
+            // Backward compatibility. In V3 mode selection rule EL expression based can be defined with "#something" while it is usually defined with "{#something}" everywhere else.
+            return "{" + selectionRule + "}";
+        }
+        return selectionRule;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/ServiceMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/ServiceMapperTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.mapper;
+
+import static io.gravitee.apim.core.api.model.utils.MigrationResultUtils.get;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
+import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckResponse;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
+import io.gravitee.definition.model.v4.service.Service;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ServiceMapperTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void convert_should_return_null_when_input_is_null() {
+        assertThat(ServiceMapper.convert(null, "ENDPOINT", "testEndpoint")).isNull();
+    }
+
+    @Test
+    void convert_healthCheckService_without_steps_should_map_basic_fields() throws Exception {
+        HealthCheckService v2 = new HealthCheckService();
+        v2.setEnabled(true);
+        v2.setSchedule("*/10 * * * * *");
+        v2.setSteps(null);
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+        assertThat(get(result))
+            .satisfies(v4 -> {
+                assertThat(v4).isNotNull();
+                assertThat(v4.getType()).isEqualTo("http-health-check");
+                assertThat(v4.isEnabled()).isTrue();
+                assertThat(v4.isOverrideConfiguration()).isFalse();
+
+                JsonNode cfg = MAPPER.readTree(v4.getConfiguration());
+                assertThat(cfg.get("schedule").asText()).isEqualTo("*/10 * * * * *");
+                assertThat(cfg.get("failureThreshold").asInt()).isEqualTo(2);
+                assertThat(cfg.get("successThreshold").asInt()).isEqualTo(2);
+
+                assertThat(cfg.get("headers")).isNull();
+                assertThat(cfg.get("method")).isNull();
+                assertThat(cfg.get("target")).isNull();
+                assertThat(cfg.get("assertion")).isNull();
+                assertThat(cfg.get("overrideEndpointPath")).isNull();
+            });
+    }
+
+    @Test
+    void convert_healthCheckService_with_null_schedule_should_write_null_schedule() throws Exception {
+        HealthCheckService v2 = new HealthCheckService();
+        v2.setEnabled(false);
+        v2.setSchedule(null);
+        v2.setSteps(null);
+
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+        assertThat(get(result))
+            .satisfies(v4 -> {
+                assertThat(v4).isNotNull();
+                JsonNode cfg = MAPPER.readTree(v4.getConfiguration());
+                assertThat(cfg.get("schedule").isNull()).isTrue();
+            });
+    }
+
+    @Test
+    void convert_healthCheckService_with_one_step_should_fill_step_derived_config() throws Exception {
+        // given
+        String assertStr = "#response.status == 200";
+
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest healthCheckRequest = new HealthCheckRequest();
+        healthCheckRequest.setMethod(HttpMethod.GET);
+        healthCheckRequest.setPath("/_health");
+        healthCheckRequest.setFromRoot(true);
+        healthCheckRequest.setHeaders(List.of(new HttpHeader("X-Test", "1")));
+        step.setRequest(healthCheckRequest);
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse();
+        healthCheckResponse.setAssertions(List.of(assertStr));
+        step.setResponse(healthCheckResponse);
+
+        HealthCheckService v2 = new HealthCheckService();
+        v2.setEnabled(true);
+        v2.setSchedule("*/30 * * * * *");
+        v2.setSteps(List.of(step));
+
+        // when
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+
+        // then
+        assertThat(get(result))
+            .satisfies(v4 -> {
+                assertThat(v4).isNotNull();
+                assertThat(v4.getType()).isEqualTo("http-health-check");
+                assertThat(v4.isOverrideConfiguration()).isFalse();
+
+                JsonNode cfg = MAPPER.readTree(v4.getConfiguration());
+                assertThat(cfg.get("schedule").asText()).isEqualTo("*/30 * * * * *");
+                assertThat(cfg.get("failureThreshold").asInt()).isEqualTo(2);
+                assertThat(cfg.get("successThreshold").asInt()).isEqualTo(2);
+
+                // Step-derived fields
+                assertThat(cfg.get("method").asText()).isEqualTo("GET");
+                assertThat(cfg.get("target").asText()).isEqualTo("/_health");
+                assertThat(cfg.get("overrideEndpointPath").asBoolean()).isTrue();
+
+                assertThat(cfg.get("headers")).isNotNull();
+                assertThat(cfg.get("headers").get(0).get("name").asText()).isEqualTo("X-Test");
+                assertThat(cfg.get("headers").get(0).get("value").asText()).isEqualTo("1");
+                assertThat(cfg.get("assertion")).isNotNull();
+                assertThat(cfg.get("assertion").asText()).isEqualTo("{" + assertStr + "}");
+            });
+    }
+
+    @Test
+    void convert_healthCheckService_with_multiple_assertions_should_throw() {
+        // given
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest healthCheckRequest = new HealthCheckRequest();
+        healthCheckRequest.setMethod(HttpMethod.GET);
+        healthCheckRequest.setPath("/_health");
+        healthCheckRequest.setFromRoot(true);
+        healthCheckRequest.setHeaders(List.of(new HttpHeader("X-Test", "1")));
+        step.setRequest(healthCheckRequest);
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse();
+        healthCheckResponse.setAssertions(List.of("status == 200", "body.contains('OK')"));
+        step.setResponse(healthCheckResponse);
+
+        HealthCheckService v2 = new HealthCheckService();
+        v2.setEnabled(true);
+        v2.setSchedule("*/5 * * * * *");
+        v2.setSteps(List.of(step));
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+        assertThrows(NullPointerException.class, () -> get(result));
+        assertThat(result.issues())
+            .map(MigrationResult.Issue::message)
+            .containsExactly("Health check for endpoint : testEndpoint cannot have more than one assertion");
+        assertThat(result.issues()).map(MigrationResult.Issue::state).containsExactly(MigrationResult.State.IMPOSSIBLE);
+    }
+
+    @Test
+    void convert_endpointHealthCheckService_should_flip_override_by_inherit_flag() throws Exception {
+        // given
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest healthCheckRequest = new HealthCheckRequest();
+        healthCheckRequest.setMethod(HttpMethod.HEAD);
+        healthCheckRequest.setPath("/hc");
+        healthCheckRequest.setFromRoot(false);
+        healthCheckRequest.setHeaders(List.of(new HttpHeader("X-Test", "1")));
+        HealthCheckResponse healthCheckResponse = new HealthCheckResponse();
+        healthCheckResponse.setAssertions(List.of("status == 200"));
+        step.setResponse(healthCheckResponse);
+        step.setRequest(healthCheckRequest);
+
+        EndpointHealthCheckService v2 = new EndpointHealthCheckService();
+        v2.setEnabled(true);
+        v2.setSchedule("0 */1 * * * *");
+        v2.setSteps(List.of(step));
+        v2.setInherit(false);
+
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+
+        assertThat(get(result))
+            .satisfies(v4 -> {
+                assertThat(v4).isNotNull();
+                assertThat(v4.getType()).isEqualTo("http-health-check");
+                assertThat(v4.isEnabled()).isTrue();
+                assertThat(v4.isOverrideConfiguration()).isTrue(); // flipped because inherit=false
+
+                JsonNode cfg = MAPPER.readTree(v4.getConfiguration());
+                assertThat(cfg.get("schedule").asText()).isEqualTo("0 */1 * * * *");
+                assertThat(cfg.get("method").asText()).isEqualTo("HEAD");
+                assertThat(cfg.get("target").asText()).isEqualTo("/hc");
+            });
+    }
+
+    @Test
+    void convert_endpointHealthCheckService_inherit_true_should_keep_override_false() {
+        // given
+        EndpointHealthCheckService v2 = new EndpointHealthCheckService();
+        v2.setEnabled(false);
+        v2.setSchedule(null);
+        v2.setSteps(null);
+        v2.setInherit(true);
+
+        var result = ServiceMapper.convert(v2, "ENDPOINT", "testEndpoint");
+        assertThat(get(result))
+            .satisfies(v4 -> {
+                assertThat(v4).isNotNull();
+                assertThat(v4.isOverrideConfiguration()).isFalse();
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -27,6 +27,7 @@ import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.PlanFixtures;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.Cors;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -39,6 +40,11 @@ import io.gravitee.definition.model.LoadBalancerType;
 import io.gravitee.definition.model.ProtocolVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckResponse;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
 import io.gravitee.definition.model.ssl.pem.PEMKeyStore;
 import io.gravitee.definition.model.ssl.pem.PEMTrustStore;
 import io.gravitee.definition.model.v4.ApiType;
@@ -583,6 +589,179 @@ class V2ToV4MigrationOperatorTest {
                 softly.assertThat(endpoint2.getSharedConfigurationOverride()).isEqualTo(configJsonForEndpoint);
             });
         }
+    }
+
+    @Test
+    void should_migrate_endpointgroup_hc() {
+        // Setup Endpoint
+        Endpoint v2Endpoint = new Endpoint();
+        v2Endpoint.setName("endpoint-1");
+        v2Endpoint.setBackup(true);
+        v2Endpoint.setTenants(List.of("tenant-a"));
+        v2Endpoint.setWeight(5);
+        v2Endpoint.setInherit(false);
+        v2Endpoint.setConfiguration("{\"target\":\"http://example.com\"}");
+
+        // Setup EndpointGroup
+        EndpointGroup v2Group = new EndpointGroup();
+        v2Group.setName("default-group");
+        Set<Endpoint> endpoints = new HashSet<>();
+        endpoints.add(v2Endpoint);
+        v2Group.setEndpoints(endpoints);
+
+        ArrayList<HttpHeader> headers = new ArrayList<HttpHeader>();
+        headers.add(new HttpHeader("X-Test", "yes"));
+        v2Group.setHeaders(headers);
+
+        LoadBalancer lb = new LoadBalancer();
+        lb.setType(LoadBalancerType.RANDOM);
+        v2Group.setLoadBalancer(lb);
+
+        // Setup Proxy
+        Proxy proxy = new Proxy();
+        Set<EndpointGroup> endpointGroups = new HashSet<>();
+        endpointGroups.add(v2Group);
+        proxy.setGroups(endpointGroups);
+
+        proxy.setVirtualHosts(List.of(new VirtualHost("localhost", "/api", false)));
+        proxy.setCors(new Cors());
+        proxy.setServers(List.of("localhost"));
+
+        // Setup Api V2
+        io.gravitee.definition.model.Api v2ApiDefinition = new io.gravitee.definition.model.Api();
+        v2ApiDefinition.setId("api-id");
+        v2ApiDefinition.setName("Test API");
+        v2ApiDefinition.setVersion("1.0");
+        v2ApiDefinition.setTags(Set.of("test", "v2"));
+        v2ApiDefinition.setProxy(proxy);
+        var apiDef = new io.gravitee.definition.model.Api();
+        apiDef.setId("test-api");
+        apiDef.setName("Test API");
+        apiDef.setVersion("1.0");
+        apiDef.setProxy(proxy);
+        HealthCheckStep step = new HealthCheckStep();
+        step.setName("hc-step");
+
+        HealthCheckRequest request = new HealthCheckRequest();
+        request.setPath("/hc");
+        request.setMethod(HttpMethod.POST);
+        step.setRequest(request);
+        // Configure the expected response
+        HealthCheckResponse response = new HealthCheckResponse();
+        response.setAssertions(java.util.List.of("#status == 200"));
+        step.setResponse(response);
+        HealthCheckService healthCheckService = HealthCheckService
+            .builder()
+            .enabled(true) // comes from ScheduledService (superclass)
+            .schedule("*/30 * * * * *") // run every 30s, for example
+            .steps(List.of(step))
+            .build();
+        Services services = new Services();
+        services.setHealthCheckService(healthCheckService);
+        apiDef.setServices(services);
+        var api = ApiFixtures.aProxyApiV2().toBuilder().apiDefinition(apiDef).build();
+
+        // Act
+        var result = get(mapper.mapApi(api));
+
+        // Check Endpoint Group
+        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        String configJson =
+            "{\"schedule\":\"*/30 * * * * *\",\"failureThreshold\":2,\"successThreshold\":2,\"headers\":[],\"method\":\"POST\",\"target\":\"/hc\",\"assertion\":\"{#status == 200}\",\"overrideEndpointPath\":false}";
+        assertSoftly(softly -> {
+            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(group.getName()).isEqualTo("default-group");
+            softly.assertThat(group.getType()).isEqualTo("http-proxy");
+            softly.assertThat(group.getSharedConfiguration()).isNotNull();
+            softly.assertThat(group.getServices().getHealthCheck()).isNotNull();
+            softly.assertThat(group.getServices().getHealthCheck().getConfiguration()).isEqualTo(configJson);
+        });
+
+        // Check Endpoint
+        var endpoint = group.getEndpoints().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(endpoint.getType()).isEqualTo("http-proxy");
+            softly.assertThat(endpoint.getName()).isEqualTo("endpoint-1");
+            softly.assertThat(endpoint.getWeight()).isEqualTo(5);
+            softly.assertThat(endpoint.getConfiguration()).isEqualTo("{\"target\":\"http://example.com\"}");
+        });
+    }
+
+    @Test
+    void should_migrate_endpoint_hc() {
+        // Setup Endpoint
+        Endpoint v2Endpoint = new Endpoint();
+        v2Endpoint.setName("endpoint-1");
+        v2Endpoint.setBackup(true);
+        v2Endpoint.setTenants(List.of("tenant-a"));
+        v2Endpoint.setWeight(5);
+        v2Endpoint.setInherit(false);
+        v2Endpoint.setConfiguration(
+            "{\"name\":\"default\",\"target\":\"http://test\",\"weight\":1,\"backup\":false,\"status\":\"UP\",\"tenants\":[],\"type\":\"http\",\"inherit\":true,\"headers\":[],\"proxy\":null,\"http\":null,\"ssl\":null,\"healthcheck\":{\"schedule\":\"0 */1 * * * *\",\"steps\":[{\"name\":\"default-step\",\"request\":{\"path\":\"/hc3\",\"method\":\"GET\",\"headers\":[],\"fromRoot\":false},\"response\":{\"assertions\":[\"#response.status == 202\"]}}],\"enabled\":true,\"inherit\":false}}"
+        );
+        // Setup EndpointGroup
+        EndpointGroup v2Group = new EndpointGroup();
+        v2Group.setName("default-group");
+        Set<Endpoint> endpoints = new HashSet<>();
+        endpoints.add(v2Endpoint);
+        v2Group.setEndpoints(endpoints);
+
+        ArrayList<HttpHeader> headers = new ArrayList<HttpHeader>();
+        headers.add(new HttpHeader("X-Test", "yes"));
+        v2Group.setHeaders(headers);
+
+        LoadBalancer lb = new LoadBalancer();
+        lb.setType(LoadBalancerType.RANDOM);
+        v2Group.setLoadBalancer(lb);
+
+        // Setup Proxy
+        Proxy proxy = new Proxy();
+        Set<EndpointGroup> endpointGroups = new HashSet<>();
+        endpointGroups.add(v2Group);
+        proxy.setGroups(endpointGroups);
+
+        proxy.setVirtualHosts(List.of(new VirtualHost("localhost", "/api", false)));
+        proxy.setCors(new Cors());
+        proxy.setServers(List.of("localhost"));
+
+        // Setup Api V2
+        io.gravitee.definition.model.Api v2ApiDefinition = new io.gravitee.definition.model.Api();
+        v2ApiDefinition.setId("api-id");
+        v2ApiDefinition.setName("Test API");
+        v2ApiDefinition.setVersion("1.0");
+        v2ApiDefinition.setTags(Set.of("test", "v2"));
+        v2ApiDefinition.setProxy(proxy);
+        var apiDef = new io.gravitee.definition.model.Api();
+        apiDef.setId("test-api");
+        apiDef.setName("Test API");
+        apiDef.setVersion("1.0");
+        apiDef.setProxy(proxy);
+
+        var api = ApiFixtures.aProxyApiV2().toBuilder().apiDefinition(apiDef).build();
+
+        // Act
+        var result = get(mapper.mapApi(api));
+
+        // Check Endpoint Group
+        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(group.getName()).isEqualTo("default-group");
+            softly.assertThat(group.getType()).isEqualTo("http-proxy");
+        });
+
+        // Check Endpoint
+        var endpoint = group.getEndpoints().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(endpoint.getType()).isEqualTo("http-proxy");
+            softly.assertThat(endpoint.getName()).isEqualTo("endpoint-1");
+            softly.assertThat(endpoint.getWeight()).isEqualTo(5);
+            softly
+                .assertThat(endpoint.getServices().getHealthCheck().getConfiguration())
+                .isEqualTo(
+                    "{\"schedule\":\"0 */1 * * * *\",\"failureThreshold\":2,\"successThreshold\":2,\"headers\":[],\"method\":\"GET\",\"target\":\"/hc3\",\"assertion\":\"{#response.status == 202}\",\"overrideEndpointPath\":false}"
+                );
+        });
     }
 
     @Nested


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9849

## Description

Migrated healthcheck from v2 API to V4 API endpoint and endpointgroups .The background service is not migrated.Only the configurations are migrated
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wqmhtbfhrf.chromatic.com)
<!-- Storybook placeholder end -->
