### PR TITLE
fix(portal-next): set endDate to end of day in filters dialog

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
@@ -846,7 +846,15 @@ describe('ApplicationLogTableComponent', () => {
 
           await getSearchButton().then(btn => btn.click());
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, undefined, to, new Date('6/10/2016').getTime());
+          const expectedTo = (() => {
+            const d = new Date(to);
+            d.setHours(23, 59, 59, 999);
+            return d.getTime();
+          })();
+
+          const expectedFrom = new Date('6/10/2016').getTime();
+
+          expectGetApplicationLogs(fakeLogsResponse(), 1, undefined, expectedTo, expectedFrom);
         });
       });
 

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.spec.ts
@@ -122,4 +122,29 @@ describe('MoreFiltersDialogComponent', () => {
     await endDateCalendar.selectCell({ text: '16' });
     expect(await endDatePicker.getValue()).toEqual('6/16/2016');
   });
+
+  it('should set endDate to end of day when applying the dialog', async () => {
+    const dialog = await rootHarnessLoader.getHarness(MoreFiltersDialogHarness);
+    const endDatePicker = await dialog.getEndDatePicker();
+
+    // Open calendar and select the 15th (which other tests use and maps to 6/15/2016)
+    await endDatePicker.openCalendar();
+    const calendar = await endDatePicker.getCalendar();
+    await calendar.selectCell({ text: '15' });
+
+    // Apply filters
+    await dialog.applyFilters();
+
+    // Wait for the dialog to close and the host component to receive the result
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const result = fixture.componentInstance.result;
+    expect(result).toBeTruthy();
+    expect(result.endDate).toBeDefined();
+
+    // Build expected end-of-day timestamp for 2016-06-15 in local timezone
+    const expectedEnd = new Date(2016, 5, 15, 23, 59, 59, 999).getTime();
+    expect(result.endDate).toEqual(expectedEnd);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/more-filters-dialog/more-filters-dialog.component.ts
@@ -90,9 +90,17 @@ export class MoreFiltersDialogComponent {
   onApply() {
     const httpStatuses = this.httpStatusChoices.filter(x => this.httpStatuses?.includes(x.value));
 
+    const startDateMs = this.startDate?.getTime();
+    let endDateMs = this.endDate?.getTime();
+    if (this.endDate) {
+      const end = new Date(this.endDate);
+      end.setHours(23, 59, 59, 999);
+      endDateMs = end.getTime();
+    }
+
     this.dialogRef.close({
-      startDate: this.startDate?.getTime(),
-      endDate: this.endDate?.getTime(),
+      startDate: startDateMs,
+      endDate: endDateMs,
       ...(this.requestId?.length ? { requestId: this.requestId } : {}),
       ...(this.transactionId?.length ? { transactionId: this.transactionId } : {}),
       ...(this.httpStatuses?.length ? { httpStatuses } : {}),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11351

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/13565/console](https://pr.team-apim.gravitee.dev/13565/console)
      Portal: [https://pr.team-apim.gravitee.dev/13565/portal](https://pr.team-apim.gravitee.dev/13565/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/13565/api/management](https://pr.team-apim.gravitee.dev/13565/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/13565](https://pr.team-apim.gravitee.dev/13565)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/13565](https://pr.gateway-v3.team-apim.gravitee.dev/13565)

<!-- Environment placeholder end -->
