### PR TITLE
Apim 10278 refactor private public tokens

### DIFF
--- a/gravitee-apim-portal-webui-next/.storybook/index.scss
+++ b/gravitee-apim-portal-webui-next/.storybook/index.scss
@@ -1,0 +1,2 @@
+@forward '../projects/gravitee-markdown/src/lib/components/grid/grid.component.stories';
+@forward '../projects/gravitee-markdown/src/lib/components/card/gmd-card.component.stories';

--- a/gravitee-apim-portal-webui-next/angular.json
+++ b/gravitee-apim-portal-webui-next/angular.json
@@ -119,6 +119,7 @@
           "builder": "@storybook/angular:start-storybook",
           "options": {
             "configDir": ".storybook",
+            "styles": [".storybook/index.scss"],
             "browserTarget": "gravitee-apim-portal-webui-next:build",
             "compodoc": false,
             "port": 6006

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/README.md
@@ -68,26 +68,6 @@ The card component consists of:
 - **Header**: Contains title and subtitle elements
 - **Content**: Contains markdown content blocks
 
-## Theming Tokens
-
-The card component uses CSS custom properties for theming. You can override any token by setting the corresponding CSS variable.
-
-### Card Tokens
-
-| Token                    | CSS Variable                      | Default Value | Description | Example |
-|--------------------------|-----------------------------------|---------------|-------------|---------|
-| **Title Text Weight**    | `--gmd-card-title-text-weight`    | `700` | Text weight for card title | `600` (semi-bold) |
-| **Title Text Size**      | `--gmd-card-title-text-size`      | `16px` | Text size for card title | `18px` (larger) |
-| **Title Line Height**    | `--gmd-card-title-line-height`    | `21px` | Line height for card title | `24px` (more spacing) |
-| **Subtitle Text Weight** | `--gmd-card-subtitle-text-weight` | `400` | Text weight for card subtitle | `500` (medium) |
-| **Subtitle Text Size**   | `--gmd-card-subtitle-text-size`   | `14px` | Text size for card subtitle | `16px` (larger) |
-| **Subtitle Line Height** | `--gmd-card-subtitle-line-height` | `20px` | Line height for card subtitle | `22px` (more spacing) |
-| **Container Color**      | `--gmd-card-container-color`      | `#f4f7fd` | Background color of card | `#ffffff` (white) |
-| **Outline Color**        | `--gmd-card-outline-color`        | `#c7c7c7` | Border color of card | `#e0e0e0` (lighter gray) |
-| **Container Shape**      | `--gmd-card-container-shape`      | `16px` | Border radius of card | `8px` (less rounded) |
-| **Text Color**           | `--gmd-card-text-color`           | `#1d192b` | Text color for card content | `#333333` (dark gray) |
-| **Text Align**           | `--gmd-card-text-align`           | `left` | Text alignment | `center`, `right` |
-
 ## Input Properties
 
 The card component supports the following input properties for dynamic styling:
@@ -119,29 +99,26 @@ The card component supports the following input properties for dynamic styling:
 </gmd-card>
 ```
 
-## SCSS Override Example
+## Theming Tokens
 
-You can also customize the card tokens using SCSS by importing and using the `overrides` mixin:
+The card component uses CSS custom properties for theming. You can override any token by setting the corresponding CSS variable.
 
-```scss
-@use '@gravitee/gravitee-markdown' as gmd;
+### Card Tokens
 
-// Custom card theme
-.my-custom-cards {
-  @include gmd.card-overrides((
-    container-color: #ffffff,
-    outline-color: #e0e0e0,
-    text-color: #333333,
-    title-text-weight: 600,
-    title-text-size: 18px,
-    subtitle-text-size: 16px,
-    container-shape: 8px,
-    text-align: center,
-  ));
-}
+| Token                    | CSS Variable                      | Default Value | Description | Example |
+|--------------------------|-----------------------------------|---------------|-------------|---------|
+| **Container Color**      | `--gmd-card-container-color`      | `#f4f7fd` | Background color of card | `#ffffff` (white) |
+| **Text Color**           | `--gmd-card-text-color`           | `#1d192b` | Text color for card content | `#333333` (dark gray) |
+
+### Inline Style Overrides
+
+```html
+<gmd-card style="--gmd-card-outline-color: darkblue; --gmd-card-text-color: pink;">
+  <gmd-card-title>Centered Card</gmd-card-title>
+  <gmd-card-subtitle>With Custom Border</gmd-card-subtitle>
+  <gmd-md>This card is centered with a dark blue border.</gmd-md>
+</gmd-card>
 ```
-
-This approach allows you to scope card customizations to specific components or sections of your application.
 
 ## Advanced Usage
 
@@ -170,12 +147,28 @@ This approach allows you to scope card customizations to specific components or 
 </gmd-grid>
 ```
 
-### Inline Style Overrides
+## For Developers
 
-```html
-<gmd-card style="--gmd-card-text-align: center; --gmd-card-outline-color: darkblue;">
-  <gmd-card-title>Centered Card</gmd-card-title>
-  <gmd-card-subtitle>With Custom Border</gmd-card-subtitle>
-  <gmd-md>This card is centered with a dark blue border.</gmd-md>
-</gmd-card>
+### SCSS Override Example
+
+You can also customize the card tokens using SCSS by importing and using the `overrides` mixin:
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+// Custom card theme
+.my-custom-cards {
+  @include gmd.card-overrides((
+    container-color: #ffffff,
+    outline-color: #e0e0e0,
+    text-color: #333333,
+    title-text-weight: 600,
+    title-text-size: 18px,
+    subtitle-text-size: 16px,
+    container-shape: 8px,
+    text-align: center,
+  ));
+}
 ```
+
+This approach allows you to scope card customizations to specific components or sections of your application.

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/_overrides.scss
@@ -17,49 +17,24 @@
 
 @function tokens() {
   @return (
-    title-text-weight: (
-      value: 700,
-      css-var: --gmd-card-title-text-weight,
-    ),
-    title-text-size: (
-      value: 16px,
-      css-var: --gmd-card-title-text-size,
-    ),
-    title-line-height: (
-      value: 21px,
-      css-var: --gmd-card-title-line-height,
-    ),
-    subtitle-text-weight: (
-      value: 400,
-      css-var: --gmd-card-subtitle-text-weight,
-    ),
-    subtitle-text-size: (
-      value: 14px,
-      css-var: --gmd-card-subtitle-text-size,
-    ),
-    subtitle-line-height: (
-      value: 20px,
-      css-var: --gmd-card-subtitle-line-height,
-    ),
-    container-color: (
-      value: #f4f7fd,
-      css-var: --gmd-card-container-color,
-    ),
-    outline-color: (
-      value: #c7c7c7,
-      css-var: --gmd-card-outline-color,
-    ),
-    container-shape: (
-      value: 16px,
-      css-var: --gmd-card-container-shape,
-    ),
-    text-color: (
-      value: #1d192b,
-      css-var: --gmd-card-text-color,
-    ),
-    text-align: (
-      value: 'left',
-      css-var: --gmd-card-text-align,
+    namespace: card,
+    tokens: (
+      // Title styling
+      title-text-weight: 700,
+      title-text-size: 16px,
+      title-line-height: 21px,
+
+      // Subtitle styling
+      subtitle-text-weight: 400,
+      subtitle-text-size: 14px,
+      subtitle-line-height: 20px,
+
+      // Card styling
+      container-color: #f4f7fd,
+      outline-color: #c7c7c7,
+      container-shape: 16px,
+      text-color: #1d192b,
+      text-align: left,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.component.stories.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.component.stories.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use './public-api' as gmd;
+
+.with-global-css-overrides-1 {
+  @include gmd.card-overrides(
+    (
+      text-align: center,
+      outline-color: darkblue,
+      text-color: green,
+    )
+  );
+}
+
+.with-global-css-overrides-2 {
+  @include gmd.card-overrides(
+    (
+      text-align: right,
+      outline-color: darkred,
+      text-color: purple,
+    )
+  );
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
@@ -43,6 +43,7 @@ export default {
         <gmd-viewer [content]="contentToRender"></gmd-viewer>
       </div>
     `,
+    styles: ['@import "../projects/gravitee-markdown/src/lib/components/card/gmd-card.component.stories.scss";'],
     props: args,
   }),
 } as Meta<GmdCardComponent>;
@@ -189,11 +190,28 @@ export const WithGlobalCssOverrides: StoryObj = {
   args: {
     width: '300px',
     contentToRender: `
-<gmd-card style="--gmd-card-text-align: center; --gmd-card-outline-color: darkblue; --gmd-card-text-color: green;">
-  <gmd-card-title>A simple placeholder</gmd-card-title>
+<div style="display: flex; width: 1200px; gap: 12px;">
+<gmd-card class="with-global-css-overrides-1">
+  <gmd-card-title>A simple placeholder with one global override class</gmd-card-title>
   <gmd-card-subtitle>Version: 2.0</gmd-card-subtitle>
   <gmd-md>Here's a paragraph. Are you happy now? Just fill in your own content here.</gmd-md>
 </gmd-card>
+<gmd-card class="with-global-css-overrides-2" >
+  <gmd-card-title>A simple placeholder with another global override class</gmd-card-title>
+  <gmd-card-subtitle>Version: 2.0</gmd-card-subtitle>
+  <gmd-md>Here's a paragraph. Are you happy now? Just fill in your own content here.</gmd-md>
+</gmd-card>
+<gmd-card>
+  <gmd-card-title>A simple placeholder with no override classes</gmd-card-title>
+  <gmd-card-subtitle>Version: 2.0</gmd-card-subtitle>
+  <gmd-md>Here's a paragraph. Are you happy now? Just fill in your own content here.</gmd-md>
+</gmd-card>
+<gmd-card style="--gmd-card-outline-color: yellow;">
+  <gmd-card-title>A simple placeholder with inline styling</gmd-card-title>
+  <gmd-card-subtitle>Version: 2.0</gmd-card-subtitle>
+  <gmd-md>Here's a paragraph. Are you happy now? Just fill in your own content here.</gmd-md>
+</gmd-card>
+</div>
       `,
   },
 };

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/README.md
@@ -1,0 +1,69 @@
+# Grid Component
+
+A responsive grid component that provides flexible layout capabilities for organizing content in columns.
+
+## Usage
+
+```html
+<gmd-grid [columns]="3">
+  <gmd-cell>Content 1</gmd-cell>
+  <gmd-cell>Content 2</gmd-cell>
+  <gmd-cell>Content 3</gmd-cell>
+</gmd-grid>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `columns` | `number` | `1` | Number of columns (1-6) |
+
+## Responsive Behavior
+
+The grid automatically adjusts to different screen sizes:
+
+- **Large screens (>1200px)**: Uses the specified number of columns
+- **Medium screens (768px-1200px)**: Reduces columns for better mobile experience
+- **Small screens (<768px)**: Stacks all content in a single column
+
+## Examples
+
+### Basic Grid
+```html
+<gmd-grid [columns]="2">
+  <gmd-cell>Left content</gmd-cell>
+  <gmd-cell>Right content</gmd-cell>
+</gmd-grid>
+```
+
+### Three Column Layout
+```html
+<gmd-grid [columns]="3">
+  <gmd-cell>Column 1</gmd-cell>
+  <gmd-cell>Column 2</gmd-cell>
+  <gmd-cell>Column 3</gmd-cell>
+</gmd-grid>
+```
+
+## Styling
+
+The grid component uses CSS Grid for layout and includes responsive breakpoints. You can customize the appearance by targeting the `.grid-container` class and its responsive variants.
+
+## For Developers
+
+### SCSS Override Example
+
+You can customize the grid spacing using SCSS by importing and using the `overrides` mixin:
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+// Custom grid theme
+.my-custom-grid {
+  @include gmd.grid-overrides((
+    spacing: 24px,
+  ));
+}
+```
+
+This approach allows you to scope grid customizations to specific components or sections of your application.

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/_overrides.scss
@@ -17,9 +17,9 @@
 
 @function tokens() {
   @return (
-    spacing: (
-      value: 16px,
-      css-var: --gmd-grid-spacing,
+    namespace: grid,
+    tokens: (
+      spacing: 16px,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.scss
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use './public-api' as gmd;
+
+.small-gap {
+  @include gmd.grid-overrides(
+    (
+      spacing: 8px,
+    )
+  );
+}
+
+.large-gap {
+  @include gmd.grid-overrides(
+    (
+      spacing: 32px,
+    )
+  );
+}
+
+.no-gap {
+  @include gmd.grid-overrides(
+    (
+      spacing: 0,
+    )
+  );
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/grid/grid.component.stories.ts
@@ -263,16 +263,6 @@ export const WithCellsAndRichHTML: StoryObj<GridComponent> = {
   render: args => ({
     props: args,
     template: `
-      <style>
-        gmd-cell {
-          display: block;
-          padding: 8px;
-          border: 1px solid #e0e0e0;
-          border-radius: 4px;
-          background-color: #f9f9f9;
-          min-height: 40px;
-        }
-      </style>
       <div style="padding: 20px;">
         <h2>Grid with Rich HTML Content</h2>
         <gmd-grid [columns]="columns">
@@ -385,8 +375,6 @@ export const WithMarkdownEditor: StoryObj<GridComponent> = {
     template: `
       <style>
         .editor-container {
-          /*display: flex;*/
-          /*gap: 20px;*/
           height: 500px;
         }
       </style>
@@ -407,7 +395,7 @@ export const WithMarkdownEditor: StoryObj<GridComponent> = {
   }),
 };
 
-export const WithTokenOverrides: StoryObj<GridComponent> = {
+export const WithCustomTheming: StoryObj<GridComponent> = {
   args: {
     columns: 3,
   },
@@ -472,7 +460,7 @@ export const WithTokenOverrides: StoryObj<GridComponent> = {
             </gmd-grid>
           </div>
 
-          <div class="gap-example" style="--gmd-grid-spacing: 8px;">
+          <div class="gap-example small-gap">
             <h3>Small Gap (8px)</h3>
             <gmd-grid [columns]="columns">
               <gmd-cell>
@@ -490,7 +478,7 @@ export const WithTokenOverrides: StoryObj<GridComponent> = {
             </gmd-grid>
           </div>
 
-          <div class="gap-example" style="--gmd-grid-spacing: 32px;">
+          <div class="gap-example large-gap">
             <h3>Large Gap (32px)</h3>
             <gmd-grid [columns]="columns">
               <gmd-cell>
@@ -508,7 +496,7 @@ export const WithTokenOverrides: StoryObj<GridComponent> = {
             </gmd-grid>
           </div>
 
-          <div class="gap-example" style="--gmd-grid-spacing: 0px;">
+          <div class="gap-example no-gap">
             <h3>No Gap (0px)</h3>
             <gmd-grid [columns]="columns">
               <gmd-cell>
@@ -529,4 +517,12 @@ export const WithTokenOverrides: StoryObj<GridComponent> = {
       </div>
     `,
   }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates custom theming using the new @gmd.grid-overrides() mixin. Each example shows different gap spacing applied via SCSS classes.',
+      },
+    },
+  },
 };

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/_overrides.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,9 @@
 
 @function tokens() {
   @return (
-    container-outline-color: (
-      value: #b2aaa9,
-      css-var: --gmd-editor-container-outline-color,
+    namespace: editor,
+    tokens: (
+      container-outline-color: #b2aaa9,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/scss/_token-utils.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/scss/_token-utils.scss
@@ -18,16 +18,13 @@
 
 // Get the css variable value from the token mapping
 @function slot($token-name, $gmd-tokens) {
-  $token-data: map.get($gmd-tokens, $token-name);
+  $tokens: map.get($gmd-tokens, tokens);
+  $token-data: map.get($tokens, $token-name);
+  $namespace: map.get($gmd-tokens, namespace);
   @if $token-data {
-    $value: map.get($token-data, 'value');
-    $css-var: map.get($token-data, 'css-var');
+    $css-var: -calculate-css-var($namespace, $token-name);
 
-    @if $value {
-      @return var(#{$css-var}, #{$value});
-    } @else {
-      @return var(#{$css-var});
-    }
+    @return var(#{$css-var}, #{$token-data});
   }
   @error 'Token #{$token-name} not found in gmd tokens';
 }
@@ -35,42 +32,33 @@
 /**
 *  Apply token overrides to the component
 */
-@mixin apply-token-overrides($token-mapping, $overrides: ()) {
+@mixin apply-token-overrides($token-values, $overrides: ()) {
+  $token-mapping: map.get($token-values, tokens);
+
   @include -validate-token-overrides($token-mapping, $overrides);
 
-  $token-values: -extract-token-data($token-mapping, 'value');
-  $token-css-vars: -extract-token-data($token-mapping, 'css-var');
-  $merged-overrides: -merge-token-overrides($token-values, $overrides);
+  $merged-overrides: -merge-token-overrides($token-mapping, $overrides);
+  $namespace: map.get($token-values, namespace);
 
-  @each $token, $value in $merged-overrides {
-    $css-var: map.get($token-css-vars, $token);
-    @if $css-var {
-      #{$css-var}: #{$value};
-    }
+  @each $key, $value in $merged-overrides {
+    $css-var: -calculate-css-var($namespace, $key);
+
+    #{$css-var}: #{$value};
   }
+}
+
+@function -calculate-css-var($prefix, $token-name) {
+  @return '--gmd-#{$prefix}-#{$token-name}';
 }
 
 @function -merge-token-overrides($default-tokens, $overrides) {
   @return map.deep-merge($default-tokens, $overrides);
 }
 
-@function -extract-token-data($tokens, $attribute) {
-  $data: ();
-  @each $token-name, $token-data in $tokens {
-    $data: map.deep-merge(
-      $data,
-      (
-        $token-name: map.get($token-data, $attribute),
-      )
-    );
-  }
-  @return $data;
-}
-
-@mixin -validate-token-overrides($token-mapping, $overrides) {
+@mixin -validate-token-overrides($default-values, $overrides) {
   @each $token, $value in $overrides {
-    @if not map.has-key($token-mapping, $token) {
-      @error 'Token "#{$token}" does not exist in the token mapping. Available tokens: #{map.keys($token-mapping)}';
+    @if not map.has-key($default-values, $token) {
+      @error 'Token "#{$token}" does not exist in the token mapping. Available tokens: #{map.keys($default-values)}';
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10278

## Description

- refactor how tokens are calculated for components
- only include publicly-supported tokens in documentation

Card component with mixins:

<img width="1685" height="891" alt="Screenshot 2025-09-24 at 17 45 44" src="https://github.com/user-attachments/assets/9f44a3d8-05b6-413b-beeb-2aa8d81890f7" />

Grid component with mixins:

<img width="1452" height="846" alt="Screenshot 2025-09-24 at 18 10 02" src="https://github.com/user-attachments/assets/967b9f7e-3099-4c8a-993e-13589f3a4d6e" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

