### PR TITLE
APIM 10861 improve empty analytics

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -57,6 +57,7 @@ type WidgetDisplayConfig = {
   type: ApiAnalyticsWidgetType;
   isClickable?: boolean;
   relativePath?: string;
+  minHeight?: 'small' | 'medium' | 'large';
 };
 
 interface Range {
@@ -189,6 +190,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       tooltip: 'Displays the distribution of HTTP status codes returned by the API',
       groupByField: 'status',
       analyticsType: 'GROUP_BY',
+      minHeight: 'medium',
       ranges: [
         { label: '100-199', value: '100:199', color: '#2B72FB' },
         { label: '200-299', value: '200:299', color: '#64BDC6' },
@@ -210,6 +212,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       tooltip: 'Visualizes the breakdown of HTTP status codes (2xx, 4xx, 5xx) across time',
       shouldSortBuckets: true,
       analyticsType: 'HISTOGRAM',
+      minHeight: 'medium',
     },
     {
       type: 'line',
@@ -230,6 +233,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       tooltip: 'Measures response time for gateway and endpoint',
       shouldSortBuckets: false,
       analyticsType: 'HISTOGRAM',
+      minHeight: 'medium',
     },
     {
       type: 'line',
@@ -238,6 +242,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       tooltip: 'Hits repartition by application',
       shouldSortBuckets: false,
       analyticsType: 'HISTOGRAM',
+      minHeight: 'medium',
       aggregations: [
         {
           type: AggregationTypes.FIELD,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -157,7 +157,8 @@ export class ApiAnalyticsWidgetService {
     statsResponse: AnalyticsStatsResponse,
     widgetConfig: ApiAnalyticsDashboardWidgetConfig,
   ): ApiAnalyticsWidgetConfig {
-    if (Object.values(statsResponse).every((value) => value === 0)) {
+    const statsValue = widgetConfig.statsKey ? statsResponse[widgetConfig.statsKey] : undefined;
+    if (statsValue == null || statsValue === 0) {
       return this.createEmptyConfig(widgetConfig);
     }
 
@@ -166,7 +167,7 @@ export class ApiAnalyticsWidgetService {
       tooltip: widgetConfig.tooltip,
       state: 'success',
       widgetType: 'stats' as const,
-      widgetData: { stats: statsResponse[widgetConfig.statsKey], statsUnit: widgetConfig.statsUnit },
+      widgetData: { stats: statsValue, statsUnit: widgetConfig.statsUnit },
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -304,6 +304,7 @@ export class ApiAnalyticsWidgetService {
       title: widgetConfig.title,
       tooltip: widgetConfig.tooltip,
       state: 'success',
+      minHeight: widgetConfig.minHeight,
       widgetType: 'table',
       widgetData: {
         columns: transformedColumns,
@@ -396,6 +397,7 @@ export class ApiAnalyticsWidgetService {
         title: widgetConfig.title,
         tooltip: widgetConfig.tooltip,
         state: 'success',
+        minHeight: widgetConfig.minHeight,
         widgetType: 'multi-stats' as const,
         widgetData: multiStatsData,
       };
@@ -436,6 +438,7 @@ export class ApiAnalyticsWidgetService {
         title: widgetConfig.title,
         tooltip: widgetConfig.tooltip,
         state: 'success',
+        minHeight: widgetConfig.minHeight,
         widgetType: 'line' as const,
         widgetData: { data: lineData, options },
       };
@@ -527,6 +530,7 @@ export class ApiAnalyticsWidgetService {
         title: widgetConfig.title,
         tooltip: widgetConfig.tooltip,
         state: 'success',
+        minHeight: widgetConfig.minHeight,
         widgetType: 'bar' as const,
         widgetData: { data: barData, options },
       };
@@ -550,6 +554,7 @@ export class ApiAnalyticsWidgetService {
       title: widgetConfig.title,
       tooltip: widgetConfig.tooltip,
       state,
+      minHeight: widgetConfig.minHeight,
       ...(errors && { errors }),
     };
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.html
@@ -15,7 +15,13 @@
     limitations under the License.
 
 -->
-<gio-widget-layout [title]="config().title" [state]="config().state" [errors]="config().errors" [tooltip]="config().tooltip">
+<gio-widget-layout
+  [title]="config().title"
+  [state]="config().state"
+  [errors]="config().errors"
+  [tooltip]="config().tooltip"
+  [minHeight]="config().minHeight"
+>
   <div [ngClass]="config().widgetType" gioWidgetLayoutChart>
     @if (config().state === 'success') {
       @switch (config().widgetType) {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-widget/api-analytics-widget.component.ts
@@ -57,6 +57,7 @@ interface BaseApiAnalyticsWidgetConfig {
   tooltip?: string;
   state: GioWidgetLayoutState;
   errors?: string[];
+  minHeight?: 'small' | 'medium' | 'large';
 }
 
 type ApiAnalyticsWidgetStatsConfig = BaseApiAnalyticsWidgetConfig & {

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
@@ -46,7 +46,7 @@
         </div>
       }
       @default {
-        <div class="empty">
+        <div class="empty" [ngClass]="'empty--' + minHeight()">
           <div class="icon">
             <mat-icon svgIcon="gio:stat-up"></mat-icon>
           </div>

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.html
@@ -48,7 +48,7 @@
       @default {
         <div class="empty">
           <div class="icon">
-            <mat-icon svgIcon="gio:search"></mat-icon>
+            <mat-icon svgIcon="gio:stat-up"></mat-icon>
           </div>
           <div class="mat-h3" data-test-id="empty-title">No data to display</div>
           <div data-test-id="empty-message">Adjust your search criteria and filters for better results.</div>

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
@@ -82,6 +82,18 @@ $cardHeaderBorderColor: map.get(gio.$mat-theme, foreground);
   flex-direction: column;
   word-break: break-word;
   text-align: center;
+
+  &.empty--small {
+    min-height: 180px;
+  }
+
+  &.empty--medium {
+    min-height: 240px;
+  }
+
+  &.empty--large {
+    min-height: 350px;
+  }
 }
 
 // Success state (chart content)

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
@@ -41,8 +41,8 @@ $cardHeaderBorderColor: map.get(gio.$mat-theme, foreground);
 }
 
 .icon {
-  color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, default);
-  background: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'lighter');
+  color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, darker80);
+  background: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, lighter40);
   border-radius: 50%;
   display: flex;
   justify-content: center;

--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, input, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { GioLoaderModule } from '@gravitee/ui-particles-angular';
 import { MatIconModule } from '@angular/material/icon';
@@ -24,7 +25,7 @@ export type GioWidgetLayoutState = 'loading' | 'error' | 'success' | 'empty';
 @Component({
   selector: 'gio-widget-layout',
   standalone: true,
-  imports: [MatCardModule, MatIconModule, GioLoaderModule, MatTooltipModule],
+  imports: [CommonModule, MatCardModule, MatIconModule, GioLoaderModule, MatTooltipModule],
   templateUrl: './gio-widget-layout.component.html',
   styleUrl: './gio-widget-layout.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -34,6 +35,7 @@ export class GioWidgetLayoutComponent implements OnChanges {
   tooltip = input<string>();
   state = input.required<GioWidgetLayoutState>();
   errors = input<string[]>();
+  minHeight = input<'small' | 'medium' | 'large'>('small');
 
   errorMessage = computed(() => {
     const errors = this.errors();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10861

## Description

- Update empty state icon to stat up with new color and background.
- Fix Handle missing/zero data for stats
- Make line and pie chart empty states taller, basically the left column to occupy more space.



https://github.com/user-attachments/assets/379cb5ba-1725-4a9e-94b6-e0573831942a


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hhsrbbasps.chromatic.com)
<!-- Storybook placeholder end -->
