### PR TITLE
chore(jira): switch getJiraIssuesOfVersion from GET to POST /search/jql

### DIFF
--- a/release/helpers/jira-helper.mjs
+++ b/release/helpers/jira-helper.mjs
@@ -34,15 +34,20 @@ export function getJiraVersion(versionName) {
 export async function getJiraIssuesOfVersion(versionId) {
   const token = process.env.JIRA_TOKEN;
 
-  const issuesFromJira = await fetch(`https://gravitee.atlassian.net/rest/api/3/search?jql=project=APIM AND fixVersion=${versionId}`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Basic ${token}`,
-      Accept: 'application/json',
-    },
-  })
-    .then((response) => response.json())
-    .then((body) => body.issues);
+    const issuesFromJira = await fetch('https://gravitee.atlassian.net/rest/api/3/search/jql', {
+        method: 'POST',
+        headers: {
+            Authorization: `Basic ${token}`,
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            jql: `project = APIM AND fixVersion = "${versionId}"`,
+            fields: ['issuetype', 'summary', 'components', 'customfield_10115'],
+        }),
+    })
+        .then((response) => response.json())
+        .then((body) => body.issues);
 
   // Filter out issues that are not public bugs or public security issues
   const issues = issuesFromJira


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- Updated Jira API call to use POST /search/jql instead of GET /search
- Sends JQL in request body instead of URL query
- No changes to filtering or remote link extraction logic

Current cURL and new cURL: 


https://github.com/user-attachments/assets/80b9ebcd-791e-49a2-9db6-fa8a37a26162



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

