### PR TITLE
feat: add snackbar notifications for feedback submission in Newt AI service

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/newtai.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/newtai.service.ts
@@ -15,9 +15,11 @@
  */
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { ElAiPromptState, FeedbackSubmission, GioElService } from '@gravitee/ui-particles-angular';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, tap } from 'rxjs/operators';
+
+import { SnackBarService } from './snack-bar.service';
 
 import { Constants } from '../entities/Constants';
 
@@ -39,6 +41,7 @@ export class NewtAIService {
   private httpClient = inject(HttpClient);
   private constants = inject(Constants);
   private gioElService = inject(GioElService);
+  private snackBarService = inject(SnackBarService);
   private context: Partial<Record<NewtAIContextKeys, string>> = {};
 
   constructor() {
@@ -60,14 +63,22 @@ export class NewtAIService {
       );
   }
   public submitFeedback(fs: FeedbackSubmission): Observable<void> {
-    return this.httpClient.post<void>(`${this.constants.env.v2BaseURL}/newtai/el/feedback`, {
-      answerHelpful: fs.feedback === 'helpful',
-      feedbackRequestId: {
-        chatId: fs.feedbackRequestId?.chatId,
-        userMessageId: fs.feedbackRequestId?.userMessageId,
-        agentMessageId: fs.feedbackRequestId?.agentMessageId,
-      },
-    });
+    return this.httpClient
+      .post<void>(`${this.constants.env.v2BaseURL}/newtai/el/feedback`, {
+        answerHelpful: fs.feedback === 'helpful',
+        feedbackRequestId: {
+          chatId: fs.feedbackRequestId?.chatId,
+          userMessageId: fs.feedbackRequestId?.userMessageId,
+          agentMessageId: fs.feedbackRequestId?.agentMessageId,
+        },
+      })
+      .pipe(
+        tap(() => this.snackBarService.success('Thanks for your feedback!')),
+        catchError((error) => {
+          this.snackBarService.error(error.error?.message ?? 'Error while submitting feedback.');
+          return EMPTY;
+        }),
+      );
   }
 
   public addToContext(key: NewtAIContextKeys, value: string): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11336

## Description

Integrated success and error snackbars for feedback submission in the Newt AI service. Updated tests to validate snackbar interactions.

## Additional context

<img width="2704" height="1624" alt="image" src="https://github.com/user-attachments/assets/8443ffee-e694-4e70-8a20-f321c583e350" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flqtrjwiqu.chromatic.com)
<!-- Storybook placeholder end -->
