### PR TITLE
fix: allow application names up to 512 chars to match backend

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -23,7 +23,7 @@
           <div class="details-card__header__info-inputs__first-row">
             <mat-form-field class="details-card__header__info-inputs__first-row__name-field">
               <mat-label>Application name</mat-label>
-              <input formControlName="name" matInput type="text" maxlength="50" required />
+              <input formControlName="name" matInput type="text" maxlength="512" required />
               <mat-error *ngIf="applicationForm.get('details.name').hasError('required')">Application name is required. </mat-error>
             </mat-form-field>
           </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10879

## Description

Previously, applications with names >50 chars could be created but not updated via the UI due to a frontend validation limit. The backend (mAPI) allows names up to 512 chars (matching the DB column). This change updates the UI to allow up to 512 characters for both create and update, ensuring consistent behavior between UI and API.

Issue -

<img width="1064" height="823" alt="APIM_10879" src="https://github.com/user-attachments/assets/32fc4a2a-ae5f-41d1-b519-14c83ef1665b" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xaqfreoenp.chromatic.com)
<!-- Storybook placeholder end -->
