### PR TITLE
fix: restore the full endpoint URL in health-check response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
@@ -431,7 +431,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
                 .flatMap(group -> group.getEndpoints().stream())
                 .filter(endpoint -> endpoint.getName().equalsIgnoreCase(endpointName))
                 .findFirst()
-                .map(endpoint -> Map.of("target", endpoint.getType()))
+                .map(endpoint -> Map.of("target", endpoint.getTarget()))
                 .orElse(Map.of("deleted", "true"));
             case FEDERATED, FEDERATED_AGENT -> Map.of();
             case null -> Map.of();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11071

## Description

This commit addresses a regression introduced between APIM versions 4.5.x and 4.8.x, where the Management API's health-check response for a specific API no longer returned the full endpoint URL. Instead, it only provided the endpoint type (e.g., 'http' or 'https').

This change restores the previous behavior by ensuring the `endpoint.target` field in the health-check response contains the complete endpoint URL (e.g., `http://backend.service:8080`). This is crucial for monitoring systems that rely on the full URL for accurate endpoint identification and status tracking.

The fix ensures compatibility with existing monitoring setups and maintains the expected behavior of the health-check API.

Fix:
https://github.com/user-attachments/assets/0b477232-4fdf-400b-8017-ec01a605f3c0



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

