### PR TITLE
fix: set the default origin when duplicating PortalNotificationConfig during upgrade

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNotificationConfigUpgrader.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.PORTAL_NOTIFICATION_CONFIG_UPGRADER;
 
+import io.gravitee.definition.model.Origin;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.DuplicateKeyException;
@@ -106,6 +107,7 @@ public class PortalNotificationConfigUpgrader implements Upgrader {
             .referenceId(environment.getId())
             .referenceType(NotificationReferenceType.ENVIRONMENT)
             .hooks(portalNotificationConfig.getHooks())
+            .origin(portalNotificationConfig.getOrigin() != null ? portalNotificationConfig.getOrigin() : Origin.MANAGEMENT)
             .user(portalNotificationConfig.getUser())
             .createdAt(portalNotificationConfig.getCreatedAt())
             .updatedAt(portalNotificationConfig.getUpdatedAt())


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11244

## Description

When upgrading directly from 4.2.x to 4.8.x on a JDBC backend, startup fails with:

    ERROR: null value in column "origin" of relation "portal_notification_configs" violates not-null constraint

This happens because `PortalNotificationConfigUpgrader` duplicates existing PORTAL/DEFAULT notification configs into ENVIRONMENT configs without setting the `origin` field, which became NOT NULL in 4.8.

Fixes:
- Ensure `duplicate()` sets `origin`, preserving the original if present or defaulting to `Origin.MANAGEMENT`.
- Added tests to verify both behaviours (preserve existing origin, default when null).


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

