### PR TITLE
fix: correct pagination response to use 1-based indexing

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
@@ -47,7 +47,7 @@ public class PagedResult<T> {
     }
 
     public PagedResult(io.gravitee.common.data.domain.Page<T> page, int perPage) {
-        this(page.getContent(), page.getPageNumber()+1, perPage, (int) page.getTotalElements());
+        this(page.getContent(), page.getPageNumber(), perPage, (int) page.getTotalElements());
     }
 
     @Getter

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
@@ -47,7 +47,7 @@ public class PagedResult<T> {
     }
 
     public PagedResult(io.gravitee.common.data.domain.Page<T> page, int perPage) {
-        this(page.getContent(), page.getPageNumber(), perPage, (int) page.getTotalElements());
+        this(page.getContent(), page.getPageNumber()+1, perPage, (int) page.getTotalElements());
     }
 
     @Getter

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/wrapper/ApplicationListItemPagedResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/wrapper/ApplicationListItemPagedResult.java
@@ -34,6 +34,6 @@ public class ApplicationListItemPagedResult extends PagedResult<ApplicationListI
     }
 
     public ApplicationListItemPagedResult(io.gravitee.common.data.domain.Page<ApplicationListItem> page, int perPage) {
-        super(page, perPage);
+        super(page.getContent(), page.getPageNumber() + 1, perPage, (int) page.getTotalElements());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResourceTest.java
@@ -129,7 +129,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
         var responseContent = response.readEntity(ApplicationListItemPagedResult.class);
         var pagedApplicationsResult = (ApplicationListItemPagedResult) responseContent;
-        assertEquals(0, pagedApplicationsResult.getPage().getCurrent());
+        assertEquals(1, pagedApplicationsResult.getPage().getCurrent());
         assertEquals(20, pagedApplicationsResult.getPage().getPerPage());
         assertEquals(3, pagedApplicationsResult.getPage().getSize());
         assertEquals(1, pagedApplicationsResult.getPage().getTotalPages());
@@ -154,7 +154,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
         var responseContent = response.readEntity(ApplicationListItemPagedResult.class);
         var pagedApplicationsResult = (ApplicationListItemPagedResult) responseContent;
-        assertEquals(2, pagedApplicationsResult.getPage().getCurrent());
+        assertEquals(3, pagedApplicationsResult.getPage().getCurrent());
         assertEquals(3, pagedApplicationsResult.getPage().getPerPage());
         assertEquals(1, pagedApplicationsResult.getPage().getSize());
         assertEquals(3, pagedApplicationsResult.getPage().getTotalPages());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10868

## Description

Fixes page.current returning 0 when user requests page=1 by adding 
proper conversion from repository 0-based to API 1-based indexing.

## Additional context

### Before
<img width="1712" height="992" alt="Screenshot 2025-08-22 at 8 18 05 PM" src="https://github.com/user-attachments/assets/44193336-5314-432a-a4c3-3092ac924d89" />

### After
<img width="1712" height="992" alt="Screenshot 2025-08-22 at 8 15 42 PM" src="https://github.com/user-attachments/assets/124b1ca2-72f2-40b8-b6ea-74658639fa41" />



