### PR TITLE
fix(api): Avoid redeploy on multiple methods in common flow (v4)

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/HttpSelector.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/HttpSelector.java
@@ -52,7 +52,7 @@ public class HttpSelector extends Selector {
     @Builder.Default
     private Operator pathOperator = DEFAULT_OPERATOR;
 
-    @JsonDeserialize(as = LinkedHashSet.class)
+    @JsonDeserialize(as = LinkedHashSet.class, contentAs = HttpMethod.class)
     private Set<HttpMethod> methods;
 
     public HttpSelector() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10220

## Description

Using multiple methods in common flow like GET and POST is not breaking and letting the API deployed. Also, tested on other methods like PUT, HEAD, CONNECT, TRACE, DELETE, etc..

## Additional context

Proofs:

**Before solution video:**


https://github.com/user-attachments/assets/3991c39e-1e41-4699-b0e7-c7630d39cc4b


**After solution video:**


https://github.com/user-attachments/assets/777d807f-5e4b-4e87-842f-c9f2961c7d4a


## Steps to reproduce the behaviour:

1. Create an V4 proxy API.
2. Go to policy and in common flow add GET and POST method or any method except for ALL.
3. Save and deploy.
4. API will be showing out of sync and will ask for redeploy.



----
