### PR TITLE
fix: change api.description datatype to clob

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_28/00_change_api_description_datatype.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_28/00_change_api_description_datatype.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.28_00_change_api_description_datatype
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}apis
+            columnName: description
+            newDataType: clob

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -219,3 +219,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_0/07_add_scoring_ruleset_table.yml
     - include:
           - file: liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml
+    - include:
+          - file: liquibase/changelogs/v4_5_28/00_change_api_description_datatype.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11107

## Description

Schema limitation (nvarchar(4000)) for apis.description are causing import and configuration issues for some on-premise users. Updated datatype to nclob via Liquibase changelog to prevent database inconsistency and broken API definitions.

Test Results:

`Postgresql:`

<img width="521" height="739" alt="Screenshot 2025-09-30 at 11 42 08 PM" src="https://github.com/user-attachments/assets/8dcc2ad6-960d-4fc3-b17d-7456292b9fd4" />

`mysql`

<img width="561" height="613" alt="Screenshot 2025-09-30 at 10 56 24 PM" src="https://github.com/user-attachments/assets/47e7320f-638e-4a6f-ada1-382a610e73e7" />


`mssql`
<img width="557" height="372" alt="Screenshot 2025-09-30 at 10 55 11 PM" src="https://github.com/user-attachments/assets/5aa4c1ca-b3b8-4a49-9309-925d171b86d3" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

