### PR TITLE
fix(test):fix tests for opensearch and events

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/AnatlyticsDatabase.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/AnatlyticsDatabase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AnatlyticsDatabase {
+
+    enum DatabaseType {
+        ELASTICSEARCH,
+        OPENSEARCH,
+    }
+
+    private DatabaseType databaseType;
+    private String databaseVersion;
+
+    public String getDatabaseMajorVersion() {
+        return databaseVersion.split("\\.")[0];
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 
 /**
  * Spring configuration for the test.
@@ -44,7 +45,7 @@ public class TestConfiguration {
 
     public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.17.2";
     public static final String DEFAULT_OPENSEARCH_VERSION = "2";
-    private static final String DEFAULT_SEARCH_TYPE = "elasticsearch";
+    public static final String DEFAULT_SEARCH_TYPE = "elasticsearch";
 
     public static final String CLUSTER_NAME = "gravitee_test";
     private boolean isElasticsearch = true;
@@ -70,7 +71,15 @@ public class TestConfiguration {
 
     @Bean
     public DatabaseHydrator databaseHydrator(Client client, FreeMarkerComponent freeMarkerComponent, TimeProvider timeProvider) {
-        return new DatabaseHydrator(client, freeMarkerComponent, elasticsearchVersion, timeProvider);
+        AnatlyticsDatabase anatlyticsDatabase = new AnatlyticsDatabase();
+        if (isElasticsearch) {
+            anatlyticsDatabase.setDatabaseType(AnatlyticsDatabase.DatabaseType.ELASTICSEARCH);
+            anatlyticsDatabase.setDatabaseVersion(elasticsearchVersion);
+        } else {
+            anatlyticsDatabase.setDatabaseType(AnatlyticsDatabase.DatabaseType.OPENSEARCH);
+            anatlyticsDatabase.setDatabaseVersion(opensearchVersion);
+        }
+        return new DatabaseHydrator(client, freeMarkerComponent, anatlyticsDatabase, timeProvider);
     }
 
     @Bean

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics;
 
 import static io.gravitee.definition.model.DefinitionVersion.V2;
 import static io.gravitee.definition.model.DefinitionVersion.V4;
+import static io.gravitee.repository.elasticsearch.TestConfiguration.DEFAULT_SEARCH_TYPE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.offset;
 import static org.assertj.core.api.Assertions.withPrecision;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.common.query.QueryContext;
@@ -69,11 +71,13 @@ import java.util.function.Predicate;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.SoftAssertions;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -1087,6 +1091,15 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         private static final String NATIVE_API_ID = "273f4728-1e30-4c78-bf47-281e304c78a5";
         private static final QueryContext QUERY_CONTEXT = new QueryContext("DEFAULT", "DEFAULT");
         private static final TimeProvider TIME_PROVIDER = new TimeProvider();
+
+        @Value("${search.type:" + DEFAULT_SEARCH_TYPE + "}")
+        private String searchType;
+
+        @BeforeEach
+        void beforeEach() {
+            // Event Analytics can only be executed on Elasticsearch.
+            assumeTrue(searchType.equals(DEFAULT_SEARCH_TYPE));
+        }
 
         @Test
         void should_search_top_value_hits_for_active_connections() {

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>6.2.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>6.2.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.5.5</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.6.4</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.6.0</gravitee-reporter-cloud.version>


### PR DESCRIPTION
Configure database init for the specific case of opensearch and events.
However, existing tests about events are failing for OpenSearch. So this PR skips them for OpenSearch DB.

We officially assume that we do not yet support OpenSearch for event metrics.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vxpvclgjew.chromatic.com)
<!-- Storybook placeholder end -->
