### PR TITLE
fix: increase entrypoints.value length for jdbc from 64 to 255

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.27_increase_entrypoints_value_length
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}entrypoints
+            columnName: value
+            newDataType: nvarchar(255)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -217,3 +217,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_0/06_add_scoring_table.yml
     - include:
           - file: liquibase/changelogs/v4_5_0/07_add_scoring_ruleset_table.yml
+    - include:
+          - file: liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10466

## Description

jdbc schema limitation (nvarchar(64)) for entrypoints.value is too short for long endpoint URLs (e.g., Azure environments). Updated column to nvarchar(255) via Liquibase changelog to prevent import and configuration issues.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

