### PR TITLE
fix: optimize audit search for large datasets to prevent OOM

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.createPagingClause;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static io.gravitee.repository.jdbc.management.JdbcHelper.*;
 import static java.lang.String.format;
@@ -195,35 +196,33 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
     }
 
     @Override
-    public Page<Audit> search(AuditCriteria filter, Pageable page) {
+    public Page<Audit> search(AuditCriteria filter, Pageable pageable) {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("JdbcEventRepository.search({}, {})", criteriaToString(filter), page);
+            LOGGER.debug("JdbcAuditRepository.search({}, {})", criteriaToString(filter), pageable);
         }
-        final List<Object> argsList = new ArrayList<>();
-        final StringBuilder builder = new StringBuilder(
-            getOrm().getSelectAllSql() + " a left join " + AUDIT_PROPERTIES + " ap on a.id = ap.audit_id "
-        );
+
+        List<Object> argsList = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
         boolean started = false;
+
         if (filter.getFrom() > 0) {
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
-            builder.append("created_at >= ?");
+            builder.append("a.created_at >= ?");
             argsList.add(new Date(filter.getFrom()));
             started = true;
         }
         if (filter.getTo() > 0) {
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
-            builder.append("created_at <= ?");
+            builder.append("a.created_at <= ?");
             argsList.add(new Date(filter.getTo()));
             started = true;
         }
-
         if (!isEmpty(filter.getEnvironmentIds())) {
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
             builder.append("a.environment_id in (").append(getOrm().buildInClause(filter.getEnvironmentIds())).append(")");
             argsList.addAll(filter.getEnvironmentIds());
             started = true;
         }
-
         if (filter.getOrganizationId() != null) {
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
             builder.append("a.organization_id = ?");
@@ -235,35 +234,29 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
         started = addReferencesWhereClause(filter, argsList, builder, started);
         addStringsWhereClause(filter.getEvents(), "event", argsList, builder, started);
 
-        builder.append(" order by created_at desc ");
+        String whereClause = builder.toString();
+        String countSql =
+            "SELECT COUNT(*) FROM " + this.tableName + " a LEFT JOIN " + AUDIT_PROPERTIES + " ap ON a.id = ap.audit_id " + whereClause;
 
-        String sql = builder.toString();
-
-        LOGGER.debug("argsList = {}", argsList);
-        Object[] args = argsList.toArray();
-        LOGGER.debug("SQL: {}", sql);
-        LOGGER.debug("Args ({}): {}", args.length, args);
-        for (int i = 0; i < args.length; ++i) {
-            LOGGER.debug("args[{}] = {} {}", i, args[i], args[i].getClass());
+        Long total = jdbcTemplate.queryForObject(countSql, argsList.toArray(), Long.class);
+        if (total == null || total == 0) {
+            return new Page<>(List.of(), pageable.pageNumber(), 0, 0);
         }
+        String sql =
+            getOrm().getSelectAllSql() +
+            " a LEFT JOIN " +
+            AUDIT_PROPERTIES +
+            " ap ON a.id = ap.audit_id " +
+            whereClause +
+            " ORDER BY a.created_at DESC " +
+            createPagingClause(pageable.pageSize(), pageable.from());
 
-        List<Audit> audits;
-        try {
-            JdbcHelper.CollatingRowMapper<Audit> rowMapper = new JdbcHelper.CollatingRowMapper<>(
-                getOrm().getRowMapper(),
-                CHILD_ADDER,
-                "id"
-            );
-            jdbcTemplate.query(sql, rowMapper, args);
-            audits = rowMapper.getRows();
-        } catch (final Exception ex) {
-            LOGGER.error("Failed to find audit records:", ex);
-            throw new IllegalStateException("Failed to find audit records", ex);
-        }
+        JdbcHelper.CollatingRowMapper<Audit> rowMapper = new JdbcHelper.CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
 
-        LOGGER.debug("audit records found ({}): {}", audits.size(), audits);
+        jdbcTemplate.query(sql, rowMapper, argsList.toArray());
+        List<Audit> audits = rowMapper.getRows();
 
-        return getResultAsPage(page, audits);
+        return new Page<>(audits, pageable.pageNumber(), audits.size(), total);
     }
 
     private boolean addReferencesWhereClause(AuditCriteria filter, List<Object> argsList, StringBuilder builder, boolean started) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcAuditRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcAuditRepositoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.search.AuditCriteria;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.model.Audit;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class JdbcAuditRepositoryTest {
+
+    @Test
+    void shouldReturnPageWithCorrectPagination() throws Exception {
+        JdbcAuditRepository repo = spy(new JdbcAuditRepository(""));
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        Field field = null;
+        Class<?> clazz = repo.getClass();
+        while (clazz != null) {
+            try {
+                field = clazz.getDeclaredField("jdbcTemplate");
+                field.setAccessible(true);
+                field.set(repo, jdbcTemplate);
+                break;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        if (field == null) throw new RuntimeException("jdbcTemplate field not found");
+        when(jdbcTemplate.queryForObject(anyString(), any(Object[].class), eq(Long.class))).thenReturn(5L);
+
+        doAnswer(invocation -> {
+                JdbcHelper.CollatingRowMapper<Audit> rowMapper = invocation.getArgument(1);
+                rowMapper.getRows().add(new Audit());
+                rowMapper.getRows().add(new Audit());
+                return null;
+            })
+            .when(jdbcTemplate)
+            .query(anyString(), any(JdbcHelper.CollatingRowMapper.class), any(Object[].class));
+        AuditCriteria criteria = new AuditCriteria.Builder().organizationId("org1").build();
+        var pageable = new PageableBuilder().pageNumber(0).pageSize(2).build();
+
+        Page<Audit> result = repo.search(criteria, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(5);
+        assertThat(result.getPageNumber()).isEqualTo(0);
+
+        verify(jdbcTemplate).queryForObject(anyString(), any(Object[].class), eq(Long.class));
+        verify(jdbcTemplate).query(anyString(), any(JdbcHelper.CollatingRowMapper.class), any(Object[].class));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9691

## Description

Issue -
Organization-level Audit page in Gravitee APIM was failing with `java.lang.OutOfMemoryError` when using JDBC, especially with large volumes of audit entries.

Root cause -
The previous implementation loaded all matching audit records into memory before applying pagination, causing excessive heap usage.

Solution -
- Refactored JdbcAuditRepository.search() to use server-side pagination with LIMIT/OFFSET.  
- COUNT query now only queries the parent `audits` table (no joins), reducing execution time and memory usage.  
- Applied CollatingRowMapper only to the page of results, avoiding full table materialization in memory.  

Before:

https://github.com/user-attachments/assets/b79c8165-0e56-42f8-bc80-7e05a571ab35

After:

https://github.com/user-attachments/assets/b2a97ed6-0073-46d2-9515-356fb4b36b0e



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

