### PR TITLE
fix: http client options are migrated with required fields based on the http protocol version

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ServiceMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ServiceMapper.java
@@ -145,7 +145,7 @@ public final class ServiceMapper {
     }
 
     private static MigrationResult<Service> mapServiceDiscovery(EndpointDiscoveryService discoveryService) {
-        if (discoveryService == null) {
+        if (discoveryService == null || discoveryService.getProvider() == null) {
             return MigrationResult.value(new Service());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMapper.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.definition.model.HttpClientSslOptions;
+import io.gravitee.definition.model.v4.ssl.KeyStore;
+import io.gravitee.definition.model.v4.ssl.SslOptions;
+import io.gravitee.definition.model.v4.ssl.TrustStore;
+import java.util.Set;
+
+public class SharedConfigurationMapper {
+
+    private static final Set<String> HTTP11_ALLOWED = Set.of(
+        "version",
+        "keepAlive",
+        "keepAliveTimeout",
+        "connectTimeout",
+        "pipelining",
+        "readTimeout",
+        "useCompression",
+        "propagateClientAcceptEncoding",
+        "propagateClientHost",
+        "idleTimeout",
+        "followRedirects",
+        "maxConcurrentConnections"
+    );
+
+    private static final Set<String> HTTP2_ALLOWED = Set.of(
+        "version",
+        "clearTextUpgrade",
+        "keepAlive",
+        "keepAliveTimeout",
+        "connectTimeout",
+        "pipelining",
+        "readTimeout",
+        "useCompression",
+        "propagateClientAcceptEncoding",
+        "propagateClientHost",
+        "idleTimeout",
+        "followRedirects",
+        "maxConcurrentConnections",
+        "http2MultiplexingLimit"
+    );
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SharedConfigurationMapper() {}
+
+    public static String convert(io.gravitee.definition.model.EndpointGroup source) throws JsonProcessingException {
+        ObjectNode httpClientOptions = mapHttpClientOptions(source.getHttpClientOptions());
+        ObjectNode httpClientSslOptionsNode = mapHttpClientSslOptions(source.getHttpClientSslOptions());
+        ObjectNode sharedConfiguration = OBJECT_MAPPER.createObjectNode();
+        sharedConfiguration.set("http", httpClientOptions);
+        sharedConfiguration.set("ssl", httpClientSslOptionsNode);
+        sharedConfiguration.set("headers", source.getHeaders() == null ? null : OBJECT_MAPPER.valueToTree(source.getHeaders()));
+        sharedConfiguration.set("proxy", source.getHttpProxy() == null ? null : OBJECT_MAPPER.valueToTree((source.getHttpProxy())));
+        return OBJECT_MAPPER.writeValueAsString(sharedConfiguration);
+    }
+
+    private static ObjectNode mapHttpClientOptions(io.gravitee.definition.model.HttpClientOptions httpClientOptions) {
+        if (httpClientOptions == null) {
+            return null;
+        }
+
+        var v4 = new io.gravitee.definition.model.v4.http.HttpClientOptions();
+
+        var versionV4 = httpClientOptions.getVersion().equals(io.gravitee.definition.model.ProtocolVersion.HTTP_1_1)
+            ? io.gravitee.definition.model.v4.http.ProtocolVersion.HTTP_1_1
+            : io.gravitee.definition.model.v4.http.ProtocolVersion.HTTP_2;
+
+        v4.setVersion(versionV4);
+        v4.setKeepAlive(httpClientOptions.isKeepAlive());
+        v4.setPipelining(httpClientOptions.isPipelining());
+        v4.setUseCompression(httpClientOptions.isUseCompression());
+        v4.setPropagateClientAcceptEncoding(httpClientOptions.isPropagateClientAcceptEncoding());
+        v4.setFollowRedirects(httpClientOptions.isFollowRedirects());
+        v4.setMaxConcurrentConnections(httpClientOptions.getMaxConcurrentConnections());
+        v4.setIdleTimeout(httpClientOptions.getIdleTimeout());
+        v4.setKeepAliveTimeout(httpClientOptions.getKeepAliveTimeout());
+        v4.setConnectTimeout(httpClientOptions.getConnectTimeout());
+        v4.setReadTimeout(httpClientOptions.getReadTimeout());
+
+        if (versionV4 == io.gravitee.definition.model.v4.http.ProtocolVersion.HTTP_2) {
+            v4.setClearTextUpgrade(httpClientOptions.isClearTextUpgrade());
+        }
+
+        ObjectNode node = OBJECT_MAPPER.valueToTree(v4);
+
+        if (versionV4 == io.gravitee.definition.model.v4.http.ProtocolVersion.HTTP_1_1) {
+            node.retain(HTTP11_ALLOWED);
+        } else {
+            node.retain(HTTP2_ALLOWED);
+        }
+
+        return node;
+    }
+
+    private static ObjectNode mapHttpClientSslOptions(HttpClientSslOptions httpClientSslOptions) {
+        if (httpClientSslOptions == null) {
+            return null;
+        }
+        SslOptions sslOptionsV4 = new SslOptions();
+        sslOptionsV4.setHostnameVerifier(httpClientSslOptions.isHostnameVerifier());
+        sslOptionsV4.setTrustAll(httpClientSslOptions.isTrustAll());
+        TrustStore trustStoreV4 = httpClientSslOptions.getTrustStore() != null
+            ? TrustStoreMapper.convert(httpClientSslOptions.getTrustStore())
+            : null;
+        sslOptionsV4.setTrustStore(trustStoreV4);
+        KeyStore keyStoreV4 = httpClientSslOptions.getKeyStore() != null
+            ? KeyStoreMapper.convert(httpClientSslOptions.getKeyStore())
+            : null;
+        sslOptionsV4.setKeyStore(keyStoreV4);
+
+        return OBJECT_MAPPER.valueToTree(sslOptionsV4);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -451,7 +451,7 @@ class V2ToV4MigrationOperatorTest {
             // Check Endpoint Group
             var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
             String configJson =
-                "{\"http\":{\"http2MultiplexingLimit\":-1,\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"clearTextUpgrade\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
             assertSoftly(softly -> {
                 softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
                 softly.assertThat(group.getName()).isEqualTo("default-group");
@@ -487,7 +487,7 @@ class V2ToV4MigrationOperatorTest {
             v2Endpoint2.setWeight(5);
             v2Endpoint2.setInherit(false);
             String configJsonForEndpoint =
-                "{\"http\":{\"http2MultiplexingLimit\":-1,\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"clearTextUpgrade\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}],\"proxy\":null}";
             v2Endpoint2.setConfiguration(configJsonForEndpoint);
             // Setup EndpointGroup
             EndpointGroup v2Group = new EndpointGroup();
@@ -564,7 +564,7 @@ class V2ToV4MigrationOperatorTest {
             // Check Endpoint Group
             var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
             String configJson =
-                "{\"http\":{\"http2MultiplexingLimit\":-1,\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"clearTextUpgrade\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
             assertSoftly(softly -> {
                 softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
                 softly.assertThat(group.getName()).isEqualTo("default-group");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10942

## Description

When migrating APIs, the `HttpClientOptions` object was serialized with **all fields present**, regardless of the selected protocol version.  

As a result, for APIs configured with **HTTP/1.1**, the migrated JSON object incorrectly contained fields that are only valid for **HTTP/2**. Since the [JSON Schema](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json) enforces a strict `oneOf` validation with `additionalProperties: false`, this caused validation errors during API updates/edits.  

Specifically, the `http-proxy` plugin validation rejected the configuration, making the API uneditable after migration.

The migration logic was updated to **trim the serialized HTTP client configuration** and only include the fields that are valid for the given protocol version:

- For **HTTP/1.1**, HTTP/2-only fields such as `http2MultiplexingLimit` and `clearTextUpgrade` are removed.  
- For **HTTP/2**, all relevant HTTP/2 fields are retained.  

This ensures that the migrated configuration strictly complies with the JSON Schema and passes validation during API updates.  

## Additional Info

- I also extracted parts of the migration logic responsible for SharedConfiguration to a separate class 
- Add a small null check to fix the discovery provider migration when it was first enabled and then disabled 