### PR TITLE
fix(e2e): Avoiding strict compilation of e2e tests

### DIFF
--- a/gravitee-apim-e2e/tsconfig.json
+++ b/gravitee-apim-e2e/tsconfig.json
@@ -17,8 +17,7 @@
       "@api-test-resources/*": ["<rootDir>/api-test/resources/$1"],
       "@lib/jest-utils": ["lib/jest-utils"],
       "@gravitee/utils/*": ["<rootDir>/lib/utils/$1"]
-    },
-    "isolatedModules": true
+    }
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10220

## Description


Recent changes led to the failing of e2e tests(PR Link: [PR-12880](https://github.com/gravitee-io/gravitee-api-management/pull/12880/files) ):
<img width="1356" height="412" alt="image" src="https://github.com/user-attachments/assets/196a3543-74d0-4d28-9fe2-9a4d75616193" />


e2e tests were failing during `yarn build`:

<img width="1710" height="1035" alt="image" src="https://github.com/user-attachments/assets/0267737b-5d9c-4f25-a061-9fb30d7ab4be" />


