### PR TITLE
feat: add Published/Unpublished badges to homepage header

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.html
@@ -18,7 +18,12 @@
 <div class="portal-header">
   <div class="portal-header__content">
     <div>
-      <div class="mat-h2">{{ title() }}</div>
+      <div class="portal-header__title-row">
+        <div class="mat-h2">
+          {{ title() }}
+          <ng-content select="[badge]" />
+        </div>
+      </div>
       @if (subtitle()) {
         <div class="portal-header__subtitle mat-body-2">{{ subtitle() }}</div>
       }

--- a/gravitee-apim-console-webui/src/portal/homepage/homepage.component.html
+++ b/gravitee-apim-console-webui/src/portal/homepage/homepage.component.html
@@ -16,6 +16,12 @@
 
 -->
 <portal-header subtitle="Edit your Developer Portal Homepage with Gravitee Markdown" [title]="'Homepage'" [showActions]="true">
+  @if (portalHomepage()) {
+    <span badge [class]="portalHomepage()?.published ? 'gio-badge-success' : 'gio-badge-warning'" data-testid="status-badge">
+      {{ portalHomepage()?.published ? 'Published' : 'Unpublished' }}
+    </span>
+  }
+
   <div
     additionalActions
     matTooltip="You don’t have the permissions to update this page. Please contact your administrator."

--- a/gravitee-apim-console-webui/src/portal/homepage/homepage.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/homepage/homepage.component.spec.ts
@@ -163,6 +163,12 @@ describe('HomepageComponent', () => {
 
       expect(snackBarService.success).toHaveBeenCalledWith('Page has been published successfully.');
       expect(await toggleButton.getText()).toBe('Unpublish');
+
+      const badgeElement = fixture.nativeElement.querySelector('[data-testid="status-badge"]');
+
+      expect(badgeElement).toBeTruthy();
+      expect(badgeElement?.textContent?.trim()).toBe('Published');
+      expect(badgeElement?.classList.contains('gio-badge-success')).toBe(true);
     });
 
     it('should unpublish a published page after confirmation', async () => {
@@ -186,6 +192,12 @@ describe('HomepageComponent', () => {
 
       expect(snackBarService.success).toHaveBeenCalledWith('Page has been unpublished successfully.');
       expect(await toggleButton.getText()).toBe('Publish');
+
+      const badgeElement = fixture.nativeElement.querySelector('[data-testid="status-badge"]');
+
+      expect(badgeElement).toBeTruthy();
+      expect(badgeElement?.textContent?.trim()).toBe('Unpublished');
+      expect(badgeElement?.classList.contains('gio-badge-warning')).toBe(true);
     });
 
     it('should not perform any action if the confirmation dialog is cancelled', async () => {

--- a/gravitee-apim-console-webui/src/portal/homepage/homepage.component.ts
+++ b/gravitee-apim-console-webui/src/portal/homepage/homepage.component.ts
@@ -65,7 +65,7 @@ export class HomepageComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly matDialog = inject(MatDialog);
 
-  private readonly portalHomepage: WritableSignal<PortalPageWithDetails | null> = signal(null);
+  readonly portalHomepage: WritableSignal<PortalPageWithDetails | null> = signal(null);
   private readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-documentation-u']));
   private readonly contentValue = toSignal(this.contentControl.valueChanges.pipe(startWith(this.contentControl.value)));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11330

## Description

Add publish/unpublish badge to homepage header in portal settings.

<img width="640" height="271" alt="image" src="https://github.com/user-attachments/assets/874bb3ce-86b6-431d-b755-05c77a266fbd" />

<img width="640" height="271" alt="image" src="https://github.com/user-attachments/assets/a91e6475-07f6-45ff-9054-0579c127244d" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sbbexzqwda.chromatic.com)
<!-- Storybook placeholder end -->
