### PR TITLE
fix(console): On smaller screen fields were hidden on alert page

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/_alert.scss
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/_alert.scss
@@ -1,6 +1,17 @@
+.prevent-overlap {
+  overflow-x: auto;
+}
 .gv-alerts-alert {
   md-tab-content {
     padding-bottom: 2rem;
+  }
+
+  .scrollable {
+    overflow-x: auto;
+    width: 100%;
+    display: grid;
+    flex-direction: row;
+    flex-wrap: nowrap;
   }
 
   .gv-alerts-alert_trigger-msg {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
@@ -167,7 +167,7 @@
                   <div class="ipsum">Field metrics and condition for the rule</div>
                 </div>
 
-                <div class="gv-form-content" layout="column">
+                <div class="gv-form-content scrollable" layout="column">
                   <div class="gv-alerts-alert_trigger-msg" ng-if="$ctrl.alert.type == null">
                     Select a rule before setting the condition.
                   </div>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.html
@@ -16,7 +16,7 @@
 
 -->
 
-<md-input-container class="md-block" flex="30">
+<md-input-container class="md-block flex-gt-sm">
   <label>Threshold</label>
   <input
     ng-model="$ctrl.condition.threshold"

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-timeframe.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-timeframe.html
@@ -20,7 +20,7 @@
   <div class="ipsum">Timeframe when notifications should be sent</div>
 </div>
 
-<div class="gv-form-content" layout="column">
+<div class="gv-form-content scrollable" layout="column">
   <div ng-repeat="period in $ctrl.alert.notificationPeriods" layout-gt-sm="row">
     <div flex="90">
       Every <code>{{$ctrl.getDayNames(period)}}</code>
@@ -66,7 +66,7 @@
         </gv-switch>
       </div>
       <div layout-gt-sm="row" layout-align="space-between center">
-        <div flex="65">
+        <div flex="65" class="prevent-overlap">
           <gv-date-picker label="Time range" time strict range gv-model ng-model="timeframe.range"></gv-date-picker>
         </div>
         <gv-switch


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10946

## Description

When creating a new alert in APIM Console (v4), some input fields on the “Condition” section are rendered outside the visible area.
This might be preventing from completing the alert configuration (e.g., typing the threshold value).

## Additional context

Proof of solution:

Before solution:


https://github.com/user-attachments/assets/005dd4cd-6352-493d-8a63-7ca0ff0f8e2a



v4:
https://github.com/user-attachments/assets/7409c99c-57db-47c0-966d-81ec87b6039d

v2:

https://github.com/user-attachments/assets/80f6ba18-bb7b-4c4d-9ca7-5997b00f909e



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ibzjomoixd.chromatic.com)
<!-- Storybook placeholder end -->
