### PR TITLE
fix: Exported json of API configuration contains CORS information

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListene
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
 import io.gravitee.definition.model.v4.nativeapi.NativeListener;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
+import io.gravitee.rest.api.management.v2.rest.mapper.CorsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.EndpointV4;
@@ -120,7 +121,9 @@ public interface ImportExportApiMapper {
         };
     }
 
+    @Mapping(target = "cors", expression = "java(CorsMapper.INSTANCE.map(http.getCors()))")
     io.gravitee.rest.api.management.v2.rest.model.HttpListener mapHttpListener(HttpListener http);
+
     io.gravitee.rest.api.management.v2.rest.model.SubscriptionListener mapSubscriptionListener(SubscriptionListener subscription);
     io.gravitee.rest.api.management.v2.rest.model.TcpListener mapTcpListener(TcpListener tcp);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.ListenerModelFixtures;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+public class ImportExportApiMapperTest extends AbstractMapperTest {
+
+    private final ImportExportApiMapper importExportApiMapper = Mappers.getMapper(ImportExportApiMapper.class);
+
+    @Test
+    void shouldMapHttpListenerWithCors() {
+        HttpListener httpListener = ListenerModelFixtures.aModelHttpListener();
+
+        var result = importExportApiMapper.mapHttpListener(httpListener);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCors()).isNotNull();
+
+        assertThat(result.getCors().getEnabled()).isEqualTo(httpListener.getCors().isEnabled());
+        assertThat(result.getCors().getAllowOrigin()).isEqualTo(httpListener.getCors().getAccessControlAllowOrigin());
+        assertThat(result.getCors().getAllowHeaders()).isEqualTo(httpListener.getCors().getAccessControlAllowHeaders());
+        assertThat(result.getCors().getAllowMethods()).isEqualTo(httpListener.getCors().getAccessControlAllowMethods());
+        assertThat(result.getCors().getAllowCredentials()).isEqualTo(httpListener.getCors().isAccessControlAllowCredentials());
+        assertThat(result.getCors().getExposeHeaders()).isEqualTo(httpListener.getCors().getAccessControlExposeHeaders());
+        assertThat(result.getCors().getMaxAge()).isEqualTo(httpListener.getCors().getAccessControlMaxAge());
+        assertThat(result.getCors().getRunPolicies()).isEqualTo(httpListener.getCors().isRunPolicies());
+    }
+
+    @Test
+    void shouldMapHttpListenerWithNullCors() {
+        HttpListener httpListener = mock(HttpListener.class);
+        when(httpListener.getCors()).thenReturn(null);
+
+        var result = importExportApiMapper.mapHttpListener(httpListener);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCors()).isNull();
+    }
+
+    @Test
+    void shouldUseCorsMappperForHttpListener() {
+        HttpListener httpListener = ListenerModelFixtures.aModelHttpListener();
+        var expectedCors = CorsMapper.INSTANCE.map(httpListener.getCors());
+        var result = importExportApiMapper.mapHttpListener(httpListener);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCors()).isNotNull();
+
+        assertThat(result.getCors().getEnabled()).isEqualTo(expectedCors.getEnabled());
+        assertThat(result.getCors().getAllowOrigin()).isEqualTo(expectedCors.getAllowOrigin());
+        assertThat(result.getCors().getAllowHeaders()).isEqualTo(expectedCors.getAllowHeaders());
+        assertThat(result.getCors().getAllowMethods()).isEqualTo(expectedCors.getAllowMethods());
+        assertThat(result.getCors().getAllowCredentials()).isEqualTo(expectedCors.getAllowCredentials());
+        assertThat(result.getCors().getExposeHeaders()).isEqualTo(expectedCors.getExposeHeaders());
+        assertThat(result.getCors().getMaxAge()).isEqualTo(expectedCors.getMaxAge());
+        assertThat(result.getCors().getRunPolicies()).isEqualTo(expectedCors.getRunPolicies());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10867

## Description

When creating an API with CORS enabled and then exporting the API definition, the CORS settings (such as allowOrigins, allowMethods, allowHeaders, etc.) were unexpectedly missing from the "listeners[].cors" section of the exported JSON.
Now, they are present.

## Additional context

Screenshot of the change is added:

<img width="1719" height="457" alt="image" src="https://github.com/user-attachments/assets/7f932b3a-61d0-42d6-b280-82780f1ef060" />

Updated Json exported: 
[13236-0-1 (37).json](https://github.com/user-attachments/files/21946403/13236-0-1.37.json)

Video proof:

https://github.com/user-attachments/assets/a64c283b-ceea-47ce-a2a5-c2a95e3e41a5

