### PR TITLE
fix: increase default api startupProbe to 1 hour to handle large index creation

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -564,7 +564,7 @@ api:
       enabled: true
       tcpSocket:
         port: http
-      failureThreshold: 30
+      failureThreshold: 360
       periodSeconds: 10
 
     customStartupProbe: {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11003

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

