### PR TITLE
fix(console): Fetching groups for an application takes long time

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.html
@@ -21,8 +21,17 @@
       <div class="application-general-access-groups__body">
         <mat-form-field>
           <mat-label>Groups</mat-label>
-          <mat-select formControlName="selectedGroups" multiple>
-            <mat-option *ngFor="let availableGroup of groups" [value]="availableGroup.id">{{ availableGroup.name }}</mat-option>
+          <mat-select
+            #groupsMatSelect
+            formControlName="selectedGroups"
+            (openedChange)="onSelectToggle($event)"
+            role="listbox"
+            aria-multiselectable="true"
+            multiple
+          >
+            <mat-option *ngFor="let availableGroup of groups" [value]="availableGroup.id">
+              {{ availableGroup.name }}
+            </mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
@@ -22,6 +22,7 @@ import { ActivatedRoute } from '@angular/router';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { of } from 'rxjs';
 
 import { ApplicationGeneralGroupsComponent } from './application-general-groups.component';
 
@@ -43,7 +44,7 @@ describe('ApplicationGeneralGroupsComponent', () => {
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
-          isFocusable: () => true, // This checks focus trap, set it to true to  avoid the warning
+          isFocusable: () => true,
           isTabbable: () => true,
         },
       })
@@ -85,8 +86,205 @@ describe('ApplicationGeneralGroupsComponent', () => {
     });
   });
 
+  describe('Infinite scroll and selection behavior', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      const comp = fixture.componentInstance as any;
+      comp.cleanupScrollListener?.();
+    });
+
+    it('should order selected groups first and deduplicate initial page', () => {
+      const app = fakeApplication({ id: APPLICATION_ID, groups: ['g1', 'g2'] } as any);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
+
+      const page1Groups: Group[] = [
+        fakeGroup({ id: 'g1', name: 'G1' } as any),
+        fakeGroup({ id: 'g3', name: 'G3' } as any),
+        fakeGroup({ id: 'g2', name: 'G2' } as any),
+      ];
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' }).flush({
+        data: page1Groups,
+        pagination: { page: 1, perPage: 50, pageCount: 1, pageItemsCount: 3, totalCount: 3 },
+      });
+
+      const postReq = httpTestingController.expectOne(
+        (req) => req.method === 'POST' && req.urlWithParams.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search`),
+      );
+      expect(postReq.request.body.ids).toEqual(['g1', 'g2']);
+      postReq.flush({
+        data: [fakeGroup({ id: 'g1', name: 'G1' } as any), fakeGroup({ id: 'g2', name: 'G2' } as any)],
+        pagination: { page: 1, perPage: 2, pageCount: 1, pageItemsCount: 2, totalCount: 2 },
+      });
+
+      fixture.detectChanges();
+
+      const idsInOrder = fixture.componentInstance.groups.map((g) => g.id);
+      expect(idsInOrder.slice(0, 2)).toEqual(['g1', 'g2']);
+      expect(new Set(idsInOrder).size).toBe(idsInOrder.length);
+    });
+
+    it('should attach scroll listener on open and call load when threshold reached', () => {
+      const app = fakeApplication({ id: APPLICATION_ID, groups: ['g1'] } as any);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
+
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' }).flush({
+        data: [fakeGroup({ id: 'g1' } as any)],
+        pagination: { page: 1, perPage: 50, pageCount: 2, pageItemsCount: 1, totalCount: 2 },
+      });
+
+      const postReq = httpTestingController.expectOne(
+        (req) => req.method === 'POST' && req.urlWithParams.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search`),
+      );
+      postReq.flush({
+        data: [fakeGroup({ id: 'g1' } as any)],
+        pagination: { page: 1, perPage: 1, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+      });
+
+      fixture.detectChanges();
+
+      const comp = fixture.componentInstance as any;
+      const scrollDiv = document.createElement('div');
+      Object.defineProperty(scrollDiv, 'scrollHeight', { value: 1000 });
+      Object.defineProperty(scrollDiv, 'clientHeight', { value: 300 });
+      Object.defineProperty(scrollDiv, 'scrollTop', { value: 800, writable: true });
+      comp.groupMatSelect = { panel: { nativeElement: scrollDiv } } as any;
+
+      const loadSpy = jest.spyOn(comp, 'loadGroups').mockReturnValue(of([]));
+
+      comp.onSelectToggle(true);
+      scrollDiv.dispatchEvent(new Event('scroll'));
+
+      expect(loadSpy).toHaveBeenCalledWith(comp.page);
+    });
+
+    it('should load next page on loadGroups and update flags and list without duplicates', () => {
+      const app = fakeApplication({ id: APPLICATION_ID, groups: ['g1'] } as any);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
+
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' }).flush({
+        data: [fakeGroup({ id: 'g1' } as any), fakeGroup({ id: 'g2' } as any)],
+        pagination: { page: 1, perPage: 50, pageCount: 2, pageItemsCount: 2, totalCount: 3 },
+      });
+
+      const postReq = httpTestingController.expectOne(
+        (req) => req.method === 'POST' && req.urlWithParams.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search`),
+      );
+      postReq.flush({
+        data: [fakeGroup({ id: 'g1' } as any)],
+        pagination: { page: 1, perPage: 1, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+      });
+
+      fixture.detectChanges();
+      const comp = fixture.componentInstance as any;
+      expect(comp.page).toBe(2);
+      expect(comp.hasMoreGroups).toBe(true);
+
+      comp.loadGroups(2).subscribe();
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=2&perPage=50`, method: 'GET' }).flush({
+        data: [fakeGroup({ id: 'g2' } as any), fakeGroup({ id: 'g3' } as any)],
+        pagination: { page: 2, perPage: 50, pageCount: 2, pageItemsCount: 2, totalCount: 3 },
+      });
+
+      fixture.detectChanges();
+
+      const ids = comp.groups.map((g) => g.id);
+      expect(ids[0]).toBe('g1');
+      expect(ids).toContain('g3');
+      expect(ids.filter((id) => id === 'g2').length).toBe(1);
+      expect(comp.hasMoreGroups).toBe(false);
+    });
+
+    it('should not call loadGroups on scroll when not reaching threshold or when loading/nomore', () => {
+      const app = fakeApplication({ id: APPLICATION_ID, groups: [] } as any);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' })
+        .flush({ data: [], pagination: { page: 1, perPage: 50, pageCount: 1, pageItemsCount: 0, totalCount: 0 } });
+
+      fixture.detectChanges();
+
+      const comp = fixture.componentInstance as any;
+      const spy = jest.spyOn(comp, 'loadGroups');
+
+      comp.hasMoreGroups = true;
+      comp.isLoading = false;
+      comp.page = 2;
+      const evt1: any = { target: { scrollHeight: 1000, clientHeight: 300, scrollTop: 300 } };
+      comp.onScroll(evt1);
+      expect(spy).not.toHaveBeenCalled();
+
+      comp.isLoading = true;
+      const evt2: any = { target: { scrollHeight: 1000, clientHeight: 300, scrollTop: 800 } };
+      comp.onScroll(evt2);
+      expect(spy).not.toHaveBeenCalled();
+
+      comp.isLoading = false;
+      comp.hasMoreGroups = false;
+      const evt3: any = { target: { scrollHeight: 1000, clientHeight: 300, scrollTop: 800 } };
+      comp.onScroll(evt3);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should cleanup scroll listener by calling the stored remover and resetting fields', () => {
+      const app = fakeApplication({ id: APPLICATION_ID, groups: [] } as any);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' })
+        .flush({ data: [], pagination: { page: 1, perPage: 50, pageCount: 1, pageItemsCount: 0, totalCount: 0 } });
+
+      fixture.detectChanges();
+
+      const comp = fixture.componentInstance as any;
+      const remover = jest.fn();
+      comp.scrollListener = remover;
+      comp.scrollContainer = document.createElement('div');
+
+      comp.cleanupScrollListener();
+
+      expect(remover).toHaveBeenCalled();
+      expect(comp.scrollListener).toBeNull();
+      expect(comp.scrollContainer).toBeNull();
+    });
+  });
+
   function expectGetGroupsListRequest(groups: Group[]) {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups`, method: 'GET' }).flush(groups);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=50`, method: 'GET' }).flush({
+      data: groups,
+      pagination: {
+        page: 1,
+        perPage: 50,
+        pageCount: 1,
+        pageItemsCount: groups.length,
+        totalCount: groups.length,
+      },
+    });
+
+    const postReq = httpTestingController.expectOne((req) => {
+      return (
+        req.method === 'POST' &&
+        req.urlWithParams.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search`) &&
+        req.params.get('page') === '1'
+      );
+    });
+
+    const ids: string[] = (postReq.request.body && postReq.request.body.ids) || [];
+    const selectedGroups = ids.map((id) => ({ id, name: `${id}-name` })) as Group[];
+
+    postReq.flush({
+      data: selectedGroups,
+      pagination: {
+        page: 1,
+        perPage: ids.length || 10,
+        pageCount: 1,
+        pageItemsCount: ids.length,
+        totalCount: ids.length,
+      },
+    });
+
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
@@ -33,7 +33,8 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testi
 import { Role } from '../../../../../entities/role/role';
 import { fakeRole } from '../../../../../entities/role/role.fixture';
 import { RoleService } from '../../../../../services-ngx/role.service';
-import { fakeGroup, fakeGroupsResponse, Member } from '../../../../../entities/management-api-v2';
+import { fakeGroup, fakeGroupsResponse } from '../../../../../entities/management-api-v2';
+import { Member } from '../../../../../entities/members/members';
 import { fakeMembers } from '../../../../../entities/members/Members.fixture';
 import { fakeApplication } from '../../../../../entities/application/Application.fixture';
 import { Application } from '../../../../../entities/application/Application';
@@ -201,7 +202,9 @@ describe('ApplicationGeneralMembersComponent', () => {
   function expectRequests(application: Application, membersList: Member[]) {
     expectGetApplication(application);
     expectGetMembers(membersList);
-    expectGetGroupsListRequest(application.groups);
+    if (application.groups && application.groups.length > 0) {
+      expectGetGroupsListRequest(application.groups);
+    }
   }
 
   function expectGetMembers(members: Member[]) {
@@ -221,8 +224,93 @@ describe('ApplicationGeneralMembersComponent', () => {
 
   function expectGetGroupsListRequest(groups: string[]) {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=9999`, method: 'GET' })
-      .flush(fakeGroupsResponse({ data: groups.map((id) => fakeGroup({ id, name: id + '-name' })) }));
+      .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=${groups.length || 10}`, method: 'POST' })
+      .flush(
+        fakeGroupsResponse({
+          data: groups.map((id) => fakeGroup({ id, name: id + '-name' })),
+          pagination: {
+            page: 1,
+            perPage: groups.length || 10,
+            pageCount: 1,
+            pageItemsCount: groups.length,
+            totalCount: groups.length,
+          },
+        }),
+      );
     fixture.detectChanges();
   }
+
+  describe('fetchGroupsForApp', () => {
+    it('should not call groups search and set empty groupData when no groups', () => {
+      const applicationDetails = fakeApplication({ type: 'NATIVE', groups: [] });
+      const membersList = [fakeMembers()];
+
+      expectGetApplication(applicationDetails);
+      expectGetMembers(membersList);
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.groupData).toEqual([]);
+    });
+
+    it('should map groupData from paged result when groups exist', () => {
+      const groups = ['group-1', 'group-2'];
+      const applicationDetails = fakeApplication({ type: 'NATIVE', groups });
+      const membersList = [fakeMembers()];
+
+      expectGetApplication(applicationDetails);
+      expectGetMembers(membersList);
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=${groups.length}`,
+          method: 'POST',
+        })
+        .flush(
+          fakeGroupsResponse({
+            data: groups.map((id) => fakeGroup({ id, name: id + '-name' })),
+            pagination: {
+              page: 1,
+              perPage: groups.length,
+              pageCount: 1,
+              pageItemsCount: groups.length,
+              totalCount: groups.length,
+            },
+          }),
+        );
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.groupData).toEqual(groups.map((id) => ({ id, name: `${id}-name`, isVisible: true })));
+    });
+
+    it('should map groupData when backend returns a paginated object (real backend shape)', () => {
+      const groups = ['group-a'];
+      const applicationDetails = fakeApplication({ type: 'NATIVE', groups });
+      const membersList = [fakeMembers()];
+
+      expectGetApplication(applicationDetails);
+      expectGetMembers(membersList);
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups/_search?page=1&perPage=${groups.length}`,
+          method: 'POST',
+        })
+        .flush({
+          data: groups.map((id) => fakeGroup({ id, name: id + '-name' })),
+          pagination: {
+            page: 1,
+            perPage: groups.length,
+            pageCount: 1,
+            pageItemsCount: groups.length,
+            totalCount: groups.length,
+          },
+        });
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.groupData).toEqual(groups.map((id) => ({ id, name: `${id}-name`, isVisible: true })));
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
@@ -90,11 +90,10 @@ export class ApplicationGeneralMembersComponent {
     combineLatest([
       this.applicationService.getById(this.activatedRoute.snapshot.params.applicationId),
       this.applicationMembersService.get(this.activatedRoute.snapshot.params.applicationId),
-      this.groupService.list(1, 9999),
       this.roleService.list('APPLICATION'),
     ])
       .pipe(
-        tap(([application, members, groups, roles]) => {
+        tap(([application, members, roles]) => {
           this.isReadOnly = application.origin === 'KUBERNETES';
           this.members = members;
           this.application = application;
@@ -109,11 +108,8 @@ export class ApplicationGeneralMembersComponent {
               notSaved: false,
             };
           });
-          this.groupData = application.groups?.map((id) => ({
-            id,
-            name: groups?.data.find((g) => g.id === id)?.name,
-            isVisible: true,
-          }));
+
+          this.fetchGroupsForApp(application.groups)?.pipe(takeUntil(this.unsubscribe$)).subscribe();
         }),
         takeUntil(this.unsubscribe$),
       )
@@ -138,6 +134,24 @@ export class ApplicationGeneralMembersComponent {
           this.form.disable({ emitEvent: false });
         }
       });
+  }
+
+  fetchGroupsForApp(groups: string[]) {
+    if (!groups?.length) {
+      this.groupData = [];
+      return EMPTY;
+    }
+
+    return this.groupService.listById(groups, 1, groups.length).pipe(
+      tap((res) => {
+        const groupArray = res ? res.data : [];
+        this.groupData = groupArray.map((g) => ({
+          id: g.id,
+          name: g.name,
+          isVisible: true,
+        }));
+      }),
+    );
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10518

## Description

In the APIM UI, the User & Group Access tab within an application takes up long time to load. This performance degradation appears to be linked to the high number of groups and group memberships configured in the environment.

What the PR is doing (strengths):

1. The PR addresses performance: instead of fetching all groups (e.g. list(1, 9999)), it moves to paginated loading and selective fetching.
2. It introduces listById use for fetching only relevant groups (selected ones) rather than always loading full dataset.
3. It retains backward compatibility by deduplicating, merging, and ordering selected groups first, then others.
4. It correctly reads pagination metadata (pageCount, pagination) to stop infinite scroll at the right point.

Request URL 1: 

management/v2/environments/DEFAULT/groups?page=1&perPage=9999

Request URL 2: 

management/organizations/DEFAULT/environments/DEFAULT/configuration/groups

## Additional context

Problem video:

https://github.com/user-attachments/assets/bd07698e-0427-4d6b-a30e-2f006a30203e

After fix video:

https://github.com/user-attachments/assets/55ca0da1-39f6-42c9-a8aa-59b455e5619e

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fqvkavzeaz.chromatic.com)
<!-- Storybook placeholder end -->
