### PR TITLE
feat: add delete token command

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static io.gravitee.rest.api.service.cockpit.command.handler.TargetTokenCommandHandler.CLOUD_TOKEN_SOURCE;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenCommand;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenCommandPayload;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenReply;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.reactivex.rxjava3.core.Single;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DeleteTargetTokenCommandHandler implements CommandHandler<DeleteTargetTokenCommand, DeleteTargetTokenReply> {
+
+    private final UserService userService;
+
+    @Override
+    public String supportType() {
+        return CockpitCommandType.DELETE_TARGET_TOKEN.name();
+    }
+
+    public Single<DeleteTargetTokenReply> handle(DeleteTargetTokenCommand command) {
+        DeleteTargetTokenCommandPayload payload = command.getPayload();
+        ExecutionContext context = new ExecutionContext(payload.organizationId(), payload.environmentId());
+        try {
+            var userEntity = userService.findBySource(payload.organizationId(), CLOUD_TOKEN_SOURCE, payload.id(), false);
+            userService.delete(context, userEntity.getId());
+            log.info("User with id [{}] has been deleted.", userEntity.getId());
+        } catch (UserNotFoundException e) {
+            log.info("User with id [{}] has not been found.", payload.id());
+        } catch (Exception e) {
+            log.error("Error occurred while deleting target token for user with id [{}].", payload.id(), e);
+            return Single.just(new DeleteTargetTokenReply(command.getId(), CommandStatus.ERROR));
+        }
+
+        return Single.just(new DeleteTargetTokenReply(command.getId(), CommandStatus.SUCCEEDED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static io.gravitee.rest.api.service.cockpit.command.handler.TargetTokenCommandHandler.CLOUD_TOKEN_SOURCE;
+import static java.util.Objects.nonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenCommand;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenCommandPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteTargetTokenCommandHandlerTest {
+
+    private static final String ORGANISATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String COMMAND_ID = "command-id";
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private DeleteTargetTokenCommandHandler deleteTargetTokenCommandHandler;
+
+    private DeleteTargetTokenCommand command;
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = new UserEntity();
+        user.setId(USER_ID);
+    }
+
+    @Test
+    void should_delete_user() {
+        command = new DeleteTargetTokenCommand(generatePayload());
+
+        when(userService.findBySource(ORGANISATION_ID, CLOUD_TOKEN_SOURCE, COMMAND_ID, false)).thenReturn(user);
+
+        deleteTargetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(reply -> nonNull(reply.getCommandId()))
+            .assertValue(reply -> CommandStatus.SUCCEEDED.equals(reply.getCommandStatus()));
+    }
+
+    @Test
+    void should_not_failed_if_user_not_found() {
+        command = new DeleteTargetTokenCommand(generatePayload());
+
+        when(userService.findBySource(ORGANISATION_ID, CLOUD_TOKEN_SOURCE, COMMAND_ID, false)).thenThrow(
+            new UserNotFoundException(user.getId())
+        );
+
+        deleteTargetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(reply -> nonNull(reply.getCommandId()))
+            .assertValue(reply -> CommandStatus.SUCCEEDED.equals(reply.getCommandStatus()));
+    }
+
+    @Test
+    void should_failed_if_error_when_delete_user() {
+        command = new DeleteTargetTokenCommand(generatePayload());
+
+        when(userService.findBySource(ORGANISATION_ID, CLOUD_TOKEN_SOURCE, COMMAND_ID, false)).thenReturn(user);
+        doThrow(new RuntimeException("Error during deletion"))
+            .when(userService)
+            .delete(new ExecutionContext(ORGANISATION_ID, ENVIRONMENT_ID), user.getId());
+
+        deleteTargetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(reply -> nonNull(reply.getCommandId()))
+            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()));
+    }
+
+    private static DeleteTargetTokenCommandPayload generatePayload() {
+        return DeleteTargetTokenCommandPayload.builder()
+            .organizationId(ORGANISATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .id(COMMAND_ID)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
@@ -226,7 +226,6 @@ class TargetTokenCommandHandlerTest {
         targetTokenCommandHandler.handle(command).test().awaitDone(2, SECONDS);
 
         verify(userService, times(1)).delete(any(), eq(USER_ID));
-        verify(membershipService, times(1)).removeMemberMemberships(any(), eq(MembershipMemberType.USER), eq(USER_ID));
     }
 
     @Test
@@ -245,7 +244,6 @@ class TargetTokenCommandHandlerTest {
         targetTokenCommandHandler.handle(command).test().awaitDone(2, SECONDS);
 
         verify(userService, times(1)).delete(any(), eq(USER_ID));
-        verify(membershipService, times(1)).removeMemberMemberships(any(), eq(MembershipMemberType.USER), eq(USER_ID));
     }
 
     private static TargetTokenCommandPayload generatePayload(TargetTokenCommandPayload.Scope scope) {

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.3.41</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.10.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>3.11.0-cj-3183-delete-cloud-token-SNAPSHOT</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.1.1</gravitee-cloud-initializer.version>
         <gravitee-common.version>4.7.3</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3450

## Description

Added the Delete Target Token command. 
Simplified the creation command. For rollback, user deletion is sufficient, as membership removal and token revocation are already included in the `UserService.delete()` method

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dayqxhkugo.chromatic.com)
<!-- Storybook placeholder end -->
