### PR TITLE
Apim 10278 allow hyphened names for doc

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
@@ -159,6 +159,11 @@ export class MonacoEditorComponent implements OnDestroy {
       });
     });
 
+    // Configure word boundaries to include hyphens, i.e. gmd-button
+    monaco.languages.setLanguageConfiguration('markdown', {
+      wordPattern: /[a-zA-Z0-9-]+/g,
+    });
+
     monaco.editor.defineTheme('gmdTheme', {
       base: 'vs',
       inherit: true,
@@ -284,7 +289,7 @@ export class MonacoEditorComponent implements OnDestroy {
 
   private getComponentTag(text: string): string | null {
     // Look for the most recent opening tag that contains the current position
-    const openingTagRegex = /<(\w+)(?:\s[^>]*)?/g;
+    const openingTagRegex = /<([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^>]*)?/g;
     const match = openingTagRegex.exec(text);
 
     if (!match) {
@@ -294,19 +299,10 @@ export class MonacoEditorComponent implements OnDestroy {
     const tagName = match[1];
 
     // Check if this tag is in our component suggestion map
-    const tagNameStartIndex = match.index! + tagName.length;
-    if (componentSuggestionMap[tagName] && this.checkIfInsideTag(text, tagName, tagNameStartIndex)) {
+    if (componentSuggestionMap[tagName]) {
       return tagName;
     }
 
     return null;
-  }
-
-  private checkIfInsideTag(textBeforeCursor: string, tagName: string, tagNameStartIndex: number): boolean {
-    const afterOpeningTag = textBeforeCursor.substring(tagNameStartIndex);
-    const closingTagRegex = new RegExp(`</${tagName}>`);
-
-    // If we do not find a closing tag after the opening tag, we are inside the tag
-    return !closingTagRegex.test(afterOpeningTag);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10278

## Description

Allow Monaco to recognize tags with hyphens for hover documentation.

<img width="536" height="471" alt="Screenshot 2025-09-23 at 16 33 02" src="https://github.com/user-attachments/assets/9ab270ba-8d1e-4fa5-bdcb-6bbc9ec296e4" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

