### PR TITLE
APIM-10942 After migrating api to v4 and performing a rollback to v2, this api cannot be located by searching on the api list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -15,56 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl.search.lucene.transformer;
 
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES_ASC_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES_DESC_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CREATED_AT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_LOWERCASE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HOSTS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HOSTS_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_LOWERCASE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_LOWERCASE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ORIGIN;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_LOWERCASE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_MAIL;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PORTAL_STATUS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PORTAL_STATUS_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_STATUS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_STATUS_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_ASC_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_DESC_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_SPLIT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_UPDATED_AT;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_VISIBILITY;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_VISIBILITY_SORTED;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.SPECIAL_CHARS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.*;
 
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.search.model.IndexableApi;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -201,6 +158,8 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
 
         if (api.getDefinitionVersion() == DefinitionVersion.V4) {
             transformV4Api(doc, indexableApi);
+        } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {
+            transformV2Api(doc, indexableApi);
         }
 
         return doc;
@@ -222,8 +181,8 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
 
         if (api.getDefinitionVersion() != null) {
             return switch (api.getDefinitionVersion()) {
-                case V4, FEDERATED, FEDERATED_AGENT -> true;
-                case V1, V2 -> false;
+                case V4, FEDERATED, FEDERATED_AGENT, V2 -> true;
+                case V1 -> false;
             };
         }
         return true;
@@ -295,6 +254,84 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
         if (host != null && !host.isEmpty()) {
             doc.add(new StringField(FIELD_HOSTS, host, Field.Store.NO));
             doc.add(new TextField(FIELD_HOSTS_SPLIT, host, Field.Store.NO));
+        }
+    }
+
+    private void transformV2Api(Document doc, IndexableApi indexableApi) {
+        var api = indexableApi.getApi();
+
+        // Handle v2 API paths from proxy configuration
+        if (api.getApiDefinition() != null && api.getApiDefinition().getProxy() != null) {
+            final int[] pathIndex = { 0 };
+            api
+                .getApiDefinition()
+                .getProxy()
+                .getVirtualHosts()
+                .forEach(virtualHost -> appendPath(doc, pathIndex, virtualHost.getHost(), virtualHost.getPath()));
+        }
+
+        // Handle v2 API tags
+        if (api.getApiDefinition() != null && api.getApiDefinition().getTags() != null && !api.getApiDefinition().getTags().isEmpty()) {
+            for (String tag : api.getApiDefinition().getTags()) {
+                doc.add(new StringField(FIELD_TAGS, tag, Field.Store.NO));
+                doc.add(new TextField(FIELD_TAGS_SPLIT, tag, Field.Store.NO));
+            }
+            String tagsAsc = api.getApiDefinition().getTags().stream().sorted().collect(Collectors.joining(","));
+            String tagsDesc = api.getApiDefinition().getTags().stream().sorted(Comparator.reverseOrder()).collect(Collectors.joining(","));
+            doc.add(new SortedDocValuesField(FIELD_TAGS_ASC_SORTED, toSortedValue(tagsAsc)));
+            doc.add(new SortedDocValuesField(FIELD_TAGS_DESC_SORTED, toSortedValue(tagsDesc)));
+        }
+
+        // Handle v2 API health check
+        doc.add(new StringField(FIELD_HAS_HEALTH_CHECK, Boolean.toString(hasHealthCheckEnabledV2(api)), Field.Store.NO));
+    }
+
+    private boolean hasHealthCheckEnabledV2(Api api) {
+        if (api.getApiDefinition() == null) {
+            return false;
+        }
+
+        var apiDefinition = api.getApiDefinition();
+
+        // Check for global health check services at API level
+        if (apiDefinition.getServices() != null) {
+            boolean hasGlobalHealthCheck = apiDefinition
+                .getServices()
+                .getAll()
+                .stream()
+                .anyMatch(service -> service.isEnabled() && service instanceof HealthCheckService);
+            if (hasGlobalHealthCheck) {
+                return true;
+            }
+        }
+
+        // Check for endpoint-level health checks
+        if (apiDefinition.getProxy() != null && apiDefinition.getProxy().getGroups() != null) {
+            return apiDefinition
+                .getProxy()
+                .getGroups()
+                .stream()
+                .anyMatch(group ->
+                    group.getEndpoints() != null &&
+                    group
+                        .getEndpoints()
+                        .stream()
+                        .anyMatch(endpoint -> endpoint.getHealthCheck() != null && endpoint.getHealthCheck().isEnabled())
+                );
+        }
+
+        return false;
+    }
+
+    private void appendPath(final Document doc, final int[] pathIndex, final String host, final String path) {
+        doc.add(new StringField(FIELD_PATHS, path, Field.Store.NO));
+        doc.add(new TextField(FIELD_PATHS_SPLIT, path, Field.Store.NO));
+        if (host != null && !host.isEmpty()) {
+            doc.add(new StringField(FIELD_HOSTS, host, Field.Store.NO));
+            doc.add(new TextField(FIELD_HOSTS_SPLIT, host, Field.Store.NO));
+        }
+        if (pathIndex[0]++ == 0) {
+            doc.add(new SortedDocValuesField(FIELD_PATHS_SORTED, toSortedValue(path)));
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -23,6 +23,7 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_LOWERCASE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HAS_HEALTH_CHECK;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HOSTS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS;
@@ -40,31 +41,47 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SPLIT;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_ASC_SORTED;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_DESC_SORTED;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_SPLIT;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.service.ApiService;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 public class IndexableApiDocumentTransformerTest {
 
@@ -203,13 +220,14 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_throw_when_not_V4_api() {
         // Given
-        var indexable = new IndexableApi(ApiFixtures.aProxyApiV2(), PRIMARY_OWNER, Map.of(), Set.of());
+        var apiV1 = Api.builder().id(API_ID).lifecycleState(Api.LifecycleState.STARTED).definitionVersion(DefinitionVersion.V1).build();
+        var indexable = new IndexableApi(apiV1, PRIMARY_OWNER, Map.of(), Set.of());
 
         // When
         var throwable = catchThrowable(() -> cut.transform(indexable));
 
         // Then
-        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessage("Unsupported definition version: V2");
+        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessage("Unsupported definition version: V1");
     }
 
     @Test
@@ -409,5 +427,348 @@ public class IndexableApiDocumentTransformerTest {
         Api api = Api.builder().definitionVersion(DefinitionVersion.FEDERATED_AGENT).build();
         String apiType = new IndexableApiDocumentTransformer().generateApiType(api);
         assertThat(apiType).isEqualTo("FEDERATED_AGENT");
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class V2ApiDocumentTransformer {
+
+        @Mock
+        ApiService apiService;
+
+        private final IndexableApiDocumentTransformer indexableApiDocumentTransformer = new IndexableApiDocumentTransformer();
+        private ApiDocumentTransformer apiDocumentTransformer;
+
+        @BeforeEach
+        void setUp() {
+            this.apiDocumentTransformer = new ApiDocumentTransformer(apiService);
+        }
+
+        @Test
+        void should_transform_v2_api_with_same_fields_as_api_document_transformer() {
+            // Given
+            var v2Api = createV2ApiWithFullData();
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of("metadata1", "value1"), Set.of("category1", "category2"));
+            var genericApiEntity = convertToGenericApiEntity(v2Api);
+
+            // When
+            var indexableApiDocument = indexableApiDocumentTransformer.transform(indexableApi);
+            var apiDocument = apiDocumentTransformer.transform(genericApiEntity);
+
+            // Then
+            assertDocumentsAreEquivalent(indexableApiDocument, apiDocument);
+        }
+
+        @Test
+        void should_handle_v2_api_paths_correctly() {
+            // Given
+            var v2Api = createV2ApiWithPaths();
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var genericApiEntity = convertToGenericApiEntity(v2Api);
+
+            // When
+            var indexableApiDocument = indexableApiDocumentTransformer.transform(indexableApi);
+            var apiDocument = apiDocumentTransformer.transform(genericApiEntity);
+
+            // Then
+            SoftAssertions.assertSoftly(softly -> {
+                softly
+                    .assertThat(indexableApiDocument.getFields(FIELD_PATHS))
+                    .extracting(IndexableField::stringValue)
+                    .containsExactlyInAnyOrderElementsOf(
+                        Arrays.stream(apiDocument.getFields(FIELD_PATHS)).map(IndexableField::stringValue).toList()
+                    );
+                softly
+                    .assertThat(indexableApiDocument.getFields(FIELD_HOSTS))
+                    .extracting(IndexableField::stringValue)
+                    .containsExactlyInAnyOrderElementsOf(
+                        Arrays.stream(apiDocument.getFields(FIELD_HOSTS)).map(IndexableField::stringValue).toList()
+                    );
+            });
+        }
+
+        @Test
+        void should_handle_v2_api_tags_correctly() {
+            // Given
+            var v2Api = createV2ApiWithTags();
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var genericApiEntity = convertToGenericApiEntity(v2Api);
+
+            // When
+            var indexableApiDocument = indexableApiDocumentTransformer.transform(indexableApi);
+            var apiDocument = apiDocumentTransformer.transform(genericApiEntity);
+
+            // Then
+            SoftAssertions.assertSoftly(softly -> {
+                softly
+                    .assertThat(indexableApiDocument.getFields(FIELD_TAGS))
+                    .extracting(IndexableField::stringValue)
+                    .containsExactlyInAnyOrderElementsOf(
+                        Arrays.stream(apiDocument.getFields(FIELD_TAGS)).map(IndexableField::stringValue).toList()
+                    );
+                softly
+                    .assertThat(indexableApiDocument.getField(FIELD_TAGS_ASC_SORTED).binaryValue())
+                    .isEqualTo(apiDocument.getField(FIELD_TAGS_ASC_SORTED).binaryValue());
+                softly
+                    .assertThat(indexableApiDocument.getField(FIELD_TAGS_DESC_SORTED).binaryValue())
+                    .isEqualTo(apiDocument.getField(FIELD_TAGS_DESC_SORTED).binaryValue());
+            });
+        }
+
+        @Test
+        void should_handle_v2_api_health_check_correctly() {
+            // Given
+            var v2Api = createV2ApiWithHealthCheck();
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var genericApiEntity = convertToGenericApiEntity(v2Api);
+            when(apiService.hasHealthCheckEnabled(any(), eq(false))).thenReturn(true);
+
+            // When
+            var indexableApiDocument = indexableApiDocumentTransformer.transform(indexableApi);
+            var apiDocument = apiDocumentTransformer.transform(genericApiEntity);
+
+            // Then
+            assertThat(indexableApiDocument.getField(FIELD_HAS_HEALTH_CHECK).stringValue())
+                .isEqualTo(apiDocument.getField(FIELD_HAS_HEALTH_CHECK).stringValue());
+        }
+
+        @Test
+        void should_handle_v2_api_origin_context_correctly() {
+            // Given
+            var v2Api = createV2ApiWithOriginContext();
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var genericApiEntity = convertToGenericApiEntity(v2Api);
+
+            // When
+            var indexableApiDocument = indexableApiDocumentTransformer.transform(indexableApi);
+            var apiDocument = apiDocumentTransformer.transform(genericApiEntity);
+
+            // Then
+            assertThat(indexableApiDocument.getField(FIELD_ORIGIN).stringValue())
+                .isEqualTo(apiDocument.getField(FIELD_ORIGIN).stringValue());
+        }
+
+        private Api createV2ApiWithFullData() {
+            return ApiFixtures.aProxyApiV2().toBuilder().labels(List.of("label1", "label2")).build();
+        }
+
+        private Api createV2ApiWithPaths() {
+            return ApiFixtures
+                .aProxyApiV2()
+                .toBuilder()
+                .apiDefinition(
+                    io.gravitee.definition.model.Api
+                        .builder()
+                        .id("api-id")
+                        .name("api-name")
+                        .version("1.0.0")
+                        .definitionVersion(DefinitionVersion.V2)
+                        .proxy(
+                            io.gravitee.definition.model.Proxy
+                                .builder()
+                                .virtualHosts(
+                                    List.of(
+                                        new io.gravitee.definition.model.VirtualHost("host1", "/path1"),
+                                        new io.gravitee.definition.model.VirtualHost("host2", "/path2")
+                                    )
+                                )
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+        }
+
+        private Api createV2ApiWithTags() {
+            return ApiFixtures
+                .aProxyApiV2()
+                .toBuilder()
+                .apiDefinition(
+                    io.gravitee.definition.model.Api
+                        .builder()
+                        .id("api-id")
+                        .name("api-name")
+                        .version("1.0.0")
+                        .definitionVersion(DefinitionVersion.V2)
+                        .tags(Set.of("tag1", "tag2", "tag3"))
+                        .proxy(
+                            io.gravitee.definition.model.Proxy
+                                .builder()
+                                .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/path")))
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+        }
+
+        private Api createV2ApiWithHealthCheck() {
+            return ApiFixtures
+                .aProxyApiV2()
+                .toBuilder()
+                .apiDefinition(
+                    io.gravitee.definition.model.Api
+                        .builder()
+                        .id("api-id")
+                        .name("api-name")
+                        .version("1.0.0")
+                        .definitionVersion(DefinitionVersion.V2)
+                        .proxy(
+                            io.gravitee.definition.model.Proxy
+                                .builder()
+                                .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/path")))
+                                .groups(
+                                    Set.of(
+                                        io.gravitee.definition.model.EndpointGroup
+                                            .builder()
+                                            .name("default-group")
+                                            .endpoints(
+                                                Set.of(
+                                                    io.gravitee.definition.model.Endpoint
+                                                        .builder()
+                                                        .name("default")
+                                                        .type("http1")
+                                                        .target("https://api.gravitee.io/echo")
+                                                        .healthCheck(EndpointHealthCheckService.builder().enabled(true).build())
+                                                        .build()
+                                                )
+                                            )
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+        }
+
+        private Api createV2ApiWithOriginContext() {
+            return ApiFixtures
+                .aProxyApiV2()
+                .toBuilder()
+                .originContext(new io.gravitee.rest.api.model.context.OriginContext.Management())
+                .build();
+        }
+
+        private io.gravitee.rest.api.model.v4.api.GenericApiEntity convertToGenericApiEntity(Api api) {
+            return new io.gravitee.rest.api.model.api.ApiEntity() {
+                @Override
+                public String getId() {
+                    return api.getId();
+                }
+
+                @Override
+                public String getName() {
+                    return api.getName();
+                }
+
+                @Override
+                public String getDescription() {
+                    return api.getDescription();
+                }
+
+                @Override
+                public io.gravitee.definition.model.DefinitionVersion getDefinitionVersion() {
+                    return api.getDefinitionVersion();
+                }
+
+                @Override
+                public io.gravitee.rest.api.model.api.ApiLifecycleState getLifecycleState() {
+                    return api.getApiLifecycleState() == Api.ApiLifecycleState.PUBLISHED
+                        ? io.gravitee.rest.api.model.api.ApiLifecycleState.PUBLISHED
+                        : io.gravitee.rest.api.model.api.ApiLifecycleState.UNPUBLISHED;
+                }
+
+                @Override
+                public Lifecycle.State getState() {
+                    return api.getLifecycleState() == Api.LifecycleState.STARTED ? Lifecycle.State.STARTED : Lifecycle.State.STOPPED;
+                }
+
+                @Override
+                public io.gravitee.rest.api.model.Visibility getVisibility() {
+                    return api.getVisibility() == Api.Visibility.PUBLIC
+                        ? io.gravitee.rest.api.model.Visibility.PUBLIC
+                        : io.gravitee.rest.api.model.Visibility.PRIVATE;
+                }
+
+                @Override
+                public io.gravitee.rest.api.model.PrimaryOwnerEntity getPrimaryOwner() {
+                    return io.gravitee.rest.api.model.PrimaryOwnerEntity
+                        .builder()
+                        .id(PRIMARY_OWNER.id())
+                        .email(PRIMARY_OWNER.email())
+                        .displayName(PRIMARY_OWNER.displayName())
+                        .type(PRIMARY_OWNER.type().name())
+                        .build();
+                }
+
+                @Override
+                public java.util.List<String> getLabels() {
+                    return api.getLabels();
+                }
+
+                @Override
+                public java.util.Set<String> getCategories() {
+                    return Set.of("category1", "category2");
+                }
+
+                @Override
+                public java.util.Set<String> getTags() {
+                    return api.getApiDefinition() != null ? api.getApiDefinition().getTags() : Set.of();
+                }
+
+                @Override
+                public java.util.Date getCreatedAt() {
+                    return java.util.Date.from(api.getCreatedAt().toInstant());
+                }
+
+                @Override
+                public java.util.Date getUpdatedAt() {
+                    return java.util.Date.from(api.getUpdatedAt().toInstant());
+                }
+
+                @Override
+                public String getReferenceId() {
+                    return api.getEnvironmentId();
+                }
+
+                @Override
+                public String getReferenceType() {
+                    return "ENVIRONMENT";
+                }
+
+                @Override
+                public java.util.Map<String, Object> getMetadata() {
+                    return Map.of("metadata1", "value1");
+                }
+
+                @Override
+                public io.gravitee.rest.api.model.context.OriginContext getOriginContext() {
+                    return api.getOriginContext();
+                }
+
+                @Override
+                public io.gravitee.definition.model.Proxy getProxy() {
+                    return api.getApiDefinition() != null ? api.getApiDefinition().getProxy() : null;
+                }
+            };
+        }
+
+        private void assertDocumentsAreEquivalent(Document newDoc, Document oldDoc) {
+            SoftAssertions.assertSoftly(softly -> {
+                var newFieldNames = newDoc.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
+                var oldFieldNames = oldDoc.getFields().stream().map(IndexableField::name).collect(Collectors.toSet());
+
+                softly.assertThat(newFieldNames).isEqualTo(oldFieldNames);
+
+                for (String fieldName : newFieldNames) {
+                    var newValues = Arrays.stream(newDoc.getFields(fieldName)).map(IndexableField::stringValue).collect(Collectors.toSet());
+                    var oldValues = Arrays.stream(oldDoc.getFields(fieldName)).map(IndexableField::stringValue).collect(Collectors.toSet());
+
+                    softly.assertThat(newValues).as("Field: %s", fieldName).isEqualTo(oldValues);
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10924

## Description

- The V4 → V2 rollback process now removes the existing V4 API index and recreates it as a V2 index.
- The IndexableApiDocumentTransformer now supports V2 indexable APIs, allowing them to be properly transformed into documents.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sygjhmzune.chromatic.com)
<!-- Storybook placeholder end -->
