### PR TITLE
load gateway instance detail dynamically in api logs detail page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture.ts
@@ -38,11 +38,7 @@ export const fakeApiMetricResponse = (modifier?: Partial<ApiMetricsDetailRespons
       name: 'Unknown',
       apiKeyMode: 'UNSPECIFIED',
     },
-    gateway: {
-      id: 'b504bb7b-8b6e-426f-84bb-7b8b6e626f3f',
-      hostname: 'Mac.lan',
-      ip: '192.168.1.139',
-    },
+    gateway: 'b504bb7b-8b6e-426f-84bb-7b8b6e626f3f',
     uri: '/v4/echo',
     status: 202,
     requestContentLength: 0,

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.ts
@@ -31,7 +31,7 @@ export interface ApiMetricsDetailResponse {
   host: string;
   plan: BasePlan;
   application: BaseApplication;
-  gateway: BaseInstance;
+  gateway: string;
   uri: string;
   status: number;
   requestContentLength: number;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
@@ -18,6 +18,6 @@
 <a mat-flat-button routerLink=".." aria-label="Back to logs"><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a>
 <div class="mat-h2">Log</div>
 <div class="card__container">
-  <api-proxy-request-metric-overview [metric]="apiMetricsDetail()" />
+  <api-proxy-request-metric-overview [metric]="apiMetricsDetail()" [instance]="gatewayInstanceDetail()" />
   <api-proxy-request-log-overview class="log-details" [log]="connectionLog()" />
 </div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.scss
@@ -17,7 +17,6 @@
 
   &__container {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     margin-bottom: 16px;
     gap: 16px;
@@ -26,7 +25,7 @@
   &__section {
     display: flex;
     flex-direction: column;
-    flex: 1 1 calc(50% - 8px);
+    flex: 1 1 400px;
     min-width: 0;
     box-sizing: border-box;
     border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
@@ -40,6 +39,10 @@
       font-size: 14px;
       overflow-wrap: break-word;
       word-break: break-all;
+
+      > dd {
+        margin-left: 0;
+      }
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.stories.ts
@@ -28,6 +28,7 @@ import {
   fakeConnectionLogDetailRequest,
   fakeConnectionLogDetailResponse,
 } from '../../../../../../entities/management-api-v2';
+import { InstanceService } from '../../../../../../services-ngx/instance.service';
 
 const bodyExample = `{
   "message": "hello world"
@@ -51,6 +52,12 @@ export default {
           provide: ApiLogsV2Service,
           useValue: {
             searchConnectionLogDetail: (apiId: string, requestId: string) => of(fakeConnectionLogDetail({ apiId, requestId })),
+          },
+        },
+        {
+          provide: InstanceService,
+          useValue: {
+            getByGatewayId: (id: string) => of({ id, hostname: 'hostname.example.com', ip: 'ip.example' }),
           },
         },
       ],

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.html
@@ -15,88 +15,87 @@
     limitations under the License.
 
 -->
-@if (metric(); as metric) {
-  <div class="mat-h3">Overview</div>
-  <mat-card class="card">
-    <mat-card-content>
-      <div class="card__container">
-        <div class="card__section">
-          <span class="mat-body-strong">Request</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Date</dt>
-            <dd class="gio-caption-2">{{ metric.timestamp | date: 'medium' }}</dd>
-
-            <dt class="mat-caption">Host</dt>
-            <dd class="gio-caption-2">{{ metric.host }}</dd>
-
-            <dt class="mat-caption">Method</dt>
-            <dd class="gio-caption-2">
-              <div [class]="'gio-method-badge-' + metric.method.toLocaleLowerCase()">{{ metric.method }}</div>
-            </dd>
-
-            <dt class="mat-caption">URI</dt>
-            <dd class="gio-caption-2">{{ metric.uri }}</dd>
-
-            <dt class="mat-caption">Request ID</dt>
-            <dd class="gio-caption-2">{{ metric.requestId }}</dd>
-
-            <dt class="mat-caption">Transaction ID</dt>
-            <dd class="gio-caption-2">{{ metric.transactionId }}</dd>
-
-            <dt class="mat-caption">Remote IP</dt>
-            <dd class="gio-caption-2">{{ metric.remoteAddress }}</dd>
-          </dl>
-        </div>
-        <div class="card__section">
-          <span class="mat-body-strong">Response</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Status</dt>
-            <dd class="gio-caption-2">
-              <div
-                [class.gio-badge-success]="metric.status < 400"
-                [class.gio-badge-warning]="metric.status >= 400 && metric.status <= 499"
-                [class.gio-badge-error]="metric.status >= 500"
-              >
-                {{ metric.status }}
-              </div>
-            </dd>
-
-            <dt class="mat-caption">Global response time</dt>
-            <dd class="gio-caption-2">{{ metric.gatewayResponseTime }}</dd>
-
-            <dt class="mat-caption">API response time</dt>
-            <dd class="gio-caption-2">{{ metric.endpointResponseTime }}</dd>
-
-            <dt class="mat-caption">Latency</dt>
-            <dd class="gio-caption-2">{{ metric.gatewayLatency }}</dd>
-
-            <dt class="mat-caption">Content-length</dt>
-            <dd class="gio-caption-2">{{ metric.responseContentLength }}</dd>
-          </dl>
-        </div>
-      </div>
-
-      <mat-expansion-panel class="mat-elevation-z0 more-details">
-        <mat-expansion-panel-header>
-          <mat-panel-title> More details </mat-panel-title>
-        </mat-expansion-panel-header>
+@let metricValue = metric();
+<div class="mat-h3">Overview</div>
+<mat-card class="card">
+  <mat-card-content>
+    <div class="card__container">
+      <div class="card__section">
+        <span class="mat-body-strong">Request</span>
         <dl class="card__section__kv">
-          <dt class="mat-caption">Application</dt>
-          <dd class="gio-caption-2">{{ metric.application.name }}</dd>
+          <dt class="mat-caption">Date</dt>
+          <dd class="gio-caption-2">{{ metricValue?.timestamp | date: 'medium' }}</dd>
 
-          <dt class="mat-caption">Plan</dt>
-          <dd class="gio-caption-2">{{ metric.plan.name }}</dd>
+          <dt class="mat-caption">Host</dt>
+          <dd class="gio-caption-2">{{ metricValue?.host }}</dd>
 
-          <dt class="mat-caption">Endpoint</dt>
-          <dd class="gio-caption-2">{{ metric.endpoint }}</dd>
+          <dt class="mat-caption">Method</dt>
+          <dd class="gio-caption-2">
+            <div [class]="'gio-method-badge-' + metricValue?.method.toLocaleLowerCase()">{{ metricValue?.method }}</div>
+          </dd>
 
-          <dt class="mat-caption">Gateway Host</dt>
-          <dd class="gio-caption-2">{{ metric.gateway?.hostname }}</dd>
+          <dt class="mat-caption">URI</dt>
+          <dd class="gio-caption-2">{{ metricValue?.uri }}</dd>
 
-          <dt class="mat-caption">Gateway IP</dt>
-          <dd class="gio-caption-2">{{ metric.gateway?.ip }}</dd>
+          <dt class="mat-caption">Request ID</dt>
+          <dd class="gio-caption-2">{{ metricValue?.requestId }}</dd>
+
+          <dt class="mat-caption">Transaction ID</dt>
+          <dd class="gio-caption-2">{{ metricValue?.transactionId }}</dd>
+
+          <dt class="mat-caption">Remote IP</dt>
+          <dd class="gio-caption-2">{{ metricValue?.remoteAddress }}</dd>
         </dl>
-      </mat-expansion-panel>
-    </mat-card-content>
-  </mat-card>
-}
+      </div>
+      <div class="card__section">
+        <span class="mat-body-strong">Response</span>
+        <dl class="card__section__kv">
+          <dt class="mat-caption">Status</dt>
+          <dd class="gio-caption-2">
+            <div
+              [class.gio-badge-success]="metricValue?.status < 400"
+              [class.gio-badge-warning]="metricValue?.status >= 400 && metricValue?.status <= 499"
+              [class.gio-badge-error]="metricValue?.status >= 500"
+            >
+              {{ metricValue?.status }}
+            </div>
+          </dd>
+
+          <dt class="mat-caption">Global response time</dt>
+          <dd class="gio-caption-2">{{ metricValue?.gatewayResponseTime }}</dd>
+
+          <dt class="mat-caption">API response time</dt>
+          <dd class="gio-caption-2">{{ metricValue?.endpointResponseTime }}</dd>
+
+          <dt class="mat-caption">Latency</dt>
+          <dd class="gio-caption-2">{{ metricValue?.gatewayLatency }}</dd>
+
+          <dt class="mat-caption">Content-length</dt>
+          <dd class="gio-caption-2">{{ metricValue?.responseContentLength }}</dd>
+        </dl>
+      </div>
+    </div>
+
+    <mat-expansion-panel class="mat-elevation-z0 more-details">
+      <mat-expansion-panel-header>
+        <mat-panel-title> More details </mat-panel-title>
+      </mat-expansion-panel-header>
+      <dl class="card__section__kv">
+        <dt class="mat-caption">Application</dt>
+        <dd class="gio-caption-2">{{ metricValue?.application.name }}</dd>
+
+        <dt class="mat-caption">Plan</dt>
+        <dd class="gio-caption-2">{{ metricValue?.plan.name }}</dd>
+
+        <dt class="mat-caption">Endpoint</dt>
+        <dd class="gio-caption-2">{{ metricValue?.endpoint }}</dd>
+
+        <dt class="mat-caption">Gateway Host</dt>
+        <dd class="gio-caption-2">{{ instance()?.hostname }}</dd>
+
+        <dt class="mat-caption">Gateway IP</dt>
+        <dd class="gio-caption-2">{{ instance()?.ip }}</dd>
+      </dl>
+    </mat-expansion-panel>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.ts
@@ -18,7 +18,10 @@ import { DatePipe } from '@angular/common';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
 
-import { ApiMetricsDetailResponse } from '../../../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
+import {
+  ApiMetricsDetailResponse,
+  BaseInstance,
+} from '../../../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
 
 @Component({
   selector: 'api-proxy-request-metric-overview',
@@ -28,4 +31,5 @@ import { ApiMetricsDetailResponse } from '../../../../../../../../entities/manag
 })
 export class ApiProxyRequestMetricOverviewComponent {
   metric: InputSignal<ApiMetricsDetailResponse> = input.required<ApiMetricsDetailResponse>();
+  instance: InputSignal<BaseInstance> = input<BaseInstance>();
 }

--- a/gravitee-apim-console-webui/src/services-ngx/instance.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/instance.service.spec.ts
@@ -93,6 +93,23 @@ describe('InstanceService', () => {
     });
   });
 
+  describe('getByGatewayId', () => {
+    it('should call the API', (done) => {
+      const instanceId = '5bc17c57-b350-460d-817c-57b350060db3';
+      const fakeInstanceObject = fakeInstance();
+
+      instanceService.getByGatewayId(instanceId).subscribe((instance) => {
+        expect(instance).toMatchObject(fakeInstanceObject);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/instances/${instanceId}`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeInstanceObject);
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/services-ngx/instance.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/instance.service.ts
@@ -21,6 +21,7 @@ import { Constants } from '../entities/Constants';
 import { Instance } from '../entities/instance/instance';
 import { MonitoringData } from '../entities/instance/monitoringData';
 import { SearchResult } from '../entities/instance/searchResult';
+import { BaseInstance } from '../entities/management-api-v2/analytics/apiMetricsDetailResponse';
 
 @Injectable({
   providedIn: 'root',
@@ -59,6 +60,10 @@ export class InstanceService {
 
   get(id: string): Observable<Instance> {
     return this.http.get<Instance>(`${this.constants.env.baseURL}/instances/${id}`);
+  }
+
+  getByGatewayId(id: string): Observable<BaseInstance> {
+    return this.http.get<Instance>(`${this.constants.env.v2BaseURL}/instances/${id}`);
   }
 
   getMonitoringData(id: string, gatewayId: string): Observable<MonitoringData> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/InstancesMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/InstancesMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.gateway.model.BaseInstance;
+import io.gravitee.rest.api.management.v2.rest.model.InstanceDetailResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface InstancesMapper {
+    InstancesMapper INSTANCE = Mappers.getMapper(InstancesMapper.class);
+
+    InstanceDetailResponse map(BaseInstance instance);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
@@ -107,6 +107,11 @@ public class EnvironmentResource extends AbstractResource {
         return resourceContext.getResource(EnvironmentNewtAIResource.class);
     }
 
+    @Path("/instances")
+    public InstancesResource getInstancesResource() {
+        return resourceContext.getResource(InstancesResource.class);
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Environment getEnvironment(@PathParam("envId") String envId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/InstancesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/InstancesResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.installation;
+
+import io.gravitee.apim.core.gateway.use_case.GetInstanceDetailUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.InstancesMapper;
+import io.gravitee.rest.api.management.v2.rest.model.InstanceDetailResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+public class InstancesResource extends AbstractResource {
+
+    @Inject
+    private GetInstanceDetailUseCase getInstanceDetailUseCase;
+
+    @GET
+    @Path("{instanceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_INSTANCE, acls = RolePermissionAction.READ) })
+    public InstanceDetailResponse getInstanceById(@PathParam("instanceId") String instanceId) {
+        return getInstanceDetailUseCase
+            .execute(new GetInstanceDetailUseCase.Input(GraviteeContext.getExecutionContext(), instanceId))
+            .instance()
+            .map(InstancesMapper.INSTANCE::map)
+            .orElseThrow(() -> new NotFoundException("Instance: " + instanceId + "not found"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -8859,7 +8859,9 @@ components:
                   application:
                     $ref: "#/components/schemas/BaseApplication"
                   gateway:
-                    $ref: "#/components/schemas/BaseInstance"
+                    type: string
+                    description: The id of the gateway.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
                   uri:
                     type: string
                     description: URI of the request.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -8076,22 +8076,6 @@ components:
             agentMessageId:
               type: string
 
-        BaseInstance:
-          type: object
-          properties:
-            id:
-              type: string
-              description: Gateway's uuid.
-              example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
-            hostname:
-              type: string
-              description: Gateway's hostname.
-              example: my-gateway.example.com
-            ip:
-              type: string
-              description: Gateway's ip.
-              example: 10.0.1.123
-
     parameters:
         #############
         # PathParam #

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -613,6 +613,21 @@ paths:
           default:
             $ref: "#/components/responses/Error"
 
+    # Instances
+    /instances/{instanceId}:
+      get:
+        tags:
+          - Instances
+        summary: Get a Gateway instance details
+        operationId: getInstanceById
+        parameters:
+            - $ref: "#/components/parameters/instanceId"
+        responses:
+          "200":
+            $ref: "#/components/responses/InstanceDetailResponse"
+          default:
+            $ref: "#/components/responses/Error"
+
 components:
     schemas:
         # Analytics
@@ -1459,6 +1474,15 @@ components:
               - updatedAt
               - -updatedAt
 
+        # Instances
+        instanceId:
+          name: instanceId
+          in: path
+          description: The gateway instance ID
+          required: true
+          schema:
+            type: string
+
     responses:
         SchemaFormResponse:
             description: Schema form of a plugin
@@ -1714,6 +1738,28 @@ components:
                     type: string
                   feedbackRequestId:
                     $ref: '#/components/schemas/FeedbackRequestId'
+                    
+        
+        # Instances
+        InstanceDetailResponse:
+          description: The gateway instance details.
+          content:
+            application/json:
+              schema:
+                title: "InstanceDetailResponse"
+                properties:
+                  id:
+                    type: string
+                    description: Gateway's uuid.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                  hostname:
+                    type: string
+                    description: Gateway's hostname.
+                    example: my-gateway.example.com
+                  ip:
+                    type: string
+                    description: Gateway's ip.
+                    example: 10.0.1.123
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
@@ -24,11 +24,9 @@ import assertions.MAPIAssertions;
 import fakes.FakeAnalyticsQueryService;
 import fixtures.core.model.ApiFixtures;
 import inmemory.ApiCrudServiceInMemory;
-import inmemory.InstanceQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.apim.core.analytics.model.HistogramAnalytics;
 import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
-import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsAverageConnectionDurationResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsAverageMessagesPerRequestResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsOverPeriodResponse;
@@ -56,7 +54,6 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.inject.Inject;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -1066,7 +1063,6 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
                         .containsExactly(applicationId, appName);
 
                     assertThat(apiMetricsDetail.getPlan()).extracting(BasePlan::getId, BasePlan::getName).containsExactly(planId, planName);
-
                 });
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
@@ -87,9 +87,6 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
     ApiCrudServiceInMemory apiCrudServiceInMemory;
 
     @Inject
-    InstanceQueryServiceInMemory instanceQueryService;
-
-    @Inject
     private PlanCrudServiceInMemory planCrudServiceInMemory;
 
     @Override
@@ -110,7 +107,6 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
         GraviteeContext.cleanContext();
         fakeAnalyticsQueryService.reset();
         apiCrudServiceInMemory.reset();
-        instanceQueryService.reset();
         planCrudServiceInMemory.reset();
     }
 
@@ -1006,12 +1002,6 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
             );
 
             var instanceId = "instance-id";
-            var hostname = "foo.example.com";
-            var ip = "42.42.42.1";
-            instanceQueryService.initWith(
-                List.of(Instance.builder().id(instanceId).hostname(hostname).ip(ip).environments(Set.of(ENVIRONMENT)).build())
-            );
-
             var timestamp = "2025-08-01T17:29:20.385+02:00";
             var transactionId = "transaction-id";
             var host = "request.host.example.com";
@@ -1069,6 +1059,7 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
                     assertThat(apiMetricsDetail.getMethod()).isEqualTo(HttpMethod.GET);
                     assertThat(apiMetricsDetail.getEndpointResponseTime()).isEqualTo(endpointResponseTime);
                     assertThat(apiMetricsDetail.getEndpoint()).isEqualTo(endpoint);
+                    assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
 
                     assertThat(apiMetricsDetail.getApplication())
                         .extracting(BaseApplication::getId, BaseApplication::getName)
@@ -1076,13 +1067,6 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
 
                     assertThat(apiMetricsDetail.getPlan()).extracting(BasePlan::getId, BasePlan::getName).containsExactly(planId, planName);
 
-                    assertThat(apiMetricsDetail.getGateway())
-                        .extracting(
-                            io.gravitee.rest.api.management.v2.rest.model.BaseInstance::getId,
-                            io.gravitee.rest.api.management.v2.rest.model.BaseInstance::getHostname,
-                            io.gravitee.rest.api.management.v2.rest.model.BaseInstance::getIp
-                        )
-                        .containsExactly(instanceId, hostname, ip);
                 });
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentInstancesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentInstancesResourceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.installation;
+
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import assertions.MAPIAssertions;
+import inmemory.InstanceQueryServiceInMemory;
+import io.gravitee.apim.core.gateway.model.Instance;
+import io.gravitee.rest.api.management.v2.rest.model.InstanceDetailResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EnvironmentInstancesResourceTest extends AbstractResourceTest {
+
+    public static final String FAKE_ENVIRONMENT_ID = "fake-environment";
+    public static final String ENVIRONMENT_ID = "env-id";
+
+    @Inject
+    InstanceQueryServiceInMemory instanceQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT_ID + "/instances";
+    }
+
+    @BeforeEach
+    public void init() {
+        GraviteeContext.setCurrentEnvironment(FAKE_ENVIRONMENT_ID);
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT_ID).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT_ID)).thenReturn(environmentEntity);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        instanceQueryService.reset();
+    }
+
+    @Test
+    public void should_return_instance_details() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_INSTANCE,
+                ENVIRONMENT_ID,
+                RolePermissionAction.READ
+            )
+        )
+            .thenReturn(true);
+
+        var instanceId = "instance-id";
+        var hostname = "foo.example.com";
+        var ip = "42.42.42.1";
+        instanceQueryService.initWith(
+            List.of(Instance.builder().id(instanceId).hostname(hostname).ip(ip).environments(Set.of(ENVIRONMENT_ID)).build())
+        );
+
+        final Response response = rootTarget().path(instanceId).request().get();
+
+        MAPIAssertions
+            .assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(InstanceDetailResponse.class)
+            .satisfies(instanceDetail -> {
+                assertThat(instanceDetail.getHostname()).isEqualTo(hostname);
+                assertThat(instanceDetail.getIp()).isEqualTo(ip);
+                assertThat(instanceDetail.getId()).isEqualTo(instanceId);
+            });
+    }
+
+    @Test
+    public void should_return_not_found_if_no_instance_found() {
+        var instanceId = "instance-id";
+        var hostname = "foo.example.com";
+        var ip = "42.42.42.1";
+        instanceQueryService.initWith(
+            List.of(Instance.builder().id(instanceId).hostname(hostname).ip(ip).environments(Set.of(ENVIRONMENT_ID)).build())
+        );
+
+        final Response response = rootTarget().path("not-existing-id").request().get();
+
+        MAPIAssertions.assertThat(response).hasStatus(NOT_FOUND_404);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.analytics.model;
 
-import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
@@ -33,7 +32,7 @@ public class ApiMetricsDetail {
     String host;
     BaseApplicationEntity application;
     GenericPlanEntity plan;
-    BaseInstance gateway;
+    String gateway;
     String uri;
     int status;
     long requestContentLength;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
@@ -39,7 +39,6 @@ public class FindApiMetricsDetailUseCase {
     private final AnalyticsQueryService analyticsQueryService;
     private final ApplicationCrudService applicationCrudService;
     private final PlanCrudService planCrudService;
-    private final InstanceQueryService instanceQueryService;
 
     public FindApiMetricsDetailUseCase.Output execute(ExecutionContext executionContext, FindApiMetricsDetailUseCase.Input input) {
         return analyticsQueryService
@@ -72,7 +71,7 @@ public class FindApiMetricsDetailUseCase {
             .host(apiMetricsDetail.getHost())
             .application(getApplication(executionContext.getEnvironmentId(), apiMetricsDetail.getApplicationId()))
             .plan(getPlan(apiMetricsDetail.getPlanId()))
-            .gateway(instanceQueryService.findById(executionContext, apiMetricsDetail.getGateway()))
+            .gateway(apiMetricsDetail.getGateway())
             .uri(apiMetricsDetail.getUri())
             .status(apiMetricsDetail.getStatus())
             .requestContentLength(apiMetricsDetail.getRequestContentLength())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/use_case/GetInstanceDetailUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/use_case/GetInstanceDetailUseCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.gateway.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.gateway.model.BaseInstance;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetInstanceDetailUseCase {
+
+    private final InstanceQueryService instanceQueryService;
+
+    public Output execute(Input input) {
+        var instance = instanceQueryService.findById(input.executionContext(), input.instanceId());
+        return new Output(Optional.ofNullable(instance));
+    }
+
+    public record Input(ExecutionContext executionContext, String instanceId) {}
+
+    public record Output(Optional<BaseInstance> instance) {
+        public Output(BaseInstance instance) {
+            this(Optional.ofNullable(instance));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
@@ -46,7 +46,6 @@ class FindApiMetricsDetailUseCaseTest {
     ApplicationCrudServiceInMemory applicationCrudServiceInMemory = new ApplicationCrudServiceInMemory();
     PlanCrudServiceInMemory planCrudServiceInMemory = new PlanCrudServiceInMemory();
     FakeInstanceService fakeInstanceService = new FakeInstanceService();
-    InstanceQueryServiceLegacyWrapper instanceQueryServiceLegacyWrapper = new InstanceQueryServiceLegacyWrapper(fakeInstanceService);
 
     FindApiMetricsDetailUseCase useCase;
 
@@ -56,8 +55,7 @@ class FindApiMetricsDetailUseCaseTest {
             new FindApiMetricsDetailUseCase(
                 fakeAnalyticsQueryService,
                 applicationCrudServiceInMemory,
-                planCrudServiceInMemory,
-                instanceQueryServiceLegacyWrapper
+                planCrudServiceInMemory
             );
     }
 
@@ -138,6 +136,7 @@ class FindApiMetricsDetailUseCaseTest {
                 .responseContentLength(responseContentLength)
                 .gatewayLatency(gatewayLatency)
                 .gatewayResponseTime(gatewayResponseTime)
+                .gateway(instanceId)
                 .remoteAddress(remoteAddress)
                 .method(HttpMethod.GET)
                 .endpointResponseTime(endpointResponseTime)
@@ -163,6 +162,7 @@ class FindApiMetricsDetailUseCaseTest {
                 assertThat(apiMetricsDetail.getMethod()).isEqualTo(HttpMethod.GET);
                 assertThat(apiMetricsDetail.getEndpointResponseTime()).isEqualTo(endpointResponseTime);
                 assertThat(apiMetricsDetail.getEndpoint()).isEqualTo(endpoint);
+                assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
 
                 assertThat(apiMetricsDetail.getApplication())
                     .extracting(BaseApplicationEntity::getId, BaseApplicationEntity::getName)
@@ -171,10 +171,6 @@ class FindApiMetricsDetailUseCaseTest {
                 assertThat(apiMetricsDetail.getPlan())
                     .extracting(GenericPlanEntity::getId, GenericPlanEntity::getName)
                     .containsExactly(PLAN_ID, planName);
-
-                assertThat(apiMetricsDetail.getGateway())
-                    .extracting(BaseInstance::getId, BaseInstance::getHostname, BaseInstance::getIp)
-                    .containsExactly(instanceId, hostname, ip);
             });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
@@ -18,12 +18,9 @@ package io.gravitee.apim.core.analytics.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import fakes.FakeAnalyticsQueryService;
-import fakes.FakeInstanceService;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
-import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.plan.model.Plan;
-import io.gravitee.apim.infra.query_service.gateway.InstanceQueryServiceLegacyWrapper;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
@@ -45,18 +42,12 @@ class FindApiMetricsDetailUseCaseTest {
     FakeAnalyticsQueryService fakeAnalyticsQueryService = new FakeAnalyticsQueryService();
     ApplicationCrudServiceInMemory applicationCrudServiceInMemory = new ApplicationCrudServiceInMemory();
     PlanCrudServiceInMemory planCrudServiceInMemory = new PlanCrudServiceInMemory();
-    FakeInstanceService fakeInstanceService = new FakeInstanceService();
 
     FindApiMetricsDetailUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase =
-            new FindApiMetricsDetailUseCase(
-                fakeAnalyticsQueryService,
-                applicationCrudServiceInMemory,
-                planCrudServiceInMemory
-            );
+        useCase = new FindApiMetricsDetailUseCase(fakeAnalyticsQueryService, applicationCrudServiceInMemory, planCrudServiceInMemory);
     }
 
     @AfterEach
@@ -105,11 +96,6 @@ class FindApiMetricsDetailUseCaseTest {
         );
 
         var instanceId = "instance-id";
-        var hostname = "foo.example.com";
-        var ip = "42.42.42.1";
-        fakeInstanceService.instanceEntity =
-            io.gravitee.rest.api.model.InstanceEntity.builder().id(instanceId).hostname(hostname).ip(ip).build();
-
         var transactionId = "transaction-id";
         var host = "request.host.example.com";
         var uri = "/example/api";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/instance/GetInstanceDetailUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/instance/GetInstanceDetailUseCaseTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fakes.FakeInstanceService;
+import io.gravitee.apim.core.gateway.use_case.GetInstanceDetailUseCase;
+import io.gravitee.apim.infra.query_service.gateway.InstanceQueryServiceLegacyWrapper;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetInstanceDetailUseCaseTest {
+
+    private static final String instanceId = "instance-id";
+    private static final String hostname = "foo.example.com";
+    private static final String ip = "42.42.42.1";
+    private static final String environmentId = "env-id";
+
+    FakeInstanceService fakeInstanceService = new FakeInstanceService();
+    InstanceQueryServiceLegacyWrapper instanceQueryServiceLegacyWrapper = new InstanceQueryServiceLegacyWrapper(fakeInstanceService);
+    GetInstanceDetailUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetInstanceDetailUseCase(instanceQueryServiceLegacyWrapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        fakeInstanceService.instanceEntity = null;
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    void should_return_instance_details() {
+        fakeInstanceService.instanceEntity =
+            io.gravitee.rest.api.model.InstanceEntity
+                .builder()
+                .id(instanceId)
+                .hostname(hostname)
+                .ip(ip)
+                .environments(Set.of(environmentId))
+                .build();
+        var result = useCase.execute(new GetInstanceDetailUseCase.Input(GraviteeContext.getExecutionContext(), instanceId));
+
+        var instance = result.instance();
+        assertThat(instance).isNotEmpty();
+        assertThat(instance)
+            .hasValueSatisfying(instanceDetails -> {
+                assertThat(instanceDetails.getId()).isEqualTo(instanceId);
+                assertThat(instanceDetails.getIp()).isEqualTo(ip);
+                assertThat(instanceDetails.getHostname()).isEqualTo(hostname);
+            });
+    }
+
+    @Test
+    void should_return_empty_if_not_found() {
+        var result = useCase.execute(new GetInstanceDetailUseCase.Input(GraviteeContext.getExecutionContext(), "unknown-id"));
+        assertThat(result.instance()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10952

## Summary

This PR improves the performance of the API request metric details endpoint by avoiding unnecessary loading of gateway instance details.

## Problem

Currently, when a user views API request metrics, the backend also loads gateway instance details from events.
- This can be slow: in my tests, loading gateway details added 1.6–2.5s of latency.
- This results in a poor user experience, especially on the logs detail page. 

## Solution

- Removed gateway instance details from the resource when fetching API request metrics.
- Response time is now reduced from >2s to around 100ms.
- This significantly improves the user experience by making log details load almost instantly.

Additional Improvements

In the last commit the layout for small screens has been adjusted, ensuring that request/response details are displayed correctly and remain readable.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zdokylszkm.chromatic.com)
<!-- Storybook placeholder end -->
