### PR TITLE
feat: add filters row in kafka metrics dashboard

### DIFF
--- a/docker/quick-setup/native-kafka/README.md
+++ b/docker/quick-setup/native-kafka/README.md
@@ -17,6 +17,7 @@ Docker compose will create the following services :
 - `gio_apim_kafka` : Kafka broker which must be accessible via Gravitee Gateway
 - `gio_apim_kafka-ui` : Simple Kafka UI to see topics and messages. Useful for testing
 - `gio_apim_kafka-client` : Kafka client container to run kafka commands. This avoids to configure kafka-client on your local machine.
+- `kibana` : Kibana service to view runtime data from Elasticsearch e.g. event metrics, logs.
 
 Docker volumes :
 - `./.license` : License file

--- a/docker/quick-setup/native-kafka/docker-compose.yml
+++ b/docker/quick-setup/native-kafka/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.17.2}
     container_name: gio_apim_elasticsearch
     restart: always
+    ports:
+      - "9200:9200"
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
     environment:
@@ -73,6 +75,16 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    networks:
+      - storage
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.8.1-arm64
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
     networks:
       - storage
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
@@ -18,7 +18,7 @@
 <api-analytics-native-filter-bar
   [activeFilters]="activeFilters()"
   [plans]="apiPlans$ | async"
-  [applications]="applications$ | async"
+  [applications]="applications"
   (filtersChange)="onFiltersChange($event)"
   (refresh)="onRefreshFilters()"
 />

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
@@ -18,7 +18,7 @@
 <api-analytics-native-filter-bar
   [activeFilters]="activeFilters()"
   [plans]="apiPlans$ | async"
-  [applications]="applications"
+  [applications]="applications$ | async"
   (filtersChange)="onFiltersChange($event)"
   (refresh)="onRefreshFilters()"
 />

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
@@ -18,6 +18,7 @@
 <api-analytics-native-filter-bar
   [activeFilters]="activeFilters()"
   [plans]="apiPlans$ | async"
+  [applications]="applications$ | async"
   (filtersChange)="onFiltersChange($event)"
   (refresh)="onRefreshFilters()"
 />

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
@@ -113,7 +113,7 @@ describe('ApiAnalyticsNativeComponent', () => {
     });
 
     it('should use and select plans from query params', async () => {
-      await initComponent({ plans: '1' });
+      await initComponent({ plans: '1', terms: 'plan-id:1' });
 
       expectPlanList([plan1, plan2]);
 
@@ -139,6 +139,7 @@ describe('ApiAnalyticsNativeComponent', () => {
         queryParams: {
           period: '1d',
           plans: '2',
+          terms: 'plan-id:2',
         },
         queryParamsHandling: 'replace',
       });
@@ -166,7 +167,7 @@ describe('ApiAnalyticsNativeComponent', () => {
     });
 
     it('should make backend calls with custom period from query params', async () => {
-      await initComponent({ period: 'custom', from: '1', to: '2' });
+      await initComponent({ period: 'custom', from: '1', to: '2', terms: 'plan-id:1,app-id:1,plan-id:2,app-id:2' });
 
       // Verify that backend calls are made with 7d time range
       const requests = httpTestingController.match((req) => req.url.includes('/analytics'));
@@ -179,6 +180,7 @@ describe('ApiAnalyticsNativeComponent', () => {
           expect(req.request.url).toContain('from=1');
           expect(req.request.url).toContain('to=2');
           expect(req.request.url).toContain('interval=0');
+          expect(req.request.url).toContain('terms=plan-id:1,app-id:1,plan-id:2,app-id:2');
         });
 
       flushAllRequests();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
@@ -290,7 +290,7 @@ describe('ApiAnalyticsNativeComponent', () => {
   function expectApplicationList(applications: Application[]) {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.baseURL}/applications/_paged?page=1&size=200`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/subscribers?page=1&perPage=200`,
         method: 'GET',
       })
       .flush(fakePagedResult(applications));

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
@@ -19,8 +19,8 @@ import { GioCardEmptyStateModule, GioLoaderModule } from '@gravitee/ui-particles
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { Observable } from 'rxjs';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Observable, of } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { map, shareReplay } from 'rxjs/operators';
 
 import { timeFrames } from '../../../../../shared/utils/timeFrameRanges';
@@ -70,7 +70,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
   public leftColumnTransformed$: Observable<ApiAnalyticsWidgetConfig>[];
   public rightColumnTransformed$: Observable<ApiAnalyticsWidgetConfig>[];
   public bottomRowTransformed$: Observable<ApiAnalyticsWidgetConfig>[];
-  public applications: BaseApplication[] = [];
+  public applications$: Observable<BaseApplication[]> = of([]);
 
   public activeFilters: Signal<ApiAnalyticsNativeFilters> = computed(() => this.mapQueryParamsToFilters(this.activatedRouteQueryParams()));
 
@@ -267,15 +267,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.apiService
-      .getSubscribers(this.apiId, null, 1, 200)
-      .pipe(
-        map((response) => {
-          this.applications = response.data;
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+    this.applications$ = this.apiService.getSubscribers(this.apiId, null, 1, 200).pipe(map((response) => response?.data ?? []));
 
     this.topRowTransformed$ = this.topRowWidgets.map((widgetConfig) => {
       return this.apiAnalyticsWidgetService.getApiAnalyticsWidgetConfig$(widgetConfig);

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
@@ -1159,6 +1159,18 @@ describe('ApiAnalyticsWidgetService', () => {
         ).toBe('application-id:("app1" OR "app2")');
       });
 
+      it('should build query for terms', () => {
+        expect(
+          service['queryOf']({
+            httpStatuses: [],
+            plans: [],
+            terms: ['app-id:app1', 'app-id:app2', 'plan-id:plan1', 'plan-id:plan2'],
+            applications: ['app1', 'app2'],
+            timeRangeParams: undefined,
+          }),
+        ).toBe('application-id:("app1" OR "app2")&terms=app-id:app1,app-id:app2,plan-id:plan1,plan-id:plan2');
+      });
+
       it('should build query for multiple filters', () => {
         expect(
           service['queryOf']({
@@ -1175,6 +1187,7 @@ describe('ApiAnalyticsWidgetService', () => {
           service['queryOf']({
             httpStatuses: [],
             plans: ['plan1'],
+            terms: [],
             applications: [],
             timeRangeParams: undefined,
           }),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -38,6 +38,7 @@ export interface ApiAnalyticsWidgetUrlParamsData {
   httpStatuses: string[];
   applications: string[];
   plans: string[];
+  terms?: string[];
 }
 
 // Colors for charts
@@ -54,6 +55,7 @@ export class ApiAnalyticsWidgetService {
     httpStatuses: [],
     applications: [],
     plans: [],
+    terms: [],
   });
 
   // Cache for stats requests to avoid multiple backend calls
@@ -354,7 +356,14 @@ export class ApiAnalyticsWidgetService {
     if (urlParamsData.applications && urlParamsData.applications.length > 0) {
       filters.push({ type: 'isin', field: 'application-id', values: urlParamsData.applications });
     }
-    return toQuery(filters);
+
+    let queryString = toQuery(filters);
+
+    if (urlParamsData.terms && urlParamsData.terms.length > 0) {
+      queryString  = queryString + '&terms=' + urlParamsData.terms;
+    }
+
+      return queryString;
   }
 
   private transformHistogramResponseToApiAnalyticsWidgetConfig(

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -360,10 +360,10 @@ export class ApiAnalyticsWidgetService {
     let queryString = toQuery(filters);
 
     if (urlParamsData.terms && urlParamsData.terms.length > 0) {
-      queryString  = queryString + '&terms=' + urlParamsData.terms;
+      queryString = queryString + '&terms=' + urlParamsData.terms;
     }
 
-      return queryString;
+    return queryString;
   }
 
   private transformHistogramResponseToApiAnalyticsWidgetConfig(

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.html
@@ -17,6 +17,12 @@
 -->
 <form [formGroup]="form" class="form">
   <gio-select-search [options]="planOptions()" formControlName="plans" label="Plan" placeholder="Search plans..." />
+  <gio-select-search
+    [options]="applicationOptions()"
+    formControlName="applications"
+    label="Application"
+    placeholder="Search applications..."
+  />
   <div class="form__timeframe">
     <gio-timeframe
       formControlName="timeframe"

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.spec.ts
@@ -34,6 +34,7 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
     from: null,
     to: null,
     plans: [],
+    applications: [],
   };
 
   beforeEach(async () => {
@@ -54,6 +55,7 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
         to: mockActiveFilters.to ? moment(mockActiveFilters.to) : null,
       },
       plans: mockActiveFilters.plans,
+      applications: mockActiveFilters.applications,
     });
 
     fixture.detectChanges();
@@ -191,6 +193,23 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
         plans: plans,
       });
     });
+
+    it('should emit filtersChange when application(s) is selected', () => {
+      // Arrange
+      const spy = jest.spyOn(component.filtersChange, 'emit');
+      const applications = ['appId1', 'appId2'];
+
+      // Act
+      component.form.patchValue({
+        applications: applications,
+      });
+
+      // Assert
+      expect(spy).toHaveBeenCalledWith({
+        ...mockActiveFilters,
+        applications: applications,
+      });
+    });
   });
 
   describe('Form State', () => {
@@ -249,26 +268,30 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
     const filters: ApiAnalyticsNativeFilters = {
       ...mockActiveFilters,
       plans: ['plan1', 'plan2'],
+      applications: ['app1', 'app2'],
     };
 
     beforeEach(() => {
       emitSpy = jest.spyOn(component.filtersChange, 'emit');
       component.form.controls.plans.setValue(['plan1', 'plan2']);
+      component.form.controls.applications.setValue(['app1', 'app2']);
       fixture.componentRef.setInput('activeFilters', filters);
       fixture.detectChanges();
     });
 
     it('should create filter chips from activeFilters using computed signals', () => {
-      expect(component.currentFilterChips()).toHaveLength(2);
+      expect(component.currentFilterChips()).toHaveLength(4);
       expect(component.currentFilterChips()).toEqual([
         { key: 'plans', value: 'plan1', display: 'plan1' },
         { key: 'plans', value: 'plan2', display: 'plan2' },
+        { key: 'applications', value: 'app1', display: 'app1' },
+        { key: 'applications', value: 'app2', display: 'app2' },
       ]);
 
       expect(component.isFiltering()).toBeTruthy();
     });
 
-    it('should remove any filter and update form', () => {
+    it('should remove plan filter and update form', () => {
       component.removeFilter('plans', 'plan1');
 
       expect(component.form.controls.plans.value).toEqual(['plan2']);
@@ -278,12 +301,23 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
       });
     });
 
+    it('should remove application filter and update form', () => {
+      component.removeFilter('applications', 'app1');
+
+      expect(component.form.controls.applications.value).toEqual(['app2']);
+      expect(emitSpy).toHaveBeenCalledWith({
+        ...filters,
+        applications: ['app2'],
+      });
+    });
+
     it('should reset all filters', () => {
       component.resetAllFilters();
 
       expect(emitSpy).toHaveBeenCalledWith({
         ...filters,
         plans: null,
+        applications: null,
       });
     });
 
@@ -292,6 +326,7 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
       const newFilters: ApiAnalyticsNativeFilters = {
         ...mockActiveFilters,
         plans: ['plan1'],
+        applications: ['app1'],
       };
 
       // Act
@@ -299,8 +334,11 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
       fixture.detectChanges();
 
       // Assert
-      expect(component.currentFilterChips()).toHaveLength(1);
-      expect(component.currentFilterChips()).toEqual([{ key: 'plans', value: 'plan1', display: 'plan1' }]);
+      expect(component.currentFilterChips()).toHaveLength(2);
+      expect(component.currentFilterChips()).toEqual([
+        { key: 'plans', value: 'plan1', display: 'plan1' },
+        { key: 'applications', value: 'app1', display: 'app1' },
+      ]);
       expect(component.isFiltering()).toBeTruthy();
     });
 
@@ -309,6 +347,7 @@ describe('ApiAnalyticsNativeFilterBarComponent', () => {
       const emptyFilters: ApiAnalyticsNativeFilters = {
         ...mockActiveFilters,
         plans: null,
+        applications: null,
       };
 
       // Act

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
@@ -111,7 +111,7 @@ export class ApiAnalyticsNativeFilterBarComponent implements OnInit {
 
     if (filters?.applications?.length) {
       const applications = this.applications();
-      filters.applications.forEach((appId) => {
+      for (const appId of filters.applications) {
         const application = applications?.find((p) => p.id === appId);
         const display = application ? application.name : appId;
         chips.push({
@@ -119,7 +119,7 @@ export class ApiAnalyticsNativeFilterBarComponent implements OnInit {
           value: appId,
           display: display,
         });
-      });
+      }
     }
 
     return chips;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
@@ -30,9 +30,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { customTimeFrames, timeFrames } from '../../../../../../shared/utils/timeFrameRanges';
 import { GioSelectSearchComponent, SelectOption } from '../../../../../../shared/components/gio-select-search/gio-select-search.component';
-import { Plan } from '../../../../../../entities/management-api-v2';
+import { BaseApplication, Plan } from '../../../../../../entities/management-api-v2';
 import { GioTimeframeComponent } from '../../../../../../shared/components/gio-timeframe/gio-timeframe.component';
-import { Application } from '../../../../../../entities/application/Application';
 
 interface ApiAnalyticsNativeFilterBarForm {
   timeframe: FormControl<{ period: string; from: Moment | null; to: Moment | null } | null>;
@@ -80,7 +79,7 @@ export class ApiAnalyticsNativeFilterBarComponent implements OnInit {
   refresh = output<void>();
 
   plans = input<Plan[]>([]);
-  applications: InputSignal<Application[]> = input<Application[]>();
+  applications: InputSignal<BaseApplication[]> = input<BaseApplication[]>();
   protected readonly timeFrames = [...timeFrames, ...customTimeFrames];
 
   public planOptions = computed<SelectOption[]>(() => {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.component.ts
@@ -43,6 +43,7 @@ export interface ApiAnalyticsNativeFilters {
   from?: number | null;
   to?: number | null;
   plans: string[] | null;
+  applications: string[] | null;
 }
 
 interface FilterChip {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-native-filter-bar/api-analytics-native-filter-bar.harness.ts
@@ -14,7 +14,29 @@
  * limitations under the License.
  */
 import { BaseFilterBarHarness } from '../base-analytics-filter-bar/base-filter-bar.harness';
+import { GioSelectSearchHarness } from '../../../../../../shared/components/gio-select-search/gio-select-search.harness';
 
 export class ApiAnalyticsNativeFilterBarHarness extends BaseFilterBarHarness {
   static hostSelector = 'api-analytics-native-filter-bar';
+
+  async getApplicationSelect(): Promise<GioSelectSearchHarness | null> {
+    return await this.locatorForOptional(GioSelectSearchHarness.with({ formControlName: 'applications' }))();
+  }
+
+  async getSelectedApplications(): Promise<string[] | null> {
+    const select = await this.getApplicationSelect();
+    await select.open();
+
+    return await select.getSelectedValues();
+  }
+
+  async selectApplication(optionText: string): Promise<void> {
+    const select = await this.getApplicationSelect();
+
+    if (select) {
+      await select.open();
+      await select.checkOptionByLabel(optionText);
+      await select.close();
+    }
+  }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -1359,11 +1359,13 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
             Aggregation agg2 = new Aggregation("upstream-publish-messages-total", AggregationType.VALUE);
             Aggregation agg3 = new Aggregation("downstream-publish-message-bytes", AggregationType.VALUE);
             Aggregation agg4 = new Aggregation("upstream-publish-message-bytes", AggregationType.VALUE);
-            Term appIdFilter = new Term("app-id", "yyy-yyy-yyy");
+            Term appIdFilter1 = new Term("app-id", "yyy-yyy-yyy");
+            Term appIdFilter2 = new Term("app-id", "kkkk-yyy-yyy");
+            Term planIdFilter = new Term("plan-id", "ec3c2f14-b669-4b4c-bc2f-14b6694b4c10");
 
             var result = cut.searchEventAnalytics(
                 QUERY_CONTEXT,
-                buildHistogramQuery(List.of(agg1, agg2, agg3, agg4), List.of(appIdFilter), "xxx-xxx-xxx")
+                buildHistogramQuery(List.of(agg1, agg2, agg3, agg4), List.of(appIdFilter1, appIdFilter2, planIdFilter), "xxx-xxx-xxx")
             );
 
             assertThat(result).hasValueSatisfying(aggregate -> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -228,6 +228,7 @@ public interface ApiMapper {
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
     @Mapping(target = "listeners", source = "source.apiDefinitionNativeV4.listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
+    @Mapping(target = "analytics", source = "source.apiDefinitionNativeV4.analytics")
     ApiV4 mapToNativeV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.FailoverV4;
@@ -187,6 +188,9 @@ public class ApiMapperTest {
             apiV4.setListeners(List.of(new Listener(ListenerFixtures.aKafkaListener())));
             apiV4.setFlows(List.of(FlowFixtures.aFlowNativeV4()));
             apiV4.setType(ApiType.NATIVE);
+            Analytics analytics = new Analytics();
+            analytics.setEnabled(true);
+            apiV4.setAnalytics(analytics);
 
             var result = ApiMapper.INSTANCE.toApiExport(apiV4);
             SoftAssertions.assertSoftly(softly -> {
@@ -207,6 +211,8 @@ public class ApiMapperTest {
 
                 var expectedFlow = FlowFixtures.aModelFlowNativeV4().toBuilder().tags(Set.of("tag1", "tag2")).build();
                 softly.assertThat(result.getFlows()).isNotNull().first().isEqualTo(expectedFlow);
+                io.gravitee.definition.model.v4.analytics.Analytics mappedAnalytics = result.getAnalytics();
+                softly.assertThat(mappedAnalytics.isEnabled()).isTrue();
             });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -83,6 +83,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
@@ -413,7 +414,8 @@ class ApisResourceTest extends AbstractResourceTest {
                 .satisfies(api ->
                     SoftAssertions.assertSoftly(soft -> {
                         soft.assertThat(api.getId()).isEqualTo("api-id");
-                        soft.assertThat(api.getAnalytics()).isEqualTo(newApi.getAnalytics());
+                        soft.assertThat(api.getAnalytics()).isNotNull();
+                        soft.assertThat(Objects.requireNonNull(api.getAnalytics()).getEnabled()).isTrue();
                         soft.assertThat(api.getApiVersion()).isEqualTo(newApi.getApiVersion());
                         soft.assertThat(api.getEndpointGroups()).isEqualTo(newApi.getEndpointGroups());
                         soft.assertThat(api.getDescription()).isEqualTo(newApi.getDescription());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
@@ -75,7 +75,7 @@ public class ApiExport {
 
     private List<? extends AbstractListener<? extends AbstractEntrypoint>> listeners;
     private List<? extends AbstractEndpointGroup<? extends AbstractEndpoint>> endpointGroups;
-    private Analytics analytics;
+    private Analytics analytics = new Analytics();
     private Failover failover;
 
     @Builder.Default

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -28,17 +28,16 @@ import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
 import io.gravitee.rest.api.service.v4.validation.ResourcesValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.Objects;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -216,6 +215,8 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
 
         // Validate and clean flows
         apiDefinition.setFlows(flowValidationDomainService.validateAndSanitizeNativeV4(apiDefinition.getFlows()));
+
+        apiDefinition.setAnalytics(apiDefinition.getAnalytics() != null ? apiDefinition.getAnalytics() : new NativeAnalytics());
 
         apiValidationService.validateDynamicProperties(
             apiDefinition.getServices() != null ? apiDefinition.getServices().getDynamicProperty() : null

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -40,6 +40,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
@@ -230,6 +231,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
                                 .build()
                         )
+                        .analytics(new NativeAnalytics(true))
                         .build()
                 )
                 .build();
@@ -293,7 +295,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .first()
                     .isInstanceOf(KafkaListener.class)
                     .hasFieldOrPropertyWithValue("type", ListenerType.KAFKA)
-                    .extracting(l -> l.getEntrypoints().get(0))
+                    .extracting(l -> l.getEntrypoints().getFirst())
                     .hasFieldOrPropertyWithValue("type", "sanitized");
                 soft
                     .assertThat(result.getApiDefinitionNativeV4().getEndpointGroups())
@@ -301,7 +303,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .first()
                     .isInstanceOf(NativeEndpointGroup.class)
                     .hasFieldOrPropertyWithValue("type", "sanitized")
-                    .extracting(ls -> ls.getEndpoints().get(0))
+                    .extracting(ls -> ls.getEndpoints().getFirst())
                     .isInstanceOf(NativeEndpoint.class)
                     .hasFieldOrPropertyWithValue("name", "sanitized")
                     .hasFieldOrPropertyWithValue("type", "sanitized");
@@ -309,6 +311,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 soft
                     .assertThat(result.getApiDefinitionNativeV4().getServices().getDynamicProperty().getConfiguration())
                     .isEqualTo("sanitized");
+                soft.assertThat(result.getApiDefinitionNativeV4().getAnalytics().isEnabled()).isTrue();
             });
         }
 
@@ -448,7 +451,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .first()
                     .isInstanceOf(KafkaListener.class)
                     .hasFieldOrPropertyWithValue("type", ListenerType.KAFKA)
-                    .extracting(l -> l.getEntrypoints().get(0))
+                    .extracting(l -> l.getEntrypoints().getFirst())
                     .hasFieldOrPropertyWithValue("type", "sanitized");
                 soft
                     .assertThat(result.getApiDefinitionNativeV4().getEndpointGroups())
@@ -456,7 +459,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .first()
                     .isInstanceOf(NativeEndpointGroup.class)
                     .hasFieldOrPropertyWithValue("type", "sanitized")
-                    .extracting(ls -> ls.getEndpoints().get(0))
+                    .extracting(ls -> ls.getEndpoints().getFirst())
                     .isInstanceOf(NativeEndpoint.class)
                     .hasFieldOrPropertyWithValue("name", "sanitized")
                     .hasFieldOrPropertyWithValue("type", "sanitized");

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.0.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>8.0.0</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>4.0.0</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>4.1.0</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>7.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10052

## Description

This Pull Request adds new features for filtering analytics with applications alongside existing plans and enhances Docker service setup by introducing Kibana and updated Elasticsearch configurations.

**APIM Console**
- Introduced application filters in analytics native components, updating logic to include application-based filtering in addition to plans.
- Updated UI components for filter bar to support applications.
- Fix: When API is imported the setting to enabled metrics was not set. Now, it is being set while importing the APIs.
- Enhanced backend services and repository logic to process multiple terms (plan-id, app-id) efficiently.
- Bumped gravitee-reactor-native-kafka version in pom.xml from 4.0.0 to 4.1.0.

**Unit Tests**
- Extended test cases to validate new application filters and term functionalities across analytics components and services.

**Docker Setup**
- Added Kibana service to the docker-compose.yml file and updated the README to include its details.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lvahvnvrco.chromatic.com)
<!-- Storybook placeholder end -->
