### PR TITLE
APIM 10281 memorize filters

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-header/action-buttons.directive.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-header/action-buttons.directive.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[actionButtons]',
+  standalone: true,
+})
+export class ActionButtonsDirective {}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-header/api-navigation-header.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-header/api-navigation-header.component.html
@@ -35,5 +35,6 @@
         }
       </div>
     }
+    <ng-content select="[actionButtons]"></ng-content>
   </div>
 }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.module.ts
@@ -43,6 +43,7 @@ import { ApiNavigationTitleComponent } from './api-navigation-title/api-navigati
 import { ApiNavigationComponent } from './api-navigation.component';
 import { ApiNavigationDisabledComponent } from './api-navigation-disabled/api-navigation-disabled.component';
 import { ApiNavigationHeaderComponent } from './api-navigation-header/api-navigation-header.component';
+import { ActionButtonsDirective } from './api-navigation-header/action-buttons.directive';
 
 @NgModule({
   imports: [
@@ -66,6 +67,7 @@ import { ApiNavigationHeaderComponent } from './api-navigation-header/api-naviga
     MatSnackBarModule,
     RouterModule,
     GioMenuModule,
+    ActionButtonsDirective,
   ],
   declarations: [
     ApiNavigationComponent,
@@ -76,6 +78,6 @@ import { ApiNavigationHeaderComponent } from './api-navigation-header/api-naviga
     ApiConfirmDeploymentDialogComponent,
     ApiReviewDialogComponent,
   ],
-  exports: [ApiNavigationComponent],
+  exports: [ApiNavigationComponent, ApiNavigationHeaderComponent, ActionButtonsDirective],
 })
 export class ApiNavigationModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -25,6 +25,7 @@ import { GioPermissionService } from '../../../shared/components/gio-permission/
 import { ApiV4 } from '../../../entities/management-api-v2';
 import { ApiDocumentationV2Service } from '../../../services-ngx/api-documentation-v2.service';
 import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
+import { ApiType } from '../../../entities/management-api-v2/api/v4/apiType';
 
 @Injectable()
 export class ApiV4MenuService implements ApiMenuService {
@@ -49,7 +50,7 @@ export class ApiV4MenuService implements ApiMenuService {
       this.addConsumersMenuEntry(hasTcpListeners),
       this.addDocumentationMenuEntry(api),
       this.addDeploymentMenuEntry(),
-      this.addApiTrafficMenuEntry(hasTcpListeners),
+      this.addApiTrafficMenuEntry(hasTcpListeners, api.type),
       ...(api.type !== 'NATIVE' ? [this.addLogs(hasTcpListeners)] : []),
       ...(api.type !== 'NATIVE' ? [this.addApiRuntimeAlertsMenuEntry()] : []),
       ...this.addAlertsMenuEntry(),
@@ -372,16 +373,23 @@ export class ApiV4MenuService implements ApiMenuService {
     };
   }
 
-  private addApiTrafficMenuEntry(hasTcpListeners: boolean): MenuItem {
+  private addApiTrafficMenuEntry(hasTcpListeners: boolean, apiType: ApiType): MenuItem {
     if (this.permissionService.hasAnyMatching(['api-analytics-r'])) {
-      return {
+      const baseMenuItem = {
         displayName: 'API Traffic',
         icon: 'bar-chart-2',
         routerLink: hasTcpListeners ? 'DISABLED' : 'v4/analytics',
-        header: {
-          title: 'API Traffic',
-        },
       };
+      if (apiType === 'PROXY') {
+        return baseMenuItem;
+      } else {
+        return {
+          ...baseMenuItem,
+          header: {
+            title: 'API Traffic',
+          },
+        };
+      }
     }
     return null;
   }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.html
@@ -15,6 +15,12 @@
     limitations under the License.
 
 -->
+<api-navigation-header [menuItemHeader]="menuItemHeader">
+  <div actionButtons>
+    <button mat-raised-button (click)="navigateToLogs()">View Logs</button>
+  </div>
+</api-navigation-header>
+
 <api-analytics-proxy-filter-bar
   [activeFilters]="activeFilters()"
   [plans]="apiPlans$ | async"

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
@@ -88,6 +88,9 @@ describe('ApiAnalyticsProxyComponent', () => {
     const plan1 = fakePlanV4({ id: '1', name: 'plan 1' });
     const plan2 = fakePlanV4({ id: '2', name: 'plan 2' });
 
+    const mockCustomFromTimestamp = 1640908800000;
+    const mockCustomToTimestamp = 1640995200000;
+
     it('should use default time range when no query params provided', async () => {
       await initComponent();
       handleAllRequests();
@@ -169,6 +172,68 @@ describe('ApiAnalyticsProxyComponent', () => {
           httpStatuses: '404',
         },
         queryParamsHandling: 'replace',
+      });
+    });
+
+    it('should navigate to logs with custom timestamp query parameters', async () => {
+      const mockQueryParams = {
+        period: 'custom',
+        from: mockCustomFromTimestamp.toString(),
+        to: mockCustomToTimestamp.toString(),
+        httpStatuses: '200,404',
+        plans: 'plan-1,plan-2',
+        applications: 'app-1,app-2',
+      };
+
+      await initComponent(mockQueryParams);
+      handleAllRequests();
+
+      const router = TestBed.inject(Router);
+      const routerSpy = jest.spyOn(router, 'navigate');
+
+      const component = fixture.componentInstance;
+
+      component.navigateToLogs();
+
+      expect(routerSpy).toHaveBeenCalledWith(['../runtime-logs'], {
+        relativeTo: expect.anything(),
+        queryParams: {
+          from: mockCustomFromTimestamp,
+          to: mockCustomToTimestamp,
+          statuses: '200,404',
+          planIds: 'plan-1,plan-2',
+          applicationIds: 'app-1,app-2',
+        },
+      });
+    });
+
+    it('should navigate to logs with predefined time period query parameters', async () => {
+      const mockQueryParams = {
+        period: '1d',
+        httpStatuses: '200,404',
+        plans: 'plan-1,plan-2',
+        applications: 'app-1,app-2',
+      };
+
+      await initComponent(mockQueryParams);
+      handleAllRequests();
+
+      const router = TestBed.inject(Router);
+      const routerSpy = jest.spyOn(router, 'navigate');
+
+      const component = fixture.componentInstance;
+
+      component.navigateToLogs();
+
+      expect(routerSpy).toHaveBeenCalledWith(['../runtime-logs'], {
+        relativeTo: expect.anything(),
+        queryParams: {
+          from: expect.any(Number),
+          to: expect.any(Number),
+          statuses: '200,404',
+          planIds: 'plan-1,plan-2',
+          applicationIds: 'app-1,app-2',
+        },
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -22,6 +22,7 @@ import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map, shareReplay } from 'rxjs/operators';
+import { MatButtonModule } from '@angular/material/button';
 
 import { timeFrames } from '../../../../../shared/utils/timeFrameRanges';
 import {
@@ -44,6 +45,8 @@ import { GioChartPieModule } from '../../../../../shared/components/gio-chart-pi
 import { Stats, StatsField } from '../../../../../entities/management-api-v2/analytics/analyticsStats';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
 import { StatsUnitType } from '../../../../../shared/components/analytics-stats/analytics-stats.component';
+import { ApiNavigationModule } from '../../../api-navigation/api-navigation.module';
+import { MenuItemHeader } from '../../../api-navigation/MenuGroupItem';
 
 type WidgetDisplayConfig = {
   title: string;
@@ -101,6 +104,8 @@ export type ApiAnalyticsDashboardWidgetConfig = WidgetDisplayConfig & WidgetData
     ApiAnalyticsProxyFilterBarComponent,
     ApiAnalyticsWidgetComponent,
     GioChartPieModule,
+    ApiNavigationModule,
+    MatButtonModule,
   ],
   templateUrl: './api-analytics-proxy.component.html',
   styleUrl: './api-analytics-proxy.component.scss',
@@ -115,6 +120,10 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
   public rightColumnTransformed$: Observable<ApiAnalyticsWidgetConfig>[];
 
   public activeFilters: Signal<ApiAnalyticsProxyFilters> = computed(() => this.mapQueryParamsToFilters(this.activatedRouteQueryParams()));
+
+  public menuItemHeader: MenuItemHeader = {
+    title: 'API Traffic',
+  };
 
   private topRowWidgets: ApiAnalyticsDashboardWidgetConfig[] = [
     {
@@ -373,6 +382,23 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
     this.apiAnalyticsWidgetService.clearStatsCache();
   }
 
+  navigateToLogs(): void {
+    const queryParams = this.activatedRoute.snapshot.queryParams;
+
+    const queryParamsForLogs = {
+      from: this.getFromAndToTimestamps(queryParams).fromTimestamp,
+      to: this.getFromAndToTimestamps(queryParams).toTimestamp,
+      statuses: queryParams.httpStatuses,
+      planIds: queryParams.plans,
+      applicationIds: queryParams.applications,
+    };
+
+    this.router.navigate(['../runtime-logs'], {
+      relativeTo: this.activatedRoute,
+      queryParams: queryParamsForLogs,
+    });
+  }
+
   private updateQueryParamsFromFilters(filters: ApiAnalyticsProxyFilters): void {
     const queryParams = this.createQueryParamsFromFilters(filters);
     this.router.navigate([], {
@@ -470,5 +496,20 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
   private calculateCustomInterval(from: number, to: number, nbValuesByBucket = 30): number {
     const range: number = to - from;
     return Math.floor(range / nbValuesByBucket);
+  }
+
+  private getFromAndToTimestamps(queryParams: any) {
+    let fromTimestamp: number;
+    let toTimestamp: number;
+    if (queryParams.period === 'custom' && queryParams.from && queryParams.to) {
+      fromTimestamp = +queryParams.from;
+      toTimestamp = +queryParams.to;
+    } else {
+      const timeFrame = timeFrames.find((tf) => tf.id === queryParams.period);
+      const timeRangeParams = timeFrame.timeFrameRangesParams();
+      fromTimestamp = timeRangeParams.from;
+      toTimestamp = timeRangeParams.to;
+    }
+    return { fromTimestamp, toTimestamp };
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -146,8 +146,10 @@ export class ApiRuntimeLogsComponent implements OnInit {
                 const application = applications.data.find((app) => app.id === id);
                 return { value: id, label: `${application.name} ( ${application.owner?.displayName} )` };
               }) ?? undefined,
-            from: this.activatedRoute.snapshot.queryParams?.from ? moment(this.activatedRoute.snapshot.queryParams.from) : undefined,
-            to: this.activatedRoute.snapshot.queryParams?.to ? moment(this.activatedRoute.snapshot.queryParams.to) : undefined,
+            from: this.activatedRoute.snapshot.queryParams?.from
+              ? moment(Number(this.activatedRoute.snapshot.queryParams.from))
+              : undefined,
+            to: this.activatedRoute.snapshot.queryParams?.to ? moment(Number(this.activatedRoute.snapshot.queryParams.to)) : undefined,
             methods: this.activatedRoute.snapshot.queryParams?.methods?.split(',') ?? undefined,
             statuses: statuses?.size > 0 ? statuses : undefined,
             entrypoints: this.activatedRoute.snapshot.queryParams?.entrypointIds?.split(',') ?? undefined,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10281

## Description

- Add view logs button in proxy analytics.
- Memorize filters while navigating.

## Additional context

On Traffic page:

<img width="1914" height="834" alt="image" src="https://github.com/user-attachments/assets/ff2a3e84-61c7-4c9b-a856-735e6d95daea" />

On Logs Page:

<img width="1914" height="834" alt="image" src="https://github.com/user-attachments/assets/a4056b7e-b4c5-4b2e-a720-437fec271e67" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hxtxeukiym.chromatic.com)
<!-- Storybook placeholder end -->
