### PR TITLE
fix: icons the same color for analytics widgets

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
@@ -20,7 +20,7 @@
     <mat-card-title class="card__title">
       {{ title() }}
       @if (tooltip()) {
-        <mat-icon [matTooltip]="tooltip()" matTooltipPosition="after" svgIcon="gio:info" />
+        <mat-icon class="card__title__tooltip-icon" [matTooltip]="tooltip()" matTooltipPosition="after" svgIcon="gio:info" />
       }
     </mat-card-title>
   </mat-card-header>

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
@@ -15,6 +15,10 @@ $cardHeaderBorderColor: map.get(gio.$mat-theme, foreground);
     align-items: center;
     gap: 8px;
     margin-bottom: 16px;
+
+    &__tooltip-icon {
+      color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker20');
+    }
   }
 
   &__header {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11161

## Description
all icons in the same gray color

<img width="1401" height="785" alt="image" src="https://github.com/user-attachments/assets/691b08ed-4216-4725-9fa6-4135fdf21f0e" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gzvdipvebg.chromatic.com)
<!-- Storybook placeholder end -->
