### PR TITLE
fix: allow custom API keys up to 128 characters in UI and backend

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.html
@@ -17,11 +17,11 @@
 -->
 <div class="api-key-validation">
   <mat-form-field appearance="outline" class="api-key-validation__form-field">
-    <input matInput [formControl]="apiKeyFormControl" minlength="8" maxlength="64" pattern="^[^#%@\;=?|^~, \\]*$" />
+    <input matInput [formControl]="apiKeyFormControl" minlength="8" maxlength="128" pattern="^[^#%@\;=?|^~, \\]*$" />
     <mat-label>Custom API Key</mat-label>
     <mat-error *ngIf="apiKeyFormControl.errors?.pattern">No special characters allowed</mat-error>
     <mat-error *ngIf="apiKeyFormControl.errors?.minlength">Must be longer than 8 characters</mat-error>
-    <mat-error *ngIf="apiKeyFormControl.errors?.maxlength">Must be shorter than 64 characters</mat-error>
+    <mat-error *ngIf="apiKeyFormControl.errors?.maxlength">Must be shorter than 128 characters</mat-error>
     <mat-error *ngIf="apiKeyFormControl.errors?.unique">Key already exists with given value</mat-error>
   </mat-form-field>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
@@ -85,7 +85,7 @@ describe('ApiKeyValidationComponent', () => {
     expect(await harness.isValid()).toEqual(false);
     expect(fixture.componentInstance.apiKey.touched).toEqual(true);
   });
-  it('should be invalid if more than 64 characters', async () => {
+  it('should be invalid if more than 128 characters', async () => {
     const harness = await loader.getHarness(ApiKeyValidationHarness);
     await harness.setInputValue(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_29/00_increase_key_length.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_29/00_increase_key_length.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.29_increase_length_keys_table_key_column
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}keys
+            columnName: key
+            newDataType: nvarchar(128)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -221,3 +221,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_27/00_increase_entrypoints_value_length.yml
     - include:
           - file: liquibase/changelogs/v4_5_28/00_change_api_description_datatype.yml
+    - include:
+          - file: liquibase/changelogs/v4_5_29/00_increase_key_length.yml

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/CustomApiKey.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/CustomApiKey.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Size(min = 8, max = 64, message = "Should have length between 8 and 64 characters")
+@Size(min = 8, max = 128, message = "Should have length between 8 and 128 characters")
 @Pattern(regexp = "[^#%@/;=?|^~, \\\\]*", message = "Should not contain: ^ # % @ \\ / ; = ? | ~ , (space)")
 @Target({ ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RUNTIME)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/CustomApiKeyTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/CustomApiKeyTest.java
@@ -43,11 +43,11 @@ public class CustomApiKeyTest {
         return Arrays.asList(
             new Object[][] {
                 { "Contains_at_least_8_chars", 0, null },
-                { "less8", 1, "Should have length between 8 and 64 characters" },
+                { "less8", 1, "Should have length between 8 and 128 characters" },
                 {
-                    "VeryLongLengthTOHaveMoreThan64charsVeryLongLengthTOHaveMoreThan64chars",
+                    "VeryLongLengthTOHaveMoreThan128charsVeryLongLengthTOHaveMoreThan128charsVeryLongLengthTOHaveMoreThan128charsVeryLongLengthTOHaveMoreThan128chars",
                     1,
-                    "Should have length between 8 and 64 characters",
+                    "Should have length between 8 and 128 characters",
                 },
                 { "No pattern compliant", 1, "Should not contain: ^ # % @ \\ / ; = ? | ~ , (space)" },
             }
@@ -69,8 +69,8 @@ public class CustomApiKeyTest {
     }
 
     @Test
-    public void shoultTestCustomApiKeyValidation() {
-        LOGGER.info("Exectute custom API Key validation test for: " + this.customApiKeyParam);
+    public void shouldTestCustomApiKeyValidation() {
+        LOGGER.info("Execute custom API Key validation test for: " + this.customApiKeyParam);
 
         CustomApiKeyObject customApiKeyObject = new CustomApiKeyObject(this.customApiKeyParam);
         Set<ConstraintViolation<CustomApiKeyObject>> violations = validator.validate(customApiKeyObject);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11388

## Description

Previously, custom API keys created through the Console UI were truncated to 64 characters, while keys created via the /subscriptions mAPI endpoint could be longer.

Changes:
- Increased key column length in JDBC schema to 128 characters.
- Updated UI validation to accept keys between 8 and 128 characters.
- mAPI still works as it is for mongo (no limit/truncation) and for jdbc now limit is 128.
- Keys longer than 128 chars are truncated when entered through the UI.

This ensures consistent behavior between the Console and mAPI for custom API keys.

`JDBC Change`
<img width="421" height="378" alt="Screenshot 2025-10-05 at 7 46 59 AM" src="https://github.com/user-attachments/assets/b8b5da6e-9a38-4028-be90-15a32ffe48a1" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qybnxuecmd.chromatic.com)
<!-- Storybook placeholder end -->
