### PR TITLE
Optimization: Audit History Groups Fetch Timeout (v2)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResource.java
@@ -66,7 +66,7 @@ public class GroupsResource extends AbstractResource {
     @Inject
     private SearchGroupsUseCase searchGroupsUseCase;
 
-    private final GroupMapper mapper = GroupMapper.INSTANCE;
+    private static final GroupMapper MAPPER = GroupMapper.INSTANCE;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -77,7 +77,7 @@ public class GroupsResource extends AbstractResource {
         List<GroupEntity> groupsSubset = computePaginationData(groups, paginationParam);
 
         return new GroupsResponse()
-            .data(mapper.map(groupsSubset))
+            .data(MAPPER.map(groupsSubset))
             .pagination(PaginationInfo.computePaginationInfo(groups.size(), groupsSubset.size(), paginationParam))
             .links(computePaginationLinks(groups.size(), paginationParam));
     }
@@ -95,7 +95,7 @@ public class GroupsResource extends AbstractResource {
         io.gravitee.rest.api.management.v2.rest.model.Links links = computePaginationLinks(pagedGroups.getTotalElements(), paginationParam);
 
         return new GroupsResponse()
-            .data(mapper.mapFromCoreList(pagedGroups.getContent()))
+            .data(MAPPER.mapFromCoreList(pagedGroups.getContent()))
             .pagination(PaginationInfo.computePaginationInfo(pagedGroups.getPageElements(), paginationParam.getPerPage(), paginationParam))
             .links(links);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -122,12 +122,10 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
                 .isEqualTo(
-                    GroupsResponse
-                        .builder()
+                    new GroupsResponse()
                         .data(List.of())
-                        .pagination(Pagination.builder().build())
-                        .links(Links.builder().self(paginatedTarget.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination())
+                        .links(new Links().self(paginatedTarget.getUri().toString()))
                 );
         }
 
@@ -180,12 +178,10 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
                 .isEqualTo(
-                    GroupsResponse
-                        .builder()
+                    new GroupsResponse()
                         .data(Stream.of(group1, group2).map(GroupMapper.INSTANCE::map).toList())
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .pagination(new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L))
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
     }
@@ -259,13 +255,11 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().build())
+                    new MembersResponse()
+                        .pagination(new Pagination())
                         .data(List.of())
                         .metadata(Map.of("groupName", GROUP_NAME))
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
 
@@ -283,13 +277,11 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(MembersResponse.class)
                 .isEqualTo(
-                    MembersResponse
-                        .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2L).build())
+                    new MembersResponse()
+                        .pagination(new Pagination().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2L))
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .metadata(Map.of("groupName", GROUP_NAME))
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                        .links(new Links().self(target.getUri().toString()))
                 );
         }
     }
@@ -329,12 +321,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
                 .isEqualTo(
-                    GroupsResponse
-                        .builder()
-                        .data(List.of())
-                        .pagination(Pagination.builder().build())
-                        .links(Links.builder().self(target.getUri().toString()).build())
-                        .build()
+                    new GroupsResponse().data(List.of()).pagination(new Pagination()).links(new Links().self(target.getUri().toString()))
                 );
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10310

## Description

Calls to the groups endpoint (outside the Groups page) time out when many groups exist, causing failure on the Audit History page.

Expected: Groups endpoint responds successfully.

Current: Group Endpoint times out on history page.

## Additional context

**Steps to Reproduce:**

1. Create a large number of groups.
2. Open an API’s Audit History page -> request to /management/v2/environments/DEFAULT/groups?page=1&perPage=99999 times out.

Proof screenshot:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/6ec91125-8d26-44df-bd97-f6102b255aa5" />

Proof video:

https://github.com/user-attachments/assets/6094c08f-fcce-4a78-9718-f13987f68165