### PR TITLE
fix(console): Fetching groups for an application takes a really long time

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.html
@@ -21,7 +21,13 @@
       <div class="application-general-access-groups__body">
         <mat-form-field>
           <mat-label>Groups</mat-label>
-          <mat-select formControlName="selectedGroups" multiple>
+          <mat-select
+            formControlName="selectedGroups"
+            (openedChange)="onSelectToggle($event)"
+            role="listbox"
+            aria-multiselectable="true"
+            multiple
+          >
             <mat-option *ngFor="let availableGroup of groups" [value]="availableGroup.id">{{ availableGroup.name }}</mat-option>
           </mat-select>
         </mat-form-field>

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Group } from 'src/entities/group/group';
+import { GroupV2Service } from 'src/services-ngx/group-v2.service';
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, EMPTY, Subject } from 'rxjs';
@@ -21,7 +22,6 @@ import { ActivatedRoute } from '@angular/router';
 import { catchError, takeUntil, tap } from 'rxjs/operators';
 import { FormControl, FormGroup } from '@angular/forms';
 
-import { GroupService } from '../../../../../services-ngx/group.service';
 import { ApplicationService } from '../../../../../services-ngx/application.service';
 import { Application } from '../../../../../entities/application/Application';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
@@ -32,35 +32,76 @@ import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
   styleUrls: ['./application-general-groups.component.scss'],
 })
 export class ApplicationGeneralGroupsComponent implements OnInit, OnDestroy {
-  public groups: Group[];
+  public groups: Group[] = [];
   public application: Application;
   public form: FormGroup;
   public initialFormValue: unknown;
   public isReadonly = false;
 
+  public page = 1;
+  public pageSize = 50;
+  public hasMoreGroups = true;
+  public isLoading = false;
+
   private unsubscribe$: Subject<void> = new Subject<void>();
+  private scrollContainer: HTMLElement | null = null;
+  private scrollListener: (() => void) | null = null;
+  private totalPages = 0;
 
   constructor(
-    private readonly groupService: GroupService,
+    private readonly groupv2Service: GroupV2Service,
     private readonly applicationService: ApplicationService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly snackBarService: SnackBarService,
   ) {}
 
   ngOnInit() {
-    combineLatest([this.applicationService.getById(this.activatedRoute.snapshot.params.applicationId), this.groupService.list()])
+    this.applicationService
+      .getById(this.activatedRoute.snapshot.params.applicationId)
       .pipe(
-        tap(([application, groups]) => {
-          this.groups = groups;
+        tap((application) => {
           this.application = application;
           this.isReadonly = application.origin === 'KUBERNETES';
         }),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => {
-        const userGroupList: Group[] = this.groups.filter((group) => this.application.groups?.includes(group.id));
+        this.loadInitialGroups();
+      });
+  }
+
+  /**
+   * Load first page + selected groups together
+   */
+  private loadInitialGroups(): void {
+    this.isLoading = true;
+    const selectedGroupIds = this.application.groups ?? [];
+
+    combineLatest([
+      this.groupv2Service.list(1, this.pageSize),
+      selectedGroupIds.length > 0 ? this.groupv2Service.listById(selectedGroupIds, 1, selectedGroupIds.length) : EMPTY,
+    ])
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(([page1Res, selectedRes]: any) => {
+        const page1Groups: Group[] = page1Res?.data ?? [];
+        const selectedGroups: Group[] = Array.isArray(selectedRes) ? selectedRes : selectedRes?.data ?? [];
+
+        // Deduplicate and order: selected groups first
+        const selectedMap = new Map(selectedGroups.map((g) => [g.id, g]));
+        const otherGroups = page1Groups.filter((g) => !selectedMap.has(g.id));
+
+        this.groups = [...selectedGroups, ...otherGroups];
+
+        const pagination = page1Res?.pagination;
+        if (pagination) {
+          this.totalPages = pagination.pageCount;
+          this.page = pagination.page + 1;
+          this.hasMoreGroups = this.page <= this.totalPages;
+        }
+
+        const userGroupList: Group[] = this.groups.filter((g) => this.application.groups?.includes(g.id));
         this.form = new FormGroup({
-          selectedGroups: new FormControl(userGroupList.map((group) => group.id)),
+          selectedGroups: new FormControl(userGroupList.map((g) => g.id)),
         });
 
         if (this.isReadonly) {
@@ -68,12 +109,85 @@ export class ApplicationGeneralGroupsComponent implements OnInit, OnDestroy {
         }
 
         this.initialFormValue = this.form.getRawValue();
+
+        this.isLoading = false;
       });
+  }
+
+  private loadGroups(page: number): void {
+    if (this.isLoading || !this.hasMoreGroups) return;
+
+    this.isLoading = true;
+    this.groupv2Service
+      .list(page, this.pageSize)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((res: any) => {
+        const pagination = res?.pagination;
+        const newGroups: Group[] = res?.data ?? [];
+
+        // Deduplicate, keep selected groups at the top
+        const selectedIds = new Set(this.application.groups ?? []);
+        const existingIds = new Set(this.groups.map((g) => g.id));
+
+        const filteredNewGroups = newGroups.filter((g) => !existingIds.has(g.id));
+
+        // Append only non-selected groups (to keep order)
+        this.groups = [
+          ...this.groups.filter((g) => selectedIds.has(g.id)),
+          ...this.groups.filter((g) => !selectedIds.has(g.id)),
+          ...filteredNewGroups,
+        ];
+
+        if (pagination) {
+          this.totalPages = pagination.pageCount;
+          if (pagination.page >= this.totalPages) {
+            this.hasMoreGroups = false;
+          } else {
+            this.page = pagination.page + 1;
+          }
+        }
+
+        this.isLoading = false;
+      });
+  }
+
+  onSelectToggle(opened: boolean): void {
+    if (opened) {
+      const checkInterval = setInterval(() => {
+        this.scrollContainer = document.querySelector('div[role="listbox"][aria-multiselectable="true"]') as HTMLElement;
+        if (this.scrollContainer) {
+          clearInterval(checkInterval);
+          const boundScrollHandler = this.onScroll.bind(this);
+          this.scrollContainer.addEventListener('scroll', boundScrollHandler);
+          this.scrollListener = () => this.scrollContainer?.removeEventListener('scroll', boundScrollHandler);
+        }
+      }, 50);
+    } else {
+      this.cleanupScrollListener();
+    }
+  }
+
+  private onScroll(event: Event): void {
+    const target = event.target as HTMLElement;
+    const threshold = 0.7 * target.scrollHeight;
+
+    if (target.scrollTop + target.clientHeight >= threshold && this.hasMoreGroups && !this.isLoading) {
+      this.loadGroups(this.page);
+    }
+  }
+
+  private cleanupScrollListener(): void {
+    if (this.scrollListener) {
+      this.scrollListener();
+    }
+    this.scrollListener = null;
+    this.scrollContainer = null;
   }
 
   ngOnDestroy() {
     this.unsubscribe$.next();
     this.unsubscribe$.unsubscribe();
+    this.cleanupScrollListener();
   }
 
   save() {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
@@ -90,11 +90,10 @@ export class ApplicationGeneralMembersComponent {
     combineLatest([
       this.applicationService.getById(this.activatedRoute.snapshot.params.applicationId),
       this.applicationMembersService.get(this.activatedRoute.snapshot.params.applicationId),
-      this.groupService.list(1, 9999),
       this.roleService.list('APPLICATION'),
     ])
       .pipe(
-        tap(([application, members, groups, roles]) => {
+        tap(([application, members, roles]) => {
           this.isReadOnly = application.origin === 'KUBERNETES';
           this.members = members;
           this.application = application;
@@ -109,11 +108,8 @@ export class ApplicationGeneralMembersComponent {
               notSaved: false,
             };
           });
-          this.groupData = application.groups?.map((id) => ({
-            id,
-            name: groups?.data.find((g) => g.id === id)?.name,
-            isVisible: true,
-          }));
+
+          this.fetchGroupsForApp(application.groups);
         }),
         takeUntil(this.unsubscribe$),
       )
@@ -137,6 +133,25 @@ export class ApplicationGeneralMembersComponent {
         if (this.isReadOnly) {
           this.form.disable({ emitEvent: false });
         }
+      });
+  }
+
+  fetchGroupsForApp(groups: string[]) {
+    if (!groups?.length) {
+      this.groupData = [];
+      return;
+    }
+
+    this.groupService
+      .listById(groups, 1, groups.length)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((res) => {
+        const groupArray = Array.isArray(res) ? res : res?.data ?? [];
+        this.groupData = groupArray.map((g) => ({
+          id: g.id,
+          name: g.name,
+          isVisible: true,
+        }));
       });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10518

## Description

In the APIM UI, the User & Group Access tab within an application takes up long time to load. This performance degradation appears to be linked to the high number of groups and group memberships configured in the environment.

What the PR is doing (strengths):

1. The PR addresses performance: instead of fetching all groups (e.g. list(1, 9999)), it moves to paginated loading and selective fetching.
2. It introduces listById use for fetching only relevant groups (selected ones) rather than always loading full dataset.
3. It retains backward compatibility by deduplicating, merging, and ordering selected groups first, then others.
4. It correctly reads pagination metadata (pageCount, pagination) to stop infinite scroll at the right point.

Request URL 1: 

management/v2/environments/DEFAULT/groups?page=1&perPage=9999

Request URL 2: 

management/organizations/DEFAULT/environments/DEFAULT/configuration/groups

## Additional context

Problem video:

https://github.com/user-attachments/assets/bd07698e-0427-4d6b-a30e-2f006a30203e





<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ihuravwkma.chromatic.com)
<!-- Storybook placeholder end -->
