### PR TITLE
fix: when cluster def role is read only & cluster member is read (and update) should be able to see (and update) its members

### DIFF
--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.html
@@ -99,7 +99,7 @@
         <td mat-cell *matCellDef="let element">
           <div class="actions_btn">
             <button
-              *gioPermission="{ anyOf: ['cluster-definition-u'] }; roleContext: { role: 'CLUSTER', id: element.id }"
+              *gioPermission="{ anyOf: ['cluster-definition-u'] }; else readOnly; roleContext: { role: 'CLUSTER', id: element.id }"
               mat-button
               aria-label="Button to edit"
               matTooltip="Edit"
@@ -107,6 +107,18 @@
             >
               <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
             </button>
+
+            <ng-template #readOnly>
+              <button
+                *gioPermission="{ anyOf: ['cluster-definition-r'] }; roleContext: { role: 'CLUSTER', id: element.id }"
+                mat-button
+                aria-label="Button to view"
+                matTooltip="View"
+                [routerLink]="[element.id]"
+              >
+                <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              </button>
+            </ng-template>
 
             <button
               *gioPermission="{ anyOf: ['cluster-definition-d'] }; roleContext: { role: 'CLUSTER', id: element.id }"


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-11099
https://gravitee.atlassian.net/browse/APIM-11101
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gmuslbesbu.chromatic.com)
<!-- Storybook placeholder end -->
