### PR TITLE
feat: use isTcpProxy() from core API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
@@ -51,17 +51,15 @@ public interface CategoryApiMapper {
 
         switch (api.getDefinitionVersion()) {
             case V4 -> {
-                if (Objects.nonNull(api.getApiDefinitionHttpV4()) && Objects.nonNull(api.getApiDefinitionHttpV4().getListeners())) {
-                    Stream<String> tcpListenerHostsStream = api
-                        .getApiDefinitionHttpV4()
+                if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api v4 && Objects.nonNull(v4.getListeners())) {
+                    Stream<String> tcpListenerHostsStream = v4
                         .getListeners()
                         .stream()
                         .filter(listener -> ListenerType.TCP.equals(listener.getType()))
                         .map(TcpListener.class::cast)
                         .flatMap(listener -> listener.getHosts().stream());
 
-                    Stream<String> httpListenerHostsStream = api
-                        .getApiDefinitionHttpV4()
+                    Stream<String> httpListenerHostsStream = v4
                         .getListeners()
                         .stream()
                         .filter(listener -> ListenerType.HTTP.equals(listener.getType()))
@@ -75,11 +73,11 @@ public interface CategoryApiMapper {
             }
             case V2 -> {
                 if (
-                    Objects.nonNull(api.getApiDefinition()) &&
-                    Objects.nonNull(api.getApiDefinition().getProxy()) &&
-                    Objects.nonNull(api.getApiDefinition().getProxy().getVirtualHosts())
+                    api.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api apiV2 &&
+                    Objects.nonNull(apiV2.getProxy()) &&
+                    Objects.nonNull(apiV2.getProxy().getVirtualHosts())
                 ) {
-                    var virtualHosts = api.getApiDefinition().getProxy().getVirtualHosts();
+                    var virtualHosts = apiV2.getProxy().getVirtualHosts();
                     if (Objects.nonNull(virtualHosts)) {
                         return virtualHosts
                             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
@@ -49,12 +49,12 @@ public class SearchAverageConnectionDurationUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
+        validateApiIsNotTcp(api);
         validateApiMultiTenancyAccess(api, input.environmentId);
     }
 
-    private void validateApiIsNotTcp(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
-        if (apiDefinitionV4.isTcpProxy()) {
+    private void validateApiIsNotTcp(Api api) {
+        if (api.isTcpProxy()) {
             throw new IllegalArgumentException("Analytics are not supported for TCP Proxy APIs");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
@@ -52,7 +52,7 @@ public class SearchAverageMessagesPerRequestAnalyticsUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
+        validateApiIsNotTcp(api);
         validateApiType(api.getType(), input.apiId);
         validateApiMultiTenancyAccess(api, input.environmentId);
     }
@@ -75,8 +75,8 @@ public class SearchAverageMessagesPerRequestAnalyticsUseCase {
         }
     }
 
-    private void validateApiIsNotTcp(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
-        if (apiDefinitionV4.isTcpProxy()) {
+    private void validateApiIsNotTcp(Api api) {
+        if (api.isTcpProxy()) {
             throw new IllegalArgumentException("Analytics are not supported for TCP Proxy APIs");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
@@ -50,7 +50,7 @@ public class SearchRequestsCountAnalyticsUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
+        validateApiIsNotTcp(api);
         validateApiMultiTenancyAccess(api, input.environmentId);
     }
 
@@ -66,8 +66,8 @@ public class SearchRequestsCountAnalyticsUseCase {
         }
     }
 
-    private void validateApiIsNotTcp(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
-        if (apiDefinitionV4.isTcpProxy()) {
+    private void validateApiIsNotTcp(Api api) {
+        if (api.isTcpProxy()) {
             throw new IllegalArgumentException("Analytics are not supported for TCP Proxy APIs");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusOverTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusOverTimeUseCase.java
@@ -67,7 +67,7 @@ public class SearchResponseStatusOverTimeUseCase {
     }
 
     private void validateApiIsNotTcp(Api api) {
-        if (api.getApiDefinitionHttpV4().isTcpProxy()) {
+        if (api.isTcpProxy()) {
             throw new TcpProxyNotSupportedException(api.getId());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusRangesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusRangesUseCase.java
@@ -67,7 +67,7 @@ public class SearchResponseStatusRangesUseCase {
     }
 
     private void validateApiIsNotTcp(Api api) {
-        if (api.getApiDefinitionHttpV4().isTcpProxy()) {
+        if (api.isTcpProxy()) {
             throw new TcpProxyNotSupportedException(api.getId());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCase.java
@@ -68,7 +68,7 @@ public class SearchResponseTimeUseCase {
     }
 
     private static Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
@@ -36,12 +36,14 @@ import io.gravitee.apim.core.parameters.model.ParameterContext;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
 import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 
 @DomainService
 @RequiredArgsConstructor
@@ -158,16 +160,12 @@ public class CreateApiDomainService {
         }
     }
 
+    @Nullable
     private List<? extends AbstractFlow> saveApiFlows(Api api) {
-        return switch (api.getDefinitionVersion()) {
-            case V4 -> switch (api.getType()) {
-                case LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> flowCrudService.saveApiFlows(
-                    api.getId(),
-                    api.getApiDefinitionHttpV4().getFlows()
-                );
-                case NATIVE -> flowCrudService.saveNativeApiFlows(api.getId(), api.getApiDefinitionNativeV4().getFlows());
-            };
-            case V1, V2, FEDERATED, FEDERATED_AGENT -> null;
+        return switch (api.getApiDefinitionValue()) {
+            case NativeApi nativeApi -> flowCrudService.saveNativeApiFlows(api.getId(), nativeApi.getFlows());
+            case io.gravitee.definition.model.v4.Api v4Api -> flowCrudService.saveApiFlows(v4Api.getId(), v4Api.getFlows());
+            default -> null;
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
@@ -29,6 +29,7 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -140,8 +141,7 @@ public class VerifyApiHostsDomainService {
                 api ->
                     !api.getId().equals(apiId) &&
                     DefinitionVersion.V4.equals(api.getDefinitionVersion()) &&
-                    ((ApiType.PROXY.equals(api.getType()) && null != api.getApiDefinitionHttpV4()) ||
-                        (ApiType.NATIVE.equals(api.getType()) && null != api.getApiDefinitionNativeV4()))
+                    EnumSet.of(ApiType.PROXY, ApiType.NATIVE).contains(api.getType())
             )
             .flatMap(this::extractHostsFromListeners)
             .map(String::toLowerCase)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -189,14 +189,29 @@ public class Api {
         return this;
     }
 
+    /**
+     * @deprecated use {@link #getApiDefinitionValue()} instead.
+     * @return the api definition value or null.
+     */
+    @Deprecated
     public io.gravitee.definition.model.v4.Api getApiDefinitionHttpV4() {
         return apiDefinitionValue instanceof io.gravitee.definition.model.v4.Api api ? api : null;
     }
 
+    /**
+     * @deprecated use {@link #getApiDefinitionValue()} instead.
+     * @return the api definition value or null.
+     */
+    @Deprecated
     public NativeApi getApiDefinitionNativeV4() {
         return apiDefinitionValue instanceof NativeApi api ? api : null;
     }
 
+    /**
+     * @deprecated use {@link #getApiDefinitionValue()} instead.
+     * @return the api definition value or null.
+     */
+    @Deprecated
     public io.gravitee.definition.model.Api getApiDefinition() {
         return apiDefinitionValue instanceof io.gravitee.definition.model.Api api ? api : null;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -20,7 +20,6 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.federation.FederatedAgent;
-import io.gravitee.definition.model.federation.FederatedApi;
 import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
@@ -201,10 +200,6 @@ public class Api {
 
     public io.gravitee.definition.model.Api getApiDefinition() {
         return apiDefinitionValue instanceof io.gravitee.definition.model.Api api ? api : null;
-    }
-
-    public FederatedApi getFederatedApiDefinition() {
-        return apiDefinitionValue instanceof FederatedApi api ? api : null;
     }
 
     public FederatedAgent getFederatedAgent() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -19,7 +19,6 @@ import io.gravitee.apim.core.api.model.property.DynamicApiProperties;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.federation.FederatedAgent;
 import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
@@ -200,10 +199,6 @@ public class Api {
 
     public io.gravitee.definition.model.Api getApiDefinition() {
         return apiDefinitionValue instanceof io.gravitee.definition.model.Api api ? api : null;
-    }
-
-    public FederatedAgent getFederatedAgent() {
-        return apiDefinitionValue instanceof FederatedAgent agent ? agent : null;
     }
 
     public Api setApiDefinitionHttpV4(io.gravitee.definition.model.v4.Api apiDefinitionHttpV4) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -271,30 +271,33 @@ public class Api {
     }
 
     public Api rollbackTo(io.gravitee.definition.model.v4.Api source) {
-        final io.gravitee.definition.model.v4.Api currentDefinition = getApiDefinitionHttpV4();
-        return toBuilder()
-            .name(source.getName())
-            .version(source.getApiVersion())
-            .apiDefinitionHttpV4(
-                currentDefinition
-                    .toBuilder()
-                    .tags(source.getTags())
-                    .listeners(source.getListeners())
-                    .endpointGroups(source.getEndpointGroups())
-                    .analytics(source.getAnalytics())
-                    .properties(source.getProperties())
-                    .resources(source.getResources())
-                    .failover(source.getFailover())
-                    .flowExecution(source.getFlowExecution())
-                    .flows(source.getFlows())
-                    .responseTemplates(source.getResponseTemplates())
-                    .services(source.getServices())
-                    // Ignore plans from definition for API rollback
-                    .plans(null)
-                    .build()
-            )
-            .build()
-            .setTags(source.getTags());
+        if (apiDefinitionValue instanceof io.gravitee.definition.model.v4.Api currentDefinition) {
+            return toBuilder()
+                .name(source.getName())
+                .version(source.getApiVersion())
+                .apiDefinitionValue(
+                    currentDefinition
+                        .toBuilder()
+                        .tags(source.getTags())
+                        .listeners(source.getListeners())
+                        .endpointGroups(source.getEndpointGroups())
+                        .analytics(source.getAnalytics())
+                        .properties(source.getProperties())
+                        .resources(source.getResources())
+                        .failover(source.getFailover())
+                        .flowExecution(source.getFlowExecution())
+                        .flows(source.getFlows())
+                        .responseTemplates(source.getResponseTemplates())
+                        .services(source.getServices())
+                        // Ignore plans from definition for API rollback
+                        .plans(null)
+                        .build()
+                )
+                .build()
+                .setTags(source.getTags());
+        } else {
+            return this;
+        }
     }
 
     public abstract static class ApiBuilder<C extends Api, B extends ApiBuilder<C, B>> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -201,26 +201,10 @@ public class Api {
         return apiDefinitionValue instanceof io.gravitee.definition.model.Api api ? api : null;
     }
 
-    public Api setApiDefinitionHttpV4(io.gravitee.definition.model.v4.Api apiDefinitionHttpV4) {
-        return setApiDefinitionValue(apiDefinitionHttpV4);
-    }
-
     public Api setApiDefinitionValue(ApiDefinition apiDefinition) {
         this.apiDefinitionValue = apiDefinition;
         this.definitionVersion = apiDefinition.getDefinitionVersion();
         return this;
-    }
-
-    public Api setApiDefinition(ApiDefinition apiDefinition) {
-        return setApiDefinitionValue(apiDefinition);
-    }
-
-    public Api setFederatedApiDefinition(io.gravitee.definition.model.federation.FederatedApi federatedApiDefinition) {
-        return setApiDefinitionValue(federatedApiDefinition);
-    }
-
-    public Api setApiDefinitionNativeV4(NativeApi nativeApi) {
-        return setApiDefinitionValue(nativeApi);
     }
 
     public List<? extends AbstractListener<? extends AbstractEntrypoint>> getApiListeners() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -81,12 +81,8 @@ public class ApiModelFactory {
             .disableMembershipNotifications(!crd.isNotifyMembers())
             .build();
 
-        if (api.isNative()) {
-            api.setApiDefinitionNativeV4(crd.toNativeApiDefinitionBuilder().id(id).build());
-        } else {
-            io.gravitee.definition.model.v4.Api build = crd.toApiDefinitionBuilder().id(id).build();
-            api.setApiDefinitionHttpV4(build);
-        }
+        var definition = api.isNative() ? crd.toNativeApiDefinitionBuilder().id(id).build() : crd.toApiDefinitionBuilder().id(id).build();
+        api.setApiDefinitionValue(definition);
 
         return api;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -79,9 +79,13 @@ class ApiMigration {
     }
 
     MigrationResult<Api> mapApi(Api source) {
-        return apiDefinitionHttpV4(source.getApiDefinition()).map(definition ->
-            source.toBuilder().apiDefinitionValue(definition).type(ApiType.PROXY).build()
-        );
+        if (source.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api apiDefinitionV2) {
+            return apiDefinitionHttpV4(apiDefinitionV2).map(definition ->
+                source.toBuilder().apiDefinitionValue(definition).type(ApiType.PROXY).build()
+            );
+        } else {
+            return MigrationResult.issue(MigrationWarnings.V2_API_NOT_NULL, MigrationResult.State.IMPOSSIBLE);
+        }
     }
 
     private MigrationResult<io.gravitee.definition.model.v4.Api> apiDefinitionHttpV4(io.gravitee.definition.model.Api apiDefinitionV2) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
@@ -42,7 +42,6 @@ import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainServ
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.v4.flow.Flow;
 import jakarta.inject.Inject;
@@ -98,14 +97,17 @@ public class MigrateApiUseCase {
 
     public Output execute(Input input) {
         var api = apiCrudService.findById(input.apiId()).orElseThrow(() -> new ApiNotFoundException(input.apiId()));
-        if (api.getDefinitionVersion() != DefinitionVersion.V2) {
+        io.gravitee.definition.model.Api apiDefinition;
+        if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api ap) {
+            apiDefinition = ap;
+        } else {
             // Fatal issue, we don’t try to do anything in this case
             return new Output(
                 input.apiId(),
                 List.of(new MigrationResult.Issue(MigrationWarnings.API_NOT_V2_DEFINITION, MigrationResult.State.IMPOSSIBLE))
             );
         }
-        MigrationResult<?> precondition = chekPreconditions(input, api);
+        MigrationResult<?> precondition = chekPreconditions(input, api, apiDefinition);
         var pageEntities = pageQueryService.searchByApiId(input.apiId());
         precondition = precondition.addIssues(checkPages(pageEntities));
         // Migration
@@ -134,12 +136,12 @@ public class MigrateApiUseCase {
         return new Output(input.apiId(), migrationResult.issues(), state);
     }
 
-    private MigrationResult<?> chekPreconditions(Input input, Api api) {
+    private MigrationResult<?> chekPreconditions(Input input, Api api, io.gravitee.definition.model.Api apiDefinition) {
         MigrationResult<?> precondition = MigrationResult.value(1);
         if (!apiStateService.isSynchronized(api, input.auditInfo())) {
             precondition = precondition.addIssue(MigrationWarnings.API_OUT_OF_SYNC, CAN_BE_FORCED);
         }
-        if (api.getApiDefinition().getExecutionMode() == ExecutionMode.V3) {
+        if (apiDefinition.getExecutionMode() == ExecutionMode.V3) {
             precondition = precondition.addIssue(MigrationWarnings.V4_EMULATION_ENGINE_REQUIRED, IMPOSSIBLE);
         }
         return precondition;
@@ -226,17 +228,19 @@ public class MigrateApiUseCase {
 
     private void storeMigration(Input input, Migration migration, Api api) {
         if (
-            migration.api().getApiDefinitionHttpV4().getServices() != null &&
-            migration.api().getApiDefinitionHttpV4().getServices().getDynamicProperty() != null &&
-            migration.api().getApiDefinitionHttpV4().getServices().getDynamicProperty().isEnabled()
+            migration.api().getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api v4 &&
+            v4.getServices() != null &&
+            v4.getServices().getDynamicProperty() != null &&
+            v4.getServices().getDynamicProperty().isEnabled()
         ) {
             apiStateService.stopV2DynamicProperties(input.apiId());
         }
         var upgraded = apiCrudService.update(migration.api());
         if (
-            migration.api().getApiDefinitionHttpV4().getServices() != null &&
-            migration.api().getApiDefinitionHttpV4().getServices().getDynamicProperty() != null &&
-            migration.api().getApiDefinitionHttpV4().getServices().getDynamicProperty().isEnabled()
+            migration.api().getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api v4 &&
+            v4.getServices() != null &&
+            v4.getServices().getDynamicProperty() != null &&
+            v4.getServices().getDynamicProperty().isEnabled()
         ) {
             apiStateService.startV4DynamicProperties(input.apiId());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.property.Property;
 import java.util.List;
 import java.util.function.UnaryOperator;
@@ -91,10 +92,9 @@ public class UpdateNativeApiUseCase {
                 .categories(updateNativeApi.getCategories())
                 .groups(updateNativeApi.getGroups())
                 .disableMembershipNotifications(updateNativeApi.isDisableMembershipNotifications())
-                .apiDefinitionNativeV4(
-                    currentApi.getApiDefinitionNativeV4() != null
-                        ? currentApi
-                            .getApiDefinitionNativeV4()
+                .apiDefinitionValue(
+                    currentApi.getApiDefinitionValue() instanceof NativeApi nativeApi
+                        ? nativeApi
                             .toBuilder()
                             .name(updateNativeApi.getName())
                             .apiVersion(updateNativeApi.getApiVersion())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/AvailabilityUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/AvailabilityUseCase.java
@@ -48,7 +48,7 @@ public class AvailabilityUseCase {
     }
 
     private Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchAverageHealthCheckResponseTimeOvertimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchAverageHealthCheckResponseTimeOvertimeUseCase.java
@@ -63,7 +63,7 @@ public class SearchAverageHealthCheckResponseTimeOvertimeUseCase {
     }
 
     private Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchAverageHealthCheckResponseTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchAverageHealthCheckResponseTimeUseCase.java
@@ -60,7 +60,7 @@ public class SearchAverageHealthCheckResponseTimeUseCase {
     }
 
     private Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchHealthCheckLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_health/use_case/SearchHealthCheckLogsUseCase.java
@@ -67,7 +67,7 @@ public class SearchHealthCheckLogsUseCase {
     }
 
     private Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplate.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplate.java
@@ -68,13 +68,9 @@ public class ApiFreemarkerTemplate {
         if (api == null) {
             return;
         }
-        if (DefinitionVersion.V4.equals(api.getDefinitionVersion())) {
-            if (api.getApiDefinitionHttpV4() != null) {
-                this.tags = api.getApiDefinitionHttpV4().getTags();
-            }
-        } else if (api.getApiDefinition() != null) {
-            this.tags = api.getApiDefinition().getTags();
-            this.proxy = api.getApiDefinition().getProxy();
+        this.tags = api.getTags();
+        if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api v2) {
+            this.proxy = v2.getProxy();
         }
 
         this.state = api.getLifecycleState();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCase.java
@@ -318,7 +318,7 @@ public class IngestFederatedApisUseCase {
                 .name(newOne.getName())
                 .description(newOne.getDescription())
                 .version(newOne.getVersion())
-                .federatedApiDefinition(newOne.getFederatedApiDefinition())
+                .apiDefinitionValue(newOne.getApiDefinitionValue())
                 .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCase.java
@@ -40,6 +40,7 @@ import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.federation.FederatedAgent;
 import io.gravitee.definition.model.federation.FederatedPlan;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -183,7 +184,7 @@ public class StartIngestIntegrationApisUseCase {
                             )
                     );
 
-                Plan plan = fromIntegration(api);
+                Plan plan = fromIntegration(api, federatedAgent);
                 planCrudService
                     .findById(plan.getId())
                     .ifPresentOrElse(
@@ -219,14 +220,14 @@ public class StartIngestIntegrationApisUseCase {
                 .name(newOne.getName())
                 .description(newOne.getDescription())
                 .version(newOne.getVersion())
-                .apiDefinitionValue(newOne.getFederatedAgent())
+                .apiDefinitionValue(newOne.getApiDefinitionValue())
                 .build();
     }
 
-    public static Plan fromIntegration(Api api) {
+    public static Plan fromIntegration(Api api, FederatedAgent federatedAgent) {
         var id = UuidString.generateForEnvironment(api.getId(), PlanSecurityType.KEY_LESS.getLabel());
         var now = TimeProvider.now();
-        var oid = api.getFederatedAgent().getProvider() != null ? api.getFederatedAgent().getProvider().organization() : null;
+        var oid = federatedAgent.getProvider() != null ? federatedAgent.getProvider().organization() : null;
         return Plan.builder()
             .id(id)
             .name("Key less plan")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
@@ -48,7 +48,7 @@ public class CreatePlanUseCase {
 
         var plan = input.toPlan.apply(api);
 
-        if (isMtls(api, plan) && api.getApiDefinitionHttpV4() != null && api.getApiDefinitionHttpV4().isTcpProxy()) {
+        if (isMtls(api, plan) && api.isTcpProxy()) {
             throw new PlanInvalidException("Cannot create mTLS plan for TCP API");
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -186,14 +186,13 @@ public interface ApiAdapter {
     }
 
     default String serializeApiDefinition(Api api) {
-        return switch (api.getDefinitionVersion()) {
-            case V1, V2 -> serialize(api.getApiDefinition(), "V2 API");
-            case V4 -> switch (api.getType()) {
-                case NATIVE -> serialize(api.getApiDefinitionNativeV4(), "V4 Native API");
-                case LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> serialize(api.getApiDefinitionHttpV4(), "V4 API");
-            };
-            case FEDERATED -> serialize(api.getFederatedApiDefinition(), "Federated API");
-            case FEDERATED_AGENT -> serialize(api.getFederatedAgent(), "Federated Agent");
+        return switch (api.getApiDefinitionValue()) {
+            case io.gravitee.definition.model.Api v2 -> serialize(v2, "V2 API");
+            case NativeApi nativeApi -> serialize(nativeApi, "V4 Native API");
+            case io.gravitee.definition.model.v4.Api v4 -> serialize(v4, "V4 API");
+            case FederatedApi federatedApi -> serialize(federatedApi, "Federated API");
+            case FederatedAgent federatedAgent -> serialize(federatedAgent, "Federated Agent");
+            default -> null;
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -27,6 +27,8 @@ import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.ApiDefinition;
+import io.gravitee.definition.model.federation.FederatedApi;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -145,7 +147,7 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "type", source = "apiEntity.type")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
-    @Mapping(target = "providerId", source = "apiEntity.federatedApiDefinition.providerId")
+    @Mapping(target = "providerId", expression = "java(providerId(apiEntity.getApiDefinitionValue()))")
     @Mapping(target = "originContext.integrationId", source = "integration.id")
     @Mapping(target = "originContext.integrationName", source = "integration.name")
     @Mapping(target = "originContext.provider", source = "integration.provider")
@@ -162,6 +164,10 @@ public interface GraviteeDefinitionAdapter {
         Collection<NewApiMetadata> metadata,
         Integration.ApiIntegration integration
     );
+
+    default String providerId(ApiDefinition apiDefinition) {
+        return apiDefinition instanceof FederatedApi federatedApi ? federatedApi.getProviderId() : null;
+    }
 
     @Mapping(target = "id", source = "apiEntity.id")
     @Mapping(target = "apiVersion", source = "apiEntity.version")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -86,11 +86,18 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         if (existingApi.getDefinitionVersion() != DefinitionVersion.V4) {
             throw new ValidationDomainException("Definition not supported, should be V4");
         }
-        if (existingApi.getType() != ApiType.NATIVE) {
+        if (existingApi.getType() == ApiType.NATIVE && apiToBeUpdated.getApiDefinitionValue() instanceof NativeApi nativeApi) {
+            return validateAndSanitizeNativeV4ForUpdate(
+                existingApi,
+                apiToBeUpdated,
+                nativeApi,
+                primaryOwner,
+                environmentId,
+                organizationId
+            );
+        } else {
             throw new ValidationDomainException("Only Native V4 APIs are currently supported");
         }
-
-        return validateAndSanitizeNativeV4ForUpdate(existingApi, apiToBeUpdated, primaryOwner, environmentId, organizationId);
     }
 
     private void validateAndSanitizeHttpV4ForCreation(
@@ -136,28 +143,29 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         String environmentId,
         String organizationId
     ) {
-        if (newApi.getType() != ApiType.NATIVE) {
+        if (newApi.getType() == ApiType.NATIVE && newApi.getApiDefinitionValue() instanceof NativeApi nativeApi) {
+            var executionContext = new ExecutionContext(organizationId, environmentId);
+
+            // Clean description
+            newApi.setDescription(HtmlSanitizer.sanitize(newApi.getDescription()));
+
+            // Validate tags
+            newApi.setTags(tagsValidationService.validateAndSanitize(executionContext, null, newApi.getTags()));
+
+            // Validate groups
+            newApi.setGroups(groupValidationService.validateAndSanitize(newApi.getGroups(), newApi.getEnvironmentId(), primaryOwner, true));
+
+            // Validate and clean definition
+            newApi.setApiDefinitionValue(validateAndSanitizeNativeV4Definition(nativeApi, executionContext));
+        } else {
             throw new ValidationDomainException("Api type not supported, should be NATIVE");
         }
-
-        var executionContext = new ExecutionContext(organizationId, environmentId);
-
-        // Clean description
-        newApi.setDescription(HtmlSanitizer.sanitize(newApi.getDescription()));
-
-        // Validate tags
-        newApi.setTags(tagsValidationService.validateAndSanitize(executionContext, null, newApi.getTags()));
-
-        // Validate groups
-        newApi.setGroups(groupValidationService.validateAndSanitize(newApi.getGroups(), newApi.getEnvironmentId(), primaryOwner, true));
-
-        // Validate and clean definition
-        newApi.setApiDefinitionValue(validateAndSanitizeNativeV4Definition(newApi.getApiDefinitionNativeV4(), executionContext));
     }
 
     private Api validateAndSanitizeNativeV4ForUpdate(
         final Api existingApi,
         Api toBeUpdatedApi,
+        NativeApi nativeApiToBeUpdated,
         PrimaryOwnerEntity primaryOwner,
         String environmentId,
         String organizationId
@@ -188,14 +196,11 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         );
 
         // Validate and clean definition
-        toBeUpdatedApi.setApiDefinitionValue(
-            validateAndSanitizeNativeV4Definition(toBeUpdatedApi.getApiDefinitionNativeV4(), executionContext)
-        );
-
+        NativeApi newDefinition = validateAndSanitizeNativeV4Definition(nativeApiToBeUpdated, executionContext);
         // Validate and clean resources
-        toBeUpdatedApi
-            .getApiDefinitionNativeV4()
-            .setResources(resourcesValidationService.validateAndSanitize(toBeUpdatedApi.getApiDefinitionNativeV4().getResources()));
+        newDefinition.setResources(resourcesValidationService.validateAndSanitize(nativeApiToBeUpdated.getResources()));
+
+        toBeUpdatedApi.setApiDefinitionValue(newDefinition);
 
         return toBeUpdatedApi;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -152,7 +152,7 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         newApi.setGroups(groupValidationService.validateAndSanitize(newApi.getGroups(), newApi.getEnvironmentId(), primaryOwner, true));
 
         // Validate and clean definition
-        newApi.setApiDefinitionNativeV4(validateAndSanitizeNativeV4Definition(newApi.getApiDefinitionNativeV4(), executionContext));
+        newApi.setApiDefinitionValue(validateAndSanitizeNativeV4Definition(newApi.getApiDefinitionNativeV4(), executionContext));
     }
 
     private Api validateAndSanitizeNativeV4ForUpdate(
@@ -188,7 +188,7 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         );
 
         // Validate and clean definition
-        toBeUpdatedApi.setApiDefinitionNativeV4(
+        toBeUpdatedApi.setApiDefinitionValue(
             validateAndSanitizeNativeV4Definition(toBeUpdatedApi.getApiDefinitionNativeV4(), executionContext)
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -189,14 +189,12 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
     }
 
     private void transformV4Api(Document doc, IndexableApi api) {
-        var apiDefinitionV4 = api.getApi().getType() == ApiType.NATIVE
-            ? api.getApi().getApiDefinitionNativeV4()
-            : api.getApi().getApiDefinitionHttpV4();
+        var apiDefinitionV4 = api.getApi().getApiDefinitionValue();
 
-        if (api.getApi().getType() == ApiType.NATIVE) {
-            transformV4ApiNativeListeners(doc, api.getApi().getApiDefinitionNativeV4());
-        } else {
-            transformV4ApiHttpListeners(doc, api.getApi().getApiDefinitionHttpV4());
+        switch (apiDefinitionV4) {
+            case io.gravitee.definition.model.v4.Api v4Api -> transformV4ApiHttpListeners(doc, v4Api);
+            case io.gravitee.definition.model.v4.nativeapi.NativeApi v4NativeApi -> transformV4ApiNativeListeners(doc, v4NativeApi);
+            default -> {}
         }
 
         // tags

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
@@ -49,7 +49,7 @@ import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.rest.api.model.CategoryEntity;
+import io.gravitee.definition.model.federation.FederatedApi;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
@@ -170,9 +170,7 @@ class UpdateFederatedApiDomainServiceTest {
             .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
             .build();
 
-        CategoryEntity categoryEntity = new CategoryEntity();
         String categoryId = "categoryId-1";
-        categoryEntity.setId(categoryId);
         when(categoryDomainService.toCategoryId(any(), any())).thenReturn(Set.of(categoryId));
         when(categoryDomainService.toCategoryKey(any(), any())).thenReturn(Set.of(categoryKey));
         var ownerEntity = buildPrimaryOwnerEntity();
@@ -180,11 +178,11 @@ class UpdateFederatedApiDomainServiceTest {
         //when
         var updatedApi = usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity, oneShotIndexation(auditInfo));
         //then
-        assertThat(apiCrudService.storage()).extracting("federatedApiDefinition").doesNotContainNull();
+        assertThat(apiCrudService.storage()).map(Api::getApiDefinitionValue).doesNotContainNull();
         SoftAssertions.assertSoftly(soft -> {
             assertThat(updatedApi.getName()).isEqualTo("updated-name");
             assertThat(updatedApi.getDescription()).isEqualTo("updated-description");
-            assertThat(updatedApi.getFederatedApiDefinition()).isNotNull();
+            assertThat(updatedApi.getApiDefinitionValue()).isInstanceOf(FederatedApi.class);
             assertThat(updatedApi.getVersion()).isEqualTo("2.0.0");
             assertThat(updatedApi.getLabels()).containsExactly("label-1");
             assertThat(updatedApi.getCategories()).containsExactly(categoryKey);
@@ -206,9 +204,6 @@ class UpdateFederatedApiDomainServiceTest {
             .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
             .build();
 
-        CategoryEntity categoryEntity = new CategoryEntity();
-        String categoryId = "categoryId-1";
-        categoryEntity.setId(categoryId);
         var ownerEntity = buildPrimaryOwnerEntity();
 
         //when

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
@@ -358,7 +358,7 @@ class UpdateNativeApiDomainServiceTest {
         var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
         var apiToUpdate = ApiFixtures.aNativeApi();
         var nativeFlow = NativeFlow.builder().id("native-flow").build();
-        apiToUpdate.setApiDefinitionNativeV4(apiToUpdate.getApiDefinitionNativeV4().toBuilder().flows(List.of(nativeFlow)).build());
+        apiToUpdate.setApiDefinitionValue(apiToUpdate.getApiDefinitionNativeV4().toBuilder().flows(List.of(nativeFlow)).build());
         var ownerEntity = buildPrimaryOwnerEntity();
 
         var updatedApi = cut.update(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
@@ -265,7 +265,7 @@ class RollbackApiUseCaseTest {
         // Then
         assertThat(throwable)
             .isInstanceOf(IllegalStateException.class)
-            .hasMessage("Cannot determine API definition version from event" + event.getId());
+            .hasMessage("Cannot rollback an API that is not a V4 or V2 API (%s)".formatted(event.getId()));
     }
 
     @Test
@@ -283,7 +283,9 @@ class RollbackApiUseCaseTest {
         var throwable = catchThrowable(() -> useCase.execute(new RollbackApiUseCase.Input(event.getId(), AUDIT_INFO)));
 
         // Then
-        assertThat(throwable).isInstanceOf(IllegalStateException.class).hasMessage("Cannot rollback a federated API");
+        assertThat(throwable)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Cannot rollback an API that is not a V4 or V2 API (%s)".formatted(event.getId()));
     }
 
     @Test
@@ -301,7 +303,9 @@ class RollbackApiUseCaseTest {
         var throwable = catchThrowable(() -> useCase.execute(new RollbackApiUseCase.Input(event.getId(), AUDIT_INFO)));
 
         // Then
-        assertThat(throwable).isInstanceOf(IllegalStateException.class).hasMessage("Cannot rollback an API that is not a V4 API");
+        assertThat(throwable)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Cannot rollback an API that is not a V4 or V2 API (%s)".formatted(event.getId()));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
@@ -278,7 +278,7 @@ class UpdateFederatedApiUseCaseTest {
         assertThat(result.getDefinitionVersion()).isEqualTo(DefinitionVersion.FEDERATED);
         assertThat(result.getApiDefinitionHttpV4()).isEqualTo(null);
         assertThat(result.getApiDefinition()).isEqualTo(null);
-        assertThat(result.getFederatedApiDefinition()).isEqualTo(FederatedApi.builder().build());
+        assertThat(result.getApiDefinitionValue()).isEqualTo(FederatedApi.builder().build());
         assertThat(result.getType()).isEqualTo(ApiType.PROXY);
         assertThat(result.getDeployedAt()).isEqualTo(oldDate);
         assertThat(result.getCreatedAt()).isEqualTo(oldDate);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
@@ -1886,7 +1886,7 @@ class IngestFederatedApisUseCaseTest {
         assertThat(result.getName()).isEqualTo("input");
         assertThat(result.getDescription()).isEqualTo("input");
         assertThat(result.getVersion()).isEqualTo("input");
-        assertThat(result.getFederatedApiDefinition()).isEqualTo(FederatedApi.builder().id("input").build());
+        assertThat(result.getApiDefinitionValue()).isEqualTo(FederatedApi.builder().id("input").build());
     }
 
     private void givenAnIngestJob(AsyncJob job) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -318,7 +318,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
         @Test
         void should_throw_when_multiple_api_flows() {
             var nativeApi = ApiFixtures.aNativeApi();
-            nativeApi.setApiDefinitionNativeV4(
+            nativeApi.setApiDefinitionValue(
                 nativeApi
                     .getApiDefinitionNativeV4()
                     .toBuilder()
@@ -474,7 +474,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
         @Test
         void should_throw_when_multiple_api_flows() {
             var nativeApi = ApiFixtures.aNativeApi();
-            nativeApi.setApiDefinitionNativeV4(
+            nativeApi.setApiDefinitionValue(
                 nativeApi
                     .getApiDefinitionNativeV4()
                     .toBuilder()


### PR DESCRIPTION
## Issue

no issue related

## Description

After some work to use only one field whatever the tye of definition in Api, now it’s some work to replace usage of each specific getter by the polymorph one.

Basically it’s replacing:

```java
if (api.DefinitionVersion() == V2) {
    api.getApiDefinition().get//...
}
```

by

```java
if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api definitionV2) {
    definitionV2.get//...
}
```

It’s only one batch to keep the PR small
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nfnvmcndcw.chromatic.com)
<!-- Storybook placeholder end -->
