### PR TITLE
feat(gmd): allow custom grid spacing for grid component

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/_overrides.scss
@@ -13,5 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/components/grid/public-api';
+@use '../../scss/token-utils' as token-utils;
+
+@function tokens() {
+  @return (
+    spacing: (
+      value: 16px,
+      css-var: --gmd-grid-spacing,
+    )
+  );
+}
+
+// Component-level override mixin
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.scss
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use './overrides' as overrides;
+@use '../../scss/token-utils' as token-utils;
+
 .grid-container {
   display: grid;
   width: 100%;
-  gap: 16px;
+  gap: token-utils.slot(spacing, overrides.tokens());
 }
 
 .grid-cols-1 {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.ts
@@ -406,3 +406,127 @@ export const WithMarkdownEditor: StoryObj<GridComponent> = {
     `,
   }),
 };
+
+export const WithTokenOverrides: StoryObj<GridComponent> = {
+  args: {
+    columns: 3,
+  },
+  render: args => ({
+    props: args,
+    template: `
+      <style>
+        gmd-cell {
+          display: block;
+          padding: 12px;
+          border: 1px solid #e0e0e0;
+          border-radius: 6px;
+          background-color: #f8f9fa;
+          min-height: 60px;
+        }
+
+        .gap-examples {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+        }
+
+        .gap-example {
+          border: 1px solid #dee2e6;
+          border-radius: 8px;
+          padding: 16px;
+          background: white;
+        }
+
+        .gap-example h3 {
+          margin-top: 0;
+          margin-bottom: 12px;
+          color: #495057;
+        }
+
+        .gap-example p {
+          margin-bottom: 16px;
+          color: #6c757d;
+          font-size: 14px;
+        }
+      </style>
+      <div style="padding: 20px;">
+        <h2>Grid Component with Custom Gap Overrides</h2>
+        <p>This story demonstrates how to customize the grid gap using CSS custom properties.</p>
+
+        <div class="gap-examples">
+          <div class="gap-example">
+            <h3>Default Gap (16px)</h3>
+            <gmd-grid [columns]="columns">
+              <gmd-cell>
+                <h4>Cell 1</h4>
+                <p>Default spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 2</h4>
+                <p>Default spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 3</h4>
+                <p>Default spacing</p>
+              </gmd-cell>
+            </gmd-grid>
+          </div>
+
+          <div class="gap-example" style="--gmd-grid-spacing: 8px;">
+            <h3>Small Gap (8px)</h3>
+            <gmd-grid [columns]="columns">
+              <gmd-cell>
+                <h4>Cell 1</h4>
+                <p>Tighter spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 2</h4>
+                <p>Tighter spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 3</h4>
+                <p>Tighter spacing</p>
+              </gmd-cell>
+            </gmd-grid>
+          </div>
+
+          <div class="gap-example" style="--gmd-grid-spacing: 32px;">
+            <h3>Large Gap (32px)</h3>
+            <gmd-grid [columns]="columns">
+              <gmd-cell>
+                <h4>Cell 1</h4>
+                <p>More spacious</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 2</h4>
+                <p>More spacious</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 3</h4>
+                <p>More spacious</p>
+              </gmd-cell>
+            </gmd-grid>
+          </div>
+
+          <div class="gap-example" style="--gmd-grid-spacing: 0px;">
+            <h3>No Gap (0px)</h3>
+            <gmd-grid [columns]="columns">
+              <gmd-cell>
+                <h4>Cell 1</h4>
+                <p>No spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 2</h4>
+                <p>No spacing</p>
+              </gmd-cell>
+              <gmd-cell>
+                <h4>Cell 3</h4>
+                <p>No spacing</p>
+              </gmd-cell>
+            </gmd-grid>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/public-api.scss
@@ -1,17 +1,16 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/components/grid/public-api';
+@forward './overrides' as grid-* show grid-overrides;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10279

## Description

Allow the user to customize the grid spacing.

<img width="930" height="919" alt="Screenshot 2025-09-18 at 11 47 22" src="https://github.com/user-attachments/assets/f9f0b292-832f-4e25-9ea3-921ad4493736" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

