### PR TITLE
fix: manage index upgraders with dedicated mongo client to handle lar…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.repository.mongodb.management;
 
+import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import io.gravitee.platform.repository.api.Scope;
 import io.gravitee.repository.mongodb.common.AbstractRepositoryConfiguration;
 import io.gravitee.repository.mongodb.common.MongoFactory;
 import io.gravitee.repository.mongodb.encryption.EncryptionConfiguration;
 import io.gravitee.repository.mongodb.management.converters.BsonUndefinedToNullReadingConverter;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -28,10 +30,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 /**
@@ -72,10 +77,25 @@ public class ManagementRepositoryConfiguration extends AbstractRepositoryConfigu
         }
     }
 
+    @Primary
     @Bean(name = "managementMongoTemplate")
     public MongoOperations mongoOperations(MongoClient mongo) {
         try {
             return new MongoTemplate(mongo, getDatabaseName());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Bean(name = "indexManagementReactiveMongoTemplate")
+    public ReactiveMongoOperations indexReactiveMongoOperations() {
+        try {
+            MongoClientSettings build = MongoClientSettings
+                .builder(mongoFactory.buildMongoClientSettings(true))
+                .applyToSocketSettings(b -> b.connectTimeout(1, TimeUnit.HOURS).readTimeout(1, TimeUnit.HOURS)) // long window for slow index builds
+                .applyToConnectionPoolSettings(b -> b.maxSize(5).minSize(0))
+                .build();
+            return new ReactiveMongoTemplate(com.mongodb.reactivestreams.client.MongoClients.create(build), getDatabaseName());
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/IndexMongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/IndexMongoUpgrader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.common;
+
+import com.mongodb.reactivestreams.client.MongoCollection;
+import io.gravitee.node.api.upgrader.Upgrader;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author GraviteeSource Team
+ */
+public abstract class IndexMongoUpgrader implements Upgrader {
+
+    protected ReactiveMongoOperations template;
+
+    private String prefix;
+
+    @Autowired
+    @Qualifier("indexManagementReactiveMongoTemplate")
+    public void setMongoTemplate(ReactiveMongoOperations template) {
+        this.template = template;
+    }
+
+    @Autowired
+    public void setEnvironment(Environment environment) {
+        this.prefix = environment.getProperty("management.mongodb.prefix", "");
+    }
+
+    protected Mono<MongoCollection<Document>> getCollection(String collectionName) {
+        return template.getCollection(buildCollectionName(collectionName));
+    }
+
+    protected String buildCollectionName(String collectionName) {
+        return prefix + collectionName;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/Index.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/Index.java
@@ -20,9 +20,12 @@ import com.mongodb.client.model.IndexOptions;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Singular;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
 
 /**
  * @author GraviteeSource Team
@@ -52,5 +55,34 @@ public class Index {
 
     public IndexOptions options() {
         return new IndexOptions().name(name).unique(unique).collation(collation);
+    }
+
+    public IndexDefinition toIndexDefinition() {
+        return new IndexDefinition() {
+            @NonNull
+            @Override
+            public Document getIndexKeys() {
+                return Document.parse(bson().asDocument().toJson());
+            }
+
+            @NonNull
+            @Override
+            public Document getIndexOptions() {
+                Document doc = new Document();
+                if (name != null) {
+                    doc.append("name", name);
+                }
+                if (unique) {
+                    doc.append("unique", true);
+                }
+                if (collation != null) {
+                    doc.append(
+                        "collation",
+                        Document.parse(collation.asDocument().toJson())
+                    );
+                }
+                return doc;
+            }
+        };
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgrader.java
@@ -15,20 +15,19 @@
  */
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.index;
 
-import com.mongodb.MongoCommandException;
-import com.mongodb.client.model.IndexOptions;
-import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import org.bson.BsonDocument;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.IndexMongoUpgrader;
+import java.time.Duration;
 import org.bson.BsonInt32;
-import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * @author GraviteeSource Team
  */
-public abstract class IndexUpgrader extends MongoUpgrader {
+public abstract class IndexUpgrader extends IndexMongoUpgrader {
 
     private static final Logger LOG = LoggerFactory.getLogger(IndexUpgrader.class);
 
@@ -42,26 +41,42 @@ public abstract class IndexUpgrader extends MongoUpgrader {
         return new BsonInt32(-1);
     }
 
-    protected static BsonValue text(String fieldName) {
-        return new BsonDocument(fieldName, new BsonString("text"));
-    }
-
     @Override
     public boolean upgrade() {
         Index index = buildIndex();
-        BsonDocument bson = index.bson();
-        IndexOptions options = index.options();
         String collection = buildCollectionName(index.getCollection());
-        String name = options.getName();
-        try {
-            LOG.info("creating index {} on collection {}", name, collection);
-            template.getCollection(collection).createIndex(bson, options);
-            LOG.debug("index {} has been created: {}", name, bson.toJson());
-        } catch (MongoCommandException e) {
-            String message = "unable to create index {} on collection {}: {}";
-            LOG.warn(message, name, collection, e.getMessage());
-        }
-        return true;
+        String name = index.options().getName();
+
+        Mono<Boolean> create = template
+            .indexOps(collection)
+            .ensureIndex(index.toIndexDefinition())
+            .doOnSubscribe(s ->
+                LOG.info("Starting creation of index {} on {}", name, collection)
+            )
+            .doOnSuccess(r ->
+                LOG.info("Index {} has been created successfully on {}", name, collection)
+            )
+            .thenReturn(true)
+            .onErrorResume(e -> {
+                LOG.error(
+                    "Unexpected error while creating index {} on {}",
+                    name,
+                    collection,
+                    e
+                );
+                return Mono.just(false);
+            })
+            .cache();
+
+        Flux
+            .interval(Duration.ofSeconds(10))
+            .doOnNext(t ->
+                LOG.info("Index {} on {} is still being created...", name, collection)
+            )
+            .takeUntilOther(create)
+            .subscribe();
+
+        return Boolean.TRUE.equals(create.block());
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import org.bson.BsonDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.io.ClassPathResource;
@@ -109,10 +111,23 @@ public class MongoTestRepositoryConfiguration extends AbstractRepositoryConfigur
         return com.mongodb.reactivestreams.client.MongoClients.create(mongoDBContainer.getReplicaSetUrl());
     }
 
+    @Primary
     @Bean(name = "managementMongoTemplate")
     public MongoOperations mongoOperations(MongoClient mongoClient) {
         try {
             return new MongoTemplate(mongoClient, getDatabaseName());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Bean(name = "indexManagementReactiveMongoTemplate")
+    public ReactiveMongoOperations indexReactiveMongoOperations() {
+        try {
+            return new ReactiveMongoTemplate(
+                com.mongodb.reactivestreams.client.MongoClients.create(mongoDBContainer.getReplicaSetUrl()),
+                getDatabaseName()
+            );
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryInitializer.java
@@ -18,7 +18,10 @@ package io.gravitee.repository.mongodb;
 import com.mongodb.client.MongoClient;
 import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.config.TestRepositoryInitializer;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.IndexMongoUpgrader;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import java.util.concurrent.TimeUnit;
 import org.bson.BsonDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +57,17 @@ public class MongoTestRepositoryInitializer implements TestRepositoryInitializer
                     upgrader.upgrade();
                 } catch (UpgraderException e) {
                     LOG.error("Failed to upgrade MongoDB with upgrader: {}", upgrader.getClass().getName(), e);
+                }
+            });
+
+        applicationContext
+            .getBeansOfType(IndexMongoUpgrader.class)
+            .values()
+            .forEach(upgrader -> {
+                try {
+                    upgrader.upgrade();
+                } catch (UpgraderException e) {
+                    LOG.error("Failed to upgrade MongoDB with index upgrader: {}", upgrader.getClass().getName(), e);
                 }
             });
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -64,7 +64,6 @@ public class GraviteeApisNode extends AbstractNode {
     @Override
     public List<Class<? extends LifecycleComponent>> components() {
         final List<Class<? extends LifecycleComponent>> components = super.components();
-        components.add(JettyEmbeddedContainer.class);
         components.add(AlertTriggerProviderManager.class);
         components.add(AlertEventProducerManager.class);
         components.add(ScheduledCommandService.class);
@@ -73,6 +72,9 @@ public class GraviteeApisNode extends AbstractNode {
         // Keep it at the end
         components.addAll(UpgraderConfiguration.getComponents());
         components.addAll(InitializerConfiguration.getComponents());
+
+        // Start Jetty server after upgraders to ensure database is validated first
+        components.add(JettyEmbeddedContainer.class);
         return components;
     }
 }


### PR DESCRIPTION
…ge index creation

## Issue

https://gravitee.atlassian.net/browse/APIM-10430

## Description

1. Dedicated Reactive Mongo Client for Index Upgrades to handle large index creation
2. Enhancements to IndexUpgrader to handle logs updates 
3. Startup Sequence Adjustment as helm deployment probe checks the mAPI port being open

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mpzutkepyr.chromatic.com)
<!-- Storybook placeholder end -->
