### PR TITLE
fix: API Image not updating while importing API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -18,7 +18,10 @@ package io.gravitee.rest.api.management.rest.resource;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.apim.core.debug.use_case.DebugApiUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -557,12 +560,14 @@ public class ApiResource extends AbstractResource {
     }
 
     private Response updateApiWithDefinitionOrUrl(Object apiDefinitionOrUrl) {
+        // Validate and sanitize inline images if present. Invalid images are ignored and treated as null.
+        Object sanitizedPayload = sanitizeInlineImages(apiDefinitionOrUrl);
         final ApiEntity apiEntity = (ApiEntity) getApi().getEntity();
 
         ApiEntity updatedApi = apiDuplicatorService.updateWithImportedDefinition(
             GraviteeContext.getExecutionContext(),
             apiEntity.getId(),
-            apiDefinitionOrUrl
+            sanitizedPayload
         );
         return Response.ok(updatedApi)
             .tag(Long.toString(updatedApi.getUpdatedAt().getTime()))
@@ -1063,5 +1068,47 @@ public class ApiResource extends AbstractResource {
         entity.setResources(null);
         entity.setPathMappings(null);
         entity.setResponseTemplates(null);
+    }
+
+    private Object sanitizeInlineImages(Object apiDefinitionOrUrl) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            if (apiDefinitionOrUrl instanceof JsonNode node && node.isObject()) {
+                ObjectNode root = (ObjectNode) node;
+                sanitizeImageField(root, "picture");
+                sanitizeImageField(root, "background");
+                return root;
+            }
+
+            if (apiDefinitionOrUrl instanceof String str) {
+                String trimmed = str.trim();
+                if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+                    JsonNode parsed = mapper.readTree(trimmed);
+                    if (parsed.isObject()) {
+                        ObjectNode root = (ObjectNode) parsed;
+                        sanitizeImageField(root, "picture");
+                        sanitizeImageField(root, "background");
+                        return mapper.writeValueAsString(root);
+                    }
+                }
+            }
+        } catch (JsonProcessingException e) {
+            LOGGER.debug("Skipping inline image sanitization due to malformed JSON input", e);
+        } catch (Exception e) {
+            LOGGER.warn("Unexpected error while sanitizing inline images, returning original payload", e);
+        }
+
+        return apiDefinitionOrUrl;
+    }
+
+    private void sanitizeImageField(ObjectNode node, String fieldName) {
+        if (node.hasNonNull(fieldName) && node.get(fieldName).isTextual()) {
+            String value = node.get(fieldName).asText();
+            try {
+                ImageUtils.verify(value);
+            } catch (InvalidImageException e) {
+                node.putNull(fieldName); // replace invalid image with null
+            }
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
@@ -58,6 +58,7 @@ import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author David BRASSELY (brasseld at gmail.com)
@@ -526,5 +527,122 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         assertEquals("application/yaml", response.getHeaders().getFirst("Content-Type"));
         assertEquals("attachment;filename=my-api-1.yml", response.getHeaders().getFirst("Content-Disposition"));
+    }
+
+    @Test
+    public void shouldSanitizeInvalidInlinePictureJson() throws Exception {
+        reset(apiDuplicatorService);
+        String json = "{\"picture\":\"data:image/svg+xml;base64,AAAA\"}";
+
+        ApiEntity updatedApi = new ApiEntity();
+        updatedApi.setId("my-api-id");
+        updatedApi.setUpdatedAt(new Date());
+        updatedApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        doReturn(updatedApi)
+            .when(apiDuplicatorService)
+            .updateWithImportedDefinition(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = envTarget().path(API + "/import").request().put(Entity.entity(json, MediaType.APPLICATION_JSON_TYPE));
+
+        assertEquals(OK_200, response.getStatus());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(apiDuplicatorService).updateWithImportedDefinition(
+            eq(GraviteeContext.getExecutionContext()),
+            any(),
+            payloadCaptor.capture()
+        );
+        Object payload = payloadCaptor.getValue();
+        assertTrue(payload instanceof com.fasterxml.jackson.databind.node.ObjectNode);
+        com.fasterxml.jackson.databind.node.ObjectNode node = (com.fasterxml.jackson.databind.node.ObjectNode) payload;
+        assertTrue(node.has("picture"));
+        assertTrue(node.get("picture").isNull());
+    }
+
+    @Test
+    public void shouldSanitizeInvalidInlinePictureInTextPlain() {
+        reset(apiDuplicatorService);
+        String body = "{\"picture\":\"data:image/svg+xml;base64,AAAA\"}";
+
+        ApiEntity updatedApi = new ApiEntity();
+        updatedApi.setId("my-api-id");
+        updatedApi.setUpdatedAt(new Date());
+        updatedApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        doReturn(updatedApi)
+            .when(apiDuplicatorService)
+            .updateWithImportedDefinition(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = envTarget().path(API + "/import-url").request().put(Entity.text(body));
+
+        assertEquals(OK_200, response.getStatus());
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(apiDuplicatorService).updateWithImportedDefinition(
+            eq(GraviteeContext.getExecutionContext()),
+            any(),
+            payloadCaptor.capture()
+        );
+        Object payload = payloadCaptor.getValue();
+        assertTrue(payload instanceof String);
+        String sanitized = (String) payload;
+        assertTrue(sanitized.contains("\"picture\":null"));
+    }
+
+    @Test
+    public void shouldSanitizeInvalidInlineBackgroundJson() throws Exception {
+        reset(apiDuplicatorService);
+        String json = "{\"background\":\"data:image/svg+xml;base64,AAAA\"}";
+
+        ApiEntity updatedApi = new ApiEntity();
+        updatedApi.setId("my-api-id");
+        updatedApi.setUpdatedAt(new Date());
+        updatedApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        doReturn(updatedApi)
+            .when(apiDuplicatorService)
+            .updateWithImportedDefinition(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = envTarget().path(API + "/import").request().put(Entity.entity(json, MediaType.APPLICATION_JSON_TYPE));
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(apiDuplicatorService).updateWithImportedDefinition(
+            eq(GraviteeContext.getExecutionContext()),
+            any(),
+            payloadCaptor.capture()
+        );
+        Object payload = payloadCaptor.getValue();
+        assertTrue(payload instanceof com.fasterxml.jackson.databind.node.ObjectNode);
+        com.fasterxml.jackson.databind.node.ObjectNode node = (com.fasterxml.jackson.databind.node.ObjectNode) payload;
+        assertTrue(node.has("background"));
+        assertTrue(node.get("background").isNull());
+    }
+
+    @Test
+    public void shouldSanitizeInvalidInlineBackgroundInTextPlain() {
+        reset(apiDuplicatorService);
+        String body = "{\"background\":\"data:image/svg+xml;base64,AAAA\"}";
+
+        ApiEntity updatedApi = new ApiEntity();
+        updatedApi.setId("my-api-id");
+        updatedApi.setUpdatedAt(new Date());
+        updatedApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        doReturn(updatedApi)
+            .when(apiDuplicatorService)
+            .updateWithImportedDefinition(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = envTarget().path(API + "/import-url").request().put(Entity.text(body));
+
+        assertEquals(OK_200, response.getStatus());
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(apiDuplicatorService).updateWithImportedDefinition(
+            eq(GraviteeContext.getExecutionContext()),
+            any(),
+            payloadCaptor.capture()
+        );
+        Object payload = payloadCaptor.getValue();
+        assertTrue(payload instanceof String);
+        String sanitized = (String) payload;
+        assertTrue(sanitized.contains("\"background\":null"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1213,9 +1213,18 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 api.setCrossId(apiToUpdate.getCrossId());
             }
 
-            // Keep existing picture as picture update has dedicated service
-            api.setPicture(apiToUpdate.getPicture());
-            api.setBackground(apiToUpdate.getBackground());
+            // Keep existing values when not provided in update entity
+            api.setBackground(
+                updateApiEntity.getBackground() == null || updateApiEntity.getBackground().isEmpty()
+                    ? apiToUpdate.getBackground()
+                    : updateApiEntity.getBackground()
+            );
+
+            api.setPicture(
+                updateApiEntity.getPicture() == null || updateApiEntity.getPicture().isEmpty()
+                    ? apiToUpdate.getPicture()
+                    : updateApiEntity.getPicture()
+            );
 
             if (updateApiEntity.getGroups() == null) {
                 api.setGroups(apiToUpdate.getGroups());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -669,6 +669,54 @@ public class ApiService_UpdateTest {
     }
 
     @Test
+    public void shouldUpdatePictureWhenProvided() throws TechnicalException {
+        prepareUpdate();
+        String newPicture = "new-picture";
+        updateApiEntity.setPicture(newPicture);
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        verify(apiRepository).update(
+            argThat(
+                updated -> Objects.equals(updated.getPicture(), newPicture) && Objects.equals(updated.getBackground(), api.getBackground())
+            )
+        );
+    }
+
+    @Test
+    public void shouldKeepExistingBackgroundWhenNotProvided() throws TechnicalException {
+        prepareUpdate();
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        verify(apiRepository).update(argThat(updated -> Objects.equals(updated.getBackground(), api.getBackground())));
+    }
+
+    @Test
+    public void shouldKeepExistingBackgroundWhenEmptyString() throws TechnicalException {
+        prepareUpdate();
+        updateApiEntity.setBackground("");
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        verify(apiRepository).update(argThat(updated -> Objects.equals(updated.getBackground(), api.getBackground())));
+    }
+
+    @Test
+    public void shouldUpdateBackgroundWhenProvided() throws TechnicalException {
+        prepareUpdate();
+        String newBackground = "new-background";
+        updateApiEntity.setBackground(newBackground);
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        verify(apiRepository).update(
+            argThat(
+                updated -> Objects.equals(updated.getBackground(), newBackground) && Objects.equals(updated.getPicture(), api.getPicture())
+            )
+        );
+    }
+
+    @Test
     public void shouldUpdateWithAllowedTag() throws TechnicalException {
         prepareUpdate();
         updateApiEntity.setTags(singleton("public"));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11026

## Description

When reimporting an API definition that contains a new picture field (base64-encoded image), the existing API image is not updated. The old image remains visible even though the import payload contains a new image. This issue occurs both via the REST API (/apis/:api/import) and when performing an export–modify–reimport workflow through the APIM UI.

Reimporting an API with a modified picture field now updating the API image.

## Additional context

After fix proof:

https://github.com/user-attachments/assets/5e87a670-856e-4920-8129-9e4e6b8d1f2d


Before fix proof:

https://github.com/user-attachments/assets/8061c210-4214-43ec-97b4-b40e950f736c

If no picture is provided in the json:


https://github.com/user-attachments/assets/a7446f98-f0fd-47e2-a28b-1b87d39cf9cd


proof for 4.5.x:

https://github.com/user-attachments/assets/f445705b-057b-4541-ad5b-e80be13f5157


base64 image example: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBAQBnHwAAAABJRU5ErkJggg==`


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yaocdjwkww.chromatic.com)
<!-- Storybook placeholder end -->
