### PR TITLE
fix(gateway): handle flatten base64 cert body in header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-bom.version>8.3.38</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.2.3</gravitee-cockpit-api.version>
-        <gravitee-common.version>4.7.0</gravitee-common.version>
+        <gravitee-common.version>4.7.3</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/11066

Gravitee-common :
Base PR : https://github.com/gravitee-io/gravitee-common/pull/147
Version bump : https://github.com/gravitee-io/gravitee-common/pull/148 
                          https://github.com/gravitee-io/gravitee-common/pull/149

**Description**

Fixes certificate parsing in mTLS plans through LB(load balancer) when the "X-Gravitee-Client-Cert" header contains only the PEM body (flattened Base64, no BEGIN/END markers, no newlines). Previously, this caused a CertificateException.

**Why these changes** :

Gravitee docs ([link](https://documentation.gravitee.io/apim/secure-and-expose-apis/plans/mtls?utm_source=chatgpt.com#how-to-terminate-tls)) state the gateway accepts a valid base64-encoded certificate in the header when TLS is terminated upstream, but the existing implementation required full PEM with newline markers (or percent-encoded PEM). 
As found (through [customer](https://graviteesource.zendesk.com/agent/tickets/13096) also) LB (F5, Ivanti) commonly forward the client certificate as the flattened PEM body (single-line Base64 without BEGIN/END and without newlines).

So, This PR adds a minimal, safe detection with Base64→DER(pem body) decode path so the gateway accepts flattened Base64 certificate bodies too. 

The change is backward-compatible and only decodes when the header clearly looks like a flattened cert body; otherwise the original PEM decoding logic remains unchanged. 

------

- Before Video (with audio)

https://github.com/user-attachments/assets/68746acb-9054-4c75-b033-c30147f06bdd

- Before video (with debugger)

https://github.com/user-attachments/assets/adfe063c-a5bf-4947-b815-7d6ec42065e5

- After 

https://github.com/user-attachments/assets/fad6b894-386e-417c-b040-c66526899c35

apim with version 4.7.2
<img width="1728" height="1055" alt="image" src="https://github.com/user-attachments/assets/3de3431c-079e-4a50-827a-24fc2ac64a11" />

apim with version 4.7.3
Getting header as response 
<img width="1667" height="406" alt="image" src="https://github.com/user-attachments/assets/59b78e80-154d-45b2-aebd-6e48344c06e3" />
