### PR TITLE
fix: add validation for endpoint weight minimum value

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -53,8 +53,9 @@
                 <span class="mat-h3">Configure the load balancer</span>
                 <mat-form-field class="endpoint-card__form__weight">
                   <mat-label>Weight</mat-label>
-                  <input id="weight" type="number" aria-label="Endpoint weight input" matInput formControlName="weight" required />
+                  <input id="weight" type="number" min="1" aria-label="Endpoint weight input" matInput formControlName="weight" required />
                   <mat-error *ngIf="formGroup.get('weight').hasError('required')"> Weight is required. </mat-error>
+                  <mat-error *ngIf="formGroup.get('weight').hasError('min')"> Weight must be at least 1. </mat-error>
                 </mat-form-field>
               </div>
             </div>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -314,7 +314,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
           ? isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, this.endpoint.name)
           : isEndpointNameUnique(this.api),
       ]),
-      weight: new UntypedFormControl(weight, Validators.required),
+      weight: new UntypedFormControl(weight, [Validators.required, Validators.min(1)]),
       inheritConfiguration: new UntypedFormControl(inheritConfiguration),
       configuration: new UntypedFormControl(configuration),
       sharedConfigurationOverride: new UntypedFormControl({ value: sharedConfigurationOverride, disabled: inheritConfiguration }),

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -172,7 +172,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
       ],
       type: [{ value: this.endpoint?.type ?? 'http', disabled: this.isReadOnly }, [Validators.required]],
       target: [{ value: this.endpoint?.target ?? null, disabled: this.isReadOnly }, [Validators.required, Validators.pattern(/^\S+$/)]],
-      weight: [{ value: this.endpoint?.weight ?? null, disabled: this.isReadOnly }, [Validators.required]],
+      weight: [{ value: this.endpoint?.weight ?? null, disabled: this.isReadOnly }, [Validators.required, Validators.min(1)]],
       tenants: [{ value: this.endpoint?.tenants ?? null, disabled: this.isReadOnly }],
       backup: [{ value: this.endpoint?.backup ?? false, disabled: this.isReadOnly }],
     });

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
@@ -61,8 +61,9 @@
         <div class="card__group-endpoint__row__weight__label">Weight</div>
         <mat-form-field class="card__group-endpoint__row__weight__form-field">
           <mat-label>Weight</mat-label>
-          <input type="number" aria-label="Endpoint weight input" matInput formControlName="weight" required />
+          <input type="number" min="1" aria-label="Endpoint weight input" matInput formControlName="weight" required />
           <mat-error *ngIf="generalForm.get('weight').hasError('required')"> Weight is required. </mat-error>
+          <mat-error *ngIf="generalForm.get('weight').hasError('min')"> Weight must be at least 1. </mat-error>
         </mat-form-field>
       </div>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgrader.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ApiEndpointWeightUpgrader implements Upgrader {
+
+    @Lazy
+    @Autowired
+    private ApiRepository apiRepository;
+
+    @Lazy
+    @Autowired
+    private EnvironmentRepository environmentRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final List<String> apisUpdated = new ArrayList<>();
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.API_ENDPOINT_WEIGHT_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() {
+        try {
+            for (Environment env : environmentRepository.findAll()) {
+                fixApiEndpointWeights(new ExecutionContext(env));
+            }
+            if (!apisUpdated.isEmpty()) {
+                log.info("{} updated {} APIs: {}", getClass().getSimpleName(), apisUpdated.size(), apisUpdated);
+            }
+            return true;
+        } catch (Exception e) {
+            log.error("Error applying {}", getClass().getSimpleName(), e);
+            return false;
+        }
+    }
+
+    private void fixApiEndpointWeights(ExecutionContext ctx) {
+        apiRepository
+            .search(
+                getDefaultApiCriteriaBuilder().environmentId(ctx.getEnvironmentId()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+            .forEach(api -> {
+                try {
+                    DefinitionVersion defVersion = api.getDefinitionVersion();
+                    if (defVersion == DefinitionVersion.V1) return;
+                    if (defVersion == null) defVersion = DefinitionVersion.V2;
+
+                    String definition = api.getDefinition();
+                    boolean updated = false;
+
+                    if (defVersion == DefinitionVersion.V4) {
+                        Api v4Api = objectMapper.readValue(definition, Api.class);
+                        updated = fixEndpointWeightsV4(v4Api);
+                        if (updated) {
+                            api.setDefinition(objectMapper.writeValueAsString(v4Api));
+                        }
+                    } else {
+                        if (defVersion != DefinitionVersion.FEDERATED) {
+                            JsonNode rootNode = objectMapper.readTree(definition);
+                            updated = fixEndpointWeightsV2(rootNode);
+                            if (updated) {
+                                api.setDefinition(objectMapper.writeValueAsString(rootNode));
+                            }
+                        }
+                    }
+                    if (updated) {
+                        api.setUpdatedAt(new Date());
+                        apiRepository.update(api);
+                        apisUpdated.add(api.getId());
+                    }
+                } catch (Exception e) {
+                    log.warn("Skipping API [{}] due to error: {}", api.getId(), e.getMessage(), e);
+                }
+            });
+    }
+
+    private boolean fixEndpointWeightsV2(JsonNode root) {
+        boolean updated = false;
+
+        for (JsonNode group : root.at("/proxy/groups")) {
+            JsonNode endpoints = group.get("endpoints");
+            if (endpoints == null || !endpoints.isArray()) continue;
+
+            for (JsonNode endpoint : endpoints) {
+                JsonNode weightNode = endpoint.get("weight");
+                if (weightNode != null && weightNode.isInt() && weightNode.intValue() < 1) {
+                    ((ObjectNode) endpoint).put("weight", 1);
+                    updated = true;
+                }
+            }
+        }
+        return updated;
+    }
+
+    private boolean fixEndpointWeightsV4(Api v4Api) {
+        boolean updated = false;
+        if (v4Api.getEndpointGroups() == null) return false;
+
+        for (var group : v4Api.getEndpointGroups()) {
+            for (var ep : group.getEndpoints()) {
+                int weight = ep.getWeight();
+                if (weight < 1) {
+                    ep.setWeight(1);
+                    updated = true;
+                }
+            }
+        }
+        return updated;
+    }
+
+    private ApiCriteria.Builder getDefaultApiCriteriaBuilder() {
+        return new ApiCriteria.Builder()
+            .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2, DefinitionVersion.V4));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -49,4 +49,5 @@ public class UpgraderOrder {
     public static final int USER_TOKEN_PERMISSION_UPGRADER = 702;
     public static final int INTEGRATION_PRIMARY_OWNER_UPGRADER = 703;
     public static final int INITIALIZE_SHARED_POLICY_GROUP_UPGRADER = 704;
+    public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgraderTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Environment;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ApiEndpointWeightUpgraderTest {
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ApiEndpointWeightUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        objectMapper = new ObjectMapper();
+        // Inject ObjectMapper manually since it's not a mock
+        org.springframework.test.util.ReflectionTestUtils.setField(upgrader, "objectMapper", objectMapper);
+    }
+
+    @Test
+    void shouldUpgradeV2ApiWeight() throws Exception {
+        // Mock environment
+        Environment env = new Environment();
+        env.setId("env1");
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        // Mock V2 API
+        Api api = new Api();
+        api.setId("api-v2");
+        api.setDefinitionVersion(DefinitionVersion.V2);
+        api.setDefinition("{\"proxy\":{\"groups\":[{\"endpoints\":[{\"name\":\"ep\",\"weight\":0}]}]}}");
+
+        when(apiRepository.search(any(), any(), any())).thenReturn(Stream.of(api));
+
+        // Run upgrader
+        upgrader.upgrade();
+
+        // Capture updated API
+        ArgumentCaptor<Api> captor = ArgumentCaptor.forClass(Api.class);
+        verify(apiRepository).update(captor.capture());
+
+        Api updatedApi = captor.getValue();
+        JsonNode rootNode = objectMapper.readTree(updatedApi.getDefinition());
+        int weight = rootNode.at("/proxy/groups/0/endpoints/0/weight").intValue();
+
+        assertEquals(1, weight, "V2 endpoint weight should be updated to 1");
+    }
+
+    @Test
+    void shouldUpgradeV4ApiWeight() throws Exception {
+        // Mock environment
+        Environment env = new Environment();
+        env.setId("env1");
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        // Mock V4 API
+        Api api = new Api();
+        api.setId("api-v4");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setDefinition("{\"endpointGroups\":[{\"endpoints\":[{\"name\":\"ep\",\"weight\":0}]}]}");
+
+        when(apiRepository.search(any(), any(), any())).thenReturn(Stream.of(api));
+
+        // Run upgrader
+        upgrader.upgrade();
+
+        // Capture updated API
+        ArgumentCaptor<Api> captor = ArgumentCaptor.forClass(Api.class);
+        verify(apiRepository).update(captor.capture());
+
+        Api updatedApi = captor.getValue();
+        JsonNode rootNode = objectMapper.readTree(updatedApi.getDefinition());
+        int weight = rootNode.at("/endpointGroups/0/endpoints/0/weight").intValue();
+
+        assertEquals(1, weight, "V4 endpoint weight should be updated to 1");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8970

## Description

Implements weight validation to prevent values less than 1 in API endpoint configurations and introduced an upgrader to fix existing APIs by resetting invalid weights.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rnazonilhy.chromatic.com)
<!-- Storybook placeholder end -->
