### PR TITLE
feat: add publish and unpublish functionality for portal pages

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContextRepository.java
@@ -37,5 +37,5 @@ public interface PortalPageContextRepository extends CrudRepository<PortalPageCo
 
     PortalPageContext findByPageId(String string);
 
-    void updateByPageId(PortalPageContext item) throws TechnicalException;
+    PortalPageContext updateByPageId(PortalPageContext item) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContextRepository.java
@@ -36,4 +36,6 @@ public interface PortalPageContextRepository extends CrudRepository<PortalPageCo
         throws TechnicalException;
 
     PortalPageContext findByPageId(String string);
+
+    void updateByPageId(PortalPageContext item) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContextRepository.java
@@ -109,7 +109,7 @@ public class JdbcPortalPageContextRepository
     }
 
     @Override
-    public void updateByPageId(PortalPageContext item) throws TechnicalException {
+    public PortalPageContext updateByPageId(PortalPageContext item) throws TechnicalException {
         LOGGER.debug("JdbcPortalPageContextRepository.updateByPageId({})", item);
 
         try {
@@ -122,9 +122,11 @@ public class JdbcPortalPageContextRepository
             if (rows == 0) {
                 throw new TechnicalException("Failed to update portal page context, no rows affected");
             }
+
             LOGGER.debug("JdbcPortalPageContextRepository.updateByPageId({}) - Done", item);
+
+            return findByPageId(item.getPageId());
         } catch (final Exception ex) {
-            LOGGER.error("Failed to update PortalPageContext by pageId [{}]", item.getPageId(), ex);
             throw new TechnicalException("Failed to update portal page context", ex);
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContextRepository.java
@@ -65,8 +65,7 @@ public class JdbcPortalPageContextRepository
     }
 
     @Override
-    public List<PortalPageContext> findAllByContextTypeAndEnvironmentId(PortalPageContextType contextType, String environmentId)
-        throws TechnicalException {
+    public List<PortalPageContext> findAllByContextTypeAndEnvironmentId(PortalPageContextType contextType, String environmentId) {
         LOGGER.debug("JdbcPortalPageContextRepository.findAllByContextTypeAndEnvironmentId({}, {})", contextType, environmentId);
 
         try {
@@ -106,6 +105,27 @@ public class JdbcPortalPageContextRepository
         } catch (final Exception ex) {
             LOGGER.error("Failed to find PortalPageContext by pageId [{}]", string, ex);
             return null;
+        }
+    }
+
+    @Override
+    public void updateByPageId(PortalPageContext item) throws TechnicalException {
+        LOGGER.debug("JdbcPortalPageContextRepository.updateByPageId({})", item);
+
+        try {
+            final int rows = jdbcTemplate.update(
+                "update " + this.tableName + " set context_type = ?, published = ? where page_id = ?",
+                item.getContextType().name(),
+                item.isPublished(),
+                item.getPageId()
+            );
+            if (rows == 0) {
+                throw new TechnicalException("Failed to update portal page context, no rows affected");
+            }
+            LOGGER.debug("JdbcPortalPageContextRepository.updateByPageId({}) - Done", item);
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to update PortalPageContext by pageId [{}]", item.getPageId(), ex);
+            throw new TechnicalException("Failed to update portal page context", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContextRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.PortalPageContext;
 import io.gravitee.repository.management.model.PortalPageContextType;
 import io.gravitee.repository.mongodb.management.internal.model.PortalPageContextMongo;
 import io.gravitee.repository.mongodb.management.internal.portalpagecontext.PortalPageContextMongoRepository;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -48,8 +49,7 @@ public class MongoPortalPageContextRepository implements PortalPageContextReposi
     }
 
     @Override
-    public List<PortalPageContext> findAllByContextTypeAndEnvironmentId(PortalPageContextType contextType, String environmentId)
-        throws TechnicalException {
+    public List<PortalPageContext> findAllByContextTypeAndEnvironmentId(PortalPageContextType contextType, String environmentId) {
         log.debug("Find all PortalPageContexts by contextType [{}] and environmentId [{}]", contextType, environmentId);
         Set<PortalPageContextMongo> mongoPortalPageContexts = internalRepo.findAllByContextTypeAndEnvironmentId(contextType, environmentId);
         List<PortalPageContext> portalPageContexts = mongoPortalPageContexts.stream().map(this::map).collect(Collectors.toList());
@@ -68,6 +68,14 @@ public class MongoPortalPageContextRepository implements PortalPageContextReposi
         Optional<PortalPageContext> portalPageContext = internalRepo.findByPageId(string).map(this::map);
         log.debug("Find PortalPageContext by pageId [{}] - Done", string);
         return portalPageContext.orElse(null);
+    }
+
+    @Override
+    public void updateByPageId(@Nonnull PortalPageContext item) throws TechnicalException {
+        log.debug("Update PortalPageContext by pageId [{}]", item.getPageId());
+        PortalPageContextMongo portalPageContextMongo = map(item);
+        internalRepo.updateByPageId(portalPageContextMongo);
+        log.debug("Update PortalPageContext by pageId [{}] - Done", item.getPageId());
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContextRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContextRepository.java
@@ -71,11 +71,12 @@ public class MongoPortalPageContextRepository implements PortalPageContextReposi
     }
 
     @Override
-    public void updateByPageId(@Nonnull PortalPageContext item) throws TechnicalException {
+    public PortalPageContext updateByPageId(@Nonnull PortalPageContext item) throws TechnicalException {
         log.debug("Update PortalPageContext by pageId [{}]", item.getPageId());
         PortalPageContextMongo portalPageContextMongo = map(item);
         internalRepo.updateByPageId(portalPageContextMongo);
         log.debug("Update PortalPageContext by pageId [{}] - Done", item.getPageId());
+        return findByPageId(item.getPageId());
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepository.java
@@ -27,7 +27,8 @@ import org.springframework.stereotype.Repository;
  * @author GraviteeSource Team
  */
 @Repository
-public interface PortalPageContextMongoRepository extends MongoRepository<PortalPageContextMongo, String> {
+public interface PortalPageContextMongoRepository
+    extends MongoRepository<PortalPageContextMongo, String>, PortalPageContextMongoRepositoryCustom {
     /**
      * Find all portal page contexts by context type and environment ID.
      */

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepositoryCustom.java
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.crud_service;
+package io.gravitee.repository.mongodb.management.internal.portalpagecontext;
 
-import io.gravitee.apim.core.portal_page.model.PageId;
-import io.gravitee.apim.core.portal_page.model.PortalPageView;
-import io.gravitee.apim.core.portal_page.model.PortalViewContext;
-import java.util.List;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.mongodb.management.internal.model.PortalPageContextMongo;
 
-public interface PortalPageContextCrudService {
-    List<PageId> findAllIdsByContextTypeAndEnvironmentId(PortalViewContext contextType, String environmentId);
-
-    PortalPageView findByPageId(PageId pageId);
-
-    void update(PageId pageId, PortalPageView toUpdate);
+public interface PortalPageContextMongoRepositoryCustom {
+    void updateByPageId(PortalPageContextMongo item) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontext/PortalPageContextMongoRepositoryImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.portalpagecontext;
+
+import com.mongodb.client.result.UpdateResult;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.mongodb.management.internal.model.PortalPageContextMongo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+public class PortalPageContextMongoRepositoryImpl implements PortalPageContextMongoRepositoryCustom {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Override
+    public void updateByPageId(PortalPageContextMongo item) throws TechnicalException {
+        Query query = Query.query(Criteria.where("pageId").is(item.getPageId()));
+        Update update = new Update().set("contextType", item.getContextType()).set("published", item.isPublished());
+        try {
+            UpdateResult result = mongoTemplate.updateFirst(query, update, PortalPageContextMongo.class);
+            if (result.getMatchedCount() == 0) {
+                throw new TechnicalException("Failed to update portal page context, no rows affected");
+            }
+        } catch (Exception e) {
+            throw new TechnicalException("Failed to update portal page context", e);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContextRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContextRepositoryTest.java
@@ -133,8 +133,7 @@ public class PortalPageContextRepositoryTest extends AbstractManagementRepositor
         assertThat(existing).isNotNull();
         assertThat(existing.isPublished()).isFalse();
 
-        PortalPageContext toUpdate = PortalPageContext
-            .builder()
+        PortalPageContext toUpdate = PortalPageContext.builder()
             .pageId(existing.getPageId())
             .contextType(existing.getContextType())
             .environmentId(existing.getEnvironmentId())

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContextRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContextRepositoryTest.java
@@ -79,7 +79,7 @@ public class PortalPageContextRepositoryTest extends AbstractManagementRepositor
     }
 
     @Test
-    public void should_throw_error_when_updating_non_existing_portal_page_context() throws TechnicalException {
+    public void should_throw_error_when_updating_non_existing_portal_page_context() {
         // Given
         PortalPageContext nonExisting = new PortalPageContext();
         nonExisting.setId("non-existing-id");
@@ -116,7 +116,7 @@ public class PortalPageContextRepositoryTest extends AbstractManagementRepositor
     }
 
     @Test
-    public void should_find_by_page_id() throws Exception {
+    public void should_find_by_page_id() {
         String pageId = "test-portal-page-id";
 
         PortalPageContext foundContext = portalPageContextRepository.findByPageId(pageId);
@@ -124,5 +124,29 @@ public class PortalPageContextRepositoryTest extends AbstractManagementRepositor
         assertThat(foundContext).isNotNull();
         assertThat(foundContext.getPageId()).isEqualTo(pageId);
         assertThat(foundContext.getId()).isEqualTo("test-portal-page-context-id");
+    }
+
+    @Test
+    public void should_update_by_page_id() throws Exception {
+        // Given
+        PortalPageContext existing = portalPageContextRepository.findById("update-portal-page-context-id").orElse(null);
+        assertThat(existing).isNotNull();
+        assertThat(existing.isPublished()).isFalse();
+
+        PortalPageContext toUpdate = PortalPageContext
+            .builder()
+            .pageId(existing.getPageId())
+            .contextType(existing.getContextType())
+            .environmentId(existing.getEnvironmentId())
+            .published(true)
+            .build();
+
+        // When
+        portalPageContextRepository.updateByPageId(toUpdate);
+
+        // Then
+        PortalPageContext updated = portalPageContextRepository.findByPageId(existing.getPageId());
+        assertThat(updated).isNotNull();
+        assertThat(updated.isPublished()).isTrue();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResource.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.portal_pages;
 
+import io.gravitee.apim.core.portal_page.model.PageId;
 import io.gravitee.apim.core.portal_page.use_case.GetHomepageUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageUseCase;
+import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageViewPublicationStatusUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalPagesMapper;
 import io.gravitee.rest.api.management.v2.rest.model.PatchPortalPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageResponse;
@@ -29,6 +31,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -40,6 +43,9 @@ public class PortalPagesResource extends AbstractResource {
 
     @Inject
     private UpdatePortalPageUseCase updatePortalPageUseCase;
+
+    @Inject
+    UpdatePortalPageViewPublicationStatusUseCase updatePortalPageViewPublicationStatusUseCase;
 
     @PathParam("envId")
     private String envId;
@@ -64,6 +70,29 @@ public class PortalPagesResource extends AbstractResource {
         var input = new UpdatePortalPageUseCase.Input(envId, pageId, patchPortalPage.getContent());
         var updatedHomepage = updatePortalPageUseCase.execute(input);
 
+        return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
+    }
+
+    @POST
+    @Produces("application/json")
+    @Consumes("application/json")
+    @Path("/{pageId}/_publish")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
+    public PortalPageResponse publishPortalPage(@PathParam("pageId") String pageId) {
+        var input = new UpdatePortalPageViewPublicationStatusUseCase.Input(PageId.of(pageId), true);
+        var updatedHomepage = updatePortalPageViewPublicationStatusUseCase.execute(input);
+
+        return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
+    }
+
+    @POST
+    @Produces("application/json")
+    @Consumes("application/json")
+    @Path("/{pageId}/_unpublish")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
+    public PortalPageResponse unpublishPortalPage(@PathParam("pageId") String pageId) {
+        var input = new UpdatePortalPageViewPublicationStatusUseCase.Input(PageId.of(pageId), false);
+        var updatedHomepage = updatePortalPageViewPublicationStatusUseCase.execute(input);
         return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -765,7 +765,7 @@ paths:
         tags:
           - Portal Pages
         summary: Patch portal page
-        description: User must have the ENVIRONMENT_DOCUMENTATION[write] permission.
+        description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
         operationId: patchPortalPage
         parameters:
           - name: pageId

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -760,18 +760,64 @@ paths:
             $ref: "#/components/responses/PortalPageResponse"
           default:
             $ref: "#/components/responses/Error"
+    /portal-pages/{pageId}:
       patch:
         tags:
           - Portal Pages
         summary: Patch portal page
         description: User must have the ENVIRONMENT_DOCUMENTATION[write] permission.
         operationId: patchPortalPage
+        parameters:
+          - name: pageId
+            in: path
+            description: The unique ID of the portal page
+            required: true
+            schema:
+              type: string
         requestBody:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PatchPortalPage"
           required: true
+        responses:
+          "200":
+            $ref: "#/components/responses/PortalPageResponse"
+          default:
+            $ref: "#/components/responses/Error"
+    /portal-pages/{pageId}/_publish:
+      post:
+        tags:
+          - Portal Pages
+        summary: Publish portal page
+        description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+        operationId: publishPortalPage
+        parameters:
+          - name: pageId
+            in: path
+            description: The unique ID of the portal page
+            required: true
+            schema:
+              type: string
+        responses:
+          "200":
+            $ref: "#/components/responses/PortalPageResponse"
+          default:
+            $ref: "#/components/responses/Error"
+    /portal-pages/{pageId}/_unpublish:
+      post:
+        tags:
+          - Portal Pages
+        summary: Unpublish portal page
+        description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+        operationId: unpublishPortalPage
+        parameters:
+          - name: pageId
+            in: path
+            description: The unique ID of the portal page
+            required: true
+            schema:
+              type: string
         responses:
           "200":
             $ref: "#/components/responses/PortalPageResponse"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContextCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContextCrudService.java
@@ -25,5 +25,5 @@ public interface PortalPageContextCrudService {
 
     PortalPageView findByPageId(PageId pageId);
 
-    void update(PageId pageId, PortalPageView toUpdate);
+    PortalPageView update(PageId pageId, PortalPageView toUpdate);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PageExistsSpecification.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PageExistsSpecification.java
@@ -16,8 +16,9 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.portal_page.exception.PortalPageSpecificationException;
-import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPage;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class PageExistsSpecification<T> {
@@ -26,6 +27,10 @@ public class PageExistsSpecification<T> {
 
     public PageExistsSpecification(Predicate<T> existenceChecker) {
         this.existenceChecker = existenceChecker;
+    }
+
+    public static PageExistsSpecification<Optional<PortalPage>> ofOptional() {
+        return new PageExistsSpecification<>(Optional::isPresent);
     }
 
     public boolean satisfies(T locator) {
@@ -43,10 +48,6 @@ public class PageExistsSpecification<T> {
     }
 
     public static PageExistsSpecification<PortalViewContext> byPortalViewContext(Predicate<PortalViewContext> existenceChecker) {
-        return new PageExistsSpecification<>(existenceChecker);
-    }
-
-    public static PageExistsSpecification<PageId> byPageId(Predicate<PageId> existenceChecker) {
         return new PageExistsSpecification<>(existenceChecker);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/IllegalPublicationStateException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/IllegalPublicationStateException.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.crud_service;
+package io.gravitee.apim.core.portal_page.exception;
 
-import io.gravitee.apim.core.portal_page.model.PageId;
-import io.gravitee.apim.core.portal_page.model.PortalPageView;
-import io.gravitee.apim.core.portal_page.model.PortalViewContext;
-import java.util.List;
+import io.gravitee.apim.core.exception.AbstractDomainException;
 
-public interface PortalPageContextCrudService {
-    List<PageId> findAllIdsByContextTypeAndEnvironmentId(PortalViewContext contextType, String environmentId);
+public class IllegalPublicationStateException extends AbstractDomainException {
 
-    PortalPageView findByPageId(PageId pageId);
+    private IllegalPublicationStateException(String message) {
+        super(message);
+    }
 
-    void update(PageId pageId, PortalPageView toUpdate);
+    public static IllegalPublicationStateException alreadyPublished() {
+        return new IllegalPublicationStateException("The page is already published.");
+    }
+
+    public static IllegalPublicationStateException alreadyUnpublished() {
+        return new IllegalPublicationStateException("The page is already unpublished.");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageView.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageView.java
@@ -15,6 +15,23 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.portal_page.exception.IllegalPublicationStateException;
 import jakarta.annotation.Nonnull;
 
-public record PortalPageView(@Nonnull PortalViewContext context, boolean published) {}
+public record PortalPageView(@Nonnull PortalViewContext context, boolean published) {
+    public PortalPageView publish() {
+        if (this.published) {
+            throw IllegalPublicationStateException.alreadyPublished();
+        }
+
+        return new PortalPageView(this.context, true);
+    }
+
+    public PortalPageView unpublish() {
+        if (!this.published) {
+            throw IllegalPublicationStateException.alreadyUnpublished();
+        }
+
+        return new PortalPageView(this.context, false);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalPageQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalPageQueryService.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.query_service;
 
 import io.gravitee.apim.core.portal_page.model.ExpandsViewContext;
 import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPageView;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import java.util.List;
@@ -33,4 +34,6 @@ public interface PortalPageQueryService {
     );
 
     PortalPageWithViewDetails findById(PageId pageId);
+
+    PortalPageWithViewDetails loadContentFor(PageId pageId, PortalPageView details);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageUseCase.java
@@ -22,9 +22,7 @@ import io.gravitee.apim.core.portal_page.domain_service.ContentSanitizedSpecific
 import io.gravitee.apim.core.portal_page.domain_service.PageExistsSpecification;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.model.PageId;
-import io.gravitee.apim.core.portal_page.model.PortalPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -41,7 +39,7 @@ public class UpdatePortalPageUseCase {
     public Output execute(Input input) {
         PageId pageId = PageId.of(input.pageId);
         var portalPageOpt = portalPageCrudService.findById(pageId);
-        var pageExistsSpec = new PageExistsSpecification<Optional<PortalPage>>(Optional::isPresent);
+        var pageExistsSpec = PageExistsSpecification.ofOptional();
         var contentSanitizedSpec = new ContentSanitizedSpecification();
 
         GraviteeMarkdown pageContent = new GraviteeMarkdown(input.content);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContextCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PageExistsSpecification;
+import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPageView;
+import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageQueryService;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdatePortalPageViewPublicationStatusUseCase {
+
+    private final PortalPageContextCrudService portalPageContextCrudService;
+    private final PortalPageQueryService portalPageQueryService;
+
+    public Output execute(Input input) {
+        var portalPageView = portalPageContextCrudService.findByPageId(input.pageId());
+        var pageExistsSpec = new PageExistsSpecification<PortalPageView>(Objects::nonNull);
+
+        pageExistsSpec.throwIfNotSatisfied(portalPageView);
+
+        PortalPageView toUpdate;
+        if (input.published()) {
+            toUpdate = portalPageView.publish();
+        } else {
+            toUpdate = portalPageView.unpublish();
+        }
+
+        portalPageContextCrudService.update(input.pageId(), toUpdate);
+
+        return new Output(portalPageQueryService.findById(input.pageId()));
+    }
+
+    public record Input(PageId pageId, boolean published) {}
+
+    public record Output(PortalPageWithViewDetails portalPage) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCase.java
@@ -45,9 +45,9 @@ public class UpdatePortalPageViewPublicationStatusUseCase {
             toUpdate = portalPageView.unpublish();
         }
 
-        portalPageContextCrudService.update(input.pageId(), toUpdate);
+        var updatedDetails = portalPageContextCrudService.update(input.pageId(), toUpdate);
 
-        return new Output(portalPageQueryService.findById(input.pageId()));
+        return new Output(portalPageQueryService.loadContentFor(input.pageId(), updatedDetails));
     }
 
     public record Input(PageId pageId, boolean published) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.portal_page.model.PageId;
 import io.gravitee.apim.core.portal_page.model.PortalPageView;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.repository.management.model.PortalPage;
@@ -71,5 +72,16 @@ public interface PortalPageAdapter {
         core.setCreatedAt(value.getCreatedAt());
         core.setUpdatedAt(value.getUpdatedAt());
         return core;
+    }
+
+    default PortalPageContext map(PageId pageId, PortalPageView toUpdate) {
+        if (pageId == null && toUpdate == null) {
+            return null;
+        }
+        PortalPageContext portalPageContext = new PortalPageContext();
+        portalPageContext.setPageId(map(pageId));
+        portalPageContext.setContextType(PortalPageContextType.valueOf(toUpdate.context().name()));
+        portalPageContext.setPublished(toUpdate.published());
+        return portalPageContext;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContextCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContextCrudServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.portal_page.model.PageId;
 import io.gravitee.apim.core.portal_page.model.PortalPageView;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.apim.infra.adapter.PortalPageAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalPageContextRepository;
 import io.gravitee.repository.management.model.PortalPageContext;
 import io.gravitee.repository.management.model.PortalPageContextType;
@@ -56,5 +57,15 @@ public class PortalPageContextCrudServiceImpl implements PortalPageContextCrudSe
     @Override
     public PortalPageView findByPageId(PageId pageId) {
         return pageAdapter.map(portalPageContextRepository.findByPageId(pageId.toString()));
+    }
+
+    @Override
+    public void update(PageId pageId, PortalPageView toUpdate) {
+        var item = pageAdapter.map(pageId, toUpdate);
+        try {
+            portalPageContextRepository.updateByPageId(item);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("Something went wrong while trying to update portal page context", e);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContextCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContextCrudServiceImpl.java
@@ -60,10 +60,10 @@ public class PortalPageContextCrudServiceImpl implements PortalPageContextCrudSe
     }
 
     @Override
-    public void update(PageId pageId, PortalPageView toUpdate) {
+    public PortalPageView update(PageId pageId, PortalPageView toUpdate) {
         var item = pageAdapter.map(pageId, toUpdate);
         try {
-            portalPageContextRepository.updateByPageId(item);
+            return pageAdapter.map(portalPageContextRepository.updateByPageId(item));
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("Something went wrong while trying to update portal page context", e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageQueryServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.query_service.portal_page;
 
 import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPageView;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageQueryService;
@@ -85,6 +86,15 @@ public class PortalPageQueryServiceImpl implements PortalPageQueryService {
             return new PortalPageWithViewDetails(pageAdapter.map(page), pageAdapter.map(context));
         } catch (TechnicalException e) {
             throw new TechnicalManagementException();
+        }
+    }
+
+    @Override
+    public PortalPageWithViewDetails loadContentFor(PageId pageId, PortalPageView details) {
+        try {
+            return new PortalPageWithViewDetails(pageAdapter.map(pageRepository.findById(pageId.toString()).orElse(null)), details);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurred while trying to load portal page content", e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContextCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContextCrudServiceInMemory.java
@@ -50,6 +50,18 @@ public class PortalPageContextCrudServiceInMemory implements PortalPageContextCr
     }
 
     @Override
+    public void update(PageId pageId, PortalPageView toUpdate) {
+        storage
+            .stream()
+            .filter(ppc -> ppc.getPageId().equals(pageId.toString()))
+            .findFirst()
+            .ifPresent(portalPageContext -> {
+                portalPageContext.setContextType(PortalPageContextType.valueOf(toUpdate.context().name()));
+                portalPageContext.setPublished(toUpdate.published());
+            });
+    }
+
+    @Override
     public void initWith(List<PortalPageContext> items) {
         this.storage = items;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContextCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContextCrudServiceInMemory.java
@@ -50,7 +50,7 @@ public class PortalPageContextCrudServiceInMemory implements PortalPageContextCr
     }
 
     @Override
-    public void update(PageId pageId, PortalPageView toUpdate) {
+    public PortalPageView update(PageId pageId, PortalPageView toUpdate) {
         storage
             .stream()
             .filter(ppc -> ppc.getPageId().equals(pageId.toString()))
@@ -59,6 +59,7 @@ public class PortalPageContextCrudServiceInMemory implements PortalPageContextCr
                 portalPageContext.setContextType(PortalPageContextType.valueOf(toUpdate.context().name()));
                 portalPageContext.setPublished(toUpdate.published());
             });
+        return toUpdate;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageQueryServiceInMemory.java
@@ -17,6 +17,7 @@ package inmemory;
 
 import io.gravitee.apim.core.portal_page.model.ExpandsViewContext;
 import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPageView;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageQueryService;
@@ -52,6 +53,15 @@ public class PortalPageQueryServiceInMemory implements PortalPageQueryService, I
 
     @Override
     public PortalPageWithViewDetails findById(PageId pageId) {
+        return storage
+            .stream()
+            .filter(p -> p.page().getId().equals(pageId))
+            .findFirst()
+            .orElse(null);
+    }
+
+    @Override
+    public PortalPageWithViewDetails loadContentFor(PageId pageId, PortalPageView details) {
         return storage
             .stream()
             .filter(p -> p.page().getId().equals(pageId))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/query_service/PortalPageQueryServiceDefaultMethodTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/query_service/PortalPageQueryServiceDefaultMethodTest.java
@@ -57,6 +57,11 @@ class PortalPageQueryServiceDefaultMethodTest {
         public PortalPageWithViewDetails findById(PageId pageId) {
             return null;
         }
+
+        @Override
+        public PortalPageWithViewDetails loadContentFor(PageId pageId, PortalPageView details) {
+            return null;
+        }
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageViewPublicationStatusUseCaseTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import inmemory.PortalPageContextCrudServiceInMemory;
+import inmemory.PortalPageQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageView;
+import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
+import io.gravitee.apim.core.portal_page.model.PortalViewContext;
+import io.gravitee.repository.management.model.PortalPageContext;
+import io.gravitee.repository.management.model.PortalPageContextType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdatePortalPageViewPublicationStatusUseCaseTest {
+
+    private final PortalPageContextCrudServiceInMemory portalPageContextCrudService = new PortalPageContextCrudServiceInMemory();
+
+    private final PortalPageQueryServiceInMemory portalPageQueryService = new PortalPageQueryServiceInMemory();
+
+    private UpdatePortalPageViewPublicationStatusUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        portalPageContextCrudService.reset();
+        portalPageQueryService.reset();
+        cut = new UpdatePortalPageViewPublicationStatusUseCase(portalPageContextCrudService, portalPageQueryService);
+    }
+
+    @Test
+    void should_publish_page() {
+        var pageId = PageId.random();
+        var repoCtx = PortalPageContext.builder()
+            .pageId(pageId.toString())
+            .contextType(PortalPageContextType.HOMEPAGE)
+            .environmentId("env")
+            .published(false)
+            .build();
+
+        portalPageContextCrudService.initWith(List.of(repoCtx));
+
+        var updatedDetails = new PortalPageView(PortalViewContext.HOMEPAGE, true);
+        var page = new PortalPage(pageId, new GraviteeMarkdown("content"));
+        var expected = new PortalPageWithViewDetails(page, updatedDetails);
+        portalPageQueryService.initWith(List.of(expected));
+
+        var output = cut.execute(new UpdatePortalPageViewPublicationStatusUseCase.Input(pageId, true));
+
+        assertSame(expected, output.portalPage());
+    }
+
+    @Test
+    void should_unpublish_page() {
+        var pageId = PageId.random();
+        var repoCtx = PortalPageContext.builder()
+            .pageId(pageId.toString())
+            .contextType(PortalPageContextType.HOMEPAGE)
+            .environmentId("env")
+            .published(true)
+            .build();
+
+        portalPageContextCrudService.initWith(List.of(repoCtx));
+
+        var updatedDetails = new PortalPageView(PortalViewContext.HOMEPAGE, false);
+        var page = new PortalPage(pageId, new GraviteeMarkdown("content"));
+        var expected = new PortalPageWithViewDetails(page, updatedDetails);
+        portalPageQueryService.initWith(List.of(expected));
+
+        var output = cut.execute(new UpdatePortalPageViewPublicationStatusUseCase.Input(pageId, false));
+
+        assertSame(expected, output.portalPage());
+    }
+
+    @Test
+    void should_throw_when_page_not_found() {
+        var pageId = PageId.random();
+
+        assertThrows(io.gravitee.apim.core.portal_page.exception.PortalPageSpecificationException.class, () ->
+            cut.execute(new UpdatePortalPageViewPublicationStatusUseCase.Input(pageId, true))
+        );
+    }
+
+    @Test
+    void should_throw_when_publishing_already_published() {
+        var pageId = PageId.random();
+        var repoCtx = PortalPageContext.builder()
+            .pageId(pageId.toString())
+            .contextType(PortalPageContextType.HOMEPAGE)
+            .environmentId("env")
+            .published(true)
+            .build();
+
+        portalPageContextCrudService.initWith(List.of(repoCtx));
+
+        assertThrows(io.gravitee.apim.core.portal_page.exception.IllegalPublicationStateException.class, () ->
+            cut.execute(new UpdatePortalPageViewPublicationStatusUseCase.Input(pageId, true))
+        );
+    }
+
+    @Test
+    void should_throw_when_unpublishing_already_unpublished() {
+        var pageId = PageId.random();
+        var repoCtx = PortalPageContext.builder()
+            .pageId(pageId.toString())
+            .contextType(PortalPageContextType.HOMEPAGE)
+            .environmentId("env")
+            .published(false)
+            .build();
+
+        portalPageContextCrudService.initWith(List.of(repoCtx));
+
+        assertThrows(io.gravitee.apim.core.portal_page.exception.IllegalPublicationStateException.class, () ->
+            cut.execute(new UpdatePortalPageViewPublicationStatusUseCase.Input(pageId, false))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageAdapterTest.java
@@ -51,4 +51,24 @@ class PortalPageAdapterTest {
         assertThat(repoPage.getId()).isEqualTo("123e4567-e89b-12d3-a456-426614174000");
         assertThat(repoPage.getContent()).isEqualTo("markdown content");
     }
+
+    @Test
+    void should_map_pageId_and_portalPageView_to_portalPageContext() {
+        var pageId = io.gravitee.apim.core.portal_page.model.PageId.of("123e4567-e89b-12d3-a456-426614174000");
+        var portalPageView = new io.gravitee.apim.core.portal_page.model.PortalPageView(
+            io.gravitee.apim.core.portal_page.model.PortalViewContext.HOMEPAGE,
+            true
+        );
+
+        var context = PortalPageAdapter.INSTANCE.map(pageId, portalPageView);
+        assertThat(context).isNotNull();
+        assertThat(context.getPageId()).isEqualTo(pageId.toString());
+        assertThat(context.getContextType().name()).isEqualTo(portalPageView.context().name());
+        assertThat(context.isPublished()).isEqualTo(portalPageView.published());
+    }
+
+    @Test
+    void should_return_null_when_both_pageId_and_portalPageView_are_null() {
+        assertThat(PortalPageAdapter.INSTANCE.map(null, null)).isNull();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageCrudServiceImplTest.java
@@ -93,6 +93,22 @@ class PortalPageCrudServiceImplTest {
     }
 
     @Test
+    void should_update_page_and_return_updated_page() throws TechnicalException {
+        PageId pageId = PageId.random();
+        var updatedPage = new PortalPage(pageId, new GraviteeMarkdown("new-content"));
+
+        var repoPageUpdated = io.gravitee.repository.management.model.PortalPage.builder()
+            .id(pageId.toString())
+            .content(updatedPage.getPageContent().content())
+            .build();
+
+        doReturn(repoPageUpdated).when(pageRepository).update(any());
+
+        var result = service.update(updatedPage);
+        assertThat(result).isEqualTo(updatedPage);
+    }
+
+    @Test
     void should_throw_technical_domain_exception_when_update_fails() throws TechnicalException {
         PageId pageId = PageId.random();
         var page = new PortalPage(pageId, new GraviteeMarkdown("content-error"));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11126

## Description

## Publish
```http
POST {{baseUrl}}management/v2/environments/DEFAULT/portal-pages/e87ae5cb-4b8e-4586-bae5-cb4b8e658603/_publish  
Authorization: {{token}}  
Content-Type: application/json
```

Response:
```json
{
  "id": "e87ae5cb-4b8e-4586-bae5-cb4b8e658603",
  "content": "## Updated?",
  "type": "gravitee_markdown",
  "context": "homepage",
  "published": true
}
```

## Unpublish
```http
POST {{baseUrl}}management/v2/environments/DEFAULT/portal-pages/e87ae5cb-4b8e-4586-bae5-cb4b8e658603/_unpublish  
Authorization: {{token}}  
Content-Type: application/json
```

Response:
```json
{
  "id": "e87ae5cb-4b8e-4586-bae5-cb4b8e658603",
  "content": "## Updated?",
  "type": "gravitee_markdown",
  "context": "homepage",
  "published": false
}
```

## Error
Invalid state for publish/unpublish:
```json
{
  "httpStatus": 500,
  "message": "The page is already unpublished.",
  "details": []
}
```


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ousvckuamv.chromatic.com)
<!-- Storybook placeholder end -->
