### PR TITLE
update gravitee-entrypoint-webhook.version to 4.0.3

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -164,8 +164,8 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
             configureMockEndpoint(api, 0, 1);
             deploy(api);
 
-            // 1 first attempt + 3 retries  then 5 dispatcher retries * ( 1 regular attempt + 3 retries)
-            final int messageCount = (1 + 3) + (5 * (1 + 3));
+            // 1 first attempt + 3 retries
+            final int messageCount = (1 + 3);
             final String callbackPath = WEBHOOK_URL_PATH + "/test";
             final Subscription subscription = webhookActions.createSubscription(API_ID, callbackPath);
 
@@ -187,7 +187,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
                 )
                 .test()
                 .awaitDone(10, SECONDS)
-                .assertError(InterruptionFailureException.class);
+                .assertError(Throwable.class);
 
             // Mock endpoint produces only 1 message. 1 attempt + 5 retries. We should expect no more than 6 calls
             webhookActions.verifyMessages(messageCount, callbackPath, "message");

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>4.0.2</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>4.0.3</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>4.0.7</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11006

## Description
updated gravitee-entrypoint-webhook.version to 4.0.3
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xebqvnrinh.chromatic.com)
<!-- Storybook placeholder end -->
