### PR TITLE
fix: audit and events cleaner should be only started on primary node

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
@@ -19,6 +19,7 @@ import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 
 import io.gravitee.apim.core.audit.use_case.RemoveOldAuditDataUseCase;
 import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.OrganizationService;
 import java.time.Duration;
@@ -38,6 +39,7 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
     private final OrganizationService organizationService;
     private final EnvironmentService environmentService;
     private final Duration maxAge;
+    private final ClusterManager clusterManager;
 
     public ScheduledAuditCleanerService(
         @Qualifier("auditTaskScheduler") TaskScheduler scheduler,
@@ -46,7 +48,8 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
         @Value("${services.audit.retention.days:365}") int maxAgeInDays,
         RemoveOldAuditDataUseCase removeOldAuditDataUseCase,
         OrganizationService organizationService,
-        EnvironmentService environmentService
+        EnvironmentService environmentService,
+        ClusterManager clusterManager
     ) {
         this.scheduler = scheduler;
         this.cronTrigger = cronTrigger;
@@ -54,7 +57,8 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
         this.removeOldAuditDataUseCase = removeOldAuditDataUseCase;
         this.organizationService = organizationService;
         this.environmentService = environmentService;
-        maxAge = Duration.ofDays(maxAgeInDays);
+        this.clusterManager = clusterManager;
+        this.maxAge = Duration.ofDays(maxAgeInDays);
     }
 
     @Override
@@ -64,12 +68,14 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
 
     @Override
     protected void doStart() throws Exception {
-        if (enabled) {
-            super.doStart();
-            log.info("Audit cleaner service has been initialized with cron [{}]", cronTrigger);
-            scheduler.schedule(this, new CronTrigger(cronTrigger));
-        } else {
-            log.warn("Audit cleaner service has been disabled");
+        if (clusterManager.self().primary()) {
+            if (enabled) {
+                super.doStart();
+                log.info("Audit cleaner service has been initialized with cron [{}]", cronTrigger);
+                scheduler.schedule(this, new CronTrigger(cronTrigger));
+            } else {
+                log.warn("Audit cleaner service has been disabled");
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.audit.use_case.RemoveOldAuditDataUseCase;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.service.EnvironmentService;
@@ -52,6 +54,9 @@ class ScheduledAuditCleanerServiceTest {
     @Mock
     TaskScheduler scheduler;
 
+    @Mock
+    ClusterManager clusterManager;
+
     ScheduledAuditCleanerService sut;
 
     @Captor
@@ -59,7 +64,17 @@ class ScheduledAuditCleanerServiceTest {
 
     @BeforeEach
     void setup() {
-        sut = new ScheduledAuditCleanerService(scheduler, "", true, 1, removeOldAuditDataUseCase, organizationService, environmentService);
+        sut =
+            new ScheduledAuditCleanerService(
+                scheduler,
+                "",
+                true,
+                1,
+                removeOldAuditDataUseCase,
+                organizationService,
+                environmentService,
+                clusterManager
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/test/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/test/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningServiceTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.event.use_case.CleanupEventsUseCase;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.OrganizationService;
 import java.time.Duration;
@@ -49,6 +51,9 @@ class ScheduledEventsCleaningServiceTest {
     @Mock
     private TaskScheduler scheduler;
 
+    @Mock
+    private ClusterManager clusterManager;
+
     private ScheduledEventsCleaningService scheduledEventsCleaningService;
 
     @BeforeEach
@@ -59,6 +64,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true,
@@ -69,12 +75,17 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_be_enabled_by_default() throws Exception {
         // Given
+        Member mockMember = org.mockito.Mockito.mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
+
         scheduledEventsCleaningService =
             new ScheduledEventsCleaningService(
                 cleanupEventsUseCase,
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true, // enabled = true
@@ -91,6 +102,9 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_schedule_task_when_enabled() throws Exception {
         // Given
+        Member mockMember = org.mockito.Mockito.mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
         String cronExpression = "@hourly";
         scheduledEventsCleaningService =
             new ScheduledEventsCleaningService(
@@ -98,6 +112,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 cronExpression,
                 5,
                 true,
@@ -114,6 +129,9 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_use_correct_cron_expression() throws Exception {
         // Given
+        Member mockMember = org.mockito.Mockito.mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
         String cronExpression = "0 0 2 * * ?"; // Daily at 2 AM
         scheduledEventsCleaningService =
             new ScheduledEventsCleaningService(
@@ -121,6 +139,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 cronExpression,
                 5,
                 true,
@@ -144,6 +163,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 eventsKeep,
                 true,
@@ -167,6 +187,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true,
@@ -189,6 +210,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5, // Use default value instead of null
                 true,
@@ -211,6 +233,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true,
@@ -233,6 +256,7 @@ class ScheduledEventsCleaningServiceTest {
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true, // Use default value instead of null
@@ -254,6 +278,7 @@ class ScheduledEventsCleaningServiceTest {
             organizationService,
             environmentService,
             scheduler,
+            clusterManager,
             "@daily",
             5,
             true,
@@ -275,12 +300,16 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_log_info_message_when_starting() throws Exception {
         // Given
+        Member mockMember = org.mockito.Mockito.mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
         scheduledEventsCleaningService =
             new ScheduledEventsCleaningService(
                 cleanupEventsUseCase,
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true,
@@ -299,12 +328,16 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_not_log_warning_when_enabled() throws Exception {
         // Given
+        Member mockMember = org.mockito.Mockito.mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
         scheduledEventsCleaningService =
             new ScheduledEventsCleaningService(
                 cleanupEventsUseCase,
                 organizationService,
                 environmentService,
                 scheduler,
+                clusterManager,
                 "@daily",
                 5,
                 true, // enabled = true


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11007

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zkizegpnpx.chromatic.com)
<!-- Storybook placeholder end -->
