### PR TITLE
APIM 10906 fix remove entrypoint filter

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapter.java
@@ -64,14 +64,6 @@ public class GroupByQueryAdapter {
         var filterArray = MAPPER.createArrayNode();
 
         // Terms
-        ObjectNode boolShould = MAPPER.createObjectNode();
-        var shouldArray = MAPPER.createArrayNode();
-        ObjectNode termsNode = MAPPER.createObjectNode();
-        termsNode.set("terms", MAPPER.createObjectNode().set("entrypoint-id", MAPPER.valueToTree(ENTRYPOINT_IDS)));
-        shouldArray.add(termsNode);
-        boolShould.set("should", shouldArray);
-        filterArray.add(MAPPER.createObjectNode().set("bool", boolShould));
-
         ObjectNode termNode = MAPPER.createObjectNode();
         termNode.set("term", MAPPER.createObjectNode().put(query.searchTermId().searchTerm().getField(), query.searchTermId().id()));
         filterArray.add(termNode);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -855,7 +855,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsExactlyEntriesOf(Map.of("http-get", 1L));
+                    assertThat(aggregate.values()).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("http-get", 1L, "sse", 1L, "webhook", 1L, "websocket", 2L)
+                    );
                 });
         }
 
@@ -881,8 +883,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsKeys("http-get", "http-post");
-                    assertThat(aggregate.order()).containsExactly("http-get", "http-post");
+                    assertThat(aggregate.values()).containsKeys("http-get", "http-post", "sse", "webhook", "websocket");
+                    assertThat(aggregate.order()).containsExactlyInAnyOrder("http-get", "http-post", "sse", "webhook", "websocket");
                 });
         }
 
@@ -908,8 +910,8 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                 .hasValueSatisfying(aggregate -> {
                     assertThat(aggregate.name()).isEqualTo("by_entrypoint-id");
                     assertThat(aggregate.field()).isEqualTo("entrypoint-id");
-                    assertThat(aggregate.values()).containsKeys("http-get", "http-post");
-                    assertThat(aggregate.order()).containsExactly("http-get", "http-post");
+                    assertThat(aggregate.values()).containsKeys("http-get", "http-post", "sse", "webhook", "websocket");
+                    assertThat(aggregate.order()).containsExactlyInAnyOrder("http-get", "http-post", "sse", "webhook", "websocket");
                 });
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/GroupByQueryAdapterTest.java
@@ -62,9 +62,9 @@ class GroupByQueryAdapterTest {
             JsonNode node = mapper.readTree(json);
 
             assertEquals(0, node.get("size").asInt());
-            assertEquals(API_ID, node.at("/query/bool/filter/1/term/api-id").asText());
-            assertEquals(FROM, node.at("/query/bool/filter/2/range/@timestamp/from").asLong());
-            assertEquals(TO, node.at("/query/bool/filter/2/range/@timestamp/to").asLong());
+            assertEquals(API_ID, node.at("/query/bool/filter/0/term/api-id").asText());
+            assertEquals(FROM, node.at("/query/bool/filter/1/range/@timestamp/from").asLong());
+            assertEquals(TO, node.at("/query/bool/filter/1/range/@timestamp/to").asLong());
             assertEquals(FIELD, node.at("/aggregations/by_status/terms/field").asText());
         }
 
@@ -85,9 +85,9 @@ class GroupByQueryAdapterTest {
             JsonNode node = mapper.readTree(json);
 
             assertEquals(0, node.get("size").asInt());
-            assertEquals(API_ID, node.at("/query/bool/filter/1/term/api-id").asText());
-            assertEquals(FROM, node.at("/query/bool/filter/2/range/@timestamp/from").asLong());
-            assertEquals(TO, node.at("/query/bool/filter/2/range/@timestamp/to").asLong());
+            assertEquals(API_ID, node.at("/query/bool/filter/0/term/api-id").asText());
+            assertEquals(FROM, node.at("/query/bool/filter/1/range/@timestamp/from").asLong());
+            assertEquals(TO, node.at("/query/bool/filter/1/range/@timestamp/to").asLong());
             assertEquals(2, node.at("/aggregations/by_status_range/range/ranges").size());
             assertEquals(0, node.at("/aggregations/by_status_range/range/ranges/0/from").asInt());
             assertEquals(100, node.at("/aggregations/by_status_range/range/ranges/0/to").asInt());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10906

## Description

Remove hardcoded entrypoint filtering in GroupByQuery and add optional entrypointIds parameter to GroupByQuery.

Now we can see 401 in pie chart:

<img width="1009" height="691" alt="image" src="https://github.com/user-attachments/assets/a3a496cd-a834-49dd-a68c-b30d6fd14436" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

