### PR TITLE
fix: [PAPI] Match portal-page object to what is returned by MAPI-v2

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/homepage/homepage.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/homepage/homepage.component.ts
@@ -27,10 +27,7 @@ import { PortalPage } from '../../entities/portal/portal-page';
   template: ` <gmd-viewer [content]="homepageContent()" /> `,
 })
 export class HomepageComponent {
-  homepage = input<PortalPage>({
-    page: { id: '', name: 'Homepage', pageContent: '', type: 'GRAVITEE_MARKDOWN' },
-    viewDetails: {},
-  });
+  homepage = input<PortalPage>({ id: '' });
 
-  homepageContent = computed(() => this.homepage().page.pageContent ?? '');
+  homepageContent = computed(() => this.homepage().content ?? '');
 }

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
@@ -58,10 +58,11 @@ describe('PortalService', () => {
     const mockPages: PortalPage[] = [
       {
         id: 'home-1',
-        name: 'Home',
-        type: 'HOMEPAGE',
+        type: 'GRAVITEE_MARKDOWN',
         content: 'Hello',
-      } as unknown as PortalPage,
+        context: 'HOME',
+        published: true,
+      } as PortalPage,
     ];
 
     service.getPortalHomepages().subscribe(data => {
@@ -70,6 +71,6 @@ describe('PortalService', () => {
 
     const req = httpMock.expectOne(`${baseURL}/portal-pages?type=HOMEPAGE&expands=CONTENT`);
     expect(req.request.method).toBe('GET');
-    req.flush(mockPages);
+    req.flush({ pages: mockPages });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.ts
@@ -27,7 +27,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import { ApiInformation } from '../entities/api/api-information';
@@ -47,11 +47,13 @@ export class PortalService {
   }
 
   public getPortalHomepages(): Observable<PortalPage[]> {
-    return this.http.get<PortalPage[]>(`${this.configService.baseURL}/portal-pages`, {
-      params: {
-        type: 'HOMEPAGE',
-        expands: 'CONTENT',
-      },
-    });
+    return this.http
+      .get<{ pages: PortalPage[] }>(`${this.configService.baseURL}/portal-pages`, {
+        params: {
+          type: 'HOMEPAGE',
+          expands: 'CONTENT',
+        },
+      })
+      .pipe(map(resp => resp?.pages ?? []));
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalPagesMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalPagesMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.portal_page.model.PageId;
+import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
+import io.gravitee.apim.core.portal_page.model.PortalViewContext;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalPageUseCase;
+import io.gravitee.rest.api.portal.rest.model.PortalPageResponse;
+import io.gravitee.rest.api.portal.rest.model.PortalPageWithDetails;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalPagesMapper {
+    PortalPagesMapper INSTANCE = Mappers.getMapper(PortalPagesMapper.class);
+
+    default PortalPageWithDetails.ContextEnum map(PortalViewContext portalViewContext) {
+        return portalViewContext == null ? null : PortalPageWithDetails.ContextEnum.valueOf(portalViewContext.name());
+    }
+
+    default String map(PageId pageId) {
+        return pageId == null ? null : pageId.toString();
+    }
+
+    default String map(Date date) {
+        if (date == null) return null;
+        return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(date.getTime()));
+    }
+
+    @Mapping(target = "id", source = "page.id")
+    @Mapping(target = "content", source = "page.pageContent.content")
+    @Mapping(target = "type", constant = "GRAVITEE_MARKDOWN")
+    @Mapping(target = "context", source = "viewDetails.context")
+    @Mapping(target = "createdAt", source = "page.createdAt")
+    @Mapping(target = "updatedAt", source = "page.updatedAt")
+    PortalPageWithDetails map(PortalPageWithViewDetails page);
+
+    default PortalPageResponse map(List<PortalPageWithViewDetails> portalPagesWithViewDetails) {
+        PortalPageResponse response = new PortalPageResponse();
+        response.setPages(portalPagesWithViewDetails == null ? List.of() : portalPagesWithViewDetails.stream().map(this::map).toList());
+        return response;
+    }
+
+    PortalPageResponse map(GetPortalPageUseCase.Output page);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/PortalPageResponse.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/PortalPageResponse.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.gravitee.rest.api.portal.rest.model;
 
-/*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- * Licensed under the Apache License, Version 2.0
- */
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
-export interface PortalPage {
-  id: string;
-  name?: string;
-  content?: string;
-  type?: string;
-  context?: string;
-  createdAt?: string;
-  updatedAt?: string;
+@Setter
+@Getter
+public class PortalPageResponse {
+
+    private List<PortalPageWithDetails> pages;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/PortalPageWithDetails.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/PortalPageWithDetails.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class PortalPageWithDetails {
+
+    public enum ContextEnum {
+        HOMEPAGE,
+    }
+
+    @NotNull
+    private String id;
+
+    private String content;
+
+    private String type;
+
+    private ContextEnum context;
+
+    private String createdAt;
+    private String updatedAt;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalPagesResource.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.portal_page.model.ExpandsViewContext;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageUseCase;
+import io.gravitee.rest.api.portal.rest.mapper.PortalPagesMapper;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
@@ -52,6 +53,7 @@ public class PortalPagesResource {
             .stream()
             .filter(page -> page.viewDetails().published())
             .toList();
-        return Response.ok(filteredPages).build();
+        var response = PortalPagesMapper.INSTANCE.map(filteredPages);
+        return Response.ok(response).build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11237

## Description

`{{baseurl}}/portal-pages?expands=CREATED_AT&expands=UPDATED_AT&expands=CONTENT&type=HOMEPAGE`

Response
```json
{
    "pages": [
        {
            "id": "002b316b-d249-42ab-9515-618fcdce0d86",
            "content": "## Welcome\n\nHello World !\nThis page will be updated soon see  https://gravitee.atlassian.net/browse/APIM-10886",
            "type": "GRAVITEE_MARKDOWN",
            "context": "HOMEPAGE",
            "createdAt": "2025-07-20T20:02:40.347Z",
            "updatedAt": "2025-07-20T21:47:56.072Z"
        }
    ]
}
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uxyxbeqzid.chromatic.com)
<!-- Storybook placeholder end -->
