### PR TITLE
fix(console): align analytics graph to display local timezone

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
@@ -52,6 +52,7 @@ export class GioChartLineComponent implements OnInit {
   ngOnInit() {
     this.chartOptions = {
       credits: { enabled: false },
+      time: { useUTC: false },
       chart: {
         backgroundColor: 'transparent',
         type: 'spline',

--- a/gravitee-apim-console-webui/src/shared/utils/timeFrameRanges.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/timeFrameRanges.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { utc } from 'moment/moment';
+import moment from 'moment/moment';
 
 export interface TimeRangeParams {
   id?: string;
@@ -31,11 +31,11 @@ export const timeInMilliseconds = {
 };
 
 export const timeFrameRangesParams = (id: string, nbValuesByBucket = 30): TimeRangeParams => {
-  const nowUtc = utc().valueOf();
+  const nowLocal = moment().valueOf();
   return {
     id,
-    from: nowUtc - timeInMilliseconds[id],
-    to: nowUtc,
+    from: nowLocal - timeInMilliseconds[id],
+    to: nowLocal,
     interval: timeInMilliseconds[id] / nbValuesByBucket,
   };
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11053

## Description

Aligned analytics graph to display local timezone instead of UTC.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
After fix:
<img width="1503" height="828" alt="Screenshot 2025-09-14 at 3 32 47 PM" src="https://github.com/user-attachments/assets/0b4b9462-b5fc-43df-84c9-677d1b1f2bca" />
<img width="1503" height="828" alt="Screenshot 2025-09-14 at 3 32 53 PM" src="https://github.com/user-attachments/assets/4e61c863-cbb9-4839-bfa6-77bb20712a7b" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cankjllqiu.chromatic.com)
<!-- Storybook placeholder end -->
