### PR TITLE
fix: Audit History groups fetch timeout(v2)

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
@@ -115,14 +115,24 @@ enum Modes {
   Design = 'Design',
 }
 
+interface EventPayload {
+  groups?: string[];
+  [key: string]: any;
+}
+
+interface EventData {
+  payload: string;
+  [key: string]: any;
+}
+
 class ApiHistoryControllerAjs {
   public activatedRoute: ActivatedRoute;
   public modes = Modes;
   public modeOptions: any;
+  public groups: any;
   private studio: any;
   private mode: string;
   private api: any;
-  private groups: any;
   private events: any;
   private eventsSelected: any;
   private eventsTimeline: any;
@@ -142,7 +152,7 @@ class ApiHistoryControllerAjs {
   public hasNextEventPageToLoad = false;
 
   constructor(
-    private $mdDialog: ng.material.IDialogService,
+    private readonly $mdDialog,
     private ApiService: ApiService,
     private NotificationService,
     private PolicyService,
@@ -166,13 +176,10 @@ class ApiHistoryControllerAjs {
 
   $onInit() {
     Promise.all([
-      this.ngGroupV2Service.list(1, 99999).toPromise(),
       this.ApiService.get(this.activatedRoute.snapshot.params.apiId),
       this.ApiService.isAPISynchronized(this.activatedRoute.snapshot.params.apiId),
-    ]).then(([groups, api, apiIsSynchronizedResult]) => {
+    ]).then(([api, apiIsSynchronizedResult]) => {
       this.api = api.data;
-      this.groups = groups.data;
-
       this.eventPage = -1;
       this.events = [];
       const toDeployEventTimeline = !apiIsSynchronizedResult.data.is_synchronized
@@ -201,6 +208,7 @@ class ApiHistoryControllerAjs {
       this.eventPageSize,
       true,
     ).then((response) => {
+      this.fetchGroupsConsumed(response);
       this.events = [...(this.events ?? []), ...response.data.content];
       this.hasNextEventPageToLoad =
         response.data.totalElements > response.data.pageNumber * this.eventPageSize + response.data.pageElements;
@@ -234,6 +242,20 @@ class ApiHistoryControllerAjs {
       });
     }
   }
+
+  fetchGroupsConsumed = (data: any) => {
+    const contentArray: EventData[] = data.data.content;
+
+    const allGroups: string[][] = contentArray.map((item: EventData) => {
+      const parsedPayload: EventPayload = JSON.parse(item.payload);
+      return parsedPayload.groups ?? [];
+    });
+
+    const flatGroupList: string[] = [...new Set(allGroups.flat())];
+    this.ngGroupV2Service.listById(flatGroupList, 1, flatGroupList.length).subscribe((res) => {
+      this.groups = res.data;
+    });
+  };
 
   setEventToStudio(eventTimeline, api) {
     this.studio.definition = {

--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { of } from 'rxjs';
+
+import ApiHistoryControllerAjs from './apiHistory.controller.ajs';
+
+describe('ApiHistoryControllerAjs', () => {
+  let controller: ApiHistoryControllerAjs;
+  let mockNgGroupV2Service: any;
+
+  beforeEach(() => {
+    mockNgGroupV2Service = {
+      listById: jest.fn(),
+    };
+
+    controller = new ApiHistoryControllerAjs(
+      {} as any, // $mdDialog
+      {} as any, // ApiService
+      {} as any, // NotificationService
+      {} as any, // PolicyService
+      {} as any, // ResourceService
+      {} as any, // FlowService
+      {} as any, // ngApiV2Service
+      mockNgGroupV2Service,
+    );
+  });
+
+  describe('fetchGroupsConsumed', () => {
+    it('should fetch and set groups correctly when payloads are valid', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"groups":["group1","group2"]}' }, { payload: '{"groups":["group2","group3"]}' }],
+        },
+      };
+      const mockGroups = ['group1', 'group2', 'group3'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1', 'group2', 'group3'], 1, 3);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should set groups to empty array if no groups are found', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"somethingElse":["value1"]}' }, { payload: '{"anotherKey":["value2"]}' }],
+        },
+      };
+      mockNgGroupV2Service.listById = jest.fn(() => of([]));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith([], 1, 0);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toEqual([]);
+      });
+    });
+
+    it('should handle empty content array', () => {
+      const mockResponse = {
+        data: {
+          content: [],
+        },
+      };
+      mockNgGroupV2Service.listById = jest.fn(() => of([]));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith([], 1, 0);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toEqual([]);
+      });
+    });
+
+    it('should handle null groups in payload', () => {
+      const mockResponse = {
+        data: {
+          content: [{ payload: '{"groups":null}' }, { payload: '{"groups":["group1"]}' }],
+        },
+      };
+      const mockGroups = ['group1'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1'], 1, 1);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should handle undefined groups in payload', () => {
+      const mockResponse = {
+        data: {
+          content: [
+            { payload: '{}' }, // undefined groups
+            { payload: '{"groups":["group1"]}' },
+          ],
+        },
+      };
+      const mockGroups = ['group1'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1'], 1, 1);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+
+    it('should deduplicate group IDs', () => {
+      const mockResponse = {
+        data: {
+          content: [
+            { payload: '{"groups":["group1","group2"]}' },
+            { payload: '{"groups":["group2","group1"]}' }, // duplicate IDs
+            { payload: '{"groups":["group3","group2"]}' }, // more duplicates
+          ],
+        },
+      };
+      const mockGroups = ['group1', 'group2', 'group3'];
+      mockNgGroupV2Service.listById = jest.fn(() => of(mockGroups));
+
+      controller.fetchGroupsConsumed(mockResponse);
+
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledWith(['group1', 'group2', 'group3'], 1, 3);
+      expect(mockNgGroupV2Service.listById).toHaveBeenCalledTimes(1);
+
+      setTimeout(() => {
+        expect(controller.groups).toBe(mockGroups);
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
@@ -47,6 +47,21 @@ export class GroupV2Service {
     });
   }
 
+  listById(ids: string[] = [], page = 1, perPage = 10): Observable<GroupsResponse> {
+    return this.http.post<GroupsResponse>(
+      `${this.constants.env.v2BaseURL}/groups/_search`,
+      {
+        ids,
+      },
+      {
+        params: {
+          page,
+          perPage,
+        },
+      },
+    );
+  }
+
   public getPermissions(groupId: string): Observable<Record<string, string>> {
     return this.http.get<Record<string, string>>(`${this.constants.env.v2BaseURL}/groups/${groupId}/permissions`);
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DateMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DateMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Objects;
 import org.mapstruct.Mapper;
@@ -39,6 +40,13 @@ public interface DateMapper {
             return null;
         }
         return Date.from(offsetDateTime.toInstant());
+    }
+
+    default OffsetDateTime map(ZonedDateTime zonedDateTime) {
+        if (Objects.isNull(zonedDateTime)) {
+            return null;
+        }
+        return zonedDateTime.toOffsetDateTime();
     }
 
     @Named("mapTimestamp")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.group.model.Group.GroupEventRule;
 import io.gravitee.rest.api.management.v2.rest.model.Group;
 import io.gravitee.rest.api.management.v2.rest.model.GroupEvent;
 import io.gravitee.rest.api.model.GroupEntity;
@@ -26,6 +27,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
@@ -75,5 +77,29 @@ public interface GroupMapper {
             return null;
         }
         return roles.get(RoleScope.APPLICATION);
+    }
+
+    List<Group> mapFromCoreList(List<io.gravitee.apim.core.group.model.Group> coreGroups);
+
+    Group mapFromCore(io.gravitee.apim.core.group.model.Group coreGroup);
+
+    default List<GroupEvent> mapCoreGroupEventRules(List<GroupEventRule> eventRules) {
+        if (Objects.isNull(eventRules)) {
+            return null;
+        }
+
+        return eventRules
+            .stream()
+            .filter(Objects::nonNull)
+            .map(rule -> {
+                try {
+                    return GroupEvent.fromValue(rule.event().name());
+                } catch (IllegalArgumentException e) {
+                    logger.error("Unable to parse GroupEventRule: " + rule.event().name());
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1124,6 +1124,30 @@ paths:
                     $ref: "#/components/responses/GroupsResponse"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/groups/_search:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - Groups
+            summary: Search for groups using filters
+            description: |
+                Search for groups using filters.
+                User must have the ENVIRONMENT_GROUP[READ] permission.
+            operationId: searchGroups
+            parameters:
+                - $ref: "#/components/parameters/pageParam"
+                - $ref: "#/components/parameters/perPageParam"
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/GroupSearchParams"
+            responses:
+                "200":
+                    $ref: "#/components/responses/GroupsResponse"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/groups/{groupId}/members:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -5184,6 +5208,15 @@ components:
             enum:
                 - API_CREATE
                 - APPLICATION_CREATE
+        GroupSearchParams:
+            type: object
+            properties:
+                ids:
+                    type: array
+                    description: List of group IDs to search for.
+                    items:
+                        type: string
+                    uniqueItems: true
         Member:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapperTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.group.model.Group.GroupEventRule;
+import io.gravitee.rest.api.management.v2.rest.model.Group;
+import io.gravitee.rest.api.management.v2.rest.model.GroupEvent;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.GroupEventRuleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import java.time.ZonedDateTime;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+public class GroupMapperTest extends AbstractMapperTest {
+
+    private final GroupMapper groupMapper = Mappers.getMapper(GroupMapper.class);
+
+    @Test
+    void should_map_GroupEntity_to_Group() {
+        GroupEntity groupEntity = createGroupEntity();
+
+        Group group = groupMapper.map(groupEntity);
+
+        assertThat(group).isNotNull();
+        assertThat(group.getId()).isEqualTo(groupEntity.getId());
+        assertThat(group.getName()).isEqualTo(groupEntity.getName());
+        assertThat(group.getManageable()).isEqualTo(groupEntity.isManageable());
+        assertThat(group.getCreatedAt().toInstant().toEpochMilli()).isEqualTo(groupEntity.getCreatedAt().getTime());
+        assertThat(group.getUpdatedAt().toInstant().toEpochMilli()).isEqualTo(groupEntity.getUpdatedAt().getTime());
+        assertThat(group.getMaxInvitation()).isEqualTo(groupEntity.getMaxInvitation());
+        assertThat(group.getApiRole()).isEqualTo(groupEntity.getRoles().get(RoleScope.API));
+        assertThat(group.getApplicationRole()).isEqualTo(groupEntity.getRoles().get(RoleScope.APPLICATION));
+        assertThat(group.getLockApiRole()).isEqualTo(groupEntity.isLockApiRole());
+        assertThat(group.getLockApplicationRole()).isEqualTo(groupEntity.isLockApplicationRole());
+        assertThat(group.getSystemInvitation()).isEqualTo(groupEntity.isSystemInvitation());
+        assertThat(group.getEmailInvitation()).isEqualTo(groupEntity.isEmailInvitation());
+        assertThat(group.getDisableMembershipNotifications()).isEqualTo(groupEntity.isDisableMembershipNotifications());
+        assertThat(group.getApiPrimaryOwner()).isEqualTo(groupEntity.getApiPrimaryOwner());
+        assertThat(group.getPrimaryOwner()).isEqualTo(groupEntity.isPrimaryOwner());
+    }
+
+    @Test
+    void should_map_list_of_GroupEntity_to_list_of_Group() {
+        List<GroupEntity> groupEntities = Arrays.asList(createGroupEntity("group1"), createGroupEntity("group2"));
+
+        List<Group> groups = groupMapper.map(groupEntities);
+
+        assertThat(groups).isNotNull();
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("group1");
+        assertThat(groups.get(1).getId()).isEqualTo("group2");
+    }
+
+    @Test
+    void should_map_GroupEventRuleEntities_to_GroupEvents() {
+        List<GroupEventRuleEntity> eventRules = Arrays.asList(
+            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE.name()),
+            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE.name())
+        );
+
+        List<GroupEvent> groupEvents = groupMapper.mapGroupEventRuleEntities(eventRules);
+
+        assertThat(groupEvents).isNotNull();
+        assertThat(groupEvents).hasSize(2);
+        assertThat(groupEvents.get(0)).isEqualTo(GroupEvent.API_CREATE);
+        assertThat(groupEvents.get(1)).isEqualTo(GroupEvent.APPLICATION_CREATE);
+    }
+
+    @Test
+    void should_handle_invalid_GroupEventRuleEntity() {
+        List<GroupEventRuleEntity> eventRules = Arrays.asList(
+            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE.name()),
+            createGroupEventRuleEntity("INVALID_EVENT")
+        );
+
+        List<GroupEvent> groupEvents = groupMapper.mapGroupEventRuleEntities(eventRules);
+
+        assertThat(groupEvents).isNotNull();
+        assertThat(groupEvents).hasSize(2);
+        assertThat(groupEvents.get(0)).isEqualTo(GroupEvent.API_CREATE);
+        assertThat(groupEvents.get(1)).isNull();
+    }
+
+    @Test
+    void should_handle_null_GroupEventRuleEntities() {
+        List<GroupEventRuleEntity> eventRules = null;
+
+        List<GroupEvent> groupEvents = groupMapper.mapGroupEventRuleEntities(eventRules);
+
+        assertThat(groupEvents).isNull();
+    }
+
+    @Test
+    void should_map_apiRole_from_roles() {
+        Map<RoleScope, String> roles = new HashMap<>();
+        roles.put(RoleScope.API, "API_ROLE");
+        roles.put(RoleScope.APPLICATION, "APP_ROLE");
+
+        String apiRole = groupMapper.mapApiRole(roles);
+
+        assertThat(apiRole).isEqualTo("API_ROLE");
+    }
+
+    @Test
+    void should_handle_null_roles_for_apiRole() {
+        Map<RoleScope, String> roles = null;
+
+        String apiRole = groupMapper.mapApiRole(roles);
+
+        assertThat(apiRole).isNull();
+    }
+
+    @Test
+    void should_map_applicationRole_from_roles() {
+        Map<RoleScope, String> roles = new HashMap<>();
+        roles.put(RoleScope.API, "API_ROLE");
+        roles.put(RoleScope.APPLICATION, "APP_ROLE");
+
+        String applicationRole = groupMapper.mapApplicationRole(roles);
+
+        assertThat(applicationRole).isEqualTo("APP_ROLE");
+    }
+
+    @Test
+    void should_handle_null_roles_for_applicationRole() {
+        Map<RoleScope, String> roles = null;
+
+        String applicationRole = groupMapper.mapApplicationRole(roles);
+
+        assertThat(applicationRole).isNull();
+    }
+
+    @Test
+    void should_map_core_Group_to_Group() {
+        io.gravitee.apim.core.group.model.Group coreGroup = createCoreGroup();
+
+        Group group = groupMapper.mapFromCore(coreGroup);
+
+        assertThat(group).isNotNull();
+        assertThat(group.getId()).isEqualTo(coreGroup.getId());
+        assertThat(group.getName()).isEqualTo(coreGroup.getName());
+        assertThat(group.getCreatedAt().toInstant()).isEqualTo(coreGroup.getCreatedAt().toInstant());
+        assertThat(group.getUpdatedAt().toInstant()).isEqualTo(coreGroup.getUpdatedAt().toInstant());
+        assertThat(group.getMaxInvitation()).isEqualTo(coreGroup.getMaxInvitation());
+        assertThat(group.getLockApiRole()).isEqualTo(coreGroup.isLockApiRole());
+        assertThat(group.getLockApplicationRole()).isEqualTo(coreGroup.isLockApplicationRole());
+        assertThat(group.getSystemInvitation()).isEqualTo(coreGroup.isSystemInvitation());
+        assertThat(group.getEmailInvitation()).isEqualTo(coreGroup.isEmailInvitation());
+        assertThat(group.getDisableMembershipNotifications()).isEqualTo(coreGroup.isDisableMembershipNotifications());
+        assertThat(group.getApiPrimaryOwner()).isEqualTo(coreGroup.getApiPrimaryOwner());
+    }
+
+    @Test
+    void should_map_list_of_core_Group_to_list_of_Group() {
+        List<io.gravitee.apim.core.group.model.Group> coreGroups = Arrays.asList(createCoreGroup("core1"), createCoreGroup("core2"));
+
+        List<Group> groups = groupMapper.mapFromCoreList(coreGroups);
+
+        assertThat(groups).isNotNull();
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("core1");
+        assertThat(groups.get(1).getId()).isEqualTo("core2");
+    }
+
+    @Test
+    void should_map_core_GroupEventRules_to_GroupEvents() {
+        List<GroupEventRule> eventRules = Arrays.asList(
+            new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE),
+            new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE)
+        );
+
+        List<GroupEvent> groupEvents = groupMapper.mapCoreGroupEventRules(eventRules);
+
+        assertThat(groupEvents).isNotNull();
+        assertThat(groupEvents).hasSize(2);
+        assertThat(groupEvents.get(0)).isEqualTo(GroupEvent.API_CREATE);
+        assertThat(groupEvents.get(1)).isEqualTo(GroupEvent.APPLICATION_CREATE);
+    }
+
+    @Test
+    void should_handle_null_core_GroupEventRules() {
+        List<GroupEventRule> eventRules = null;
+
+        List<GroupEvent> groupEvents = groupMapper.mapCoreGroupEventRules(eventRules);
+
+        assertThat(groupEvents).isNull();
+    }
+
+    private GroupEntity createGroupEntity() {
+        return createGroupEntity("group-id");
+    }
+
+    private GroupEntity createGroupEntity(String id) {
+        GroupEntity groupEntity = GroupEntity
+            .builder()
+            .id(id)
+            .name("Group " + id)
+            .manageable(true)
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .maxInvitation(10)
+            .lockApiRole(true)
+            .lockApplicationRole(false)
+            .systemInvitation(true)
+            .emailInvitation(true)
+            .disableMembershipNotifications(false)
+            .apiPrimaryOwner("user-id")
+            .primaryOwner(true)
+            .build();
+
+        Map<RoleScope, String> roles = new HashMap<>();
+        roles.put(RoleScope.API, "API_PUBLISHER");
+        roles.put(RoleScope.APPLICATION, "APPLICATION_OWNER");
+        groupEntity.setRoles(roles);
+
+        List<GroupEventRuleEntity> eventRules = new ArrayList<>();
+        eventRules.add(createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE.name()));
+        groupEntity.setEventRules(eventRules);
+
+        return groupEntity;
+    }
+
+    private GroupEventRuleEntity createGroupEventRuleEntity(String event) {
+        return GroupEventRuleEntity.builder().event(event).build();
+    }
+
+    private io.gravitee.apim.core.group.model.Group createCoreGroup() {
+        return createCoreGroup("core-group-id");
+    }
+
+    private io.gravitee.apim.core.group.model.Group createCoreGroup(String id) {
+        List<GroupEventRule> eventRules = new ArrayList<>();
+        eventRules.add(new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE));
+
+        return io.gravitee.apim.core.group.model.Group
+            .builder()
+            .id(id)
+            .environmentId("env-id")
+            .name("Core Group " + id)
+            .eventRules(eventRules)
+            .createdAt(ZonedDateTime.now())
+            .updatedAt(ZonedDateTime.now())
+            .maxInvitation(10)
+            .lockApiRole(true)
+            .lockApplicationRole(false)
+            .systemInvitation(true)
+            .emailInvitation(true)
+            .disableMembershipNotifications(false)
+            .apiPrimaryOwner("user-id")
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -87,6 +87,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
     public void tearDown() {
         super.tearDown();
         Mockito.reset(membershipService, groupService);
+        groupQueryServiceInMemory.reset();
         GraviteeContext.cleanContext();
     }
 
@@ -289,6 +290,106 @@ public class GroupsResourceTest extends AbstractResourceTest {
                         .links(Links.builder().self(target.getUri().toString()).build())
                         .build()
                 );
+        }
+    }
+
+    @Nested
+    class SearchGroupsByIds {
+
+        @BeforeEach
+        void setUp() {
+            target = rootTarget("/_search");
+        }
+
+        @Test
+        public void should_control_permissions() {
+            when(
+                permissionService.hasPermission(
+                    eq(GraviteeContext.getExecutionContext()),
+                    eq(RolePermission.ENVIRONMENT_GROUP),
+                    eq(ENVIRONMENT),
+                    eq(RolePermissionAction.READ)
+                )
+            )
+                .thenReturn(false);
+
+            final Response response = target.request().post(jakarta.ws.rs.client.Entity.json(Map.of("ids", Set.of("group-1", "group-2"))));
+
+            assertThat(response).hasStatus(FORBIDDEN_403);
+        }
+
+        @Test
+        public void should_return_empty_list_if_no_results() {
+            groupQueryServiceInMemory.reset();
+
+            final Response response = target.request().post(jakarta.ws.rs.client.Entity.json(Map.of("ids", Set.of("group-1", "group-2"))));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(GroupsResponse.class)
+                .isEqualTo(
+                    GroupsResponse
+                        .builder()
+                        .data(List.of())
+                        .pagination(Pagination.builder().build())
+                        .links(Links.builder().self(target.getUri().toString()).build())
+                        .build()
+                );
+        }
+
+        @Test
+        public void should_return_groups_with_pagination() {
+            io.gravitee.apim.core.group.model.Group group1 = io.gravitee.apim.core.group.model.Group
+                .builder()
+                .id("group-1")
+                .name("Group 1")
+                .environmentId(ENVIRONMENT)
+                .build();
+
+            io.gravitee.apim.core.group.model.Group group2 = io.gravitee.apim.core.group.model.Group
+                .builder()
+                .id("group-2")
+                .name("Group 2")
+                .environmentId(ENVIRONMENT)
+                .build();
+
+            givenExistingGroup(List.of(group1, group2));
+
+            final Response response = target.request().post(jakarta.ws.rs.client.Entity.json(Map.of("ids", Set.of("group-1", "group-2"))));
+
+            assertThat(response).hasStatus(OK_200);
+
+            GroupsResponse groupsResponse = response.readEntity(GroupsResponse.class);
+            assertThat(groupsResponse.getData()).hasSize(2);
+            assertThat(groupsResponse.getPagination().getTotalCount()).isEqualTo(2);
+        }
+
+        @Test
+        public void should_return_groups_with_links() {
+            io.gravitee.apim.core.group.model.Group group1 = io.gravitee.apim.core.group.model.Group
+                .builder()
+                .id("group-1")
+                .name("Group 1")
+                .environmentId(ENVIRONMENT)
+                .build();
+
+            io.gravitee.apim.core.group.model.Group group2 = io.gravitee.apim.core.group.model.Group
+                .builder()
+                .id("group-2")
+                .name("Group 2")
+                .environmentId(ENVIRONMENT)
+                .build();
+
+            givenExistingGroup(List.of(group1, group2));
+
+            final Response response = target.request().post(jakarta.ws.rs.client.Entity.json(Map.of("ids", Set.of("group-1", "group-2"))));
+
+            assertThat(response).hasStatus(OK_200);
+
+            GroupsResponse groupsResponse = response.readEntity(GroupsResponse.class);
+            assertThat(groupsResponse.getData()).hasSize(2);
+            assertThat(groupsResponse.getPagination().getTotalCount()).isEqualTo(2);
+            assertThat(groupsResponse.getLinks().getSelf()).isEqualTo(target.getUri().toString());
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/SearchGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/SearchGroupsUseCase.java
@@ -13,21 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.group.query_service;
+package io.gravitee.apim.core.group.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.common.data.domain.Page;
-import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
-public interface GroupQueryService {
-    Optional<Group> findById(String id);
-    Set<Group> findByIds(Set<String> ids);
-    Set<Group> findByEvent(String environmentId, Group.GroupEvent event);
-    List<Group> findByNames(String environmentId, Set<String> name);
-    Page<Group> searchGroups(ExecutionContext executionContext, Set<String> groupIds, Pageable pageable);
+@UseCase
+public class SearchGroupsUseCase {
+
+    private final GroupQueryService groupQueryService;
+
+    public SearchGroupsUseCase(GroupQueryService groupQueryService) {
+        this.groupQueryService = groupQueryService;
+    }
+
+    public Page<Group> execute(ExecutionContext executionContext, Set<String> groupIds, Pageable pageable) {
+        if (groupIds == null || groupIds.isEmpty()) return new Page<>(List.of(), 0, 0, 0);
+        return groupQueryService.searchGroups(executionContext, groupIds, pageable);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImpl.java
@@ -20,22 +20,30 @@ import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.infra.adapter.GroupAdapter;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.search.GroupCriteria;
 import io.gravitee.repository.management.model.GroupEventRule;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-public class GroupQueryServiceImpl implements GroupQueryService {
+public class GroupQueryServiceImpl extends AbstractService implements GroupQueryService {
 
     private final GroupRepository groupRepository;
 
@@ -107,5 +115,12 @@ public class GroupQueryServiceImpl implements GroupQueryService {
         } catch (TechnicalException ex) {
             throw new TechnicalDomainException("An error occurs while trying to find groups by names", ex);
         }
+    }
+
+    @Override
+    public Page<Group> searchGroups(ExecutionContext executionContext, Set<String> groupIds, Pageable pageable) {
+        return groupRepository
+            .search(GroupCriteria.builder().idIn(groupIds).build(), convert(pageable))
+            .map(GroupAdapter.INSTANCE::toModel);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/GroupQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/GroupQueryServiceInMemory.java
@@ -19,6 +19,9 @@ import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,6 +62,25 @@ public class GroupQueryServiceInMemory implements GroupQueryService, InMemoryAlt
             .filter(group -> environmentId.equals(group.getEnvironmentId()))
             .filter(group -> names.contains(group.getName()))
             .toList();
+    }
+
+    @Override
+    public Page<Group> searchGroups(ExecutionContext executionContext, Set<String> groupIds, Pageable pageable) {
+        List<Group> filteredGroups = storage.stream().filter(group -> groupIds.contains(group.getId())).toList();
+
+        int total = filteredGroups.size();
+        int pageSize = pageable.getPageSize();
+        int pageNumber = pageable.getPageNumber();
+        int from = (pageNumber - 1) * pageSize;
+
+        if (from >= total) {
+            return new Page<>(List.of(), pageNumber, pageSize, total);
+        }
+
+        int to = Math.min(from + pageSize, total);
+
+        List<Group> pageContent = filteredGroups.subList(from, to);
+        return new Page<>(pageContent, pageNumber, pageSize, total);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/SearchGroupsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/SearchGroupsUseCaseTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.group.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.GroupQueryServiceInMemory;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchGroupsUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+
+    private GroupQueryServiceInMemory groupQueryServiceInMemory;
+    private SearchGroupsUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        groupQueryServiceInMemory = new GroupQueryServiceInMemory();
+        cut = new SearchGroupsUseCase(groupQueryServiceInMemory);
+    }
+
+    @Test
+    void should_return_empty_page_when_group_ids_is_null() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        Pageable pageable = new PageableImpl(1, 10);
+
+        Page<Group> result = cut.execute(executionContext, null, pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getPageNumber()).isEqualTo(0);
+        assertThat(result.getPageElements()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    void should_return_empty_page_when_group_ids_is_empty() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        Pageable pageable = new PageableImpl(1, 10);
+
+        Page<Group> result = cut.execute(executionContext, Set.of(), pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getPageNumber()).isEqualTo(0);
+        assertThat(result.getPageElements()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    void should_delegate_to_group_query_service_when_group_ids_is_not_empty() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        Set<String> groupIds = Set.of("group-1", "group-2");
+        Pageable pageable = new PageableImpl(0, 10);
+
+        List<Group> groups = List.of(
+            Group
+                .builder()
+                .id("group-1")
+                .name("Group 1")
+                .environmentId(ENVIRONMENT_ID)
+                .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                .build(),
+            Group
+                .builder()
+                .id("group-2")
+                .name("Group 2")
+                .environmentId(ENVIRONMENT_ID)
+                .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                .build()
+        );
+
+        groupQueryServiceInMemory.initWith(groups);
+
+        Page<Group> result = cut.execute(executionContext, groupIds, pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo("group-1");
+        assertThat(result.getContent().get(1).getId()).isEqualTo("group-2");
+        assertThat(result.getPageNumber()).isEqualTo(pageable.getPageNumber());
+        assertThat(result.getPageElements()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImplTest.java
@@ -24,9 +24,13 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.GroupEvent;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Date;
@@ -296,5 +300,67 @@ class GroupQueryServiceImplTest {
             .emailInvitation(true)
             .disableMembershipNotifications(true)
             .apiPrimaryOwner("api-po-id");
+    }
+
+    @Nested
+    class SearchGroups {
+
+        @Test
+        @SneakyThrows
+        void should_search_groups_with_pagination() {
+            Set<String> groupIds = Set.of("1", "2", "3");
+            io.gravitee.rest.api.model.common.Pageable pageable = new PageableImpl(1, 10);
+            io.gravitee.repository.management.api.search.Pageable repoPageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+
+            List<io.gravitee.repository.management.model.Group> groups = List.of(aGroup("1").build(), aGroup("2").build());
+
+            Page<io.gravitee.repository.management.model.Group> page = new Page<>(groups, 0, groups.size(), 2);
+
+            when(groupRepository.search(any(), any())).thenReturn(page);
+
+            ExecutionContext executionContext = mock(ExecutionContext.class);
+            Page<Group> result = service.searchGroups(executionContext, groupIds, pageable);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0).getId()).isEqualTo("1");
+            assertThat(result.getContent().get(1).getId()).isEqualTo("2");
+            assertThat(result.getPageNumber()).isEqualTo(0);
+            assertThat(result.getPageElements()).isEqualTo(2);
+            assertThat(result.getTotalElements()).isEqualTo(2);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_page_when_no_results() {
+            Set<String> groupIds = Set.of("1", "2", "3");
+            io.gravitee.rest.api.model.common.Pageable pageable = new PageableImpl(1, 10);
+
+            Page<io.gravitee.repository.management.model.Group> page = new Page<>(List.of(), 0, 0, 0);
+
+            when(groupRepository.search(any(), any())).thenReturn(page);
+
+            ExecutionContext executionContext = mock(ExecutionContext.class);
+            Page<Group> result = service.searchGroups(executionContext, groupIds, pageable);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getPageNumber()).isEqualTo(0);
+            assertThat(result.getPageElements()).isEqualTo(0);
+            assertThat(result.getTotalElements()).isEqualTo(0);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() {
+            Set<String> groupIds = Set.of("1", "2", "3");
+            io.gravitee.rest.api.model.common.Pageable pageable = new PageableImpl(1, 10);
+
+            when(groupRepository.search(any(), any())).thenThrow(new RuntimeException("Test exception"));
+
+            ExecutionContext executionContext = mock(ExecutionContext.class);
+            Throwable throwable = catchThrowable(() -> service.searchGroups(executionContext, groupIds, pageable));
+
+            assertThat(throwable).isInstanceOf(RuntimeException.class).hasMessage("Test exception");
+        }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10310

## Description

Calls to the groups endpoint (outside the Groups page) time out when many groups exist, causing failure on the Audit History page.

Expected: Groups endpoint responds successfully.

Current: Group Endpoint times out on history page.

## Additional context

**Steps to Reproduce:**

1. Create a large number of groups.
2. Open an API’s Audit History page -> request to /management/v2/environments/DEFAULT/groups?page=1&perPage=99999 times out.

Proof screenshot:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/6ec91125-8d26-44df-bd97-f6102b255aa5" />

Proof video:

https://github.com/user-attachments/assets/6094c08f-fcce-4a78-9718-f13987f68165



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vehfkebliy.chromatic.com)
<!-- Storybook placeholder end -->
