### PR TITLE
fix: update portal pages response to return multiple only on get

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPagesMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPagesMapper.java
@@ -19,7 +19,8 @@ import io.gravitee.apim.core.portal_page.model.PageId;
 import io.gravitee.apim.core.portal_page.model.PortalPageWithViewDetails;
 import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageUseCase;
-import io.gravitee.rest.api.management.v2.rest.model.PortalPageResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPagesResponse;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -29,8 +30,8 @@ import org.mapstruct.factory.Mappers;
 public interface PortalPagesMapper {
     PortalPagesMapper INSTANCE = Mappers.getMapper(PortalPagesMapper.class);
 
-    default io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails.ContextEnum map(PortalViewContext portalViewContext) {
-        return io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails.ContextEnum.valueOf(portalViewContext.toString());
+    default PortalPageWithDetails.ContextEnum map(PortalViewContext portalViewContext) {
+        return PortalPageWithDetails.ContextEnum.valueOf(portalViewContext.toString());
     }
 
     default String map(PageId pageId) {
@@ -42,17 +43,13 @@ public interface PortalPagesMapper {
     @Mapping(target = "type", constant = "GRAVITEE_MARKDOWN")
     @Mapping(target = "context", source = "viewDetails.context")
     @Mapping(target = "published", source = "viewDetails.published")
-    io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails map(PortalPageWithViewDetails page);
+    PortalPageWithDetails map(PortalPageWithViewDetails page);
 
-    default PortalPageResponse map(List<PortalPageWithViewDetails> portalPagesWithViewDetails) {
-        PortalPageResponse response = new PortalPageResponse();
+    default PortalPagesResponse map(List<PortalPageWithViewDetails> portalPagesWithViewDetails) {
+        PortalPagesResponse response = new PortalPagesResponse();
         response.setPages(portalPagesWithViewDetails.stream().map(this::map).toList());
         return response;
     }
 
-    default PortalPageResponse mapSingle(PortalPageWithViewDetails page) {
-        return map(List.of(page));
-    }
-
-    PortalPageResponse map(GetPortalPageUseCase.Output page);
+    PortalPagesResponse map(GetPortalPageUseCase.Output page);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResource.java
@@ -25,7 +25,8 @@ import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageViewPublicationStatusUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalPagesMapper;
 import io.gravitee.rest.api.management.v2.rest.model.PatchPortalPage;
-import io.gravitee.rest.api.management.v2.rest.model.PortalPageResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPagesResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -61,7 +62,7 @@ public class PortalPagesResource extends AbstractResource {
     @GET
     @Produces("application/json")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.READ }) })
-    public PortalPageResponse getPortalPages(@QueryParam("type") String type, @QueryParam("expands") List<String> expands) {
+    public PortalPagesResponse getPortalPages(@QueryParam("type") String type, @QueryParam("expands") List<String> expands) {
         GetPortalPageUseCase.Input input = toGetPortalPageInput(envId, type, expands);
         var page = getPortalPageUseCase.execute(input);
 
@@ -82,11 +83,11 @@ public class PortalPagesResource extends AbstractResource {
     @Consumes("application/json")
     @Path("/{pageId}")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
-    public PortalPageResponse patchPortalPage(@PathParam("pageId") String pageId, PatchPortalPage patchPortalPage) {
+    public PortalPageWithDetails patchPortalPage(@PathParam("pageId") String pageId, PatchPortalPage patchPortalPage) {
         var input = new UpdatePortalPageUseCase.Input(envId, pageId, patchPortalPage.getContent());
         var updatedHomepage = updatePortalPageUseCase.execute(input);
 
-        return PortalPagesMapper.INSTANCE.mapSingle(updatedHomepage.portalPage());
+        return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
     }
 
     @POST
@@ -94,11 +95,11 @@ public class PortalPagesResource extends AbstractResource {
     @Consumes("application/json")
     @Path("/{pageId}/_publish")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
-    public PortalPageResponse publishPortalPage(@PathParam("pageId") String pageId) {
+    public PortalPageWithDetails publishPortalPage(@PathParam("pageId") String pageId) {
         var input = new UpdatePortalPageViewPublicationStatusUseCase.Input(PageId.of(pageId), true);
         var updatedHomepage = updatePortalPageViewPublicationStatusUseCase.execute(input);
 
-        return PortalPagesMapper.INSTANCE.mapSingle(updatedHomepage.portalPage());
+        return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
     }
 
     @POST
@@ -106,9 +107,9 @@ public class PortalPagesResource extends AbstractResource {
     @Consumes("application/json")
     @Path("/{pageId}/_unpublish")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
-    public PortalPageResponse unpublishPortalPage(@PathParam("pageId") String pageId) {
+    public PortalPageWithDetails unpublishPortalPage(@PathParam("pageId") String pageId) {
         var input = new UpdatePortalPageViewPublicationStatusUseCase.Input(PageId.of(pageId), false);
         var updatedHomepage = updatePortalPageViewPublicationStatusUseCase.execute(input);
-        return PortalPagesMapper.INSTANCE.mapSingle(updatedHomepage.portalPage());
+        return PortalPagesMapper.INSTANCE.map(updatedHomepage.portalPage());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -760,7 +760,7 @@ paths:
           - $ref: '#/components/parameters/expandComponents'
         responses:
           "200":
-            $ref: "#/components/responses/PortalPageResponse"
+            $ref: "#/components/responses/PortalPagesResponse"
           default:
             $ref: "#/components/responses/Error"
     /portal-pages/{pageId}:
@@ -2143,7 +2143,14 @@ components:
           content:
             application/json:
               schema:
-                title: "PortalPageResponse"
+                $ref: "#/components/schemas/PortalPageWithDetails"
+
+        PortalPagesResponse:
+          description: A list of portal pages
+          content:
+            application/json:
+              schema:
+                title: "PortalPagesResponse"
                 properties:
                   pages:
                     type: array

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/portal_pages/PortalPagesResourceTest.java
@@ -29,7 +29,8 @@ import io.gravitee.apim.core.portal_page.model.PortalViewContext;
 import io.gravitee.repository.management.model.PortalPageContext;
 import io.gravitee.repository.management.model.PortalPageContextType;
 import io.gravitee.rest.api.management.v2.rest.model.PatchPortalPage;
-import io.gravitee.rest.api.management.v2.rest.model.PortalPageResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageWithDetails;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPagesResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -82,8 +83,8 @@ public class PortalPagesResourceTest extends AbstractResourceTest {
             Response response = target.queryParam("type", "HOMEPAGE").request().get();
             assertThat(response)
                 .hasStatus(OK_200)
-                .asEntity(PortalPageResponse.class)
-                .extracting(PortalPageResponse::getPages)
+                .asEntity(PortalPagesResponse.class)
+                .extracting(PortalPagesResponse::getPages)
                 .extracting(List::getFirst)
                 .satisfies(r -> {
                     assertThat(r.getContent()).isEqualTo("Welcome!");
@@ -155,9 +156,7 @@ public class PortalPagesResourceTest extends AbstractResourceTest {
                 .method("PATCH", jakarta.ws.rs.client.Entity.json(patchPortalPage));
             assertThat(response)
                 .hasStatus(OK_200)
-                .asEntity(PortalPageResponse.class)
-                .extracting(PortalPageResponse::getPages)
-                .extracting(List::getFirst)
+                .asEntity(PortalPageWithDetails.class)
                 .satisfies(r -> {
                     assertThat(r.getContent()).isEqualTo(updatedContent);
                     assertThat(r.getContext()).isEqualTo(
@@ -189,9 +188,7 @@ public class PortalPagesResourceTest extends AbstractResourceTest {
             Response response = target.path("/" + existingHomepage.page().getId() + "/_publish").request().post(null);
             assertThat(response)
                 .hasStatus(OK_200)
-                .asEntity(PortalPageResponse.class)
-                .extracting(PortalPageResponse::getPages)
-                .extracting(List::getFirst)
+                .asEntity(PortalPageWithDetails.class)
                 .satisfies(r -> {
                     assertThat(r.getContent()).isEqualTo("Welcome!");
                     assertThat(r.getContext()).isEqualTo(
@@ -222,9 +219,7 @@ public class PortalPagesResourceTest extends AbstractResourceTest {
             Response response = target.path("/" + existingHomepage.page().getId() + "/_unpublish").request().post(null);
             assertThat(response)
                 .hasStatus(OK_200)
-                .asEntity(PortalPageResponse.class)
-                .extracting(PortalPageResponse::getPages)
-                .extracting(List::getFirst)
+                .asEntity(PortalPageWithDetails.class)
                 .satisfies(r -> {
                     assertThat(r.getContent()).isEqualTo("Welcome!");
                     assertThat(r.getContext()).isEqualTo(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11275

## Description

Request
```http
PATCH {{baseUrl}}management/v2/environments/DEFAULT/portal-pages/e87ae5cb-4b8e-4586-bae5-cb4b8e658603  
Authorization: {{token}}  
Content-Type: application/json  
  
{  
  "content": "## Updated?"}
```

Response
```json
{
  "id": "e87ae5cb-4b8e-4586-bae5-cb4b8e658603",
  "content": "## Updated?",
  "type": "gravitee_markdown",
  "context": "homepage",
  "published": true
}
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

