### PR TITLE
feat: add the cluster role to the group members

### DIFF
--- a/gravitee-apim-console-webui/src/entities/group/groupMember.ts
+++ b/gravitee-apim-console-webui/src/entities/group/groupMember.ts
@@ -15,7 +15,7 @@
  */
 
 export interface GroupMembershipMemberRoleEntity {
-  scope: 'MANAGEMENT' | 'PORTAL' | 'API' | 'APPLICATION' | 'GROUP' | 'INTEGRATION';
+  scope: 'MANAGEMENT' | 'PORTAL' | 'API' | 'APPLICATION' | 'GROUP' | 'INTEGRATION' | 'CLUSTER';
   name?: string;
 }
 

--- a/gravitee-apim-console-webui/src/management/clusters/cluster-navigation/cluster-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/cluster-navigation/cluster-navigation.component.ts
@@ -86,7 +86,7 @@ export class ClusterNavigationComponent implements OnInit, OnDestroy {
               displayName: 'General',
               routerLink: '',
               permissions: ['cluster-definition-r'],
-              tabs: [
+              tabs: this.filterMenuByPermission([
                 {
                   displayName: 'General',
                   routerLink: 'general',
@@ -95,14 +95,14 @@ export class ClusterNavigationComponent implements OnInit, OnDestroy {
                 {
                   displayName: 'Configuration',
                   routerLink: 'configuration',
-                  permissions: ['cluster-definition-r'],
+                  permissions: ['cluster-configuration-r'],
                 },
                 {
                   displayName: 'User Permissions',
                   routerLink: 'user-permissions',
-                  permissions: ['cluster-definition-r'],
+                  permissions: ['cluster-member-r'],
                 },
-              ],
+              ]),
             },
           ]);
 

--- a/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.spec.ts
@@ -38,7 +38,7 @@ describe('ClusterConfigurationComponent', () => {
   let permissions: string[];
 
   beforeEach(async () => {
-    permissions = ['cluster-definition-u'];
+    permissions = ['cluster-configuration-u'];
 
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ClusterConfigurationComponent],

--- a/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.ts
@@ -68,7 +68,7 @@ export class ClusterConfigurationComponent implements OnInit {
 
   public ngOnInit() {
     this.isLoadingData = true;
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['cluster-definition-u']);
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['cluster-configuration-u']);
     this.clusterService
       .get(this.activatedRoute.snapshot.params.clusterId)
       .pipe(

--- a/gravitee-apim-console-webui/src/management/clusters/details/user-permissions/cluster-user-permissions.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/details/user-permissions/cluster-user-permissions.component.html
@@ -23,7 +23,7 @@
 
       <div class="card__header__actions">
         <button
-          *gioPermission="{ anyOf: ['cluster-definition-u'] }"
+          *gioPermission="{ anyOf: ['cluster-member-u'] }"
           (click)="updateGroups()"
           class="card__header__actions__button"
           aria-label="Manage groups"

--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.html
@@ -58,14 +58,14 @@
       <ng-container matColumnDef="bootstrapServer">
         <th mat-header-cell *matHeaderCellDef>Bootstrap Server</th>
         <td mat-cell *matCellDef="let element">
-          {{ element.bootstrapServer }}
+          <span [innerHTML]="element.bootstrapServer"></span>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="security">
         <th mat-header-cell *matHeaderCellDef>Security</th>
         <td mat-cell *matCellDef="let element">
-          {{ element.security }}
+          <span [innerHTML]="element.security"></span>
         </td>
       </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.spec.ts
@@ -155,7 +155,7 @@ describe('ClustersListPageComponent', () => {
     expectListClusterRequest(httpTestingController, fakePagedResult([fakeCluster()]), '?page=1&perPage=25&q=Production');
 
     expect(await table.getCellTextByIndex()).toStrictEqual([
-      ['Cluster Name', 'kafka.example.com:9092', 'PLAINTEXT', 'Jan 1, 2023, 12:00:00 AM', ''],
+      ['Cluster Name', 'kafka.example.com:9092', 'Hidden', 'Jan 1, 2023, 12:00:00 AM', ''],
     ]);
   });
 

--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
@@ -113,8 +113,8 @@ export class ClusterListComponent implements OnInit {
           const items = pagedResult.data.map((cluster) => ({
             id: cluster.id,
             name: cluster.name,
-            bootstrapServer: cluster.configuration.bootstrapServers,
-            security: get(cluster.configuration, 'security.protocol', 'PLAINTEXT') as string,
+            bootstrapServer: get(cluster.configuration, 'bootstrapServers', '<i>Hidden</i>'),
+            security: get(cluster.configuration, 'security.protocol', '<i>Hidden</i>'),
             updatedAt: cluster.updatedAt,
           }));
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
@@ -45,6 +45,15 @@
       </mat-select>
     </mat-form-field>
 
+    <mat-form-field aria-hidden="false" aria-label="Select default cluster role">
+      <mat-label>Default Cluster Role</mat-label>
+      <mat-select formControlName="defaultClusterRole">
+        @for (role of defaultClusterRoles; track role.id) {
+          <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
     <mat-form-field appearance="outline">
       <mat-label>Search Users</mat-label>
       <input aria-hidden="false" aria-label="Search users" matInput formControlName="searchTerm" [matAutocomplete]="auto" />

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
@@ -34,9 +34,8 @@ import { Role } from '../../../../../entities/role/role';
 import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { SearchableUser } from '../../../../../entities/user/searchableUser';
-import { Member } from '../../../../../entities/management-api-v2';
 import { GroupMembership } from '../../../../../entities/group/groupMember';
-import { RoleName } from '../membershipState';
+import { Member, RoleName } from '../membershipState';
 import { UsersService } from '../../../../../services-ngx/users.service';
 import { AddOrInviteMembersDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
@@ -65,10 +64,12 @@ export class AddMembersDialogComponent implements OnInit {
   defaultAPIRoles: Role[];
   defaultApplicationRoles: Role[];
   defaultIntegrationRoles: Role[];
+  defaultClusterRoles: Role[];
   addMemberForm: FormGroup<{
     defaultAPIRole: FormControl<string>;
     defaultApplicationRole: FormControl<string>;
     defaultIntegrationRole: FormControl<string>;
+    defaultClusterRole: FormControl<string>;
     searchTerm: FormControl<string>;
   }>;
   disabledAPIRoles = new Set<string>();
@@ -99,6 +100,7 @@ export class AddMembersDialogComponent implements OnInit {
     this.defaultAPIRoles = this.data.defaultAPIRoles;
     this.defaultApplicationRoles = this.data.defaultApplicationRoles;
     this.defaultIntegrationRoles = this.data.defaultIntegrationRoles;
+    this.defaultClusterRoles = this.data.defaultClusterRoles;
   }
 
   private initializeForm() {
@@ -109,6 +111,7 @@ export class AddMembersDialogComponent implements OnInit {
         disabled: false,
       }),
       defaultIntegrationRole: new FormControl<string>({ value: 'USER', disabled: false }),
+      defaultClusterRole: new FormControl<string>({ value: 'USER', disabled: false }),
       searchTerm: new FormControl<string>({ value: '', disabled: false }),
     });
     this.disableSearch();
@@ -134,6 +137,7 @@ export class AddMembersDialogComponent implements OnInit {
     this.disableDefaultAPIRole();
     this.disableDefaultApplicationRole();
     this.disableDefaultIntegrationRole();
+    this.disableDefaultClusterRole();
     this.disableAPIRoleOptions();
   }
 
@@ -152,6 +156,12 @@ export class AddMembersDialogComponent implements OnInit {
   private disableDefaultIntegrationRole(): void {
     if (!this.canUpdateGroup()) {
       this.addMemberForm.controls.defaultIntegrationRole.disable();
+    }
+  }
+
+  private disableDefaultClusterRole(): void {
+    if (!this.canUpdateGroup()) {
+      this.addMemberForm.controls.defaultClusterRole.disable();
     }
   }
 
@@ -201,6 +211,10 @@ export class AddMembersDialogComponent implements OnInit {
         {
           name: this.addMemberForm.controls.defaultIntegrationRole.value,
           scope: 'INTEGRATION',
+        },
+        {
+          name: this.addMemberForm.controls.defaultClusterRole.value,
+          scope: 'CLUSTER',
         },
       ],
     };

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
@@ -30,8 +30,7 @@ import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 
 import { GroupMembership } from '../../../../../entities/group/groupMember';
-import { RoleName } from '../membershipState';
-import { Member } from '../../../../../entities/management-api-v2';
+import { Member, RoleName } from '../membershipState';
 import { UsersService } from '../../../../../services-ngx/users.service';
 import { DeleteMemberDialogData } from '../group.component';
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
@@ -45,6 +45,15 @@
       </mat-select>
     </mat-form-field>
 
+    <mat-form-field aria-hidden="false" aria-label="Select default cluster role">
+      <mat-label>Default Cluster Role</mat-label>
+      <mat-select formControlName="defaultClusterRole" (selectionChange)="onChange()">
+        @for (role of defaultClusterRoles; track role.id) {
+          <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
     <gio-form-slide-toggle class="edit-member__form__actions">
       <gio-form-label>Group Admin</gio-form-label>
       <mat-slide-toggle

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -32,7 +32,7 @@ import { GioBannerModule, GioFormSlideToggleModule } from '@gravitee/ui-particle
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 
-import { RoleName } from '../membershipState';
+import { Member, RoleName } from '../membershipState';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
@@ -40,7 +40,6 @@ import { Role } from '../../../../../entities/role/role';
 import { GroupMembership } from '../../../../../entities/group/groupMember';
 import { SearchableUser } from '../../../../../entities/user/searchableUser';
 import { UsersService } from '../../../../../services-ngx/users.service';
-import { Member } from '../../../../../entities/management-api-v2';
 import { EditMemberDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
 
@@ -77,12 +76,14 @@ export class EditMemberDialogComponent implements OnInit {
   defaultAPIRoles: Role[] = [];
   defaultApplicationRoles: Role[] = [];
   defaultIntegrationRoles: Role[] = [];
+  defaultClusterRoles: Role[] = [];
   editMemberForm: FormGroup<{
     displayName: FormControl<string>;
     groupAdmin: FormControl<boolean>;
     defaultAPIRole: FormControl<string>;
     defaultApplicationRole: FormControl<string>;
     defaultIntegrationRole: FormControl<string>;
+    defaultClusterRole: FormControl<string>;
     searchTerm: FormControl<string>;
   }>;
   ownershipTransferMessage: string = null;
@@ -121,6 +122,7 @@ export class EditMemberDialogComponent implements OnInit {
     this.defaultAPIRoles = this.data.defaultAPIRoles;
     this.defaultApplicationRoles = this.data.defaultApplicationRoles;
     this.defaultIntegrationRoles = this.data.defaultIntegrationRoles;
+    this.defaultClusterRoles = this.data.defaultClusterRoles;
   }
 
   private initializeForm() {
@@ -133,6 +135,7 @@ export class EditMemberDialogComponent implements OnInit {
       defaultAPIRole: new FormControl<string>(this.member.roles['API']),
       defaultApplicationRole: new FormControl<string>(this.member.roles['APPLICATION']),
       defaultIntegrationRole: new FormControl<string>(this.member.roles['INTEGRATION']),
+      defaultClusterRole: new FormControl<string>(this.member.roles['CLUSTER']),
       searchTerm: new FormControl<string>({ value: '', disabled: true }),
     });
   }
@@ -160,6 +163,7 @@ export class EditMemberDialogComponent implements OnInit {
     this.disableDefaultAPIRole();
     this.disableDefaultApplicationRole();
     this.disableDefaultIntegrationRole();
+    this.disableDefaultClusterRole();
     this.disableAPIRoleOptions();
   }
 
@@ -178,6 +182,12 @@ export class EditMemberDialogComponent implements OnInit {
   private disableDefaultIntegrationRole(): void {
     if (!this.canUpdateGroup()) {
       this.editMemberForm.controls.defaultIntegrationRole.disable();
+    }
+  }
+
+  private disableDefaultClusterRole(): void {
+    if (!this.canUpdateGroup()) {
+      this.editMemberForm.controls.defaultClusterRole.disable();
     }
   }
 
@@ -265,6 +275,10 @@ export class EditMemberDialogComponent implements OnInit {
         {
           name: this.editMemberForm.controls.defaultIntegrationRole.value,
           scope: 'INTEGRATION',
+        },
+        {
+          name: this.editMemberForm.controls.defaultClusterRole.value,
+          scope: 'CLUSTER',
         },
       ],
     };

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -244,6 +244,13 @@
                   </td>
                 </ng-container>
 
+                <ng-container matColumnDef="defaultClusterRole">
+                  <th mat-header-cell *matHeaderCellDef id="defaultClusterRole">Cluster Role</th>
+                  <td mat-cell *matCellDef="let row">
+                    <div>{{ row.roles['CLUSTER'] }}</div>
+                  </td>
+                </ng-container>
+
                 <ng-container matColumnDef="actions" class="group__table__actions">
                   <th mat-header-cell *matHeaderCellDef id="actions"></th>
                   <td mat-cell *matCellDef="let row">

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/invite-member-dialog/invite-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/invite-member-dialog/invite-member-dialog.component.ts
@@ -30,8 +30,7 @@ import { GioPermissionModule } from '../../../../../shared/components/gio-permis
 import { Invitation } from '../../../../../entities/invitation/invitation';
 import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
-import { RoleName } from '../membershipState';
-import { Member } from '../../../../../entities/management-api-v2';
+import { RoleName, Member } from '../membershipState';
 import { AddOrInviteMembersDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/membershipState.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/membershipState.ts
@@ -24,10 +24,12 @@ export enum RoleName {
 export enum RoleScope {
   API = 'API',
   APPLICATION = 'APPLICATION',
+  CLUSTER = 'CLUSTER',
+  INTEGRATION = 'INTEGRATION',
 }
 
 export type Roles = {
-  [scope in RoleScope]: RoleName;
+  [scope in RoleScope]: RoleName | string;
 };
 
 export interface Member {

--- a/gravitee-apim-console-webui/src/services-ngx/group.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group.service.ts
@@ -24,7 +24,7 @@ import { Constants } from '../entities/Constants';
 import { Group } from '../entities/group/group';
 import { GroupMembership } from '../entities/group/groupMember';
 import { Invitation } from '../entities/invitation/invitation';
-import { Member } from '../entities/management-api-v2';
+import { Member } from '../management/settings/groups/group/membershipState';
 
 @Injectable({
   providedIn: 'root',

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClusterResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClusterResource.java
@@ -141,7 +141,7 @@ public class ClusterResource extends AbstractResource {
     @Path("groups")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.CLUSTER_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.CLUSTER_MEMBER, acls = { RolePermissionAction.UPDATE }) })
     public Response updateClusterGroups(@Valid @NotNull final List<@NotNull String> groups) {
         var executionContext = GraviteeContext.getExecutionContext();
         var userDetails = getAuthenticatedUserDetails();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClusterResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClusterResourceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.cluster;
 
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE;
@@ -126,24 +127,24 @@ class ClusterResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_403_if_incorrect_permissions() {
             shouldReturn403(RolePermission.CLUSTER_DEFINITION, CLUSTER_ID, RolePermissionAction.READ, () -> rootTarget().request().get());
-            /*when(
-                    permissionService.hasPermission(
-                            GraviteeContext.getExecutionContext(),
-                            RolePermission.CLUSTER_DEFINITION,
-                            CLUSTER_ID,
-                            RolePermissionAction.READ
-                    )
+            when(
+                permissionService.hasPermission(
+                    GraviteeContext.getExecutionContext(),
+                    RolePermission.CLUSTER_DEFINITION,
+                    CLUSTER_ID,
+                    RolePermissionAction.READ
+                )
             )
-                    .thenReturn(false);
+                .thenReturn(false);
 
             final Response response = rootTarget().request().get();
 
             MAPIAssertions
-                    .assertThat(response)
-                    .hasStatus(FORBIDDEN_403)
-                    .asError()
-                    .hasHttpStatus(FORBIDDEN_403)
-                    .hasMessage("You do not have sufficient rights to access this resource");*/
+                .assertThat(response)
+                .hasStatus(FORBIDDEN_403)
+                .asError()
+                .hasHttpStatus(FORBIDDEN_403)
+                .hasMessage("You do not have sufficient rights to access this resource");
         }
     }
 
@@ -261,7 +262,7 @@ class ClusterResourceTest extends AbstractResourceTest {
         @Test
         void should_return_403_if_incorrect_permissions() {
             shouldReturn403(
-                RolePermission.CLUSTER_DEFINITION,
+                RolePermission.CLUSTER_MEMBER,
                 CLUSTER_ID,
                 RolePermissionAction.UPDATE,
                 () -> rootTarget().path("groups").request().put(json(Map.of("groups", Set.of("G1", "G2"))))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -228,6 +228,7 @@ public class GroupMembersResource extends AbstractResource {
             RoleEntity previousApplicationRole = null;
             RoleEntity previousGroupRole = null;
             RoleEntity previousIntegrationRole = null;
+            RoleEntity previousClusterRole = null;
 
             if (membership.getId() != null) {
                 Set<RoleEntity> userRoles = membershipService.getRoles(
@@ -249,6 +250,9 @@ public class GroupMembersResource extends AbstractResource {
                             break;
                         case INTEGRATION:
                             previousIntegrationRole = role;
+                            break;
+                        case CLUSTER:
+                            previousClusterRole = role;
                             break;
                         default:
                             break;
@@ -297,6 +301,12 @@ public class GroupMembersResource extends AbstractResource {
                     updateRole(RoleScope.INTEGRATION, roleName, previousIntegrationRole, membership, executionContext);
                 }
 
+                RoleEntity clusterRoleEntity = roleEntities.get(RoleScope.CLUSTER);
+                if (clusterRoleEntity != null && !clusterRoleEntity.equals(previousClusterRole)) {
+                    String roleName = getRoleName(RoleScope.CLUSTER, clusterRoleEntity, groupEntity, e -> true, hasPermission);
+                    updateRole(RoleScope.CLUSTER, roleName, previousClusterRole, membership, executionContext);
+                }
+
                 RoleEntity groupRoleEntity = roleEntities.get(RoleScope.GROUP);
                 if (groupRoleEntity != null && !groupRoleEntity.equals(previousGroupRole)) {
                     updateRole(RoleScope.GROUP, groupRoleEntity.getName(), previousGroupRole, membership, executionContext);
@@ -307,6 +317,7 @@ public class GroupMembersResource extends AbstractResource {
                 deleteIfNewAndPreviousRoleNull(apiRoleEntity, previousApiRole, membershipId);
                 deleteIfNewAndPreviousRoleNull(applicationRoleEntity, previousApplicationRole, membershipId);
                 deleteIfNewAndPreviousRoleNull(integrationRoleEntity, previousIntegrationRole, membershipId);
+                deleteIfNewAndPreviousRoleNull(clusterRoleEntity, previousClusterRole, membershipId);
                 deleteIfNewAndPreviousRoleNull(groupRoleEntity, previousGroupRole, membershipId);
 
                 // Send notification
@@ -315,6 +326,7 @@ public class GroupMembersResource extends AbstractResource {
                     previousApplicationRole == null &&
                     previousGroupRole == null &&
                     previousIntegrationRole == null &&
+                    previousClusterRole == null &&
                     updatedMembership != null
                 ) {
                     UserEntity userEntity = this.userService.findById(executionContext, updatedMembership.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -106,7 +106,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         "INTEGRATION",
         List.of("DEFINITION", "MEMBER"),
         "CLUSTER",
-        List.of("ANALYTICS", "DEFINITION", "GATEWAY_DEFINITION", "MEMBER")
+        List.of("ANALYTICS", "CONFIGURATION", "DEFINITION", "MEMBER")
     );
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 public enum MembershipReferenceType {
     APPLICATION(EnumSet.of(RoleScope.APPLICATION)),
     API(EnumSet.of(RoleScope.API)),
-    GROUP(EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION)),
+    GROUP(EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION, RoleScope.CLUSTER)),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),
     PLATFORM(EnumSet.allOf(RoleScope.class)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ClusterPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ClusterPermission.java
@@ -25,7 +25,7 @@ import lombok.Getter;
 public enum ClusterPermission implements Permission {
     DEFINITION("DEFINITION", 1000),
     ANALYTICS("ANALYTICS", 1200),
-    GATEWAY_DEFINITION("GATEWAY_DEFINITION", 1600),
+    CONFIGURATION("CONFIGURATION", 1600),
     MEMBER("MEMBER", 1700);
 
     String name;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -109,8 +109,10 @@ public enum RolePermission {
     INTEGRATION_DEFINITION(RoleScope.INTEGRATION, IntegrationPermission.DEFINITION),
     INTEGRATION_MEMBER(RoleScope.INTEGRATION, IntegrationPermission.MEMBER),
 
-    CLUSTER_MEMBER(RoleScope.CLUSTER, ClusterPermission.MEMBER),
-    CLUSTER_DEFINITION(RoleScope.CLUSTER, ClusterPermission.DEFINITION);
+    CLUSTER_ANALYTICS(RoleScope.CLUSTER, ClusterPermission.ANALYTICS),
+    CLUSTER_CONFIGURATION(RoleScope.CLUSTER, ClusterPermission.CONFIGURATION),
+    CLUSTER_DEFINITION(RoleScope.CLUSTER, ClusterPermission.DEFINITION),
+    CLUSTER_MEMBER(RoleScope.CLUSTER, ClusterPermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCase.java
@@ -20,11 +20,14 @@ import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterSearchCriteria;
 import io.gravitee.apim.core.cluster.query_service.ClusterQueryService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +38,7 @@ public class SearchClusterUseCase {
 
     private final ClusterQueryService clusterQueryService;
     private final MembershipQueryService membershipQueryService;
+    private final PermissionDomainService permissionDomainService;
 
     @Builder
     public record Input(String environmentId, String query, Pageable pageable, String sortBy, boolean isAdmin, String userId) {}
@@ -57,8 +61,27 @@ public class SearchClusterUseCase {
         var pageable = Optional.ofNullable(input.pageable).orElse(new PageableImpl(1, 10));
 
         return new SearchClusterUseCase.Output(
-            clusterQueryService.search(criteriaBuilder.build(), pageable, generateSortable(input.sortBy))
+            clusterQueryService
+                .search(criteriaBuilder.build(), pageable, generateSortable(input.sortBy))
+                .map(cluster -> {
+                    setClusterConfigurationIfPermitted(input, cluster);
+                    return cluster;
+                })
         );
+    }
+
+    private void setClusterConfigurationIfPermitted(Input input, Cluster cluster) {
+        if (
+            !permissionDomainService.hasPermission(
+                cluster.getOrganizationId(),
+                input.userId(),
+                RolePermission.CLUSTER_CONFIGURATION,
+                cluster.getId(),
+                RolePermissionAction.READ
+            )
+        ) {
+            cluster.setConfiguration(null);
+        }
     }
 
     private Optional<Sortable> generateSortable(String sortBy) {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-10258

✅ Allows to manage the role of a member with a cluster on the group page.

<img width="1270" height="533" alt="image" src="https://github.com/user-attachments/assets/13289588-2063-4658-b422-3ca75e28e2a1" />

✅ Replace all occurrences of GATEWAY_DEFINITION with CONFIGURATION.
✅ On the search, if the user does not have CONFIGURATION_READ, hide the config and security sections.
✅ With CONFIGURATION_UPDATE but only CONFIGURATION_READ, the configuration page is hidden; if read-only, display the page in read-only mode.
✅ User permissions must be hidden if the user does not have READ permission on cluster members.
✅ MEMBER_UPDATE must grant permission to manage groups.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fdaujirvez.chromatic.com)
<!-- Storybook placeholder end -->
