### PR TITLE
chore: bump gravitee-expression-language version to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gravitee-common.version>4.7.3</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.9.0</gravitee-exchange.version>
-        <gravitee-expression-language.version>4.1.3</gravitee-expression-language.version>
+        <gravitee-expression-language.version>4.2.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>4.0.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PEN-30

## Description

gravitee-expression-language bump up to include #xmlEscape() function feature 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hegdnevwvn.chromatic.com)
<!-- Storybook placeholder end -->
