### PR TITLE
APIM 11239 & 112340 fix color picker display

### DIFF
--- a/gravitee-apim-console-webui/src/portal/theme/portal-theme.component.scss
+++ b/gravitee-apim-console-webui/src/portal/theme/portal-theme.component.scss
@@ -46,6 +46,7 @@
 
         mat-expansion-panel {
           @include mat.elevation(0);
+          overflow: visible;
         }
 
         &__panel {
@@ -70,6 +71,8 @@
           &__editor {
             display: flex;
             flex-direction: column;
+            z-index: 1;
+            position: relative;
           }
         }
       }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11239

https://gravitee.atlassian.net/browse/APIM-11240

## Description

Display colour picker fully and prevent overlapping.

Before:

<img width="1009" height="635" alt="image" src="https://github.com/user-attachments/assets/c4032598-6142-4dee-8167-8ac5353f5532" />

After:

<img width="1009" height="635" alt="image" src="https://github.com/user-attachments/assets/8d1009ff-e629-4931-80e8-49fe2ffa2816" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oyadrvdtve.chromatic.com)
<!-- Storybook placeholder end -->
