### PR TITLE
fix: make the Primary Owner group field selectable during v2 API creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1-component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1-component.spec.ts
@@ -98,4 +98,18 @@ describe('ApiCreationStep1Component Scroll Events', () => {
     expect(instance.scrollListener).toBeNull();
     expect(instance.scrollContainer).toBeNull();
   });
+
+  it('should set useGroupAsPrimaryOwner to true if isGroupOnly returns true', () => {
+    const ctrl = new ControllerClass({ isHybrid: () => false, isGroupOnly: () => true });
+    expect(ctrl.useGroupAsPrimaryOwner).toBe(false); // default
+    ctrl.$onInit();
+    expect(ctrl.useGroupAsPrimaryOwner).toBe(true); // should be enabled
+  });
+
+  it('should keep useGroupAsPrimaryOwner false if isGroupOnly returns false', () => {
+    const ctrl = new ControllerClass({ isHybrid: () => false, isGroupOnly: () => false });
+    expect(ctrl.useGroupAsPrimaryOwner).toBe(false); // default
+    ctrl.$onInit();
+    expect(ctrl.useGroupAsPrimaryOwner).toBe(false); // should remain false
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.component.ts
@@ -34,9 +34,16 @@ const ApiCreationStep1Component: ng.IComponentOptions = {
       private isLoading = false; // to prevent repititive call at once
       private hasLoadedOnce = false;
       public hasMoreGroups = true;
+      public useGroupAsPrimaryOwner = false;
 
       constructor(private ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService) {
         this.advancedMode = false;
+      }
+
+      $onInit() {
+        if (this.ApiPrimaryOwnerModeService.isGroupOnly()) {
+          this.useGroupAsPrimaryOwner = true; // auto-enable select for group-only mode
+        }
       }
 
       toggleAdvancedMode = () => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10882

## Description

The Primary Owner group dropdown was inaccessible, preventing v2 API creation. This fix ensures the field is enabled when API Primary Owner mode is set to Group and groups are available for selection.

Issue:

https://github.com/user-attachments/assets/13426cca-c60f-4297-a1b1-69a26c1c54f3


Fix:


https://github.com/user-attachments/assets/5ef55f44-de1d-4c70-af46-375d8c5a7bb9




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ggicnvmlvu.chromatic.com)
<!-- Storybook placeholder end -->
