### PR TITLE
feat(helm): allow to specify excludes for httpClient proxy

### DIFF
--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -197,6 +197,10 @@ data:
       {{- if .Values.api.http.client.proxy }}
       proxy:
         type: {{ .Values.api.http.client.proxy.type }}
+        {{- with .Values.api.http.client.proxy.excludeHosts }}
+        exclude-hosts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- if .Values.api.http.client.proxy.http }}
         http:
           host: {{ .Values.api.http.client.proxy.http.host }}

--- a/helm/tests/api/configmap_http_client_proxy_test.yaml
+++ b/helm/tests/api/configmap_http_client_proxy_test.yaml
@@ -1,0 +1,30 @@
+suite: Test Management API configmap for HTTP client proxy
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Sets http client proxy excludes
+    template: api/api-configmap.yaml
+    set:
+      api:
+        http:
+          client:
+            proxy:
+              type: HTTP
+              excludeHosts:
+                - 'test.company.com'
+                - '*.myotherdomain.com'
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |-
+            httpClient:
+              timeout: 10000
+              proxy:
+                type: HTTP
+                exclude-hosts:
+                  - test.company.com
+                  - '\*.myotherdomain.com'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -735,6 +735,9 @@ api:
       timeout: 10000
       # proxy:
       #   type: HTTP
+      #   excludeHosts:
+      #     - '*.internal.com'
+      #     - 'internal.mycompany.com'
       #   http:
       #     host: localhost
       #     port: 3128


### PR DESCRIPTION
The gravitee config supports this value but the helm chart did not include this parameter. For example, you need it for OIDC login flows.

## Issue

https://github.com/gravitee-io/issues/issues/10855

## Description

Within the Helm chart code, I added an optional value `api.http.client.proxy.excludeHosts` and handled the input within the API component ConfigMap. I created a new test file with assertions for this feature as this part of the config map has not been covered before.