### PR TITLE
chore(deps): bump gravitee-inference related dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,12 @@
         <gravitee-resource-auth-provider-ldap.version>2.0.0</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>4.0.1</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
-        <gravitee-resource-ai-model-text-classification.version>2.1.0</gravitee-resource-ai-model-text-classification.version>
+        <gravitee-resource-ai-model-text-classification.version>2.2.0</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
-        <gravitee-inference-service.version>1.2.0</gravitee-inference-service.version>
+        <gravitee-inference-service.version>1.3.3</gravitee-inference-service.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>
         <gravitee-policy-ai-prompt-token-tracking.version>1.0.1</gravitee-policy-ai-prompt-token-tracking.version>
-        <gravitee-policy-ai-prompt-guard-rails.version>2.0.0</gravitee-policy-ai-prompt-guard-rails.version>
+        <gravitee-policy-ai-prompt-guard-rails.version>2.0.1</gravitee-policy-ai-prompt-guard-rails.version>
 
         <!-- Enterprise plugins -->
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>


### PR DESCRIPTION
## Description

This PR bumps dependencies of various gravitee-inference related topics:
- Improve classifier performance https://github.com/gravitee-io/gravitee-inference/pull/23
- Introduce remote model calling https://github.com/gravitee-io/gravitee-inference/pull/22

## Additional context

Other related PRs:
- Inference service https://github.com/gravitee-io/gravitee-inference-service/pull/21
- Ai model Text classification: https://github.com/gravitee-io/gravitee-resource-ai-model-text-classification/pull/25
- Prompt Guard Rails: https://github.com/gravitee-io/gravitee-policy-ai-prompt-guard-rails/pull/19
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xphafesrgh.chromatic.com)
<!-- Storybook placeholder end -->
