### PR TITLE
APIM 10906 fix entrypoint filtering in group by query

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/GroupByQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/GroupByQuery.java
@@ -24,7 +24,8 @@ public record GroupByQuery(
     List<Group> groups,
     Optional<Order> order,
     TimeRange timeRange,
-    Optional<String> query
+    Optional<String> query,
+    List<String> entrypointIds
 ) {
     public record Group(long from, long to) {}
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
@@ -63,15 +63,6 @@ public class GroupByQueryAdapter {
     private ObjectNode createQueryNode(GroupByQuery query) {
         var filterArray = MAPPER.createArrayNode();
 
-        // Terms
-        ObjectNode boolShould = MAPPER.createObjectNode();
-        var shouldArray = MAPPER.createArrayNode();
-        ObjectNode termsNode = MAPPER.createObjectNode();
-        termsNode.set("terms", MAPPER.createObjectNode().set("entrypoint-id", MAPPER.valueToTree(ENTRYPOINT_IDS)));
-        shouldArray.add(termsNode);
-        boolShould.set("should", shouldArray);
-        filterArray.add(MAPPER.createObjectNode().set("bool", boolShould));
-
         ObjectNode termNode = MAPPER.createObjectNode();
         termNode.set("term", MAPPER.createObjectNode().put(query.searchTermId().searchTerm().getField(), query.searchTermId().id()));
         filterArray.add(termNode);
@@ -85,6 +76,17 @@ public class GroupByQueryAdapter {
                 queryStringNode.set("query_string", MAPPER.createObjectNode().put("query", q));
                 filterArray.add(queryStringNode);
             });
+
+        // EntrypointIds
+        if (query.entrypointIds() != null && !query.entrypointIds().isEmpty()) {
+            ObjectNode boolShould = MAPPER.createObjectNode();
+            var shouldArray = MAPPER.createArrayNode();
+            ObjectNode termsNode = MAPPER.createObjectNode();
+            termsNode.set("terms", MAPPER.createObjectNode().set("entrypoint-id", MAPPER.valueToTree(query.entrypointIds())));
+            shouldArray.add(termsNode);
+            boolShould.set("should", shouldArray);
+            filterArray.add(MAPPER.createObjectNode().set("bool", boolShould));
+        }
 
         // Time range using TimeRangeAdapter
         filterArray.add(TimeRangeAdapter.toRangeNode(query.timeRange()));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
@@ -63,6 +63,7 @@ public class GroupByQueryAdapter {
     private ObjectNode createQueryNode(GroupByQuery query) {
         var filterArray = MAPPER.createArrayNode();
 
+        // Terms
         ObjectNode termNode = MAPPER.createObjectNode();
         termNode.set("term", MAPPER.createObjectNode().put(query.searchTermId().searchTerm().getField(), query.searchTermId().id()));
         filterArray.add(termNode);
@@ -76,17 +77,6 @@ public class GroupByQueryAdapter {
                 queryStringNode.set("query_string", MAPPER.createObjectNode().put("query", q));
                 filterArray.add(queryStringNode);
             });
-
-        // EntrypointIds
-        if (query.entrypointIds() != null && !query.entrypointIds().isEmpty()) {
-            ObjectNode boolShould = MAPPER.createObjectNode();
-            var shouldArray = MAPPER.createArrayNode();
-            ObjectNode termsNode = MAPPER.createObjectNode();
-            termsNode.set("terms", MAPPER.createObjectNode().set("entrypoint-id", MAPPER.valueToTree(query.entrypointIds())));
-            shouldArray.add(termsNode);
-            boolShould.set("should", shouldArray);
-            filterArray.add(MAPPER.createObjectNode().set("bool", boolShould));
-        }
 
         // Time range using TimeRangeAdapter
         filterArray.add(TimeRangeAdapter.toRangeNode(query.timeRange()));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -795,7 +795,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 Collections.emptyList(),
                 Optional.empty(),
                 new TimeRange(from, to),
-                Optional.empty()
+                Optional.empty(),
+                null
             );
             var result = cut.searchGroupBy(new QueryContext("org#1", "env#1"), query);
 
@@ -820,7 +821,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 List.of(new GroupByQuery.Group(0, 100), new GroupByQuery.Group(100, 200)),
                 Optional.empty(),
                 new TimeRange(from, to),
-                Optional.empty()
+                Optional.empty(),
+                null
             );
             var result = cut.searchGroupBy(new QueryContext("org#1", "env#1"), query);
 
@@ -846,7 +848,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 Collections.emptyList(),
                 Optional.empty(),
                 new TimeRange(from, to),
-                Optional.of(queryString)
+                Optional.of(queryString),
+                List.of("http-get")
             );
             var result = cut.searchGroupBy(new QueryContext("org#1", "env#1"), query);
 
@@ -872,7 +875,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 Collections.emptyList(),
                 Optional.of(order),
                 new TimeRange(from, to),
-                Optional.empty()
+                Optional.empty(),
+                null
             );
             var result = cut.searchGroupBy(new QueryContext("org#1", "env#1"), query);
 
@@ -881,8 +885,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsKeys("http-get", "http-post");
-                    assertThat(aggregate.order()).containsExactly("http-get", "http-post");
+                    assertThat(aggregate.values()).containsKeys("http-get", "http-post", "sse", "webhook", "websocket");
+                    assertThat(aggregate.order()).containsExactlyInAnyOrder("http-get", "http-post", "sse", "webhook", "websocket");
                 });
         }
 
@@ -899,7 +903,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 Collections.emptyList(),
                 Optional.of(order),
                 new TimeRange(from, to),
-                Optional.empty()
+                Optional.empty(),
+                null
             );
             var result = cut.searchGroupBy(new QueryContext("org#1", "env#1"), query);
 
@@ -908,8 +913,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsKeys("http-get", "http-post");
-                    assertThat(aggregate.order()).containsExactly("http-get", "http-post");
+                    assertThat(aggregate.values()).containsKeys("http-get", "http-post", "sse", "webhook", "websocket");
+                    assertThat(aggregate.order()).containsExactlyInAnyOrder("http-get", "http-post", "sse", "webhook", "websocket");
                 });
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -858,7 +858,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsExactlyEntriesOf(Map.of("http-get", 1L));
+                    assertThat(aggregate.values()).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("http-get", 1L, "sse", 1L, "websocket", 2L, "webhook", 1L)
+                    );
                 });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
@@ -341,7 +341,8 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
             repoGroups,
             repoOrder,
             new TimeRange(groupByQuery.from(), groupByQuery.to()),
-            groupByQuery.query()
+            groupByQuery.query(),
+            null
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10906

## Description

Remove hardcoded entrypoint filtering in GroupByQuery and add optional entrypointIds parameter to GroupByQuery.

Now we can see 401 in pie chart:

<img width="1009" height="691" alt="image" src="https://github.com/user-attachments/assets/a3a496cd-a834-49dd-a68c-b30d6fd14436" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-twabkbcywb.chromatic.com)
<!-- Storybook placeholder end -->
