### PR TITLE
APIM 10859 stats widget formatting

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-widget-layout/gio-widget-layout.component.scss
@@ -9,6 +9,7 @@ $cardHeaderBorderColor: map.get(gio.$mat-theme, foreground);
   border: 1px solid $borderColor;
   border-radius: 8px;
   transition: height 0.3s ease-in-out;
+  height: 100%;
 
   &__title {
     display: flex;
@@ -23,6 +24,8 @@ $cardHeaderBorderColor: map.get(gio.$mat-theme, foreground);
 
   &__header {
     border-bottom: 1px solid mat.m2-get-color-from-palette($cardHeaderBorderColor, divider);
+    flex: 1;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10859

## Description

Fix gio widget layout card header and height.

<img width="1422" height="672" alt="image" src="https://github.com/user-attachments/assets/7471e2b3-a769-4a25-bbe1-d78a752906bf" />

<img width="966" height="707" alt="image" src="https://github.com/user-attachments/assets/2467c788-fb02-4de1-b267-d34c29da9e34" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cedjcxmjhv.chromatic.com)
<!-- Storybook placeholder end -->
