### PR TITLE
introduce gmd-viewer in portal nxt

### DIFF
--- a/gravitee-apim-console-webui/src/portal/homepage/homepage.component.html
+++ b/gravitee-apim-console-webui/src/portal/homepage/homepage.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,4 @@
 
 -->
 <portal-header title="Homepage" subtitle="Edit your Developer Portal Homepage with Gravitee Markdown" />
-
-<div class="editor-container">
-  <gmd-editor [formControl]="contentControl" />
-</div>
+<gmd-editor [formControl]="contentControl" />

--- a/gravitee-apim-console-webui/src/portal/homepage/homepage.component.scss
+++ b/gravitee-apim-console-webui/src/portal/homepage/homepage.component.scss
@@ -13,14 +13,12 @@
   }
 }
 
-.editor-container {
+gmd-editor {
   @include gmd.editor-overrides(
     (
       container-outline-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20'),
     )
   );
-
-  & {
-    flex: 1;
-  }
+  height: 100%;
+  overflow: hidden;
 }

--- a/gravitee-apim-console-webui/yarn.lock
+++ b/gravitee-apim-console-webui/yarn.lock
@@ -3082,6 +3082,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gravitee/gravitee-markdown@portal:dist-lib/gravitee-markdown::locator=gravitee-apim-console-webui%40workspace%3A."
   dependencies:
+    marked-gfm-heading-id: "npm:3.2.0"
+    ngx-dynamic-hooks: "npm:^3.1.2"
     tslib: "npm:^2.3.0"
   peerDependencies:
     "@angular/common": ^19.2.0
@@ -11998,6 +12000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-slugger@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "github-slugger@npm:2.0.0"
+  checksum: 10c0/21b912b6b1e48f1e5a50b2292b48df0ff6abeeb0691b161b3d93d84f4ae6b1acd6ae23702e914af7ea5d441c096453cf0f621b72d57893946618d21dd1a1c486
+  languageName: node
+  linkType: hard
+
 "gitignore-to-glob@npm:^0.3.0":
   version: 0.3.0
   resolution: "gitignore-to-glob@npm:0.3.0"
@@ -14956,6 +14965,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked-gfm-heading-id@npm:3.2.0":
+  version: 3.2.0
+  resolution: "marked-gfm-heading-id@npm:3.2.0"
+  dependencies:
+    github-slugger: "npm:^2.0.0"
+  peerDependencies:
+    marked: ">=4 <13"
+  checksum: 10c0/aba170f042049248047db4c1202c9cf3434858ca8e15b1b0d42905a6086135e98ac5edc8437c48c1206402cdb1f0fd0fbdcad410792a7d7150bec6095108b365
+  languageName: node
+  linkType: hard
+
 "marked-highlight@npm:2.2.1":
   version: 2.2.1
   resolution: "marked-highlight@npm:2.2.1"
@@ -15810,6 +15830,20 @@ __metadata:
   peerDependencies:
     angular: ^1.2.0
   checksum: 10c0/a6c43d4c2a118540491700d20040c4cac70717bbed9df9335b0aa0d797d0d75118d6e001f7fa86b2e68ec54f495edf87dcca57c93b93d950855d9bfdd58418f2
+  languageName: node
+  linkType: hard
+
+"ngx-dynamic-hooks@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "ngx-dynamic-hooks@npm:3.1.2"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    "@angular/common": ">=17"
+    "@angular/core": ">=17"
+    "@angular/platform-browser": ">=17"
+    rxjs: ">=7"
+  checksum: 10c0/99d1b3b07f12aabd31fe1a5b3f763232451f41d35fea9b08ab79649e4e5ec6b4e10a12d9f287baf1807bf755f8a585a61a124eb080e1eb7228b64d9f96d73dc4
   languageName: node
   linkType: hard
 

--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -69,6 +69,7 @@
     "marked-extended-tables": "1.1.1",
     "marked-gfm-heading-id": "3.2.0",
     "marked-highlight": "2.2.1",
+    "ngx-dynamic-hooks": "3.1.2",
     "ngx-infinite-scroll": "19.0.0",
     "rxjs": "7.8.2",
     "swagger-ui": "5.20.1",

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.console.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.console.json
@@ -4,5 +4,6 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
+  "allowedNonPeerDependencies": ["ngx-dynamic-hooks"],
   "assets": ["index.scss", "src/public-api.scss", "src/scss/**/*.scss", "src/lib/**/!(*.component).scss"]
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.console.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.console.json
@@ -4,6 +4,6 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["ngx-dynamic-hooks"],
+  "allowedNonPeerDependencies": ["ngx-dynamic-hooks", "marked-gfm-heading-id"],
   "assets": ["index.scss", "src/public-api.scss", "src/scss/**/*.scss", "src/lib/**/!(*.component).scss"]
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.portal-next.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.portal-next.json
@@ -4,5 +4,6 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
+  "allowedNonPeerDependencies": ["ngx-dynamic-hooks"],
   "assets": ["index.scss", "src/public-api.scss", "src/scss/**/*.scss", "src/lib/**/!(*.component).scss"]
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.portal-next.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/ng-package.portal-next.json
@@ -4,6 +4,6 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["ngx-dynamic-hooks"],
+  "allowedNonPeerDependencies": ["ngx-dynamic-hooks", "marked-gfm-heading-id"],
   "assets": ["index.scss", "src/public-api.scss", "src/scss/**/*.scss", "src/lib/**/!(*.component).scss"]
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/package.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/package.json
@@ -7,7 +7,8 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "ngx-dynamic-hooks": "^3.1.2"
+    "ngx-dynamic-hooks": "^3.1.2",
+    "marked-gfm-heading-id": "3.2.0"
   },
   "sideEffects": false
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/package.json
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/package.json
@@ -6,7 +6,8 @@
     "@angular/core": "^19.2.0"
   },
   "dependencies": {
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "ngx-dynamic-hooks": "^3.1.2"
   },
   "sideEffects": false
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
@@ -48,6 +48,10 @@ export class MonacoEditorComponent implements OnDestroy {
     scrollBeyondLastLine: false,
     theme: 'vs',
     renderLineHighlight: 'none',
+    scrollbar: {
+      verticalScrollbarSize: 5,
+      horizontalScrollbarSize: 5,
+    },
   };
 
   constructor(

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
@@ -47,6 +47,7 @@ export class MonacoEditorComponent implements OnDestroy {
     automaticLayout: true,
     scrollBeyondLastLine: false,
     theme: 'vs',
+    renderLineHighlight: 'none',
   };
 
   constructor(

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
@@ -16,15 +16,12 @@
 
 -->
 <div class="container">
-  <div class="section">
-    <div class="section__inner-border">
-      <gmd-monaco-editor [value]="value" [readOnly]="isDisabled" (valueChange)="onValueChange($event)" (touched)="onTouched()" />
-    </div>
-  </div>
-  <hr />
-  <div class="section">
-    <div class="section__inner-border section__inner-border--padding">
-      <gmd-viewer [content]="value" />
-    </div>
-  </div>
+  <gmd-monaco-editor
+    class="container__inner-border"
+    [value]="value"
+    [readOnly]="isDisabled"
+    (valueChange)="onValueChange($event)"
+    (touched)="onTouched()" />
+  <hr class="hr" />
+  <gmd-viewer class="container__inner-border container__inner-border--viewer" [content]="value" />
 </div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
@@ -16,10 +16,15 @@
 
 -->
 <div class="container">
-  <gmd-monaco-editor
-    class="container__inner-border"
-    [value]="value"
-    [readOnly]="isDisabled"
-    (valueChange)="onValueChange($event)"
-    (touched)="onTouched()" />
+  <div class="section">
+    <div class="section__inner-border">
+      <gmd-monaco-editor [value]="value" [readOnly]="isDisabled" (valueChange)="onValueChange($event)" (touched)="onTouched()" />
+    </div>
+  </div>
+  <hr />
+  <div class="section">
+    <div class="section__inner-border section__inner-border--padding">
+      <gmd-viewer [content]="value" />
+    </div>
+  </div>
 </div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,13 +19,34 @@
 $token-mapping: overrides.tokens();
 
 .container {
+  display: flex;
   height: 100%;
-  padding: 16px;
   background-color: #fff;
 
-  &__inner-border {
-    padding: 4px 0;
-    border: 1px solid token-utils.slot(container-outline-color, $token-mapping);
-    border-radius: 4px;
+  .section {
+    display: flex;
+    width: calc(50% - 0.5px);
+    box-sizing: border-box;
+    padding: 16px;
+
+    &__inner-border {
+      overflow: auto;
+      flex: 1;
+      border: 1px solid token-utils.slot(container-outline-color, $token-mapping);
+      border-radius: 4px;
+    }
+
+    &__inner-border--padding {
+      padding: 16px;
+    }
+  }
+
+  hr {
+    width: 1px;
+    flex: 0 0 auto;
+    align-self: stretch;
+    border: none;
+    margin: 16px 0;
+    background-color: token-utils.slot(container-outline-color, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
@@ -21,32 +21,25 @@ $token-mapping: overrides.tokens();
 .container {
   display: flex;
   height: 100%;
+  padding: 16px;
   background-color: #fff;
 
-  .section {
-    display: flex;
-    width: calc(50% - 0.5px);
-    box-sizing: border-box;
-    padding: 16px;
+  &__inner-border {
+    width: calc(50% - 6.5px);
+    padding: 4px 0;
+    border: 1px solid token-utils.slot(container-outline-color, $token-mapping);
+    border-radius: 4px;
 
-    &__inner-border {
-      overflow: auto;
-      flex: 1;
-      border: 1px solid token-utils.slot(container-outline-color, $token-mapping);
-      border-radius: 4px;
-    }
-
-    &__inner-border--padding {
-      padding: 16px;
+    &--viewer {
+      overflow: scroll;
+      padding: 12px 16px;
     }
   }
 
-  hr {
+  .hr {
     width: 1px;
-    flex: 0 0 auto;
-    align-self: stretch;
     border: none;
-    margin: 16px 0;
+    margin: 0 12px;
     background-color: token-utils.slot(container-outline-color, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.spec.ts
@@ -20,6 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { ConfigureTestingGraviteeMarkdownEditor, GraviteeMarkdownEditorHarness, GraviteeMarkdownEditorModule } from './public-api';
+import { GraviteeMarkdownViewerHarness } from '../gravitee-markdown-viewer/public-api';
 
 @Component({
   selector: 'gmd-test-component',
@@ -33,7 +34,8 @@ class TestComponent {
 describe('GraviteeMarkdownEditorComponent', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
-  let harness: GraviteeMarkdownEditorHarness;
+  let editorHarness: GraviteeMarkdownEditorHarness;
+  let viewerHarness: GraviteeMarkdownViewerHarness;
   let loader: HarnessLoader;
 
   beforeEach(async () => {
@@ -47,7 +49,8 @@ describe('GraviteeMarkdownEditorComponent', () => {
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
-    harness = await loader.getHarness(GraviteeMarkdownEditorHarness);
+    editorHarness = await loader.getHarness(GraviteeMarkdownEditorHarness);
+    viewerHarness = await loader.getHarness(GraviteeMarkdownViewerHarness);
 
     fixture.detectChanges();
   });
@@ -58,31 +61,39 @@ describe('GraviteeMarkdownEditorComponent', () => {
     });
 
     it('should pass initial values to Monaco editor', async () => {
-      expect(await harness.getEditorValue()).toBe('');
-      expect(await harness.isEditorReadOnly()).toBe(false);
+      expect(await editorHarness.getEditorValue()).toBe('');
+      expect(await editorHarness.isEditorReadOnly()).toBe(false);
     });
   });
 
   describe('Value Flow from Form Control to Monaco Editor', () => {
     it('should pass value from writeValue to Monaco editor', async () => {
       const testValue = 'cats rule';
-      await harness.setEditorValue(testValue);
+      await editorHarness.setEditorValue(testValue);
 
-      expect(await harness.getEditorValue()).toBe(testValue);
+      expect(await editorHarness.getEditorValue()).toBe(testValue);
+    });
+
+    it('should pass value from editor to viewer', async () => {
+      const testValue = '# Hello, World!';
+      await editorHarness.setEditorValue(testValue);
+
+      expect(await editorHarness.getEditorValue()).toBe(testValue);
+      expect(await viewerHarness.getRenderedHtml()).toContain('<h1 id="hello-world">Hello, World!</h1>');
     });
   });
 
   describe('Disabled State Flow from Form Control to Monaco Editor', () => {
     it('should pass disabled state to Monaco editor as readOnly', async () => {
       component.editorControl.disable();
-      expect(await harness.isEditorReadOnly()).toBe(true);
+      expect(await editorHarness.isEditorReadOnly()).toBe(true);
     });
   });
 
   describe('Value Flow from Monaco Editor to Form Control', () => {
     it('should emit value changes from Monaco editor', async () => {
       const newValue = 'Updated content';
-      await harness.setEditorValue(newValue);
+      await editorHarness.setEditorValue(newValue);
 
       expect(component.editorControl.value).toBe(newValue);
     });

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.module.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.module.ts
@@ -21,9 +21,10 @@ import { MonacoEditorComponent } from './components/monaco-editor/monaco-editor.
 import { GraviteeMarkdownEditorComponent } from './gravitee-markdown-editor.component';
 import { GmdMonacoEditorConfig } from './models/monaco-editor-config';
 import { GMD_CONFIG } from './tokens/gmd-config.token';
+import { GraviteeMarkdownViewerModule } from '../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, GraviteeMarkdownViewerModule],
   exports: [GraviteeMarkdownEditorComponent, MonacoEditorComponent],
   declarations: [MonacoEditorComponent, GraviteeMarkdownEditorComponent],
   providers: [

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.stories.ts
@@ -124,7 +124,7 @@ You cannot edit this content when the form control is disabled.`,
 export const WithFormControl: StoryObj<GraviteeMarkdownEditorComponent> = {
   render: () => ({
     template: `
-      <div>
+      <div style="height: 650px">
         <h3>Markdown Editor with Validation</h3>
         <form [formGroup]="form">
           <gmd-editor formControlName="content"></gmd-editor>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<ngx-dynamic-hooks [content]="renderedContent" [parsers]="parsers" [options]="{ sanitize: false }" />

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.scss
@@ -13,11 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Public API Surface of gravitee-markdown
- */
-
-export * from './lib/gravitee-markdown.service';
-export * from './lib/gravitee-markdown.component';
-export * from './lib/gravitee-markdown-editor/public-api';
-export * from './lib/gravitee-markdown-viewer/public-api';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GraviteeMarkdownViewerHarness } from './gravitee-markdown-viewer.harness';
+import { GraviteeMarkdownViewerModule } from './gravitee-markdown-viewer.module';
+
+@Component({
+  selector: 'gmd-test-component',
+  imports: [GraviteeMarkdownViewerModule],
+  template: `<gmd-viewer [content]="content" />`,
+})
+class TestComponent {
+  public content = '';
+}
+
+describe('GraviteeMarkdownViewerComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let harness: GraviteeMarkdownViewerHarness;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await loader.getHarness(GraviteeMarkdownViewerHarness);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', async () => {
+    expect(component).toBeTruthy();
+    expect(await harness.getRenderedHtml()).toBe('');
+  });
+
+  it('should render markdown content', async () => {
+    component.content = '# Hello, World!';
+    fixture.detectChanges();
+
+    expect(await harness.getRenderedHtml()).toContain('<h1 id="hello-world">Hello, World!</h1>');
+  });
+
+  it('should render images', async () => {
+    component.content = '![Gravitee Logo](https://example.com/gravitee-logo.png)';
+    fixture.detectChanges();
+
+    expect(await harness.getRenderedHtml()).toContain('<p><img src="https://example.com/gravitee-logo.png" alt="Gravitee Logo"></p>');
+  });
+
+  it('should render links', async () => {
+    component.content = '[Links](https://gravitee.io)';
+    fixture.detectChanges();
+
+    expect(await harness.getRenderedHtml()).toContain('<p><a href="https://gravitee.io">Links</a></p>');
+  });
+
+  it('should render anchor', async () => {
+    component.content = '[anchor](#anchor)';
+    fixture.detectChanges();
+
+    expect(await harness.getRenderedHtml()).toContain('<p><a class="anchor" href="#anchor">anchor</a></p>');
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, effect } from '@angular/core';
+import { HookParserEntry } from 'ngx-dynamic-hooks';
+
+@Component({
+  selector: 'gmd-viewer',
+  templateUrl: './gravitee-markdown-viewer.component.html',
+  styleUrl: './gravitee-markdown-viewer.component.scss',
+  // eslint-disable-next-line @angular-eslint/prefer-standalone
+  standalone: false,
+})
+export class GraviteeMarkdownViewerComponent {
+  renderedContent!: string;
+  parsers: HookParserEntry[] = [];
+
+  constructor() {
+    effect(() => {
+      const renderedContent = 'TODO: PARSE CONTENT WITH DEDICATED SERVICE IN NEXT COMMIT';
+      const parser = new DOMParser();
+      const document = parser.parseFromString(renderedContent, 'text/html');
+      this.renderedContent = document.body.outerHTML;
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.component.ts
@@ -13,25 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, effect } from '@angular/core';
+import { Component, effect, input } from '@angular/core';
 import { HookParserEntry } from 'ngx-dynamic-hooks';
+
+import { GraviteeMarkdownViewerService } from './gravitee-markdown-viewer.service';
 
 @Component({
   selector: 'gmd-viewer',
   templateUrl: './gravitee-markdown-viewer.component.html',
-  styleUrl: './gravitee-markdown-viewer.component.scss',
   // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false,
 })
 export class GraviteeMarkdownViewerComponent {
+  content = input<string>('');
   renderedContent!: string;
   parsers: HookParserEntry[] = [];
 
-  constructor() {
+  constructor(private readonly markdownService: GraviteeMarkdownViewerService) {
     effect(() => {
-      const renderedContent = 'TODO: PARSE CONTENT WITH DEDICATED SERVICE IN NEXT COMMIT';
       const parser = new DOMParser();
-      const document = parser.parseFromString(renderedContent, 'text/html');
+      const parsedContent = this.markdownService.render(this.content());
+      const document = parser.parseFromString(parsedContent, 'text/html');
       this.renderedContent = document.body.outerHTML;
     });
   }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.harness.ts
@@ -13,3 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class GraviteeMarkdownViewerHarness extends ComponentHarness {
+  static hostSelector = 'gmd-viewer';
+
+  async getRenderedHtml(): Promise<string> {
+    const innerContainer = await this.locatorFor('ngx-dynamic-hooks')();
+    return innerContainer.getProperty('innerHTML');
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
@@ -17,9 +17,11 @@ import { NgModule } from '@angular/core';
 import { DynamicHooksComponent } from 'ngx-dynamic-hooks';
 
 import { GraviteeMarkdownViewerComponent } from './gravitee-markdown-viewer.component';
+import { GraviteeMarkdownViewerService } from './gravitee-markdown-viewer.service';
 
 @NgModule({
   imports: [DynamicHooksComponent],
+  providers: [GraviteeMarkdownViewerService],
   exports: [GraviteeMarkdownViewerComponent],
   declarations: [GraviteeMarkdownViewerComponent],
 })

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Public API Surface of gravitee-markdown
- */
+import { NgModule } from '@angular/core';
+import { DynamicHooksComponent } from 'ngx-dynamic-hooks';
 
-export * from './lib/gravitee-markdown.service';
-export * from './lib/gravitee-markdown.component';
-export * from './lib/gravitee-markdown-editor/public-api';
-export * from './lib/gravitee-markdown-viewer/public-api';
+import { GraviteeMarkdownViewerComponent } from './gravitee-markdown-viewer.component';
+
+@NgModule({
+  imports: [DynamicHooksComponent],
+  exports: [GraviteeMarkdownViewerComponent],
+  declarations: [GraviteeMarkdownViewerComponent],
+})
+export class GraviteeMarkdownViewerModule {}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.service.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import hljs from 'highlight.js';
+import { marked, Renderer, RendererObject } from 'marked';
+import { gfmHeadingId } from 'marked-gfm-heading-id';
+import { markedHighlight } from 'marked-highlight';
+
+const ANCHOR_CLASSNAME = 'anchor';
+
+@Injectable()
+export class GraviteeMarkdownViewerService {
+  constructor() {
+    marked.use(gfmHeadingId());
+    marked.use(
+      markedHighlight({
+        langPrefix: 'hljs language-',
+        highlight(_code, language) {
+          const validLanguage = hljs.getLanguage(language) ? language : 'plaintext';
+          return hljs.highlight(validLanguage, { language: validLanguage }).value;
+        },
+      }),
+    );
+    marked.setOptions({
+      breaks: true,
+      gfm: true,
+    });
+  }
+
+  public getRenderer(): RendererObject {
+    const defaultRenderer = new Renderer();
+    return {
+      image(href, title, text) {
+        return defaultRenderer.image(href, title, text);
+      },
+      link(href, title, text) {
+        if (href.startsWith('#')) {
+          return `<a class="${ANCHOR_CLASSNAME}" href="${href}">${text}</a>`;
+        }
+
+        if (href?.startsWith('/#!/')) {
+          const trimmedHref = href.substring(3);
+          return defaultRenderer.link(trimmedHref, title, text);
+        }
+
+        return defaultRenderer.link(href, title, text);
+      },
+    };
+  }
+
+  public render(content: string): string {
+    marked.use({ renderer: this.getRenderer() });
+    return marked(content) as string;
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { GraviteeMarkdownViewerComponent, GraviteeMarkdownViewerModule } from './public-api';
+
+export default {
+  title: 'Components/Gravitee Markdown Viewer',
+  component: GraviteeMarkdownViewerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GraviteeMarkdownViewerModule],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A markdown to html viewer component built using marked.js and highlight.js.',
+      },
+    },
+  },
+} as Meta<GraviteeMarkdownViewerComponent>;
+
+export const WithoutContent: StoryObj<GraviteeMarkdownViewerComponent> = {
+  render: () => ({
+    template: `
+      <div style="height: 650px">
+        <h3>Markdown viewer without content</h3>
+        <gmd-viewer></gmd-viewer>
+      </div>
+    `,
+  }),
+};
+
+export const WithSampleContent: StoryObj<GraviteeMarkdownViewerComponent> = {
+  render: () => ({
+    template: `
+      <div style="height: 650px">
+        <h3>Markdown Editor with Sample Content</h3>
+        <div style="height: 100%;background-color: #fff;">
+          <div style="min-height: 100%;padding: 16px;border: 1px solid #b2aaa9;border-radius: 4px;">
+            <gmd-viewer [content]="content"></gmd-viewer>
+          </div>
+        </div>
+      </div>
+    `,
+    props: {
+      content: `# Welcome to Gravitee API Management
+
+This is a **markdown editor** component that allows you to write and edit markdown content.
+
+## Features
+
+- *Italic text* and **bold text**
+- \`Inline code\`
+- [Links](https://gravitee.io)
+- [Anchor to image block](#image-block)
+- Lists:
+  <ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+    <li>Item 3</li>
+  </ul>
+
+## Data Table
+
+| Product | Price | Stock |
+| :--- | :---: | ---: |
+| Laptop | $1200 | 15 |
+| Phone | $800 | 50 |
+| Headset | $150 | 25 |
+
+## Quote Block
+
+> This is a blockquote Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type
+and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting,
+ remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing
+ Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+
+## Html Block
+
+<details>
+  <summary style="font-size: 1.2em; cursor: pointer;">Click to Reveal the section!</summary>
+  <p style="padding-left: 15px; font-style: italic; color: #555;">The details and summary and tags create a collapsible section</p>
+</details>
+
+<br/>
+
+<div style="background-color: #f0f8ff; padding: 20px; border-radius: 8px; border: 1px solid #cceeff;">
+  <h3 style="color: #004085;">A Styled Box</h3>
+  <p>You can use a div with style attributes to create a custom-styled container. This is great for callouts or warnings.</p>
+</div>
+
+<h2 id="image-block">Image Block</h2>
+
+![Gravitee Logo](https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/refs/heads/master/gravitee-apim-portal-webui-next/src/assets/images/logo.png)
+
+<img
+    src="https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/refs/heads/master/gravitee-apim-portal-webui-next/src/assets/images/logo.png"
+    alt="Gravitee Logo"
+/>
+
+---
+
+*Built and displayed with Marked for the best editing experience.*`,
+    },
+  }),
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
@@ -48,12 +48,10 @@ export const WithoutContent: StoryObj<GraviteeMarkdownViewerComponent> = {
 export const WithSampleContent: StoryObj<GraviteeMarkdownViewerComponent> = {
   render: () => ({
     template: `
-      <div style="height: 650px">
+      <div style="height: 650px; display: flex; flex-flow: column;">
         <h3>Markdown Editor with Sample Content</h3>
-        <div style="height: 100%;background-color: #fff;">
-          <div style="min-height: 100%;padding: 16px;border: 1px solid #b2aaa9;border-radius: 4px;">
-            <gmd-viewer [content]="content"></gmd-viewer>
-          </div>
+        <div style="background-color: #fff; overflow: scroll">
+          <gmd-viewer [content]="content"></gmd-viewer>
         </div>
       </div>
     `,

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
@@ -19,3 +19,9 @@ export * from './gravitee-markdown-viewer.module';
 
 // Components
 export * from './gravitee-markdown-viewer.component';
+
+// Services
+export * from './gravitee-markdown-viewer.service';
+
+// Testing
+export * from './gravitee-markdown-viewer.harness';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Public API Surface of gravitee-markdown
- */
 
-export * from './lib/gravitee-markdown.service';
-export * from './lib/gravitee-markdown.component';
-export * from './lib/gravitee-markdown-editor/public-api';
-export * from './lib/gravitee-markdown-viewer/public-api';
+// Module
+export * from './gravitee-markdown-viewer.module';
+
+// Components
+export * from './gravitee-markdown-viewer.component';

--- a/gravitee-apim-portal-webui-next/yarn.lock
+++ b/gravitee-apim-portal-webui-next/yarn.lock
@@ -12601,6 +12601,7 @@ __metadata:
     marked-highlight: "npm:2.2.1"
     monaco-editor: "npm:0.50.0"
     ng-packagr: "npm:19.2.0"
+    ngx-dynamic-hooks: "npm:3.1.2"
     ngx-infinite-scroll: "npm:19.0.0"
     prettier: "npm:3.5.3"
     prettier-eslint: "npm:16.4.2"
@@ -16008,6 +16009,20 @@ __metadata:
   bin:
     ng-packagr: cli/main.js
   checksum: 10c0/69fec8f09c5d4da4889332f0f7a1816f290a13cdf2c91cdabcbf6366a764da580fbfcd33280e38179c59f251d1196572918acece20fd2c57548b5bab125a90e7
+  languageName: node
+  linkType: hard
+
+"ngx-dynamic-hooks@npm:3.1.2":
+  version: 3.1.2
+  resolution: "ngx-dynamic-hooks@npm:3.1.2"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    "@angular/common": ">=17"
+    "@angular/core": ">=17"
+    "@angular/platform-browser": ">=17"
+    rxjs: ">=7"
+  checksum: 10c0/99d1b3b07f12aabd31fe1a5b3f763232451f41d35fea9b08ab79649e4e5ec6b4e10a12d9f287baf1807bf755f8a585a61a124eb080e1eb7228b64d9f96d73dc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10936

## Description

This pull request introduces the first iteration of the gmd-viewer (Gravitee Markdown Viewer), a new component for rendering Markdown content within our library.

This initial version focuses on establishing the core viewing functionality. Further enhancements and integrations are planned for subsequent PRs.

What this PR does ✅
Adds the new gmd-viewer component to the component library.

Includes a Storybook page for visualizing and testing the component's basic rendering capabilities.

Out of Scope for this PR ❌
To keep this PR focused, the following items will be addressed in future work:
- Embedded Markdown: Parsing Markdown that is embedded within other custom components is not yet supported. For example, the following will not be rendered correctly and is planned for a future iteration:

```HTML
<gmd-card>
  # This embedded title will not be parsed
</gmd-card>
```

Homepage Integration: The logic for fetching and updating the portal homepage content with this viewer will be handled in a separate PR.

Known Editor Bugs: This work does not address two existing bugs in the Monaco editor:

- The cursor jumping to the top-left corner during fast typing.
- An issue with the editor's auto-layout.

### Screenshot:
<img width="1728" height="870" alt="Capture d’écran 2025-09-11 à 07 56 10" src="https://github.com/user-attachments/assets/4b7332c5-20ef-4fa2-90cc-54159cbf2ab4" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yujwwohwwr.chromatic.com)
<!-- Storybook placeholder end -->
