### PR TITLE
fix: remove orphaned/corrupted subscriptions from a database

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_7_15/00_remove_orphaned_subscriptions.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_7_15/00_remove_orphaned_subscriptions.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.7.15_00_remove_orphaned_subscriptions
+      author: GraviteeSource Team
+      changes:
+        - sql:
+            sql: >
+              DELETE FROM ${gravitee_prefix}subscriptions
+              WHERE NOT EXISTS (
+                SELECT 1
+                FROM ${gravitee_prefix}applications a
+                WHERE a.id = ${gravitee_prefix}subscriptions.application
+              );

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -242,6 +242,8 @@ databaseChangeLog:
     - include:
         - file: liquibase/changelogs/v4_7_0/01_add_origin_to_groups_table.yml
     - include:
+        - file: liquibase/changelogs/v4_7_15/00_remove_orphaned_subscriptions.yml
+    - include:
         - file: liquibase/changelogs/v4_7_0/02_add_application_name_to_subscription_table.yml
     - include:
         - file: liquibase/changelogs/v4_7_0/03_add_deadline_to_async_jobs_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/RemoveOrphanedSubscriptionsUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/RemoveOrphanedSubscriptionsUpgrader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.subscription;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.themes.ThemeTypeUpgrader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class RemoveOrphanedSubscriptionsUpgrader extends MongoUpgrader {
+
+    public static final int REMOVE_ORPHANED_SUBSCRIPTIONS_ORDER = ThemeTypeUpgrader.THEME_TYPE_UPGRADER_ORDER + 1;
+
+    @Override
+    public boolean upgrade() {
+        MongoCollection<Document> applications = getCollection("applications");
+        MongoCollection<Document> subscriptions = getCollection("subscriptions");
+
+        Set<String> validAppIds = applications
+            .find()
+            .projection(Projections.include("_id"))
+            .map(doc -> doc.get("_id").toString())
+            .into(new HashSet<>());
+
+        if (validAppIds.isEmpty()) {
+            log.warn("No valid applications found! Skipping orphaned subscriptions cleanup.");
+            return true;
+        }
+
+        var bulkDeletes = StreamSupport.stream(
+            subscriptions.find().projection(Projections.include("_id", "application")).spliterator(),
+            false
+        )
+            .filter(doc -> !validAppIds.contains(doc.getString("application")))
+            .map(doc -> new DeleteOneModel<Document>(Filters.eq("_id", doc.get("_id"))))
+            .toList();
+
+        if (bulkDeletes.isEmpty()) {
+            log.info("No orphaned subscriptions found, nothing to delete.");
+            return true;
+        }
+
+        subscriptions.bulkWrite(bulkDeletes);
+        log.info("Deleted {} orphaned subscriptions.", bulkDeletes.size());
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return REMOVE_ORPHANED_SUBSCRIPTIONS_ORDER;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11092

## Description

Some subscriptions reference non-existent applications, breaking database migrations.

RDBMS: Added a Liquibase changeset to delete orphaned subscriptions in the correct order.

MongoDB: Implemented a upgrader to remove orphaned subscriptions with logging for verification.

<img width="1357" height="467" alt="Screenshot 2025-09-20 at 11 29 05 PM" src="https://github.com/user-attachments/assets/6c05d4e4-8566-43b6-bf17-38f4c24f1c4f" />


<img width="1466" height="313" alt="Screenshot 2025-09-20 at 11 29 54 PM" src="https://github.com/user-attachments/assets/989bd246-557c-4dd0-92b6-e6ee7187d6b3" />

Fresh mongo DB

<img width="1556" height="376" alt="Screenshot 2025-09-22 at 10 24 23 PM" src="https://github.com/user-attachments/assets/ea900b65-7404-40f8-b4b4-b4c6fafe9901" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

