### PR TITLE
fix: ensure the correct DefinitionVersion label is sent during Swagger import in pathMapping

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.spec.ts
@@ -29,6 +29,7 @@ import { ApiPathMappingsAddDialogComponent } from './api-path-mappings-add-dialo
 import { ApiPathMappingsModule } from '../api-path-mappings.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
 import { ApiV2, fakeApiV2 } from '../../../../../entities/management-api-v2';
+import { mapDefinitionVersionToLabel } from '../../../../../shared/utils/api.util';
 
 describe('ApiPathMappingsEditDialogComponent', () => {
   const API_ID = 'apiId';
@@ -124,10 +125,11 @@ describe('ApiPathMappingsEditDialogComponent', () => {
   }
 
   function expectPathMappingImportRequest(api: ApiV2, pageId: string) {
+    const defVersion = mapDefinitionVersionToLabel(api.definitionVersion);
     httpTestingController
       .expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/import-path-mappings?page=${pageId}&definitionVersion=${api.definitionVersion}`,
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/import-path-mappings?page=${pageId}&definitionVersion=${defVersion}`,
       })
       .flush(api);
     fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.ts
@@ -28,6 +28,7 @@ import { ApiV1, ApiV2 } from '../../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { onlyApiV2Filter } from '../../../../../util/apiFilter.operator';
 import { ApiService } from '../../../../../services-ngx/api.service';
+import { mapDefinitionVersionToLabel } from '../../../../../shared/utils/api.util';
 
 export interface ApiPathMappingsAddDialogData {
   api: ApiV1 | ApiV2;
@@ -77,8 +78,9 @@ export class ApiPathMappingsAddDialogComponent implements OnInit {
       .pipe(
         onlyApiV2Filter(this.snackBarService),
         switchMap((api) => {
+          const defVersion = mapDefinitionVersionToLabel(this.api.definitionVersion);
           if (this.selectedSwaggerDoc) {
-            return this.apiService.importPathMappings(api.id, this.selectedSwaggerDoc, this.api.definitionVersion);
+            return this.apiService.importPathMappings(api.id, this.selectedSwaggerDoc, defVersion);
           } else {
             api.pathMappings.push(this.pathFormGroup.getRawValue().path);
             return this.apiV2Service.update(api.id, api);

--- a/gravitee-apim-console-webui/src/shared/utils/api.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api.util.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const mapDefinitionVersionToLabel = (definitionVersion: string): string => {
+  switch (definitionVersion) {
+    case 'V1':
+      return '1.0.0';
+    case 'V2':
+      return '2.0.0';
+    case 'V4':
+      return '4.0.0';
+    default:
+      return definitionVersion;
+  }
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10973
## Description

When configuring path mapping from a Swagger (OpenAPI 2.0) document, the process failed with:

`  Cannot invoke "io.gravitee.definition.model.DefinitionVersion.equals(Object)" because "definitionVersion" is null`

Root cause:
The UI was sending the enum name (e.g. "V2") instead of the label (e.g. "2.0.0"), causing DefinitionVersion.valueOfLabel() to return null.

Changes:
- Added mapping to convert enum names (V1, V2, V4) to their proper labels ("1.0.0", "2.0.0", "4.0.0") before invoking importPathMappings.

This ensures Swagger-based path mapping works correctly and avoids null DefinitionVersion errors.

Issue:


https://github.com/user-attachments/assets/fe87103f-3d57-4912-ba35-6e8673be31ab

Fix:

https://github.com/user-attachments/assets/06c483f0-64c4-44a8-b40d-2bf4c4a0ea15




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hrsptxxzbp.chromatic.com)
<!-- Storybook placeholder end -->
