### PR TITLE
fix(mcp): null & blank check for acceptHeader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <gravitee-entrypoint-webhook.version>4.1.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
-        <gravitee-entrypoint-mcp.version>1.0.2</gravitee-entrypoint-mcp.version>
+        <gravitee-entrypoint-mcp.version>1.0.3</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-kafka.version>4.0.6</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>


### PR DESCRIPTION
Main PR (gravitee-entrypoint-mcp):  https://github.com/gravitee-io/gravitee-entrypoint-mcp/pull/12

**Issue**

https://gravitee.atlassian.net/browse/APIM-10173

**Description**

When an API has the MCP entrypoint enabled, debug mode throws an error if the Accept header is not present. Because of error, "Cannot invoke "String.contains(java.lang.CharSequence)" because "acceptHeader" is null".

So added a null check.

**Additional context**

for mcp-enabled-api 

Before : 

https://github.com/user-attachments/assets/f20fdbc0-686b-4724-bf76-c5e2c1df444b

After fix:

https://github.com/user-attachments/assets/f62ad6c9-0c7d-4d72-b0ca-d6541195e0a9

For Non mcp-enabled-apis
its working fine 

https://github.com/user-attachments/assets/560fbf9e-7cc7-4145-9ac7-c6aabdf7aade


Tested on local with the steps mentioned in https://gravitee.atlassian.net/browse/APIM-9884
Video : 

https://github.com/user-attachments/assets/8044a8ac-1744-4f33-9b6c-215650c57536





<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qkzanphkxv.chromatic.com)
<!-- Storybook placeholder end -->
