### PR TITLE
fix: [Console] White empty when menu is collapsed

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-bar/gio-chart-bar.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-bar/gio-chart-bar.component.scss
@@ -25,4 +25,10 @@
     display: flex;
     justify-content: center;
   }
+
+  .highcharts-container,
+  .highcharts-container svg {
+    width: 100% !important;
+    height: 100% !important;
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-bar/gio-chart-bar.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-bar/gio-chart-bar.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { HighchartsChartModule } from 'highcharts-angular';
 import * as Highcharts from 'highcharts';
 
@@ -45,6 +45,7 @@ export const defineBarColors = (code: string | number) => {
   templateUrl: './gio-chart-bar.component.html',
   styleUrls: ['./gio-chart-bar.component.scss'],
   standalone: true,
+  encapsulation: ViewEncapsulation.None,
   imports: [HighchartsChartModule],
 })
 export class GioChartBarComponent implements OnInit {

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.scss
@@ -25,4 +25,10 @@
     display: flex;
     justify-content: center;
   }
+
+  .highcharts-container,
+  .highcharts-container svg {
+    width: 100% !important;
+    height: 100% !important;
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-line/gio-chart-line.component.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import * as Highcharts from 'highcharts';
 
 export interface GioChartLineData {
   name: string;
   values: number[];
 }
+
 export interface GioChartLineOptions {
   pointStart: number;
   pointInterval: number;
@@ -38,6 +39,7 @@ export const defineLineColors = (code: string) => {
   selector: 'gio-chart-line',
   templateUrl: './gio-chart-line.component.html',
   styleUrls: ['./gio-chart-line.component.scss'],
+  encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
 export class GioChartLineComponent implements OnInit {

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.scss
@@ -2,8 +2,15 @@
   &__chart {
     display: block;
   }
+
   &__no-data {
     display: flex;
     justify-content: center;
+  }
+
+  .highcharts-container,
+  .highcharts-container svg {
+    width: 100% !important;
+    height: 100% !important;
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-pie/gio-chart-pie.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import * as Highcharts from 'highcharts';
 
 const defaultLabelFormatter = function () {
@@ -60,6 +60,7 @@ export interface GioChartPieInput {
   selector: 'gio-chart-pie',
   templateUrl: './gio-chart-pie.component.html',
   styleUrls: ['./gio-chart-pie.component.scss'],
+  encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
 export class GioChartPieComponent implements OnInit {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10875

the below also worked.

`
```
::ng-deep {
      .highcharts-container {
        width: 100% !important;
        height: 100% !important;
      }
      
      svg {
        width: 100% !important;
        height: 100% !important;
      }
    }
```
`

> By setting `encapsulation: ViewEncapsulation.None`, the styles in the component's SCSS file are not scoped and can target the Highcharts elements directly without needing `::ng-deep`. This is a cleaner approach than global styles and keeps everything co-located with the component.

## Description

Before

https://github.com/user-attachments/assets/7aea083d-9ab4-4575-803b-387ebd2d0711



After


https://github.com/user-attachments/assets/b1cce06b-274f-499d-923c-c87437e5b2f5



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wsxpeghoie.chromatic.com)
<!-- Storybook placeholder end -->
