### PR TITLE
fix: use order-preserving map when deserializing CORS object

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
@@ -50,7 +50,7 @@ public class CorsV3IntegrationTest extends CorsV4EmulationIntegrationTest {
                     assertThat(response.statusCode()).isEqualTo(200);
                     assertThat(extractHeaders(response)).contains(
                         Map.entry("Access-Control-Allow-Origin", "https://mydomain.com"),
-                        Map.entry("Access-Control-Allow-Methods", "POST, GET"),
+                        Map.entry("Access-Control-Allow-Methods", "GET, POST"),
                         Map.entry("Access-Control-Allow-Headers", "x-gravitee-test")
                     );
                     return response.toFlowable();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4EmulationIntegrationTest.java
@@ -64,7 +64,7 @@ public class CorsV4EmulationIntegrationTest {
                     assertThat(response.statusCode()).isEqualTo(200);
                     assertThat(extractHeaders(response)).contains(
                         Map.entry("Access-Control-Allow-Origin", "https://mydomain.com"),
-                        Map.entry("Access-Control-Allow-Methods", "POST, GET"),
+                        Map.entry("Access-Control-Allow-Methods", "GET, POST"),
                         Map.entry("Access-Control-Allow-Headers", "x-gravitee-test")
                     );
                     return response.toFlowable();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1545

## Description

linked hashmap for method dans pattern to avoid order shuffling, breaking idempotency

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

