### PR TITLE
Apim 10886 fix dom parser and gmd md style

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
@@ -293,6 +293,54 @@ This markdown editor demonstrates the **button component** integration.
         expected:
           '<gmd-card>\n  <gmd-card-title>Parent Card</gmd-card-title>\n  <gmd-card-subtitle>This card contains another card</gmd-card-subtitle>\n  <gmd-card>\n    <gmd-card-title>Child Card</gmd-card-title>\n    <gmd-card-subtitle>Nested inside parent</gmd-card-subtitle>\n    <gmd-button appearance="filled">Child Action</gmd-button>\n  </gmd-card>\n  <gmd-button appearance="outlined">Parent Action</gmd-button>\n</gmd-card>',
       },
+      {
+        description: 'should handle images inside GMD components without parsing errors',
+        input: `## Outside
+
+<img src="https://supertails.com/cdn/shop/articles/360_f_681163919_71bp2aiyziip3l4j5mbphdxtipdtm2zh_e2c1dbbd-e3b0-4c7d-bc09-1ebff39513ef.jpg?v=1747293323"
+                 alt="Sample image"
+                 style="width: 100%; max-width: 500px; height: auto; border-radius: 8px;" />
+
+<gmd-grid columns="1">
+<gmd-cell>
+        Inside
+</gmd-cell>
+  <gmd-cell>
+    <img src="https://supertails.com/cdn/shop/articles/360_f_681163919_71bp2aiyziip3l4j5mbphdxtipdtm2zh_e2c1dbbd-e3b0-4c7d-bc09-1ebff39513ef.jpg?v=1747293323"
+                 alt="Sample image"
+                 >
+  </gmd-cell>
+</gmd-grid>
+
+## Sample Content
+- *Italic text* and **bold text**
+- \`Inline code\`
+- [Links](https://gravitee.io)`,
+        expected:
+          '<h2 id="outside">Outside</h2>\n<img src="https://supertails.com/cdn/shop/articles/360_f_681163919_71bp2aiyziip3l4j5mbphdxtipdtm2zh_e2c1dbbd-e3b0-4c7d-bc09-1ebff39513ef.jpg?v=1747293323" alt="Sample image" style="width: 100%; max-width: 500px; height: auto; border-radius: 8px;">\n\n<gmd-grid columns="1">\n<gmd-cell>\n        Inside\n</gmd-cell>\n  <gmd-cell>\n    <img src="https://supertails.com/cdn/shop/articles/360_f_681163919_71bp2aiyziip3l4j5mbphdxtipdtm2zh_e2c1dbbd-e3b0-4c7d-bc09-1ebff39513ef.jpg?v=1747293323" alt="Sample image">\n  </gmd-cell>\n</gmd-grid><h2 id="sample-content">Sample Content</h2>\n<ul>\n<li><em>Italic text</em> and <strong>bold text</strong></li>\n<li><code>Inline code</code></li>\n<li><a href="https://gravitee.io">Links</a></li>\n</ul>\n',
+      },
+      {
+        description: 'should handle markdown with special characters at root level',
+        input: `# Special Characters Test
+
+> This is a blockquote at root level
+> It spans multiple lines
+> And should render properly
+
+- List item with special characters: > < * #
+- Another item with symbols: @ $ % ^ &
+
+## Code with special characters
+\`\`\`javascript
+// This code contains special characters
+const special = "> < * # @ $ % ^ &";
+console.log(special);
+\`\`\`
+
+> Final blockquote to test parsing`,
+        expected:
+          '<h1 id="special-characters-test">Special Characters Test</h1>\n<blockquote>\n<p>This is a blockquote at root level<br>It spans multiple lines<br>And should render properly</p>\n</blockquote>\n<ul>\n<li>List item with special characters: &gt; &lt; * #</li>\n<li>Another item with symbols: @ $ % ^ &amp;</li>\n</ul>\n<h2 id="code-with-special-characters">Code with special characters</h2>\n<pre><code class="language-javascript">// This code contains special characters\nconst special = &quot;&amp;gt; &amp;lt; * # @ $ % ^ &amp;amp;&quot;;\nconsole.log(special);\n</code></pre>\n<blockquote>\n<p>Final blockquote to test parsing</p>\n</blockquote>\n',
+      },
     ];
 
     complexTestCases.forEach(({ description, input, expected }) => {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
@@ -205,6 +205,46 @@ describe('GraviteeMarkdownRendererService', () => {
 </gmd-md>
         </div>`);
     });
+
+    it('should preserve style and class attributes in gmd-md elements', () => {
+      const htmlInput = `
+        <div>
+          <gmd-md style="color: red; font-size: 16px;">
+            # Styled Title
+            This is **styled** content.
+          </gmd-md>
+          <gmd-md class="custom-class">
+            # Classed Title
+            This is **classed** content.
+          </gmd-md>
+          <gmd-md style="background: blue;" class="styled-class">
+            # Both Attributes
+            This has both **style** and class.
+          </gmd-md>
+          <gmd-md>
+            # Regular Title
+            This is regular content.
+          </gmd-md>
+        </div>
+      `;
+
+      const result = service.preprocessGmdBlocks(htmlInput);
+
+      expect(result).toContain('<gmd-md style="color: red; font-size: 16px;">');
+      expect(result).toContain('<h1 id="styled-title">Styled Title</h1>');
+      expect(result).toContain('<p>This is <strong>styled</strong> content.</p>');
+
+      expect(result).toContain('<gmd-md class="custom-class">');
+      expect(result).toContain('<h1 id="classed-title">Classed Title</h1>');
+      expect(result).toContain('<p>This is <strong>classed</strong> content.</p>');
+
+      expect(result).toContain('<gmd-md style="background: blue;" class="styled-class">');
+      expect(result).toContain('<h1 id="both-attributes">Both Attributes</h1>');
+      expect(result).toContain('<p>This has both <strong>style</strong> and class.</p>');
+
+      expect(result).toContain('<gmd-md><h1 id="regular-title">Regular Title</h1>');
+      expect(result).toContain('<p>This is regular content.</p>');
+    });
   });
 
   describe('Complex Markdown Scenarios', () => {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.ts
@@ -111,11 +111,23 @@ export class GraviteeMarkdownRendererService {
    * @returns The HTML content with gmd-blocks transformed
    */
   public preprocessGmdBlocks(html: string): string {
-    return html.replace(/<gmd-md>([\s\S]*?)<\/gmd-md>/gi, (_, rawContent) => {
+    return html.replace(/<gmd-md(?:\s+[^>]+)?>([\s\S]*?)<\/gmd-md>/gi, (match, rawContent) => {
+      const attributes = this.extractAttributesFromGmdMdTag(match);
       const normalized = normalizeIndentation(rawContent);
       const rendered = marked(normalized) as string;
-      return `<gmd-md>${rendered}</gmd-md>`;
+      return `<gmd-md${attributes}>${rendered}</gmd-md>`;
     });
+  }
+
+  /**
+   * Extract attributes from a gmd-md opening tag
+   * @param tag The opening tag string (e.g., '<gmd-md style="color: red;" class="my-class">')
+   * @returns The attributes string with leading space, or empty string if no attributes
+   * @private
+   */
+  private extractAttributesFromGmdMdTag(tag: string): string {
+    const attributesMatch = tag.match(/<gmd-md\s+(.+?)>/);
+    return attributesMatch ? ` ${attributesMatch[1]}` : '';
   }
 
   /**

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.ts
@@ -100,7 +100,9 @@ export class GraviteeMarkdownRendererService {
   public render(content: string): string {
     marked.use({ renderer: this.getRenderer() });
     const processed = this.preprocessGmdBlocks(content);
-    return marked(processed) as string;
+    const parsed = new DOMParser().parseFromString(processed, 'text/html');
+    const decoded = this.decodeMarkdown(parsed.body.innerHTML);
+    return marked(decoded) as string;
   }
 
   /**
@@ -129,5 +131,16 @@ export class GraviteeMarkdownRendererService {
     }
     const componentName = componentNameMatch[1]; // Group found in the regex
     return `gmd-${componentName}`;
+  }
+
+  /**
+   * Decodes specific markdown elements by replacing encoded entities.
+   *
+   * @param {string} content - The markdown content as a string.
+   * @return {string} The decoded markdown content with replacements applied.
+   */
+  private decodeMarkdown(content: string): string {
+    // Replace greater than for blockquote
+    return content.replace(/^&gt;/gm, '>');
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10886

## Description

Correctly show images within gravitee markdown

<img width="1598" height="827" alt="Screenshot 2025-09-26 at 16 40 23" src="https://github.com/user-attachments/assets/1cb8a29e-80ef-4d6b-82f1-7aea7bd419f9" />

Allow gmd-md to retain attributes for rendering

<img width="1041" height="413" alt="Screenshot 2025-09-26 at 16 37 20" src="https://github.com/user-attachments/assets/a834846a-8d63-41af-ae39-5f98b1a42829" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lfagopmenc.chromatic.com)
<!-- Storybook placeholder end -->
