### PR TITLE
feat: add support for connection drain

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/ConnectionDrainListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/ConnectionDrainListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.connection;
+
+import java.util.function.Consumer;
+
+/**
+ * Base interface that can be implemented to register to connection drain demands.
+ * For example, it can be implemented by any API reactor to force Connection: close or stop SSE connection.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ConnectionDrainListener extends Consumer<Long> {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/ConnectionDrainManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/ConnectionDrainManager.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.connection;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ConnectionDrainManager {
+    /**
+     * Return the last requested drain timestamp or -1 if no drain has been requested.
+     *
+     * @return the last requested drain timestamp or -1 if no drain has been requested.
+     */
+    long drainRequestedAt();
+
+    /**
+     * Request connection draining.
+     * This will update the last requested drain timestamp and invoke all registered listeners.
+     */
+    void requestDrain();
+
+    /**
+     * Register a listener that will be invoked when a drain is requested.
+     *
+     * @param listener the listener to invoke.
+     *
+     * @return the id of the listener which can be reused to unregister.
+     */
+    String registerListener(ConnectionDrainListener listener);
+
+    /**
+     * Unregister the corresponding listener.
+     *
+     * @param listenerId the listener to unregister.
+     */
+    void unregisterListener(String listenerId);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/DefaultConnectionDrainManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/connection/DefaultConnectionDrainManager.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.connection;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.common.utils.UUID;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DefaultConnectionDrainManager extends AbstractService<DefaultConnectionDrainManager> implements ConnectionDrainManager {
+
+    private long drainRequestedAt = -1;
+    private final Map<String, ConnectionDrainListener> listeners = new ConcurrentHashMap<>();
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        listeners.clear();
+        drainRequestedAt = -1;
+    }
+
+    @Override
+    public long drainRequestedAt() {
+        return drainRequestedAt;
+    }
+
+    @Override
+    public void requestDrain() {
+        this.drainRequestedAt = System.currentTimeMillis();
+        notifyListeners();
+    }
+
+    @Override
+    public String registerListener(ConnectionDrainListener listener) {
+        String listenerId = UUID.random().toString();
+        listeners.put(listenerId, listener);
+        return listenerId;
+    }
+
+    @Override
+    public void unregisterListener(String listenerId) {
+        listeners.remove(listenerId);
+    }
+
+    private void notifyListeners() {
+        listeners.values().forEach(listener -> listener.accept(drainRequestedAt));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -66,6 +66,7 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
     protected TlsSession tlsSession;
     protected boolean ended;
     protected WebSocket webSocket;
+    protected long connectionTimestamp = -1;
 
     @Override
     public String id() {
@@ -328,5 +329,10 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
         }
 
         return this.messageFlow;
+    }
+
+    @Override
+    public long connectionTimestamp() {
+        return connectionTimestamp;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.reactive.core.context;
 
-import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
 import io.gravitee.gateway.reactive.api.message.Message;
 
@@ -68,4 +67,14 @@ public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<
      * @return {@link HttpRequestInternal}.
      */
     HttpRequestInternal remoteAddress(final String remoteAddress);
+
+    /**
+     * Returns the timestamp indicating when the underlying connection associated with this request was established.
+     * <p>
+     * Note that connections may be persistent and reused across multiple requests (e.g., in HTTP keep-alive scenarios),
+     * so this timestamp reflects the creation time of the connection itself—not the time when this specific request was received.
+     *
+     * @return the timestamp (in milliseconds since the epoch) when the connection was established.
+     */
+    long connectionTimestamp();
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/entrypoint/DefaultEntrypointConnectorResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/entrypoint/DefaultEntrypointConnectorResolver.java
@@ -22,34 +22,29 @@ import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.BaseEntrypointConnector;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.EntrypointConnector;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.EntrypointConnectorFactory;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.HttpEntrypointConnector;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.async.EntrypointAsyncConnector;
-import io.gravitee.gateway.reactive.api.connector.entrypoint.async.EntrypointAsyncConnectorFactory;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.async.HttpEntrypointAsyncConnector;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.async.HttpEntrypointAsyncConnectorFactory;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.qos.Qos;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 @SuppressWarnings("unchecked")
 public class DefaultEntrypointConnectorResolver extends AbstractService<DefaultEntrypointConnectorResolver> {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultEntrypointConnectorResolver.class);
+    @Getter
     private final List<BaseEntrypointConnector> entrypointConnectors;
 
     public DefaultEntrypointConnectorResolver(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/connection/DefaultConnectionDrainManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/connection/DefaultConnectionDrainManagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class DefaultConnectionDrainManagerTest {
+
+    DefaultConnectionDrainManager cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DefaultConnectionDrainManager();
+    }
+
+    @Test
+    void should_not_return_date_when_never_requested_connection_drain() {
+        assertThat(cut.drainRequestedAt()).isEqualTo(-1);
+    }
+
+    @Test
+    void should_change_date_when_request_connection_drain() {
+        long now = System.currentTimeMillis();
+        cut.requestDrain();
+        assertThat(cut.drainRequestedAt()).isBetween(now, System.currentTimeMillis());
+    }
+
+    @Test
+    void should_notify_listeners_when_request_connection_drain() {
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        cut.registerListener(aLong -> listenerCalled.set(true));
+
+        cut.requestDrain();
+        assertThat(listenerCalled.get()).isTrue();
+    }
+
+    @Test
+    void should_not_notify_unregistered_listener_when_request_connection_drain() {
+        AtomicInteger listener1CallCount = new AtomicInteger(0);
+        AtomicInteger listener2CallCount = new AtomicInteger(0);
+
+        String listener1Id = cut.registerListener(aLong -> listener1CallCount.incrementAndGet());
+        String listener2Id = cut.registerListener(aLong -> listener2CallCount.incrementAndGet());
+
+        cut.requestDrain();
+        cut.unregisterListener(listener1Id);
+        cut.requestDrain();
+        cut.unregisterListener(listener2Id);
+        cut.requestDrain();
+
+        assertThat(listener1CallCount.get()).isEqualTo(1);
+        assertThat(listener2CallCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_unregistered_listener_when_stopping_manager() {
+        AtomicInteger listener1CallCount = new AtomicInteger(0);
+        AtomicInteger listener2CallCount = new AtomicInteger(0);
+
+        cut.registerListener(aLong -> listener1CallCount.incrementAndGet());
+        cut.registerListener(aLong -> listener2CallCount.incrementAndGet());
+
+        cut.doStop();
+        cut.requestDrain();
+
+        assertThat(listener1CallCount.get()).isEqualTo(0);
+        assertThat(listener2CallCount.get()).isEqualTo(0);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -42,6 +42,7 @@ import io.gravitee.gateway.policy.impl.PolicyFactoryCreatorImpl;
 import io.gravitee.gateway.policy.impl.PolicyPluginFactoryImpl;
 import io.gravitee.gateway.reactive.core.condition.CompositeConditionFilter;
 import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.flow.condition.evaluation.HttpMethodConditionFilter;
 import io.gravitee.gateway.reactive.flow.condition.evaluation.PathBasedConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.processor.ApiProcessorChainFactory;
@@ -266,7 +267,8 @@ public class ApiHandlerConfiguration {
         @Autowired(required = false) List<InstrumenterTracerFactory> instrumenterTracerFactories,
         GatewayConfiguration gatewayConfiguration,
         DictionaryManager dictionaryManager,
-        LogGuardService logGuardService
+        LogGuardService logGuardService,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DefaultApiReactorFactory(
             applicationContext,
@@ -289,7 +291,8 @@ public class ApiHandlerConfiguration {
             instrumenterTracerFactories,
             gatewayConfiguration,
             dictionaryManager,
-            logGuardService
+            logGuardService,
+            connectionDrainManager
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -32,6 +32,7 @@ import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.policy.PolicyConfigurationFactory;
 import io.gravitee.gateway.reactive.core.condition.CompositeConditionFilter;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsUtils;
 import io.gravitee.gateway.reactive.core.v4.endpoint.DefaultEndpointManager;
@@ -43,7 +44,6 @@ import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFa
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.ApiProcessorChainFactory;
 import io.gravitee.gateway.reactive.platform.organization.policy.OrganizationPolicyChainFactoryManager;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChainFactory;
-import io.gravitee.gateway.reactive.policy.PolicyFactory;
 import io.gravitee.gateway.reactive.policy.PolicyFactoryManager;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
@@ -67,9 +67,7 @@ import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.plugin.policy.PolicyClassLoaderFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -99,8 +97,56 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
     protected final GatewayConfiguration gatewayConfiguration;
     protected final HttpAcceptorFactory httpAcceptorFactory;
     protected final LogGuardService logGuardService;
-    private final Logger logger = LoggerFactory.getLogger(DefaultApiReactorFactory.class);
+    private final ConnectionDrainManager connectionDrainManager;
 
+    public DefaultApiReactorFactory(
+        final ApplicationContext applicationContext,
+        final Configuration configuration,
+        final Node node,
+        final PolicyFactoryManager policyFactoryManager,
+        final EntrypointConnectorPluginManager entrypointConnectorPluginManager,
+        final EndpointConnectorPluginManager endpointConnectorPluginManager,
+        final ApiServicePluginManager apiServicePluginManager,
+        final OrganizationPolicyChainFactoryManager organizationPolicyChainFactoryManager,
+        final OrganizationManager organizationManager,
+        final io.gravitee.gateway.reactive.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory,
+        final RequestTimeoutConfiguration requestTimeoutConfiguration,
+        final ReporterService reporterService,
+        final AccessPointManager accessPointManager,
+        final EventManager eventManager,
+        final HttpAcceptorFactory httpAcceptorFactory,
+        final OpenTelemetryConfiguration openTelemetryConfiguration,
+        final OpenTelemetryFactory openTelemetryFactory,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final GatewayConfiguration gatewayConfiguration,
+        final DictionaryManager dictionaryManager,
+        final LogGuardService logGuardService,
+        final ConnectionDrainManager connectionDrainManager
+    ) {
+        super(applicationContext, policyFactoryManager, configuration, dictionaryManager);
+        this.node = node;
+        this.entrypointConnectorPluginManager = entrypointConnectorPluginManager;
+        this.endpointConnectorPluginManager = endpointConnectorPluginManager;
+        this.apiServicePluginManager = apiServicePluginManager;
+        this.organizationPolicyChainFactoryManager = organizationPolicyChainFactoryManager;
+        this.organizationManager = organizationManager;
+        this.accessPointManager = accessPointManager;
+        this.eventManager = eventManager;
+        this.httpAcceptorFactory = httpAcceptorFactory;
+        this.openTelemetryConfiguration = openTelemetryConfiguration;
+        this.gatewayConfiguration = gatewayConfiguration;
+        this.apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
+        this.flowResolverFactory = flowResolverFactory;
+        this.v4FlowResolverFactory = flowResolverFactory();
+        this.requestTimeoutConfiguration = requestTimeoutConfiguration;
+        this.reporterService = reporterService;
+        this.openTelemetryFactory = openTelemetryFactory;
+        this.instrumenterTracerFactories = instrumenterTracerFactories;
+        this.logGuardService = logGuardService;
+        this.connectionDrainManager = connectionDrainManager;
+    }
+
+    // FIXME: this constructor is here to keep compatibility with Message Reactor plugin. it will be deleted when Message Reactor has been updated
     public DefaultApiReactorFactory(
         final ApplicationContext applicationContext,
         final Configuration configuration,
@@ -124,72 +170,30 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         final DictionaryManager dictionaryManager,
         final LogGuardService logGuardService
     ) {
-        super(applicationContext, policyFactoryManager, configuration, dictionaryManager);
-        this.node = node;
-        this.entrypointConnectorPluginManager = entrypointConnectorPluginManager;
-        this.endpointConnectorPluginManager = endpointConnectorPluginManager;
-        this.apiServicePluginManager = apiServicePluginManager;
-        this.organizationPolicyChainFactoryManager = organizationPolicyChainFactoryManager;
-        this.organizationManager = organizationManager;
-        this.accessPointManager = accessPointManager;
-        this.eventManager = eventManager;
-        this.httpAcceptorFactory = httpAcceptorFactory;
-        this.openTelemetryConfiguration = openTelemetryConfiguration;
-        this.gatewayConfiguration = gatewayConfiguration;
-        this.apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
-        this.flowResolverFactory = flowResolverFactory;
-        this.v4FlowResolverFactory = flowResolverFactory();
-        this.requestTimeoutConfiguration = requestTimeoutConfiguration;
-        this.reporterService = reporterService;
-        this.openTelemetryFactory = openTelemetryFactory;
-        this.instrumenterTracerFactories = instrumenterTracerFactories;
-        this.logGuardService = logGuardService;
-    }
-
-    // FIXME: this constructor is here to keep compatibility with Message Reactor plugin. it will be deleted when Message Reactor has been updated
-    public DefaultApiReactorFactory(
-        final ApplicationContext applicationContext,
-        final Configuration configuration,
-        final Node node,
-        final PolicyFactory policyFactory,
-        final EntrypointConnectorPluginManager entrypointConnectorPluginManager,
-        final EndpointConnectorPluginManager endpointConnectorPluginManager,
-        final ApiServicePluginManager apiServicePluginManager,
-        final OrganizationPolicyChainFactoryManager organizationPolicyChainFactoryManager,
-        final OrganizationManager organizationManager,
-        final io.gravitee.gateway.reactive.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory,
-        final RequestTimeoutConfiguration requestTimeoutConfiguration,
-        final ReporterService reporterService,
-        final AccessPointManager accessPointManager,
-        final EventManager eventManager,
-        final HttpAcceptorFactory httpAcceptorFactory,
-        final OpenTelemetryConfiguration openTelemetryConfiguration,
-        final OpenTelemetryFactory openTelemetryFactory,
-        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
-        final GatewayConfiguration gatewayConfiguration,
-        final DictionaryManager dictionaryManager,
-        final LogGuardService logGuardService
-    ) {
-        super(applicationContext, new PolicyFactoryManager(new HashSet<>(Set.of(policyFactory))), configuration, dictionaryManager);
-        this.node = node;
-        this.entrypointConnectorPluginManager = entrypointConnectorPluginManager;
-        this.endpointConnectorPluginManager = endpointConnectorPluginManager;
-        this.apiServicePluginManager = apiServicePluginManager;
-        this.organizationPolicyChainFactoryManager = organizationPolicyChainFactoryManager;
-        this.organizationManager = organizationManager;
-        this.accessPointManager = accessPointManager;
-        this.eventManager = eventManager;
-        this.httpAcceptorFactory = httpAcceptorFactory;
-        this.openTelemetryConfiguration = openTelemetryConfiguration;
-        this.gatewayConfiguration = gatewayConfiguration;
-        this.apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
-        this.flowResolverFactory = flowResolverFactory;
-        this.v4FlowResolverFactory = flowResolverFactory();
-        this.requestTimeoutConfiguration = requestTimeoutConfiguration;
-        this.reporterService = reporterService;
-        this.openTelemetryFactory = openTelemetryFactory;
-        this.instrumenterTracerFactories = instrumenterTracerFactories;
-        this.logGuardService = logGuardService;
+        this(
+            applicationContext,
+            configuration,
+            node,
+            policyFactoryManager,
+            entrypointConnectorPluginManager,
+            endpointConnectorPluginManager,
+            apiServicePluginManager,
+            organizationPolicyChainFactoryManager,
+            organizationManager,
+            flowResolverFactory,
+            requestTimeoutConfiguration,
+            reporterService,
+            accessPointManager,
+            eventManager,
+            httpAcceptorFactory,
+            openTelemetryConfiguration,
+            openTelemetryFactory,
+            instrumenterTracerFactories,
+            gatewayConfiguration,
+            dictionaryManager,
+            logGuardService,
+            null
+        );
     }
 
     @SuppressWarnings("java:S1845")
@@ -300,6 +304,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         return new HttpPolicyChainFactory(api.getId(), policyManager, isApiTracingEnabled(api));
     }
 
+    // FIXME: this buildApiReactor is here to keep compatibility with Message Reactor plugin. it will be deleted when Message Reactor has been updated
     protected ApiReactor<Api> buildApiReactor(
         Api api,
         DefaultDeploymentContext deploymentContext,
@@ -311,6 +316,34 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         FlowChainFactory flowChainFactory,
         io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory,
         LogGuardService logGuardService
+    ) {
+        return buildApiReactor(
+            api,
+            deploymentContext,
+            componentProvider,
+            ctxTemplateVariableProviders,
+            policyManager,
+            endpointManager,
+            resourceLifecycleManager,
+            flowChainFactory,
+            v4FlowChainFactory,
+            logGuardService,
+            connectionDrainManager
+        );
+    }
+
+    protected ApiReactor<Api> buildApiReactor(
+        Api api,
+        DefaultDeploymentContext deploymentContext,
+        CompositeComponentProvider componentProvider,
+        List<TemplateVariableProvider> ctxTemplateVariableProviders,
+        PolicyManager policyManager,
+        DefaultEndpointManager endpointManager,
+        ResourceLifecycleManager resourceLifecycleManager,
+        FlowChainFactory flowChainFactory,
+        io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory,
+        LogGuardService logGuardService,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DefaultApiReactor(
             api,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -43,6 +43,8 @@ import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.policy.impl.PolicyLoader;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
+import io.gravitee.gateway.reactive.core.connection.DefaultConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.handlers.api.ApiPolicyManager;
 import io.gravitee.gateway.reactive.handlers.api.el.ApiTemplateVariableProvider;
@@ -155,8 +157,11 @@ class DefaultApiReactorFactoryTest {
     @Mock
     private LogGuardService logGuardService;
 
+    private ConnectionDrainManager connectionDrainManager;
+
     @BeforeEach
     void init() {
+        connectionDrainManager = new DefaultConnectionDrainManager();
         lenient().when(applicationContext.getBeanFactory()).thenReturn(applicationContextListable);
         lenient().when(policyFactoryManager.get(any())).thenReturn(policyFactory);
         cut =
@@ -181,7 +186,8 @@ class DefaultApiReactorFactoryTest {
                 List.of(),
                 gatewayConfiguration,
                 dictionaryManager,
-                logGuardService
+                logGuardService,
+                connectionDrainManager
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
@@ -31,7 +31,9 @@ import io.gravitee.gateway.reactive.core.BufferFlow;
 import io.gravitee.gateway.reactive.core.HttpTlsSession;
 import io.gravitee.gateway.reactive.core.context.AbstractRequest;
 import io.gravitee.gateway.reactive.http.vertx.ws.VertxWebSocket;
+import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.net.SocketAddress;
 import javax.net.ssl.SSLSession;
@@ -42,6 +44,7 @@ import javax.net.ssl.SSLSession;
  */
 public class VertxHttpServerRequest extends AbstractRequest {
 
+    public static final String NETTY_ATTR_CONNECTION_TIME = "connectionTime";
     protected final HttpServerRequest nativeRequest;
     private Boolean isWebSocket = null;
     private Boolean isStreaming = null;
@@ -60,6 +63,10 @@ public class VertxHttpServerRequest extends AbstractRequest {
         this.bufferFlow = new BufferFlow(nativeRequest.toFlowable().map(Buffer::buffer), this::isStreaming);
         this.messageFlow = null;
         this.options = options;
+        this.connectionTimestamp =
+            (Long) ((HttpServerConnection) nativeRequest.connection().getDelegate()).channel()
+                .attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))
+                .get();
     }
 
     public VertxHttpServerResponse response() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequestTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.http.vertx;
 
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,21 +35,23 @@ import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.gateway.reactive.api.ws.WebSocket;
 import io.gravitee.gateway.reactive.core.MessageFlow;
 import io.gravitee.gateway.reactive.core.context.OnMessagesInterceptor;
+import io.netty.channel.Channel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.vertx.core.http.impl.HttpServerConnection;
+import io.vertx.rxjava3.core.http.HttpConnection;
 import io.vertx.rxjava3.core.http.HttpHeaders;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -91,7 +94,23 @@ class VertxHttpServerRequestTest {
 
         when(httpServerRequest.headers()).thenReturn(HttpHeaders.headers());
         when(httpServerRequest.toFlowable()).thenReturn(chunks);
+
+        mockConnectionCreationTimestamp();
+
         cut = new VertxHttpServerRequest(httpServerRequest, idGenerator);
+    }
+
+    private void mockConnectionCreationTimestamp() {
+        HttpConnection httpConnection = mock(HttpConnection.class);
+        HttpServerConnection httpServerConnection = mock(HttpServerConnection.class);
+        Channel channel = mock(Channel.class);
+        Attribute attribute = mock(Attribute.class);
+
+        when(httpServerRequest.connection()).thenReturn(httpConnection);
+        when(httpConnection.getDelegate()).thenReturn(httpServerConnection);
+        when(httpServerConnection.channel()).thenReturn(channel);
+        when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
+        when(attribute.get()).thenReturn(System.currentTimeMillis());
     }
 
     @Nested
@@ -376,6 +395,8 @@ class VertxHttpServerRequestTest {
             reset(httpServerRequest);
             lenient().when(httpServerRequest.headers()).thenReturn(HttpHeaders.headers());
             lenient().when(httpServerRequest.toFlowable()).thenReturn(Flowable.empty());
+
+            mockConnectionCreationTimestamp();
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactory.java
@@ -16,7 +16,9 @@
 package io.gravitee.gateway.reactive.reactor.processor;
 
 import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.gateway.reactive.reactor.processor.connection.ConnectionDrainProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.forward.XForwardForProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.metrics.MetricsProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.tracing.TraceContextProcessor;
@@ -37,6 +39,7 @@ public class DefaultPlatformProcessorChainFactory extends AbstractPlatformProces
     private final boolean xForwardProcessor;
     private final boolean traceContext;
     private final GatewayConfiguration gatewayConfiguration;
+    private final ConnectionDrainManager connectionDrainManager;
 
     public DefaultPlatformProcessorChainFactory(
         TransactionPreProcessorFactory transactionHandlerFactory,
@@ -47,17 +50,20 @@ public class DefaultPlatformProcessorChainFactory extends AbstractPlatformProces
         Node node,
         String port,
         boolean tracing,
-        GatewayConfiguration gatewayConfiguration
+        GatewayConfiguration gatewayConfiguration,
+        ConnectionDrainManager connectionDrainManager
     ) {
         super(transactionHandlerFactory, reporterService, eventProducer, node, port, tracing);
         this.traceContext = traceContext;
         this.xForwardProcessor = xForwardProcessor;
         this.gatewayConfiguration = gatewayConfiguration;
+        this.connectionDrainManager = connectionDrainManager;
     }
 
     @Override
     protected List<Processor> buildPreProcessorList() {
         List<Processor> preProcessorList = new ArrayList<>();
+        preProcessorList.add(new ConnectionDrainProcessor(connectionDrainManager));
         preProcessorList.add(transactionHandlerFactory.create());
         preProcessorList.add(new MetricsProcessor(gatewayConfiguration));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/connection/ConnectionDrainProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/connection/ConnectionDrainProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.processor.connection;
+
+import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.reactivex.rxjava3.core.Completable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class ConnectionDrainProcessor implements Processor {
+
+    private SimpleDateFormat sdf;
+
+    public static final String ID = "processor-connection-drain";
+    private final ConnectionDrainManager connectionDrainManager;
+
+    public ConnectionDrainProcessor(ConnectionDrainManager connectionDrainManager) {
+        this.connectionDrainManager = connectionDrainManager;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Completable execute(final HttpExecutionContextInternal ctx) {
+        if (ctx.request().connectionTimestamp() <= connectionDrainManager.drainRequestedAt()) {
+            return Completable.fromRunnable(() -> {
+                if (log.isDebugEnabled()) {
+                    if (sdf == null) {
+                        sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+                    }
+                    log.debug(
+                        "Drain connection started at {} ({})",
+                        sdf.format(new Date(ctx.request().connectionTimestamp())),
+                        ctx.request().version().name()
+                    );
+                }
+                if (ctx.request().version() == HttpVersion.HTTP_2) {
+                    ctx.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_GO_AWAY);
+                } else {
+                    ctx.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+                }
+            });
+        }
+
+        // No flush requested or connection created way after the flush has been requested.
+        return Completable.complete();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -27,6 +27,8 @@ import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
+import io.gravitee.gateway.reactive.core.connection.DefaultConnectionDrainManager;
 import io.gravitee.gateway.reactive.reactor.DefaultHttpRequestDispatcher;
 import io.gravitee.gateway.reactive.reactor.DefaultTcpSocketDispatcher;
 import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
@@ -135,7 +137,8 @@ public class ReactorConfiguration {
         Node node,
         @Value("${http.port:8082}") String httpPort,
         OpenTelemetryConfiguration openTelemetryConfiguration,
-        GatewayConfiguration gatewayConfiguration
+        GatewayConfiguration gatewayConfiguration,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DefaultPlatformProcessorChainFactory(
             transactionHandlerFactory,
@@ -146,7 +149,8 @@ public class ReactorConfiguration {
             node,
             httpPort,
             openTelemetryConfiguration.isTracesEnabled(),
-            gatewayConfiguration
+            gatewayConfiguration,
+            connectionDrainManager
         );
     }
 
@@ -278,5 +282,10 @@ public class ReactorConfiguration {
     @Bean
     public HttpAcceptorFactory httpAcceptorFactory(GatewayConfiguration gatewayConfiguration) {
         return new HttpAcceptorFactory(gatewayConfiguration.allowOverlappingApiContexts());
+    }
+
+    @Bean
+    public ConnectionDrainManager connectionDrainManager() {
+        return new DefaultConnectionDrainManager();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.reactor;
 
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -55,6 +57,9 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
+import io.netty.channel.Channel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -63,7 +68,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.http.HttpConnection;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
 import java.util.List;
@@ -189,6 +196,8 @@ class DefaultHttpRequestDispatcherTest {
         lenient().when(requestTimeoutConfiguration.getRequestTimeout()).thenReturn(0L);
         lenient().when(requestTimeoutConfiguration.getRequestTimeoutGraceDelay()).thenReturn(10L);
 
+        mockConnectionCreationTimestamp();
+
         spyNoopTracer = spy(new NoOpTracer());
         tracingContext = new TracingContext(spyNoopTracer, true, false);
         cut =
@@ -208,6 +217,19 @@ class DefaultHttpRequestDispatcherTest {
             );
         //TODO: to check: is this needed ?
         // cut.setApplicationContext(mock(ApplicationContext.class));
+    }
+
+    private void mockConnectionCreationTimestamp() {
+        HttpConnection httpConnection = mock(HttpConnection.class);
+        HttpServerConnection httpServerConnection = mock(HttpServerConnection.class);
+        Channel channel = mock(Channel.class);
+        Attribute attribute = mock(Attribute.class);
+
+        lenient().when(rxRequest.connection()).thenReturn(httpConnection);
+        lenient().when(httpConnection.getDelegate()).thenReturn(httpServerConnection);
+        lenient().when(httpServerConnection.channel()).thenReturn(channel);
+        lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
+        lenient().when(attribute.get()).thenReturn(System.currentTimeMillis());
     }
 
     @Nested
@@ -294,6 +316,7 @@ class DefaultHttpRequestDispatcherTest {
             when(httpAcceptorResolver.resolve(HOST, PATH, SERVER_ID)).thenReturn(handlerEntrypoint);
             when(handlerEntrypoint.reactor()).thenReturn(apiReactor);
             when(apiReactor.tracingContext()).thenReturn(tracingContext);
+            mockConnectionCreationTimestamp();
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/connection/ConnectionDrainProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/connection/ConnectionDrainProcessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.processor.connection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.reactive.core.connection.DefaultConnectionDrainManager;
+import io.gravitee.gateway.reactive.reactor.processor.AbstractProcessorTest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ConnectionDrainProcessorTest extends AbstractProcessorTest {
+
+    DefaultConnectionDrainManager connectionDrainManager;
+
+    ConnectionDrainProcessor cut;
+
+    @BeforeEach
+    void setUp() {
+        connectionDrainManager = new DefaultConnectionDrainManager();
+        cut = new ConnectionDrainProcessor(connectionDrainManager);
+    }
+
+    @Test
+    void should_not_drain_connection_when_no_drain_requested() {
+        cut.execute(ctx).test().assertComplete();
+        verifyNoInteractions(mockResponse);
+    }
+
+    @Test
+    void should_not_drain_connection_when_connection_created_after_drain_request() {
+        connectionDrainManager.requestDrain();
+        when(mockRequest.connectionTimestamp()).thenReturn(System.currentTimeMillis() + 1000);
+
+        cut.execute(ctx).test().assertComplete();
+        verifyNoInteractions(mockResponse);
+    }
+
+    @Test
+    void should_add_connection_close_response_header_when_draining_http1() {
+        when(mockRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        when(mockRequest.connectionTimestamp()).thenReturn(System.currentTimeMillis() - 1000);
+        connectionDrainManager.requestDrain();
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
+    }
+
+    @Test
+    void should_add_connection_close_response_header_when_draining_http2() {
+        when(mockRequest.version()).thenReturn(HttpVersion.HTTP_2);
+        when(mockRequest.connectionTimestamp()).thenReturn(System.currentTimeMillis() - 1000);
+        connectionDrainManager.requestDrain();
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_GO_AWAY);
+    }
+
+    @Test
+    void should_return_processor_id() {
+        assertThat(cut.getId()).isEqualTo("processor-connection-drain");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -49,6 +49,7 @@ import io.gravitee.gateway.policy.ConfigurablePolicyChainProvider;
 import io.gravitee.gateway.policy.PolicyChainProviderLoader;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
 import io.gravitee.gateway.policy.impl.PolicyFactoryCreatorImpl;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.debug.DebugReactorEventListener;
 import io.gravitee.gateway.reactive.debug.handlers.api.v4.DebugV4ApiReactorHandlerFactory;
 import io.gravitee.gateway.reactive.debug.policy.condition.DebugExpressionLanguageConditionFilter;
@@ -353,7 +354,8 @@ public class DebugConfiguration {
         @Value("${debug.http.port:8482}") String httpPort,
         GatewayConfiguration gatewayConfiguration,
         EventRepository eventRepository,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DebugPlatformProcessorChainFactory(
             transactionHandlerFactory,
@@ -366,7 +368,8 @@ public class DebugConfiguration {
             false,
             gatewayConfiguration,
             eventRepository,
-            objectMapper
+            objectMapper,
+            connectionDrainManager
         );
     }
 
@@ -446,7 +449,8 @@ public class DebugConfiguration {
         AccessPointManager accessPointManager,
         EventManager eventManager,
         GatewayConfiguration gatewayConfiguration,
-        final DictionaryManager dictionaryManager
+        final DictionaryManager dictionaryManager,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DebugV4ApiReactorHandlerFactory(
             applicationContext.getParent(),
@@ -465,7 +469,8 @@ public class DebugConfiguration {
             eventManager,
             new HttpAcceptorFactory(false),
             gatewayConfiguration,
-            dictionaryManager
+            dictionaryManager,
+            connectionDrainManager
         );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
 import io.gravitee.gateway.reactive.core.v4.endpoint.DefaultEndpointManager;
 import io.gravitee.gateway.reactive.debug.handlers.api.DebugV4ApiReactor;
@@ -69,7 +70,8 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
         final EventManager eventManager,
         final HttpAcceptorFactory httpAcceptorFactory,
         final GatewayConfiguration gatewayConfiguration,
-        final DictionaryManager dictionaryManager
+        final DictionaryManager dictionaryManager,
+        final ConnectionDrainManager connectionDrainManager
     ) {
         super(
             applicationContext,
@@ -92,7 +94,8 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
             null,
             gatewayConfiguration,
             dictionaryManager,
-            null
+            null,
+            connectionDrainManager
         );
     }
 
@@ -117,7 +120,8 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
         ResourceLifecycleManager resourceLifecycleManager,
         FlowChainFactory flowChainFactory,
         io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory,
-        LogGuardService logGuardService
+        LogGuardService logGuardService,
+        ConnectionDrainManager connectionDrainManager
     ) {
         return new DebugV4ApiReactor(
             api,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugPlatformProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugPlatformProcessorChainFactory.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.debug.reactor.processor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.reactor.processor.DefaultPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
@@ -46,7 +47,8 @@ public class DebugPlatformProcessorChainFactory extends DefaultPlatformProcessor
         final boolean tracing,
         final GatewayConfiguration gatewayConfiguration,
         final EventRepository eventRepository,
-        final ObjectMapper objectMapper
+        final ObjectMapper objectMapper,
+        final ConnectionDrainManager connectionDrainManager
     ) {
         super(
             transactionHandlerFactory,
@@ -57,7 +59,8 @@ public class DebugPlatformProcessorChainFactory extends DefaultPlatformProcessor
             node,
             port,
             tracing,
-            gatewayConfiguration
+            gatewayConfiguration,
+            connectionDrainManager
         );
         this.eventRepository = eventRepository;
         this.objectMapper = objectMapper;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -15,14 +15,18 @@
  */
 package io.gravitee.gateway.reactive.standalone.vertx;
 
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
 import io.gravitee.node.api.server.ServerManager;
 import io.gravitee.node.vertx.server.http.VertxHttpServer;
+import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.AbstractVerticle;
 import io.vertx.rxjava3.core.RxHelper;
 import io.vertx.rxjava3.core.http.HttpServer;
@@ -79,6 +83,10 @@ public class HttpProtocolVerticle extends AbstractVerticle {
 
                 // Listen and dispatch http requests.
                 return rxHttpServer
+                    .connectionHandler(connection -> {
+                        HttpServerConnection delegate = (HttpServerConnection) connection.getDelegate();
+                        delegate.channel().attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME)).set(System.currentTimeMillis());
+                    })
                     .requestHandler(request -> dispatchRequest(request, gioServer.id()))
                     .rxListen()
                     .ignoreElement()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tcp/src/main/java/io/gravitee/gateway/reactive/tcp/VertxTcpRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tcp/src/main/java/io/gravitee/gateway/reactive/tcp/VertxTcpRequest.java
@@ -70,6 +70,7 @@ public class VertxTcpRequest extends AbstractRequest {
         this.tlsSession = new DefaultTlsSession(this.sslSession);
         this.parameters = new LinkedMultiValueMap<>();
         this.pathParameters = new LinkedMultiValueMap<>();
+        this.connectionTimestamp = System.currentTimeMillis();
     }
 
     @Override

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -159,7 +159,8 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             "RESPONSE flow (api-flow-1)",
             "RESPONSE policy-latency",
             "RESPONSE Processor (processor-reporter)",
-            "RESPONSE Processor (processor-response-time)"
+            "RESPONSE Processor (processor-response-time)",
+            "REQUEST Processor (processor-connection-drain)"
         );
 
         await()
@@ -227,7 +228,8 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             "message (0)",
             "policy-message-flow-ready",
             "RESPONSE Processor (processor-response-time)",
-            "RESPONSE Processor (processor-reporter)"
+            "RESPONSE Processor (processor-reporter)",
+            "REQUEST Processor (processor-connection-drain)"
         );
         await()
             .atMost(30, SECONDS)
@@ -266,7 +268,6 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
 
         var trace = data.getJsonObject(0);
         var spans = trace.getJsonArray("spans");
-        assertThat(spans).hasSameSizeAs(expectedOperationName);
 
         String[] operationNames = spans
             .stream()

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
         <gravitee-exchange.version>1.9.0</gravitee-exchange.version>
         <gravitee-expression-language.version>4.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>4.0.0-alpha.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>4.0.0-alpha.3</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
-        <gravitee-kubernetes.version>3.6.1</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>3.7.0</gravitee-kubernetes.version>
         <gravitee-node.version>7.11.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-527

## Description

This is a first PR to support connection draining. It allows for a graceful close of the connections that are currently open on the gateway (e.g., the client is asked to close the connection on his side).

## Additional information

To ensure nothing breaks on the reactor plugin and allow proper building, I left some FIXME, and I plan to add integration tests in a second step (there is a circular dependency between APIM and the reactors due to integration tests + distribution build).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fjszonlbnb.chromatic.com)
<!-- Storybook placeholder end -->
