### PR TITLE
feat: rework definition

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
@@ -44,7 +44,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
-public class Api implements Serializable {
+public class Api implements Serializable, ApiDefinition {
 
     @JsonProperty("id")
     private String id;

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiDefinition.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiDefinition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+import io.gravitee.definition.model.v4.property.Property;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
+
+public interface ApiDefinition {
+    void setId(String id);
+    DefinitionVersion getDefinitionVersion();
+
+    Set<String> getTags();
+    void setTags(Set<String> tags);
+
+    default boolean updateDynamicProperties(Function<List<Property>, UpdateDynamicPropertiesResult> updateOperator) {
+        return false;
+    }
+
+    static interface UpdateDynamicPropertiesResult {
+        List<Property> orderedProperties();
+        boolean needToUpdate();
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedAgent.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedAgent.java
@@ -17,24 +17,25 @@ package io.gravitee.definition.model.federation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 // https://google.github.io/A2A/specification/#5-agent-discovery-the-agent-card
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-public class FederatedAgent implements Serializable {
+public class FederatedAgent implements Serializable, ApiDefinition {
 
     public static final String STREAMING = "streaming";
     public static final String PUSH_NOTIFICATIONS = "pushNotifications";
@@ -66,6 +67,21 @@ public class FederatedAgent implements Serializable {
     @NotNull
     @Builder.Default
     private DefinitionVersion definitionVersion = DefinitionVersion.FEDERATED_AGENT;
+
+    @Override
+    public void setId(String id) {
+        // nothing to do
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Set.of();
+    }
+
+    @Override
+    public void setTags(Set<String> tags) {
+        // nothing to do
+    }
 
     public record Provider(String organization, String url) {}
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedApi.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedApi.java
@@ -16,11 +16,13 @@
 package io.gravitee.definition.model.federation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,7 +32,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-public class FederatedApi implements Serializable {
+public class FederatedApi implements Serializable, ApiDefinition {
 
     @JsonProperty(required = true)
     @NotBlank
@@ -56,4 +58,14 @@ public class FederatedApi implements Serializable {
     @JsonProperty(required = true)
     @NotBlank
     private Map<String, String> server;
+
+    @Override
+    public Set<String> getTags() {
+        return Set.of();
+    }
+
+    @Override
+    public void setTags(Set<String> tags) {
+        // nothing to do
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/AbstractApi.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/AbstractApi.java
@@ -22,8 +22,11 @@ import static io.gravitee.definition.model.v4.AbstractApi.PROXY_LABEL;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
+import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
@@ -68,7 +71,7 @@ import lombok.experimental.SuperBuilder;
         @JsonSubTypes.Type(value = NativeApi.class, name = NATIVE_LABEL),
     }
 )
-public abstract class AbstractApi implements Serializable {
+public abstract class AbstractApi implements Serializable, ApiDefinition {
 
     public static final String PROXY_LABEL = "proxy";
     public static final String MESSAGE_LABEL = "message";
@@ -102,4 +105,6 @@ public abstract class AbstractApi implements Serializable {
     protected List<Resource> resources;
 
     public abstract List<Plugin> getPlugins();
+
+    public abstract List<? extends AbstractListener<? extends AbstractEntrypoint>> getListeners();
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeApi.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeApi.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.definition.model.v4.resource.Resource;
 import jakarta.validation.constraints.NotEmpty;
@@ -118,5 +120,10 @@ public class NativeApi extends AbstractApi {
         )
             .flatMap(List::stream)
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<NativeListener> getListeners() {
+        return listeners != null ? listeners : List.of();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -50,7 +50,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -128,7 +129,7 @@ public class ApiProcessorChainFactory {
      */
     public ProcessorChain beforeApiExecution(final Api api, final TracingContext tracingContext) {
         final List<Processor> processors = new ArrayList<>();
-        if (api.getDefinition().getListeners() != null) {
+        if (isNotEmpty(api.getDefinition().getListeners())) {
             if (overrideXForwardedPrefix) {
                 processors.add(XForwardedPrefixProcessor.instance());
             }
@@ -141,8 +142,7 @@ public class ApiProcessorChainFactory {
             processors.add(SubscriptionProcessor.instance(clientIdentifierHeader));
 
             getHttpListener(api).ifPresent(httpListener -> {
-                final Map<String, Pattern> pathMappings = httpListener.getPathMappingsPattern();
-                if (pathMappings != null && !pathMappings.isEmpty()) {
+                if (isNotEmpty(httpListener.getPathMappingsPattern())) {
                     processors.add(PathMappingProcessor.instance());
                 }
             });
@@ -190,7 +190,7 @@ public class ApiProcessorChainFactory {
         // On error processor chain contains the after api execution processors.
         List<Processor> processors = new ArrayList<>(getAfterApiExecutionProcessors(api));
 
-        if (api.getDefinition().getResponseTemplates() != null && !api.getDefinition().getResponseTemplates().isEmpty()) {
+        if (isNotEmpty(api.getDefinition().getResponseTemplates())) {
             processors.add(ResponseTemplateBasedFailureProcessor.instance());
         } else {
             processors.add(SimpleFailureProcessor.instance());
@@ -222,23 +222,28 @@ public class ApiProcessorChainFactory {
     }
 
     private Optional<HttpListener> getHttpListener(final Api api) {
-        if (api.getDefinition().getListeners() != null) {
-            return api
-                .getDefinition()
-                .getListeners()
-                .stream()
-                .filter(listener -> listener.getType() == ListenerType.HTTP)
-                .map(HttpListener.class::cast)
-                .findFirst();
-        } else {
-            return Optional.empty();
-        }
+        return stream(api.getDefinition().getListeners())
+            .flatMap(listener ->
+                listener.getType() == ListenerType.HTTP && listener instanceof HttpListener httpListener
+                    ? Stream.of(httpListener)
+                    : Stream.empty()
+            )
+            .findFirst();
     }
 
     protected List<ProcessorHook> processorHooks(final TracingContext tracingContext) {
-        if (tracingContext.isVerbose()) {
-            return List.of(tracingHook);
-        }
-        return List.of();
+        return tracingContext.isVerbose() ? List.of(tracingHook) : List.of();
+    }
+
+    private boolean isNotEmpty(Iterable<?> iterable) {
+        return iterable != null && iterable.iterator().hasNext();
+    }
+
+    private boolean isNotEmpty(Map<?, ?> map) {
+        return map != null && !map.isEmpty();
+    }
+
+    private <T> Stream<T> stream(Iterable<T> iterable) {
+        return iterable == null ? Stream.empty() : StreamSupport.stream(iterable.spliterator(), false);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -138,7 +138,11 @@ class ApiProcessorChainFactoryTest {
         ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api, TracingContext.noop());
         assertThat(processorChain.getId()).isEqualTo("before-api-execution");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(0);
+        processors
+            .map(e -> e)
+            .test()
+            .assertComplete()
+            .assertValueCount(0);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -475,12 +475,8 @@ public class ApiResource extends AbstractResource {
         apiLicenseService.checkLicense(executionContext, apiId);
 
         var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(apiId));
-        return switch (output.definitionVersion()) {
-            case V4 -> Response.ok(
-                output.apiDefinitionNativeV4() != null ? output.apiDefinitionNativeV4() : output.apiDefinitionHttpV4()
-            ).build();
-            case V2 -> Response.ok(output.apiDefinition()).build();
-            default -> Response.status(Response.Status.BAD_REQUEST)
+        if (output.apiDefinition() == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
                 .entity(
                     new Error()
                         .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
@@ -488,7 +484,8 @@ public class ApiResource extends AbstractResource {
                         .technicalCode("api.deployment.federated")
                 )
                 .build();
-        };
+        }
+        return Response.ok(output.apiDefinition()).build();
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DeploymentsCurrentTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DeploymentsCurrentTest.java
@@ -16,7 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import fixtures.definition.ApiDefinitionFixtures;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
@@ -32,8 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class ApiResource_DeploymentsCurrentTest extends ApiResourceTest {
-
-    private static final String UNKNOWN_API = "unknown";
 
     @Autowired
     GetApiDefinitionUseCase getApiDefinitionUseCase;
@@ -45,32 +42,26 @@ public class ApiResource_DeploymentsCurrentTest extends ApiResourceTest {
 
     @Test
     public void should_get_api_v4_deployments() {
-        when(getApiDefinitionUseCase.execute(any())).thenReturn(
-            new GetApiDefinitionUseCase.Output(DefinitionVersion.V4, ApiDefinitionFixtures.anApiV4(), null, null)
-        );
+        when(getApiDefinitionUseCase.execute(any())).thenReturn(new GetApiDefinitionUseCase.Output(ApiDefinitionFixtures.anApiV4()));
 
         final Response response = rootTarget(API + "/deployments/current").request().get();
-        assertEquals(OK_200, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(OK_200);
     }
 
     @Test
     public void should_get_native_api_v4_deployments() {
-        when(getApiDefinitionUseCase.execute(any())).thenReturn(
-            new GetApiDefinitionUseCase.Output(DefinitionVersion.V4, null, ApiDefinitionFixtures.aNativeApiV4(), null)
-        );
+        when(getApiDefinitionUseCase.execute(any())).thenReturn(new GetApiDefinitionUseCase.Output(ApiDefinitionFixtures.aNativeApiV4()));
 
         final Response response = rootTarget(API + "/deployments/current").request().get();
-        assertEquals(OK_200, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(OK_200);
     }
 
     @Test
     public void should_get_api_v2_deployments() {
-        when(getApiDefinitionUseCase.execute(any())).thenReturn(
-            new GetApiDefinitionUseCase.Output(DefinitionVersion.V2, null, null, ApiDefinitionFixtures.anApiV2())
-        );
+        when(getApiDefinitionUseCase.execute(any())).thenReturn(new GetApiDefinitionUseCase.Output(ApiDefinitionFixtures.anApiV2()));
 
         final Response response = rootTarget(API + "/deployments/current").request().get();
-        assertEquals(OK_200, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(OK_200);
     }
 
     @Test
@@ -79,6 +70,6 @@ public class ApiResource_DeploymentsCurrentTest extends ApiResourceTest {
             permissionService.hasPermission(eq(GraviteeContext.getExecutionContext()), eq(RolePermission.API_DEFINITION), eq(API), any())
         ).thenReturn(false);
         final Response response = rootTarget(API + "/deployments/current").request().get();
-        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/property/DynamicApiProperties.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/property/DynamicApiProperties.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api.model.property;
 import static java.util.function.Function.identity;
 import static java.util.function.Predicate.not;
 
+import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.v4.property.Property;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -41,7 +42,8 @@ public class DynamicApiProperties {
         this.currentUserDefinedProperties = currentProperties.stream().filter(not(Property::isDynamic)).toList();
     }
 
-    public record DynamicPropertiesResult(List<Property> orderedProperties, boolean needToUpdate) {}
+    public record DynamicPropertiesResult(List<Property> orderedProperties, boolean needToUpdate) implements
+        ApiDefinition.UpdateDynamicPropertiesResult {}
 
     public DynamicPropertiesResult updateDynamicProperties(List<Property> dynamicProperties) {
         List<Property> updatedDynamicProperties = new ArrayList<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
-import com.google.common.base.Strings;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
@@ -21,6 +21,7 @@ import static fixtures.core.model.ApiFixtures.aProxyApiV2;
 import static fixtures.core.model.PlanFixtures.aPlanHttpV4;
 import static fixtures.core.model.PlanFixtures.aPlanNativeV4;
 import static fixtures.core.model.PlanFixtures.aPlanV2;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import inmemory.ApiCrudServiceInMemory;
@@ -29,6 +30,7 @@ import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import java.util.List;
@@ -69,8 +71,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertNotNull(output);
-            assertEquals(API.getApiDefinitionHttpV4(), output.apiDefinitionHttpV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionHttpV4());
         }
 
         @Test
@@ -102,14 +103,17 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertNotNull(output);
-            assertEquals(API.getApiDefinitionHttpV4(), output.apiDefinitionHttpV4());
-            assertEquals(flows, output.apiDefinitionHttpV4().getFlows());
-            assertEquals(2, output.apiDefinitionHttpV4().getPlans().size());
-            assertEquals(planFlows, output.apiDefinitionHttpV4().getPlans().get(0).getFlows());
-            assertEquals(PlanStatus.PUBLISHED, output.apiDefinitionHttpV4().getPlans().get(0).getStatus());
-            assertEquals(planFlows, output.apiDefinitionHttpV4().getPlans().get(1).getFlows());
-            assertEquals(PlanStatus.DEPRECATED, output.apiDefinitionHttpV4().getPlans().get(1).getStatus());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionHttpV4());
+            if (output.apiDefinition() instanceof io.gravitee.definition.model.v4.Api definition) {
+                assertThat(definition.getFlows()).isEqualTo(flows);
+                assertThat(definition.getPlans()).hasSize(2);
+                assertThat(definition.getPlans().getFirst().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getFirst().getStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                assertThat(definition.getPlans().getLast().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getLast().getStatus()).isEqualTo(PlanStatus.DEPRECATED);
+            } else {
+                fail("Unexpected type of api definition");
+            }
         }
     }
 
@@ -128,7 +132,7 @@ class GetApiDefinitionUseCaseTest {
 
             // Then
             assertNotNull(output);
-            assertEquals(API.getApiDefinitionNativeV4(), output.apiDefinitionNativeV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionNativeV4());
         }
 
         @Test
@@ -158,15 +162,17 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertNotNull(output);
-            assertEquals(API.getApiDefinitionNativeV4(), output.apiDefinitionNativeV4());
-            assertNull(API.getApiDefinitionHttpV4());
-            assertEquals(flows, output.apiDefinitionNativeV4().getFlows());
-            assertEquals(2, output.apiDefinitionNativeV4().getPlans().size());
-            assertEquals(planFlows, output.apiDefinitionNativeV4().getPlans().get(0).getFlows());
-            assertEquals(PlanStatus.PUBLISHED, output.apiDefinitionNativeV4().getPlans().get(0).getStatus());
-            assertEquals(planFlows, output.apiDefinitionNativeV4().getPlans().get(1).getFlows());
-            assertEquals(PlanStatus.DEPRECATED, output.apiDefinitionNativeV4().getPlans().get(1).getStatus());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionNativeV4());
+            if (output.apiDefinition() instanceof NativeApi definition) {
+                assertThat(definition.getFlows()).isEqualTo(flows);
+                assertThat(definition.getPlans()).hasSize(2);
+                assertThat(definition.getPlans().getFirst().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getFirst().getStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                assertThat(definition.getPlans().getLast().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getLast().getStatus()).isEqualTo(PlanStatus.DEPRECATED);
+            } else {
+                fail("Unexpected type of api definition");
+            }
         }
     }
 
@@ -184,8 +190,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertNotNull(output);
-            assertEquals(API.getApiDefinition(), output.apiDefinition());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinition());
         }
 
         @Test
@@ -215,14 +220,18 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertNotNull(output);
-            assertEquals(API.getApiDefinition(), output.apiDefinition());
-            assertEquals(flows, output.apiDefinition().getFlows());
-            assertEquals(2, output.apiDefinition().getPlans().size());
-            assertEquals(planFlows, output.apiDefinition().getPlans().get(0).getFlows());
-            assertEquals("PUBLISHED", output.apiDefinition().getPlans().get(0).getStatus());
-            assertEquals(planFlows, output.apiDefinition().getPlans().get(1).getFlows());
-            assertEquals("DEPRECATED", output.apiDefinition().getPlans().get(1).getStatus());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinition());
+
+            if (output.apiDefinition() instanceof io.gravitee.definition.model.Api definition) {
+                assertThat(definition.getFlows()).isEqualTo(flows);
+                assertThat(definition.getPlans()).hasSize(2);
+                assertThat(definition.getPlans().getFirst().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getFirst().getStatus()).isEqualTo("PUBLISHED");
+                assertThat(definition.getPlans().getLast().getFlows()).isEqualTo(planFlows);
+                assertThat(definition.getPlans().getLast().getStatus()).isEqualTo("DEPRECATED");
+            } else {
+                fail("Unexpected type of api definition");
+            }
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -624,7 +624,8 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_create_and_index_a_new_api() {
-            var expected = expectedApi().setPlans(List.of());
+            var expected = expectedApiV4Proxy();
+            expected.getApiDefinitionHttpV4().setPlans(List.of());
             expected.setHrid(expected.getCrossId());
 
             useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().plans(Map.of()).build()));
@@ -887,7 +888,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_start_the_api() {
-            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
             useCase.execute(
                 new ImportApiCRDUseCase.Input(
@@ -917,7 +918,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_not_start_the_api_with_no_plan() {
-            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
             useCase.execute(
                 new ImportApiCRDUseCase.Input(
@@ -951,7 +952,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_not_stop_the_api_on_creation() {
-            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
             useCase.execute(
                 new ImportApiCRDUseCase.Input(
@@ -989,7 +990,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_not_stop_the_api_with_no_plan() {
-            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
             useCase.execute(
                 new ImportApiCRDUseCase.Input(
@@ -1025,7 +1026,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_not_deploy_the_api() {
-            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+            when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
             useCase.execute(
                 new ImportApiCRDUseCase.Input(
@@ -1734,7 +1735,7 @@ class ImportApiCRDUseCaseTest {
     void should_not_deploy_the_api() {
         givenExistingApi();
 
-        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
         useCase.execute(
             new ImportApiCRDUseCase.Input(
@@ -1773,7 +1774,7 @@ class ImportApiCRDUseCaseTest {
     void should_deploy_the_api() {
         givenExistingApi();
 
-        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
         useCase.execute(
             new ImportApiCRDUseCase.Input(
@@ -1818,7 +1819,7 @@ class ImportApiCRDUseCaseTest {
     void should_stop_the_api() {
         givenExistingApi();
 
-        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
         useCase.execute(
             new ImportApiCRDUseCase.Input(
@@ -1861,7 +1862,7 @@ class ImportApiCRDUseCaseTest {
     void should_start_the_api() {
         apiQueryService.initWith(List.of(Update.API_PROXY_V4.toBuilder().lifecycleState(Api.LifecycleState.STOPPED).build()));
 
-        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApi());
+        when(updateApiDomainService.update(eq(API_ID), any(ApiCRDSpec.class), eq(AUDIT_INFO))).thenReturn(expectedApiV4Proxy());
 
         useCase.execute(
             new ImportApiCRDUseCase.Input(
@@ -2087,7 +2088,7 @@ class ImportApiCRDUseCaseTest {
             .groups(Set.of(GROUP_ID_1, "non-existing-group", GROUP_NAME));
     }
 
-    private Api expectedApi() {
+    private Api expectedApiV4Proxy() {
         return aProxyApiV4()
             .toBuilder()
             .originContext(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -287,7 +287,7 @@ public class ApiCrudServiceImplTest {
                         .definitionVersion(DefinitionVersion.FEDERATED)
                         .definition(
                             """
-                            {"id":"my-api","providerId":"provider-id","name":"My Api","apiVersion":"1.0.0","definitionVersion":"FEDERATED"}"""
+                            {"id":"my-api","providerId":"provider-id","name":"My Api","apiVersion":"1.0.0","definitionVersion":"FEDERATED","tags":[]}"""
                         )
                         .build()
                 );


### PR DESCRIPTION
## Issue

Not issue related

## Description

Before working on 4.10, I suggest making changes to the management of the API definition. Objective:

- reduce the coupling between 'io.gravitee.apim.core.api.model.Api' and each definition.
- use a better object-oriented design
- Replace some pattern matching with polymorphism.
- move some actions nearest of api definition

This is a first step to limiting the size of the pull request.