### PR TITLE
make portal next homepage public

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalPagesResource.java
@@ -45,6 +45,7 @@ public class PortalPagesResource {
     ) {
         final String envId = GraviteeContext.getCurrentEnvironment();
 
+        // TODO: handle unauthenticated users when portal page visibility is implemented.
         var output = getPortalPageUseCase.execute(new GetPortalPageUseCase.Input(envId, pageType, expands));
         var pages = output.pages();
         List<PortalPageWithViewDetails> filteredPages = Optional.ofNullable(pages)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
@@ -296,6 +296,9 @@ public class BasicSecurityConfigurerAdapter {
             // Categories
             .requestMatchers(HttpMethod.GET, uriPrefix + "/categories/**")
             .permitAll()
+            // GMD pages
+            .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-pages")
+            .permitAll()
             // Portal Menu Links
             .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-menu-links")
             .permitAll()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11281

## Description

Allow not authenticated users to get portal homepage. Here we implement the same solution than for /apis/_search for example. This means that when we will allow people to add GMD pages to APIs or Categories we will have to handle not authenticated users.


https://github.com/user-attachments/assets/7b1a2b5b-2518-44c9-b421-df07c352166b

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kuwwrevuup.chromatic.com)
<!-- Storybook placeholder end -->
