### PR TITLE
Apim 11255 fix markdown render after gmd

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
@@ -43,7 +43,6 @@ export default {
         <gmd-viewer [content]="contentToRender"></gmd-viewer>
       </div>
     `,
-    styles: ['@import "../projects/gravitee-markdown/src/lib/components/card/gmd-card.component.stories.scss";'],
     props: args,
   }),
 } as Meta<GmdCardComponent>;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
@@ -239,6 +239,60 @@ describe('GraviteeMarkdownRendererService', () => {
         input: 'Content above\n\n---\n\nContent below',
         expected: '<p>Content above</p>\n<hr>\n<p>Content below</p>\n',
       },
+      {
+        description: 'should handle nested GMD components correctly',
+        input: `# Button Component Integration
+
+This markdown editor demonstrates the **button component** integration.
+
+<gmd-grid columns="3">
+  <gmd-cell style="text-align: center;">
+    <gmd-button appearance="filled" link="/save">Save</gmd-button>
+  </gmd-cell>
+  <gmd-cell style="text-align: center;">
+    <gmd-button appearance="outlined" link="/preview">Preview</gmd-button>
+  </gmd-cell>
+  <gmd-cell style="text-align: center;">
+    <gmd-button appearance="text" link="/cancel">Cancel</gmd-button>
+  </gmd-cell>
+</gmd-grid>
+
+> All buttons use the token-based theming system.`,
+        expected:
+          '<h1 id="button-component-integration">Button Component Integration</h1>\n<p>This markdown editor demonstrates the <strong>button component</strong> integration.</p>\n<gmd-grid columns="3">\n  <gmd-cell style="text-align: center;">\n    <gmd-button appearance="filled" link="/save">Save</gmd-button>\n  </gmd-cell>\n  <gmd-cell style="text-align: center;">\n    <gmd-button appearance="outlined" link="/preview">Preview</gmd-button>\n  </gmd-cell>\n  <gmd-cell style="text-align: center;">\n    <gmd-button appearance="text" link="/cancel">Cancel</gmd-button>\n  </gmd-cell>\n</gmd-grid><blockquote>\n<p>All buttons use the token-based theming system.</p>\n</blockquote>\n',
+      },
+      {
+        description: 'should handle deeply nested GMD components',
+        input: `<gmd-card>
+  <gmd-card-title>Card Title</gmd-card-title>
+  <gmd-card-subtitle>Card Subtitle</gmd-card-subtitle>
+  <gmd-grid columns="2">
+    <gmd-cell>
+      <gmd-button appearance="filled">Action 1</gmd-button>
+    </gmd-cell>
+    <gmd-cell>
+      <gmd-button appearance="outlined">Action 2</gmd-button>
+    </gmd-cell>
+  </gmd-grid>
+</gmd-card>`,
+        expected:
+          '<gmd-card>\n  <gmd-card-title>Card Title</gmd-card-title>\n  <gmd-card-subtitle>Card Subtitle</gmd-card-subtitle>\n  <gmd-grid columns="2">\n    <gmd-cell>\n      <gmd-button appearance="filled">Action 1</gmd-button>\n    </gmd-cell>\n    <gmd-cell>\n      <gmd-button appearance="outlined">Action 2</gmd-button>\n    </gmd-cell>\n  </gmd-grid>\n</gmd-card>',
+      },
+      {
+        description: 'should handle nested components of the same type',
+        input: `<gmd-card>
+  <gmd-card-title>Parent Card</gmd-card-title>
+  <gmd-card-subtitle>This card contains another card</gmd-card-subtitle>
+  <gmd-card>
+    <gmd-card-title>Child Card</gmd-card-title>
+    <gmd-card-subtitle>Nested inside parent</gmd-card-subtitle>
+    <gmd-button appearance="filled">Child Action</gmd-button>
+  </gmd-card>
+  <gmd-button appearance="outlined">Parent Action</gmd-button>
+</gmd-card>`,
+        expected:
+          '<gmd-card>\n  <gmd-card-title>Parent Card</gmd-card-title>\n  <gmd-card-subtitle>This card contains another card</gmd-card-subtitle>\n  <gmd-card>\n    <gmd-card-title>Child Card</gmd-card-title>\n    <gmd-card-subtitle>Nested inside parent</gmd-card-subtitle>\n    <gmd-button appearance="filled">Child Action</gmd-button>\n  </gmd-card>\n  <gmd-button appearance="outlined">Parent Action</gmd-button>\n</gmd-card>',
+      },
     ];
 
     complexTestCases.forEach(({ description, input, expected }) => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11255

## Description

- Small fix to remove unused scss in the card stories
- Render markdown after a gmd component
- Render gmd components within the same gmd component

<img width="1492" height="896" alt="Screenshot 2025-09-25 at 17 47 54" src="https://github.com/user-attachments/assets/3dedabd6-2031-4636-9321-31345f516d61" />

<img width="1177" height="701" alt="Screenshot 2025-09-25 at 17 50 01" src="https://github.com/user-attachments/assets/ec02ea51-77e0-403e-b81f-1913998f34b9" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

