### PR TITLE
fix(ui): infinite loading on my tasks tab

### DIFF
--- a/gravitee-apim-console-webui/src/user/tasks/tasks.component.ts
+++ b/gravitee-apim-console-webui/src/user/tasks/tasks.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { filter, map, switchMap, takeUntil, tap, finalize } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
@@ -88,9 +88,14 @@ export class TasksComponent implements OnInit, OnDestroy {
             })
             .sort((task1, task2) => task2.createdAt - task1.createdAt);
         }),
+        finalize(() => {
+          this.loading = false;
+        }),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe(() => (this.loading = false));
+      .subscribe({
+        error: (e) => this.snackBarService.error(e.error?.message ?? 'Failed to load tasks'),
+      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10170

## Description

In the "My Tasks" tab, tasks were stuck in infinite loading despite backend data being available instantly. The loader disappeared only after user interactions (e.g., double-click, opening dev tools), showing that Angular wasn’t triggering change detection.

Using ChangeDetectorRef to explicitly set loading: false, ensuring tasks display immediately.

## Additional context

Before :

https://github.com/user-attachments/assets/ad3395af-781f-4811-a3eb-c0caa9ab9bb1

After :

https://github.com/user-attachments/assets/607e3259-4062-4cd0-8f8b-b3b795d463e6

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kgouugalfa.chromatic.com)
<!-- Storybook placeholder end -->
