### PR TITLE
fix: min height for native analytics widgets

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
@@ -153,6 +153,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
           label: 'To Broker',
         },
       ],
+      minHeight: 'large',
     },
     {
       type: 'line',
@@ -172,6 +173,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
           label: 'To Broker',
         },
       ],
+      minHeight: 'large',
     },
   ];
 
@@ -194,6 +196,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
           label: 'To Clients',
         },
       ],
+      minHeight: 'large',
     },
     {
       type: 'line',
@@ -213,6 +216,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
           label: 'To Clients',
         },
       ],
+      minHeight: 'large',
     },
   ];
 
@@ -245,6 +249,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
           label: 'Upstream Failure',
         },
       ],
+      minHeight: 'large',
     },
   ];
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7779

## Description

Add min height to native analytics widgets.

<img width="725" height="447" alt="image" src="https://github.com/user-attachments/assets/3c759de6-229b-4508-899a-7a89d25d62b5" />

<img width="725" height="447" alt="image" src="https://github.com/user-attachments/assets/9564de27-9bb6-4a0d-84d6-1091c9f79b35" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xbynlorbsv.chromatic.com)
<!-- Storybook placeholder end -->
