### PR TITLE
feat(console): show portal homepage content

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portal-page-with-details.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portal-page-with-details.fixture.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PortalPageWithDetails } from './portal-page-with-details';
+
+export function fakePortalPageWithDetails(portalPage: Partial<PortalPageWithDetails> = {}): PortalPageWithDetails {
+  const base: PortalPageWithDetails = {
+    id: 'homepage-id',
+    content: '# Welcome to Gravitee\n\nThis is the homepage content.',
+    type: 'gravitee_markdown',
+    context: 'homepage',
+    published: true,
+  };
+
+  return {
+    ...base,
+    ...portalPage,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/portal/portal-page-with-details.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portal-page-with-details.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type PortalPageType = 'gravitee_markdown';
+export type PortalPageContext = 'homepage';
+
+export interface PortalPageWithDetails {
+  /**
+   * The unique ID of the portal page
+   */
+  id: string;
+
+  /**
+   * Page content
+   */
+  content: string;
+
+  /**
+   * Content type
+   */
+  type: PortalPageType;
+
+  /**
+   * The portal context (ex. "homepage", "api_list")
+   */
+  context: PortalPageContext;
+
+  /**
+   * Whether the page is published or not
+   */
+  published: boolean;
+}

--- a/gravitee-apim-console-webui/src/services-ngx/portal-pages.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-pages.service.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PortalPagesService } from './portal-pages.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { fakePortalPageWithDetails } from '../entities/portal/portal-page-with-details.fixture';
+
+describe('PortalPagesService', () => {
+  let httpTestingController: HttpTestingController;
+  let portalPagesService: PortalPagesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    portalPagesService = TestBed.inject<PortalPagesService>(PortalPagesService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('getHomepage', () => {
+    it('should call the API', (done) => {
+      const fakePortalPage = fakePortalPageWithDetails();
+
+      portalPagesService.getHomepage().subscribe((response) => {
+        expect(response).toStrictEqual(fakePortalPage);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-pages/_homepage`,
+      });
+
+      req.flush(fakePortalPage);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/portal-pages.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-pages.service.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { PortalPageWithDetails } from '../entities/portal/portal-page-with-details';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PortalPagesService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  /**
+   * Get the homepage portal page
+   */
+  getHomepage(): Observable<PortalPageWithDetails> {
+    return this.http.get<PortalPageWithDetails>(`${this.constants.env.v2BaseURL}/portal-pages/_homepage`);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11031

## Description

Show the content of the portal homepage.

**On success:**

<img width="1612" height="958" alt="Screenshot 2025-09-10 at 16 37 23" src="https://github.com/user-attachments/assets/65a37ffd-0f7b-45ed-9461-57005df3cff5" />

**On error:**

<img width="1468" height="958" alt="Screenshot 2025-09-10 at 16 38 28" src="https://github.com/user-attachments/assets/9d0c3c46-c9fc-43bc-a7c0-2a0ebe347356" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sytokrrqto.chromatic.com)
<!-- Storybook placeholder end -->
