### PR TITLE
get an api metric by request id

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -16,6 +16,8 @@
 package io.gravitee.repository.log.v4.api;
 
 import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetail;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetailQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
@@ -75,4 +77,6 @@ public interface AnalyticsRepository {
     Optional<CountByAggregate> searchRequestsCountByEvent(QueryContext queryContext, RequestsCountByEventQuery requestsCountQuery);
 
     Optional<GroupByAggregate> searchGroupBy(QueryContext queryContext, GroupByQuery query);
+
+    Optional<ApiMetricsDetail> findApiMetricsDetail(QueryContext queryContext, ApiMetricsDetailQuery query);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/ApiMetricsDetail.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/ApiMetricsDetail.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import io.gravitee.common.http.HttpMethod;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ApiMetricsDetail {
+
+    String timestamp;
+    String apiId;
+    String requestId;
+    String transactionId;
+    String host;
+    String applicationId;
+    String planId;
+    String gateway;
+    String uri;
+    int status;
+    long requestContentLength;
+    long responseContentLength;
+    String remoteAddress;
+    long gatewayLatency;
+    long gatewayResponseTime;
+    long endpointResponseTime;
+    HttpMethod method;
+    String endpoint;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/ApiMetricsDetailQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/ApiMetricsDetailQuery.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+public record ApiMetricsDetailQuery(String apiId, String requestId) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtils.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtils.java
@@ -30,6 +30,10 @@ public class JsonNodeUtils {
         return jsonNode != null ? jsonNode.asInt() : defaultValue;
     }
 
+    public static long asLongOr(JsonNode jsonNode, long defaultValue) {
+        return jsonNode != null ? jsonNode.asLong() : defaultValue;
+    }
+
     public static boolean asBooleanOrFalse(JsonNode jsonNode) {
         return jsonNode != null && jsonNode.asBoolean();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -22,6 +22,8 @@ import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.AggregateValueCountByFieldAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.adapter.FindApiMetricsDetailQueryAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.adapter.FindApiMetricsDetailResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.GroupByQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.ResponseTimeRangeQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageConnectionDurationQueryAdapter;
@@ -38,6 +40,8 @@ import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchResponseS
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopFailedApisAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.StatsQueryAdapter;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetail;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetailQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
@@ -240,6 +244,15 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         log.debug("Search Request total counts query: {}", esQuery);
 
         return client.search(index, null, esQuery).map(SearchRequestsCountByEventQueryAdapter::adaptResponse).blockingGet();
+    }
+
+    @Override
+    public Optional<ApiMetricsDetail> findApiMetricsDetail(QueryContext queryContext, ApiMetricsDetailQuery query) {
+        var indexV4Metrics = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+
+        return this.client.search(indexV4Metrics, null, FindApiMetricsDetailQueryAdapter.adapt(query))
+            .map(FindApiMetricsDetailResponseAdapter::adaptFirst)
+            .blockingGet();
     }
 
     private String getIndices(QueryContext queryContext, Collection<DefinitionVersion> definitionVersions) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetailQuery;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class FindApiMetricsDetailQueryAdapter {
+
+    public FindApiMetricsDetailQueryAdapter() {}
+
+    public static String adapt(ApiMetricsDetailQuery query) {
+        var jsonContent = new HashMap<String, Object>();
+
+        var esQuery = buildElasticQuery(query);
+        if (esQuery != null) {
+            jsonContent.put("query", esQuery);
+        }
+
+        return new JsonObject(jsonContent).encode();
+    }
+
+    private static JsonObject buildElasticQuery(ApiMetricsDetailQuery query) {
+        if (query == null) {
+            return null;
+        }
+
+        var terms = new ArrayList<JsonObject>();
+        if (query.apiId() != null) {
+            terms.add(JsonObject.of("term", JsonObject.of("api-id", query.apiId())));
+        }
+        if (query.requestId() != null) {
+            terms.add(JsonObject.of("term", JsonObject.of("request-id", query.requestId())));
+        }
+
+        if (!terms.isEmpty()) {
+            return JsonObject.of("bool", JsonObject.of("must", JsonArray.of(terms.toArray())));
+        }
+
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asIntOr;
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asLongOr;
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asTextOrNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetail;
+import java.util.Optional;
+
+public class FindApiMetricsDetailResponseAdapter {
+
+    public FindApiMetricsDetailResponseAdapter() {}
+
+    public static Optional<ApiMetricsDetail> adaptFirst(SearchResponse response) {
+        var hits = response.getSearchHits();
+        if (hits == null) {
+            return Optional.empty();
+        }
+
+        return hits.getHits().stream().findFirst().map(h -> buildFromSource(h.getSource()));
+    }
+
+    private static ApiMetricsDetail buildFromSource(JsonNode json) {
+        return ApiMetricsDetail
+            .builder()
+            .timestamp(asTextOrNull(json.get("@timestamp")))
+            .apiId(asTextOrNull(json.get("api-id")))
+            .requestId(asTextOrNull(json.get("request-id")))
+            .transactionId(asTextOrNull(json.get("transaction-id")))
+            .host(asTextOrNull(json.get("host")))
+            .applicationId(asTextOrNull(json.get("application-id")))
+            .planId(asTextOrNull(json.get("plan-id")))
+            .gateway(asTextOrNull(json.get("gateway")))
+            .status(asIntOr(json.get("status"), 0))
+            .uri(asTextOrNull(json.get("uri")))
+            .requestContentLength(asLongOr(json.get("request-content-length"), 0))
+            .responseContentLength(asLongOr(json.get("response-content-length"), 0))
+            .remoteAddress(asTextOrNull(json.get("remote-address")))
+            .gatewayLatency(asLongOr(json.get("gateway-latency-ms"), 0))
+            .gatewayResponseTime(asLongOr(json.get("gateway-response-time-ms"), 0))
+            .endpointResponseTime(asLongOr(json.get("endpoint-response-time-ms"), 0))
+            .method(HttpMethod.get(asIntOr(json.get("http-method"), 0)))
+            .endpoint(asTextOrNull(json.get("endpoint")))
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtilsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtilsTest.java
@@ -61,4 +61,16 @@ class JsonNodeUtilsTest {
         final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", true);
         assertThat(JsonNodeUtils.asBooleanOrFalse(jsonNode.get("absent-key"))).isFalse();
     }
+
+    @Test
+    void should_get_field_as_long() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", 1);
+        assertThat(JsonNodeUtils.asLongOr(jsonNode.get("key"), -1)).isOne();
+    }
+
+    @Test
+    void should_get_default_long() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", 1);
+        assertThat(JsonNodeUtils.asLongOr(jsonNode.get("absent-key"), -1)).isEqualTo(-1);
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetailQuery;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FindApiMetricsDetailQueryAdapterTest {
+
+    @ParameterizedTest
+    @MethodSource("apiMetricsDetailQueries")
+    void should_build_query_with_filters_and_time_period(ApiMetricsDetailQuery query, String expected) {
+        var result = FindApiMetricsDetailQueryAdapter.adapt(query);
+        assertThatJson(result).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> apiMetricsDetailQueries() {
+        return Stream.of(
+            Arguments.of(
+                new ApiMetricsDetailQuery("apiId", "requestId"),
+                """
+                        {
+                          "query": {
+                            "bool": {
+                              "must": [
+                                { "term": { "api-id": "apiId" } },
+                                { "term": { "request-id": "requestId" } }
+                              ]
+                            }
+                          }
+                        }
+                        """
+            ),
+            Arguments.of(
+                new ApiMetricsDetailQuery("apiId", null),
+                """
+                        {
+                          "query": {
+                            "bool": {
+                              "must": [
+                                { "term": { "api-id": "apiId" } }
+                              ]
+                            }
+                          }
+                        }
+                        """
+            ),
+            Arguments.of(
+                new ApiMetricsDetailQuery(null, "requestId"),
+                """
+                        {
+                          "query": {
+                            "bool": {
+                              "must": [
+                                { "term": { "request-id": "requestId" } }
+                              ]
+                            }
+                          }
+                        }
+                        """
+            ),
+            Arguments.of(new ApiMetricsDetailQuery(null, null), """
+                        {}
+                        """)
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.elasticsearch.AbstractAdapterTest;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetail;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FindApiMetricsDetailResponseAdapterTest extends AbstractAdapterTest {
+
+    @Nested
+    class AdaptFirst {
+
+        @Test
+        void should_return_empty_when_no_hit() {
+            var result = FindApiMetricsDetailResponseAdapter.adaptFirst(new SearchResponse());
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_build_api_metrics_detail() {
+            final SearchResponse searchResponse = buildSearchHit("api-proxy-v4-metrics.json");
+            final Optional<ApiMetricsDetail> apiMetricsDetail = FindApiMetricsDetailResponseAdapter.adaptFirst(searchResponse);
+
+            assertThat(apiMetricsDetail)
+                .isEqualTo(
+                    Optional.of(
+                        ApiMetricsDetail
+                            .builder()
+                            .timestamp("2025-08-01T17:29:20.385+02:00")
+                            .apiId("2ebe3deb-1859-4d5b-be3d-eb1859dd5b16")
+                            .requestId("39107cc9-b8bf-4f16-907c-c9b8bf8f16fb")
+                            .transactionId("39107cc9-b8bf-4f16-907c-c9b8bf8f16fb")
+                            .host("localhost:8082")
+                            .applicationId("1")
+                            .planId("ccefeab8-2f7c-45dc-afea-b82f7c75dc1a")
+                            .gateway("b504bb7b-8b6e-426f-84bb-7b8b6e626f3f")
+                            .status(202)
+                            .uri("/v4/echo")
+                            .requestContentLength(0L)
+                            .responseContentLength(276L)
+                            .remoteAddress("0:0:0:0:0:0:0:1")
+                            .gatewayLatency(3L)
+                            .gatewayResponseTime(19L)
+                            .endpointResponseTime(16L)
+                            .method(HttpMethod.GET)
+                            .endpoint("https://api.gravitee.io/echo")
+                            .build()
+                    )
+                );
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v4-metrics.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v4-metrics.json
@@ -1,0 +1,45 @@
+{
+  "request-ended": "true",
+  "api-id": "2ebe3deb-1859-4d5b-be3d-eb1859dd5b16",
+  "request-content-length": 0,
+  "local-address": "0:0:0:0:0:0:0:1",
+  "transaction-id": "39107cc9-b8bf-4f16-907c-c9b8bf8f16fb",
+  "endpoint": "https://api.gravitee.io/echo",
+  "response-content-length": 276,
+  "endpoint-response-time-ms": 16,
+  "entrypoint-id": "http-proxy",
+  "remote-address": "0:0:0:0:0:0:0:1",
+  "host": "localhost:8082",
+  "user_agent": {
+    "original": "HTTPie/3.2.4",
+    "name": "Other",
+    "os_name": "",
+    "device": {
+      "name": "Generic Feature Phone"
+    }
+  },
+  "geoip": {
+    "continent_name": "Unknown",
+    "city_name": "Unknown",
+    "country_iso_code": "Unknown",
+    "region_name": "Unknown"
+  },
+  "subscription-id": "0:0:0:0:0:0:0:1",
+  "custom": {
+    "foo": "bar"
+  },
+  "client-identifier": "b6cf5bd6081fb775fc3f89927e582d7e945f955c35b73a07879d75bb4ea96a01",
+  "request-id": "39107cc9-b8bf-4f16-907c-c9b8bf8f16fb",
+  "uri": "/v4/echo",
+  "path-info": "",
+  "plan-id": "ccefeab8-2f7c-45dc-afea-b82f7c75dc1a",
+  "http-method": 3,
+  "@timestamp": "2025-08-01T17:29:20.385+02:00",
+  "gateway-latency-ms": 3,
+  "api-name": "v4 echo",
+  "gateway": "b504bb7b-8b6e-426f-84bb-7b8b6e626f3f",
+  "application-id": "1",
+  "gateway-response-time-ms": 19,
+  "user-agent": "HTTPie/3.2.4",
+  "status": 202
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
@@ -98,4 +98,9 @@ public class NoOpAnalyticsRepository implements AnalyticsRepository {
     public Optional<GroupByAggregate> searchGroupBy(QueryContext queryContext, GroupByQuery query) {
         return Optional.empty();
     }
+
+    @Override
+    public Optional<ApiMetricsDetail> findApiMetricsDetail(QueryContext queryContext, ApiMetricsDetailQuery query) {
+        return Optional.empty();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiAnalyticsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiAnalyticsMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.analytics.model.ApiMetricsDetail;
 import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
 import io.gravitee.apim.core.analytics.model.StatsAnalytics;
 import io.gravitee.apim.core.analytics.model.Timestamp;
@@ -25,6 +26,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsAverageMessages
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsRequestsCountResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsResponseStatusOvertimeResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsResponseStatusRangesResponse;
+import io.gravitee.rest.api.management.v2.rest.model.ApiMetricsDetailResponse;
 import io.gravitee.rest.api.management.v2.rest.model.CountAnalytics;
 import io.gravitee.rest.api.management.v2.rest.model.GroupByAnalytics;
 import io.gravitee.rest.api.management.v2.rest.model.HistogramAnalytics;
@@ -45,7 +47,7 @@ import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Mapper
+@Mapper(uses = { ApplicationMapper.class, DateMapper.class, PlanMapper.class })
 public interface ApiAnalyticsMapper {
     Logger logger = LoggerFactory.getLogger(ApiAnalyticsMapper.class);
     ApiAnalyticsMapper INSTANCE = Mappers.getMapper(ApiAnalyticsMapper.class);
@@ -75,6 +77,9 @@ public interface ApiAnalyticsMapper {
     @Mapping(target = "analyticsType", expression = "java(io.gravitee.rest.api.management.v2.rest.model.AnalyticsType.COUNT)")
     @Mapping(target = "count", source = "total")
     CountAnalytics mapToCountAnalytics(RequestsCount requestsCount);
+
+    @Mapping(source = "timestamp", target = "timestamp", qualifiedByName = "mapTimestamp")
+    ApiMetricsDetailResponse map(ApiMetricsDetail apiMetricsDetail);
 
     Map<String, Number> map(Map<String, Long> value);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2266,6 +2266,25 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/analytics/{requestId}:
+      parameters:
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/apiIdParam"
+        - $ref: "#/components/parameters/requestIdParam"
+      get:
+        tags:
+          - API Analytics
+        summary: Get API metric for a request
+        description: |-
+          Get API metric for a request.
+          User must have the API_ANALYTICS[READ] permission.
+        operationId: getApiMetricsDetail
+        responses:
+          "200":
+            $ref: "#/components/responses/ApiMetricsDetailResponse"
+          default:
+            $ref: "#/components/responses/Error"
+
     # API Analytics - Logs
     /environments/{envId}/apis/{apiId}/logs:
         parameters:
@@ -8024,6 +8043,22 @@ components:
             agentMessageId:
               type: string
 
+        BaseInstance:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Gateway's uuid.
+              example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+            hostname:
+              type: string
+              description: Gateway's hostname.
+              example: my-gateway.example.com
+            ip:
+              type: string
+              description: Gateway's ip.
+              example: 10.0.1.123
+
     parameters:
         #############
         # PathParam #
@@ -8756,6 +8791,80 @@ components:
                                     items:
                                         type: integer
                                         format: int64
+
+        ApiMetricsDetailResponse:
+          description: API metric for a particular request
+          content:
+            application/json:
+              schema:
+                title: "ApiMetricsDetailResponse"
+                description: API metrics detail for a request ID.
+                properties:
+                  timestamp:
+                    type: string
+                    format: date-time
+                    description: The date (as timestamp) of the metric.
+                    example: 2023-05-18T12:40:46.184Z
+                  apiId:
+                    type: string
+                    description: The id of the api.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                  requestId:
+                    type: string
+                    description: The id of the request.
+                    example: 1719d8d1-8d01-48f6-99d8-d18d0178f6d4
+                  transactionId:
+                    type: string
+                    description: The id of the transaction.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                  host:
+                    type: string
+                    description: The host used for the request
+                    example: mycompany.example.com
+                  plan:
+                    $ref: "#/components/schemas/BasePlan"
+                  application:
+                    $ref: "#/components/schemas/BaseApplication"
+                  gateway:
+                    $ref: "#/components/schemas/BaseInstance"
+                  uri:
+                    type: string
+                    description: URI of the request.
+                    example: /my-api
+                  status:
+                    type: integer
+                    description: The response status
+                    example: 200
+                  requestContentLength:
+                    type: integer
+                    description: The request content length
+                    example: 42
+                  responseContentLength:
+                    type: integer
+                    description: The response content length
+                    example: 42
+                  remoteAddress:
+                    type: string
+                    description: the remote address
+                    example:
+                  gatewayLatency:
+                    type: integer
+                    description: The gateway latency
+                    example: 42
+                  gatewayResponseTime:
+                    type: integer
+                    description: The gateway response time
+                    example: 42
+                  endpointResponseTime:
+                    type: integer
+                    description: The endpoint response time
+                    example: 42
+                  method:
+                    $ref: "#/components/schemas/HttpMethod"
+                  endpoint:
+                    type: string
+                    description: The endpoint URL.
+                    example: "https://my-api-example.com"
 
         # Analytics - Logs
         ApiLogsResponse:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -130,6 +130,7 @@ import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainService
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
+import io.gravitee.apim.infra.query_service.gateway.InstanceQueryServiceLegacyWrapper;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
@@ -144,6 +145,7 @@ import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.InstanceService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.OrganizationService;
@@ -814,5 +816,10 @@ public class ResourceContextConfiguration {
     @Bean
     public DeleteClusterMemberUseCase deleteClusterMemberUseCase() {
         return mock(DeleteClusterMemberUseCase.class);
+    }
+
+    @Bean
+    public InstanceQueryServiceLegacyWrapper instanceQueryServiceLegacyWrapper() {
+        return new InstanceQueryServiceLegacyWrapper(mock(InstanceService.class));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/analytics/ApiMetricsDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/analytics/ApiMetricsDetail.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.analytics;
+
+import io.gravitee.common.http.HttpMethod;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ApiMetricsDetail {
+
+    String timestamp;
+    String apiId;
+    String requestId;
+    String transactionId;
+    String host;
+    String applicationId;
+    String planId;
+    String gateway;
+    String uri;
+    int status;
+    long requestContentLength;
+    long responseContentLength;
+    String remoteAddress;
+    long gatewayLatency;
+    long gatewayResponseTime;
+    long endpointResponseTime;
+    HttpMethod method;
+    String endpoint;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.model;
+
+import io.gravitee.apim.core.gateway.model.BaseInstance;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ApiMetricsDetail {
+
+    String timestamp;
+    String apiId;
+    String requestId;
+    String transactionId;
+    String host;
+    BaseApplicationEntity application;
+    GenericPlanEntity plan;
+    BaseInstance gateway;
+    String uri;
+    int status;
+    long requestContentLength;
+    long responseContentLength;
+    String remoteAddress;
+    long gatewayLatency;
+    long gatewayResponseTime;
+    long endpointResponseTime;
+    HttpMethod method;
+    String endpoint;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
 import io.gravitee.apim.core.analytics.model.StatsAnalytics;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.analytics.TopHitsApps;
+import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
@@ -102,6 +103,8 @@ public interface AnalyticsQueryService {
     Optional<StatsAnalytics> searchStatsAnalytics(ExecutionContext executionContext, StatsQuery statsQuery);
 
     Optional<RequestsCount> searchRequestsCountByEvent(ExecutionContext executionContext, CountQuery query);
+
+    Optional<ApiMetricsDetail> findApiMetricsDetail(ExecutionContext executionContext, String apiId, String requestId);
 
     record CountQuery(SearchTermId searchTermId, Instant from, Instant to, Optional<String> query) {}
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics.model.ApiMetricsDetail;
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+
+@UseCase
+@AllArgsConstructor
+public class FindApiMetricsDetailUseCase {
+
+    static final String UNKNOWN = "Unknown";
+    private final AnalyticsQueryService analyticsQueryService;
+    private final ApplicationCrudService applicationCrudService;
+    private final PlanCrudService planCrudService;
+    private final InstanceQueryService instanceQueryService;
+
+    public FindApiMetricsDetailUseCase.Output execute(ExecutionContext executionContext, FindApiMetricsDetailUseCase.Input input) {
+        return analyticsQueryService
+            .findApiMetricsDetail(executionContext, input.apiId(), input.requestId)
+            .map(apiMetricsDetail -> mapToModel(executionContext, apiMetricsDetail))
+            .orElse(new FindApiMetricsDetailUseCase.Output());
+    }
+
+    public record Input(String apiId, String requestId) {}
+
+    public record Output(Optional<ApiMetricsDetail> apiMetricsDetail) {
+        Output(ApiMetricsDetail apiMetricsDetail) {
+            this(Optional.of(apiMetricsDetail));
+        }
+        Output() {
+            this(Optional.empty());
+        }
+    }
+
+    private Output mapToModel(
+        ExecutionContext executionContext,
+        io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail apiMetricsDetail
+    ) {
+        var result = ApiMetricsDetail
+            .builder()
+            .timestamp(apiMetricsDetail.getTimestamp())
+            .apiId(apiMetricsDetail.getApiId())
+            .requestId(apiMetricsDetail.getRequestId())
+            .transactionId(apiMetricsDetail.getTransactionId())
+            .host(apiMetricsDetail.getHost())
+            .application(getApplication(executionContext.getEnvironmentId(), apiMetricsDetail.getApplicationId()))
+            .plan(getPlan(apiMetricsDetail.getPlanId()))
+            .gateway(instanceQueryService.findById(executionContext, apiMetricsDetail.getGateway()))
+            .uri(apiMetricsDetail.getUri())
+            .status(apiMetricsDetail.getStatus())
+            .requestContentLength(apiMetricsDetail.getRequestContentLength())
+            .responseContentLength(apiMetricsDetail.getResponseContentLength())
+            .remoteAddress(apiMetricsDetail.getRemoteAddress())
+            .gatewayLatency(apiMetricsDetail.getGatewayLatency())
+            .gatewayResponseTime(apiMetricsDetail.getGatewayResponseTime())
+            .endpointResponseTime(apiMetricsDetail.getEndpointResponseTime())
+            .method(apiMetricsDetail.getMethod())
+            .endpoint(apiMetricsDetail.getEndpoint())
+            .build();
+
+        return new Output(result);
+    }
+
+    private BaseApplicationEntity getApplication(String environmentId, String applicationId) {
+        var unknownApp = BaseApplicationEntity.builder().id(applicationId).name(UNKNOWN).build();
+        try {
+            return applicationId != null ? applicationCrudService.findById(applicationId, environmentId) : unknownApp;
+        } catch (ApplicationNotFoundException | TechnicalManagementException e) {
+            return unknownApp;
+        }
+    }
+
+    private GenericPlanEntity getPlan(String planId) {
+        final BasePlanEntity unknownPlan = BasePlanEntity.builder().id(planId).name(UNKNOWN).build();
+        try {
+            return planId != null ? planCrudService.getById(planId) : unknownPlan;
+        } catch (PlanNotFoundException | TechnicalManagementException e) {
+            return unknownPlan;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/model/BaseInstance.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/model/BaseInstance.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.gateway.query_service;
+package io.gravitee.apim.core.gateway.model;
 
-import io.gravitee.apim.core.gateway.model.BaseInstance;
-import io.gravitee.apim.core.gateway.model.Instance;
-import io.gravitee.rest.api.model.InstanceEntity;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.List;
+import lombok.Builder;
+import lombok.Data;
 
-public interface InstanceQueryService {
-    List<Instance> findAllStarted(String organizationId, String environmentId);
-    BaseInstance findById(ExecutionContext executionContext, String instanceId);
+@Data
+@Builder
+public class BaseInstance {
+
+    private final String id;
+    private String hostname;
+    private String ip;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiMetricsDetailAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiMetricsDetailAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApiMetricsDetailAdapter {
+    ApiMetricsDetailAdapter INSTANCE = Mappers.getMapper(ApiMetricsDetailAdapter.class);
+
+    ApiMetricsDetail map(io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetail apiMetricsDetail);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/InstanceAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/InstanceAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.rest.api.model.InstanceEntity;
 import java.util.List;
@@ -29,6 +30,8 @@ public interface InstanceAdapter {
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     Instance fromEntity(InstanceEntity entity);
+
+    BaseInstance toBaseInstance(InstanceEntity entity);
 
     List<Instance> fromEntities(List<InstanceEntity> entities);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
@@ -22,9 +22,11 @@ import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
 import io.gravitee.apim.core.analytics.model.StatsAnalytics;
 import io.gravitee.apim.core.analytics.model.Timestamp;
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.apim.infra.adapter.ApiMetricsDetailAdapter;
 import io.gravitee.apim.infra.adapter.ResponseStatusQueryCriteriaAdapter;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
+import io.gravitee.repository.log.v4.model.analytics.ApiMetricsDetailQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
@@ -39,6 +41,7 @@ import io.gravitee.repository.log.v4.model.analytics.TopFailedQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsAggregate;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsQueryCriteria;
 import io.gravitee.rest.api.model.analytics.TopHitsApps;
+import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
@@ -388,6 +391,13 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
                 )
             )
             .map(countAggregate -> RequestsCount.builder().total(countAggregate.total()).build());
+    }
+
+    @Override
+    public Optional<ApiMetricsDetail> findApiMetricsDetail(ExecutionContext executionContext, String apiId, String requestId) {
+        return analyticsRepository
+            .findApiMetricsDetail(executionContext.getQueryContext(), new ApiMetricsDetailQuery(apiId, requestId))
+            .map(ApiMetricsDetailAdapter.INSTANCE::map);
     }
 
     private HistogramAnalytics mapHistogramAggregatesToHistogramAnalytics(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/gateway/InstanceQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/gateway/InstanceQueryServiceLegacyWrapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.query_service.gateway;
 
+import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.infra.adapter.InstanceAdapter;
@@ -33,5 +34,10 @@ public class InstanceQueryServiceLegacyWrapper implements InstanceQueryService {
     @Override
     public List<Instance> findAllStarted(String organizationId, String environmentId) {
         return InstanceAdapter.INSTANCE.fromEntities(instanceService.findAllStarted(new ExecutionContext(organizationId, environmentId)));
+    }
+
+    @Override
+    public BaseInstance findById(ExecutionContext executionContext, String instanceId) {
+        return InstanceAdapter.INSTANCE.toBaseInstance(instanceService.findById(executionContext, instanceId));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.analytics.model.StatsAnalytics;
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.analytics.TopHitsApps;
+import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
@@ -59,6 +60,7 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     public HistogramAnalytics histogramAnalytics;
     public GroupByAnalytics groupByAnalytics;
     public StatsAnalytics statsAnalytics;
+    public ApiMetricsDetail apiMetricsDetail;
 
     @Override
     public Optional<RequestsCount> searchRequestsCount(ExecutionContext executionContext, String apiId, Instant from, Instant to) {
@@ -162,5 +164,10 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     @Override
     public Optional<RequestsCount> searchRequestsCountByEvent(ExecutionContext executionContext, CountQuery query) {
         return Optional.ofNullable(requestsCount);
+    }
+
+    @Override
+    public Optional<ApiMetricsDetail> findApiMetricsDetail(ExecutionContext executionContext, String apiId, String requestId) {
+        return Optional.ofNullable(apiMetricsDetail);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeInstanceService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeInstanceService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fakes;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.InstanceEntity;
+import io.gravitee.rest.api.model.InstanceListItem;
+import io.gravitee.rest.api.model.InstanceQuery;
+import io.gravitee.rest.api.service.InstanceService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+
+public class FakeInstanceService implements InstanceService {
+
+    public Page<InstanceListItem> instanceListItem;
+    public InstanceEntity instanceEntity;
+    public List<InstanceEntity> instances;
+
+    @Override
+    public Page<InstanceListItem> search(ExecutionContext executionContext, InstanceQuery query) {
+        return instanceListItem;
+    }
+
+    @Override
+    public InstanceEntity findById(ExecutionContext executionContext, String instance) {
+        return instanceEntity;
+    }
+
+    @Override
+    public InstanceEntity findByEvent(ExecutionContext executionContext, String event) {
+        return instanceEntity;
+    }
+
+    @Override
+    public List<InstanceEntity> findAllStarted(ExecutionContext executionContext) {
+        return instances;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
@@ -15,9 +15,11 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import jakarta.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +30,18 @@ public class InstanceQueryServiceInMemory implements InstanceQueryService, InMem
     @Override
     public List<Instance> findAllStarted(String organizationId, String environmentId) {
         return storage.stream().filter(instance -> instance.getStartedAt() != null).toList();
+    }
+
+    @Override
+    public BaseInstance findById(ExecutionContext executionContext, String instanceId) {
+        return storage
+            .stream()
+            .filter(instance ->
+                instanceId.equals(instance.getId()) && instance.getEnvironments().contains(executionContext.getEnvironmentId())
+            )
+            .findFirst()
+            .map(instance -> BaseInstance.builder().ip(instance.getIp()).id(instance.getId()).hostname(instance.getHostname()).build())
+            .orElseThrow(NotFoundException::new);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fakes.FakeAnalyticsQueryService;
+import fakes.FakeInstanceService;
+import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.gateway.model.BaseInstance;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.infra.query_service.gateway.InstanceQueryServiceLegacyWrapper;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FindApiMetricsDetailUseCaseTest {
+
+    private static final String API_ID = "api-id";
+    private static final String REQUEST_ID = "request-id";
+    private static final String APP_ID = "app-id";
+    private static final String PLAN_ID = "plan-id";
+
+    FakeAnalyticsQueryService fakeAnalyticsQueryService = new FakeAnalyticsQueryService();
+    ApplicationCrudServiceInMemory applicationCrudServiceInMemory = new ApplicationCrudServiceInMemory();
+    PlanCrudServiceInMemory planCrudServiceInMemory = new PlanCrudServiceInMemory();
+    FakeInstanceService fakeInstanceService = new FakeInstanceService();
+    InstanceQueryServiceLegacyWrapper instanceQueryServiceLegacyWrapper = new InstanceQueryServiceLegacyWrapper(fakeInstanceService);
+
+    FindApiMetricsDetailUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase =
+            new FindApiMetricsDetailUseCase(
+                fakeAnalyticsQueryService,
+                applicationCrudServiceInMemory,
+                planCrudServiceInMemory,
+                instanceQueryServiceLegacyWrapper
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        fakeAnalyticsQueryService.apiMetricsDetail = null;
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    void should_return_empty_api_analytic() {
+        var result = useCase.execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(API_ID, REQUEST_ID));
+        assertThat(result).isNotNull();
+        assertThat(result.apiMetricsDetail()).isEmpty();
+    }
+
+    @Test
+    void should_return_api_analytic_with_unknow_app_and_plan() {
+        var applicationId = "unknown-app-id";
+        var planId = "unknown-plan-id";
+        fakeAnalyticsQueryService.apiMetricsDetail =
+            ApiMetricsDetail.builder().apiId(API_ID).applicationId(applicationId).planId(planId).build();
+
+        var result = useCase.execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(API_ID, REQUEST_ID));
+
+        assertThat(result).isNotNull();
+        assertThat(result.apiMetricsDetail())
+            .hasValueSatisfying(apiMetricsDetail -> {
+                assertThat(apiMetricsDetail.getApplication())
+                    .extracting(BaseApplicationEntity::getId, BaseApplicationEntity::getName)
+                    .containsExactly(applicationId, "Unknown");
+
+                assertThat(apiMetricsDetail.getPlan())
+                    .extracting(GenericPlanEntity::getId, GenericPlanEntity::getName)
+                    .containsExactly(planId, "Unknown");
+            });
+    }
+
+    @Test
+    void should_return_an_api_analytic() {
+        var appName = "app-name";
+        applicationCrudServiceInMemory.initWith(List.of(BaseApplicationEntity.builder().id(APP_ID).name(appName).build()));
+
+        var planName = "plan-name";
+        planCrudServiceInMemory.initWith(
+            List.of(Plan.builder().id(PLAN_ID).definitionVersion(DefinitionVersion.V4).name(planName).build())
+        );
+
+        var instanceId = "instance-id";
+        var hostname = "foo.example.com";
+        var ip = "42.42.42.1";
+        fakeInstanceService.instanceEntity =
+            io.gravitee.rest.api.model.InstanceEntity.builder().id(instanceId).hostname(hostname).ip(ip).build();
+
+        var transactionId = "transaction-id";
+        var host = "request.host.example.com";
+        var uri = "/example/api";
+        var status = 200;
+        var requestContentLength = 100;
+        var responseContentLength = 200;
+        var gatewayLatency = 300;
+        var gatewayResponseTime = 400;
+        var endpointResponseTime = 100;
+        var remoteAddress = "192.168.1.1";
+        var endpoint = "https://endpoint.example.com/foo";
+        fakeAnalyticsQueryService.apiMetricsDetail =
+            ApiMetricsDetail
+                .builder()
+                .apiId(API_ID)
+                .requestId(REQUEST_ID)
+                .applicationId(APP_ID)
+                .planId(PLAN_ID)
+                .transactionId(transactionId)
+                .host(host)
+                .uri(uri)
+                .status(status)
+                .requestContentLength(requestContentLength)
+                .responseContentLength(responseContentLength)
+                .gatewayLatency(gatewayLatency)
+                .gatewayResponseTime(gatewayResponseTime)
+                .remoteAddress(remoteAddress)
+                .method(HttpMethod.GET)
+                .endpointResponseTime(endpointResponseTime)
+                .endpoint(endpoint)
+                .build();
+
+        var result = useCase.execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(API_ID, REQUEST_ID));
+
+        assertThat(result).isNotNull();
+        assertThat(result.apiMetricsDetail())
+            .hasValueSatisfying(apiMetricsDetail -> {
+                assertThat(apiMetricsDetail.getApiId()).isEqualTo(API_ID);
+                assertThat(apiMetricsDetail.getRequestId()).isEqualTo(REQUEST_ID);
+                assertThat(apiMetricsDetail.getTransactionId()).isEqualTo(transactionId);
+                assertThat(apiMetricsDetail.getHost()).isEqualTo(host);
+                assertThat(apiMetricsDetail.getUri()).isEqualTo(uri);
+                assertThat(apiMetricsDetail.getStatus()).isEqualTo(status);
+                assertThat(apiMetricsDetail.getRequestContentLength()).isEqualTo(requestContentLength);
+                assertThat(apiMetricsDetail.getResponseContentLength()).isEqualTo(responseContentLength);
+                assertThat(apiMetricsDetail.getGatewayLatency()).isEqualTo(gatewayLatency);
+                assertThat(apiMetricsDetail.getGatewayResponseTime()).isEqualTo(gatewayResponseTime);
+                assertThat(apiMetricsDetail.getRemoteAddress()).isEqualTo(remoteAddress);
+                assertThat(apiMetricsDetail.getMethod()).isEqualTo(HttpMethod.GET);
+                assertThat(apiMetricsDetail.getEndpointResponseTime()).isEqualTo(endpointResponseTime);
+                assertThat(apiMetricsDetail.getEndpoint()).isEqualTo(endpoint);
+
+                assertThat(apiMetricsDetail.getApplication())
+                    .extracting(BaseApplicationEntity::getId, BaseApplicationEntity::getName)
+                    .containsExactly(APP_ID, appName);
+
+                assertThat(apiMetricsDetail.getPlan())
+                    .extracting(GenericPlanEntity::getId, GenericPlanEntity::getName)
+                    .containsExactly(PLAN_ID, planName);
+
+                assertThat(apiMetricsDetail.getGateway())
+                    .extracting(BaseInstance::getId, BaseInstance::getHostname, BaseInstance::getIp)
+                    .containsExactly(instanceId, hostname, ip);
+            });
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8652

## Description

The goal of this issue is to allow customer to get a single metric from Elasticsearch using their api and request ids. In combination with `/logs/{requestId}`, this endpoint will allow us in my next PR on the console to build the new api log detail overview page.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uldpinwdpd.chromatic.com)
<!-- Storybook placeholder end -->
