### PR TITLE
fix(ui): infinite loading on my tasks tab

### DIFF
--- a/gravitee-apim-console-webui/src/user/tasks/tasks.component.ts
+++ b/gravitee-apim-console-webui/src/user/tasks/tasks.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { Component, Inject, OnDestroy, OnInit, ChangeDetectorRef } from '@angular/core';
+import { filter, map, switchMap, takeUntil, tap, finalize } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
@@ -62,6 +62,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     private readonly promotionService: PromotionService,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
+    private readonly cdr: ChangeDetectorRef,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
@@ -88,9 +89,15 @@ export class TasksComponent implements OnInit, OnDestroy {
             })
             .sort((task1, task2) => task2.createdAt - task1.createdAt);
         }),
+        finalize(() => {
+          this.loading = false;
+          this.cdr.detectChanges();
+        }),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe(() => (this.loading = false));
+      .subscribe({
+        error: (e) => this.snackBarService.error(e.error?.message ?? 'Failed to load tasks'),
+      });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10170

Reference to previous PR  : https://github.com/gravitee-io/gravitee-api-management/pull/13145

With ChangeDetectorRef approach
## Description

In the "My Tasks" tab, tasks were stuck in infinite loading despite backend data being available instantly. The loader disappeared only after user interactions (e.g., double-click, opening dev tools), showing that Angular wasn’t triggering change detection.

Using ChangeDetectorRef to explicitly set loading: false, ensuring tasks display immediately.

## Additional context

Before :

https://github.com/user-attachments/assets/ad3395af-781f-4811-a3eb-c0caa9ab9bb1

After :


https://github.com/user-attachments/assets/6186f1b7-c30d-42e5-87a5-2fa158d3a13c

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kcnrmiycvr.chromatic.com)
<!-- Storybook placeholder end -->
