### PR TITLE
fix: remove orphaned/corrupted subscriptions from a database

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_27/01_remove_orphaned_subscriptions.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_27/01_remove_orphaned_subscriptions.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.27_01-remove_orphaned_subscriptions
+      author: GraviteeSource Team
+      changes:
+        - sql:
+            sql: >
+              DELETE FROM ${gravitee_prefix}subscriptions s
+              WHERE NOT EXISTS (
+                SELECT 1
+                FROM ${gravitee_prefix}applications a
+                WHERE a.id = s.application
+              );

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -219,3 +219,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_0/07_add_scoring_ruleset_table.yml
     - include:
           - file: liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml
+    - include:
+          - file: liquibase/changelogs/v4_5_27/01_remove_orphaned_subscriptions.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/RemoveOrphanedSubscriptionsUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/RemoveOrphanedSubscriptionsUpgrader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.subscription;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.result.DeleteResult;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.themes.ThemeTypeUpgrader;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class RemoveOrphanedSubscriptionsUpgrader extends MongoUpgrader {
+
+    public static final int REMOVE_ORPHANED_SUBSCRIPTIONS_ORDER = ThemeTypeUpgrader.THEME_TYPE_UPGRADER_ORDER + 1;
+
+    @Override
+    public boolean upgrade() {
+        MongoCollection<Document> applications = getCollection("applications");
+        MongoCollection<Document> subscriptions = getCollection("subscriptions");
+
+        // Collect all valid application IDs
+        Set<String> validAppIds = applications
+            .find()
+            .projection(Projections.include("_id"))
+            .map(doc -> doc.get("_id").toString())
+            .into(new HashSet<>());
+
+        if (validAppIds.isEmpty()) {
+            log.warn("No valid applications found! Skipping orphaned subscriptions cleanup.");
+            return true;
+        }
+
+        long orphanCount = subscriptions.countDocuments(Filters.nin("application", validAppIds));
+        if (orphanCount == 0) {
+            log.info("No orphaned subscriptions found, nothing to delete.");
+            return true;
+        }
+        DeleteResult deleteResult = subscriptions.deleteMany(Filters.nin("application", validAppIds));
+        log.info("Deleted {} orphaned subscriptions.", deleteResult.getDeletedCount());
+
+        return deleteResult.wasAcknowledged();
+    }
+
+    @Override
+    public int getOrder() {
+        return REMOVE_ORPHANED_SUBSCRIPTIONS_ORDER;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11092

## Description

Some subscriptions reference non-existent applications, breaking database migrations.

RDBMS: Added a Liquibase changeset to delete orphaned subscriptions in the correct order.

MongoDB: Implemented a batch upgrader to remove orphaned subscriptions with logging for verification.

Sample execution:
<img width="1559" height="407" alt="Screenshot 2025-09-18 at 3 57 53 PM" src="https://github.com/user-attachments/assets/e713bf63-d02b-4872-a2ec-282317984c11" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

