### PR TITLE
allow user to navigate using api documentation link in portal next

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.ts
@@ -17,7 +17,7 @@ import { NgClass } from '@angular/common';
 import { Component, Input, OnInit, signal, WritableSignal } from '@angular/core';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { Observable, of, switchMap, tap } from 'rxjs';
 
 import { ApiDocumentationComponent } from './components/api-documentation/api-documentation.component';
 import { DrawerComponent } from '../../../../components/drawer/drawer.component';
@@ -58,6 +58,20 @@ export class ApiTabDocumentationComponent implements OnInit {
     if (this.pageNodes.length == 1) {
       this.isSidebarExpanded.set(false);
     }
+
+    this.activatedRoute.url
+      .pipe(
+        switchMap(() => this.activatedRoute.firstChild?.paramMap ?? []),
+        tap(params => {
+          const pageId = params.get('pageId');
+          if (pageId) {
+            this.pageId.set(pageId);
+          } else if (this.pageNodes.length > 0) {
+            this.pageId.set(this.pageNodes[0].id);
+          }
+        }),
+      )
+      .subscribe();
   }
 
   showPage(pageId: string) {

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -33,7 +33,9 @@ import { ApplicationsComponent } from './applications/applications.component';
 import { CategoriesViewComponent } from './catalog/categories-view/categories-view.component';
 import { CategoryApisComponent } from './catalog/categories-view/category-apis/category-apis.component';
 import { TabsViewComponent } from './catalog/tabs-view/tabs-view.component';
+import { GuidesPageComponent } from './guides/components/guides-page.component';
 import { GuidesComponent } from './guides/guides.component';
+import { environmentPagesResolver } from './guides/resolvers/environment-pages.resolver';
 import { LogInComponent } from './log-in/log-in.component';
 import { ResetPasswordConfirmationComponent } from './log-in/reset-password/reset-password-confirmation/reset-password-confirmation.component';
 import { ResetPasswordComponent } from './log-in/reset-password/reset-password.component';
@@ -204,6 +206,15 @@ export const routes: Routes = [
   {
     path: 'guides',
     component: GuidesComponent,
+    data: { breadcrumb: { label: 'Documentation', disable: true } },
+    resolve: { pages: environmentPagesResolver },
+    children: [
+      {
+        path: ':pageId',
+        component: GuidesPageComponent,
+        data: { breadcrumb: { alias: 'pageName' } },
+      },
+    ],
   },
   {
     path: 'log-in',

--- a/gravitee-apim-portal-webui-next/src/app/guides/components/guides-page.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/guides/components/guides-page.component.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { GuidesPageComponent } from './guides-page.component';
+import { Page } from '../../../entities/page/page';
+import { fakePage } from '../../../entities/page/page.fixtures';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../testing/app-testing.module';
+
+@Component({
+  selector: 'app-test-component',
+  template: `<app-guides-page #guidesPage [pages]="pages"></app-guides-page>`,
+  standalone: true,
+  imports: [GuidesPageComponent],
+})
+class TestComponent {
+  pages: Page[] = [];
+}
+
+describe('GuidesPageComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let httpTestingController: HttpTestingController;
+  let paramMapSubject: BehaviorSubject<Map<string, string>>;
+
+  beforeEach(async () => {
+    paramMapSubject = new BehaviorSubject(new Map());
+
+    await TestBed.configureTestingModule({
+      imports: [TestComponent, AppTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: paramMapSubject.asObservable(),
+            snapshot: { paramMap: paramMapSubject.getValue() },
+            routeConfig: {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('Page loading', () => {
+    it('should display loader when no page is loaded', () => {
+      const loader = fixture.debugElement.nativeElement.querySelector('app-loader');
+      expect(loader).toBeTruthy();
+    });
+
+    it('should load and display markdown page when pageId is provided', async () => {
+      const testPage = fakePage({ id: 'valid-page', type: 'MARKDOWN', content: '# Test Content' });
+      fixture.componentInstance.pages = [testPage];
+      fixture.detectChanges();
+
+      paramMapSubject.next(new Map([['pageId', testPage.id]]));
+      fixture.detectChanges();
+
+      expectGetPageContent(testPage);
+    });
+
+    it('should load first page when no pageId is provided', async () => {
+      const testPage = fakePage({ id: 'first-page', type: 'MARKDOWN', content: '# First Page Content' });
+      fixture.componentInstance.pages = [testPage, fakePage({ id: 'second-page', type: 'MARKDOWN', content: '# Second Page Content' })];
+      fixture.detectChanges();
+
+      paramMapSubject.next(new Map([['foo', 'bar']]));
+      fixture.detectChanges();
+
+      expectGetPageContent(testPage);
+    });
+
+    it('should not display page when pages array is empty', () => {
+      const pageComponent = fixture.debugElement.nativeElement.querySelector('app-page');
+      expect(pageComponent).toBeFalsy();
+    });
+  });
+
+  function expectGetPageContent(page: Page) {
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/pages/${page.id}?include=content`).flush(page);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-portal-webui-next/src/app/guides/components/guides-page.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/guides/components/guides-page.component.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncPipe } from '@angular/common';
+import { Component, DestroyRef, inject, input, InputSignal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { Observable, of, tap } from 'rxjs';
+import { BreadcrumbService } from 'xng-breadcrumb';
+
+import { LoaderComponent } from '../../../components/loader/loader.component';
+import { PageComponent } from '../../../components/page/page.component';
+import { Page } from '../../../entities/page/page';
+import { PageService } from '../../../services/page.service';
+
+@Component({
+  selector: 'app-guides-page',
+  imports: [PageComponent, AsyncPipe, LoaderComponent],
+  standalone: true,
+  template: `
+    @if (selectedPageData$ | async; as selectedPageData) {
+      @if (selectedPageData) {
+        <app-page class="page-content__container" [page]="selectedPageData" [pages]="pages()"></app-page>
+      }
+    } @else {
+      <app-loader />
+    }
+  `,
+})
+export class GuidesPageComponent {
+  pages: InputSignal<Page[]> = input.required<Page[]>();
+  selectedPageData$: Observable<Page> = of();
+
+  constructor(
+    private readonly pageService: PageService,
+    private readonly breadcrumbService: BreadcrumbService,
+    private readonly destroyRef: DestroyRef,
+  ) {
+    inject(ActivatedRoute)
+      .paramMap.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(paramMap => {
+        const pageId = paramMap.get('pageId');
+        if (pageId) {
+          this.selectedPageData$ = this.getSelectedPage$(pageId);
+        } else if (this.pages().length > 0) {
+          this.selectedPageData$ = this.getSelectedPage$(this.pages()[0].id);
+        }
+      });
+  }
+
+  private getSelectedPage$(pageId: string): Observable<Page> {
+    return this.pageService.getById(pageId, true).pipe(
+      tap(page => {
+        this.breadcrumbService.set('@pageName', page.name);
+      }),
+      takeUntilDestroyed(this.destroyRef),
+    );
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/guides/guides.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/guides/guides.component.html
@@ -17,28 +17,14 @@
 -->
 <mat-card appearance="outlined">
   <mat-card-content class="guides">
-    @if (pagesData$ | async; as pagesData) {
+    @if (pagesData(); as pagesData) {
       @if (pagesData.nodes.length) {
         <div class="guides__side-bar">
-          <app-page-tree
-            class="guides__side-bar__tree"
-            [activePage]="selectedPageId()"
-            [pages]="pagesData.nodes"
-            (openFile)="showPage($event)" />
+          <app-page-tree class="guides__side-bar__tree" [activePage]="pageId()!" [pages]="pagesData.nodes" (openFile)="showPage($event)" />
         </div>
 
         <div class="guides__page-content">
-          @if (selectedPageData$ | async; as selectedPageData) {
-            @if (loadingPage()) {
-              <app-loader />
-            } @else if (selectedPageData.result) {
-              <app-page class="guides__page-content__container" [page]="selectedPageData.result" [pages]="pagesData.pages" />
-            } @else if (selectedPageData.error) {
-              <div i18n="@@apiDocumentationError">An error has occurred.</div>
-            }
-          } @else {
-            <app-loader />
-          }
+          <router-outlet />
         </div>
       } @else {
         <div class="guides__empty">

--- a/gravitee-apim-portal-webui-next/src/app/guides/resolvers/environment-pages.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/app/guides/resolvers/environment-pages.resolver.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+
+import { Page } from '../../../entities/page/page';
+import { PageService } from '../../../services/page.service';
+
+export const environmentPagesResolver = (() =>
+  inject(PageService)
+    .listByEnvironment()
+    .pipe(map(({ data }) => data ?? []))) satisfies ResolveFn<Page[]>;

--- a/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
@@ -129,7 +129,7 @@ describe('MarkdownService', () => {
       const renderedLink = renderer.link('/#!/settings/pages/123456789', 'title', 'text');
 
       expect(renderedLink).not.toBeNull();
-      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
+      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/123456789">text</a>');
     });
 
     it('should use a.internal-link for render an api page link', () => {
@@ -137,7 +137,7 @@ describe('MarkdownService', () => {
       const renderedLink = renderer.link('/#!/apis/1A2Z3E4R5T6Y/documentation/123456789', 'title', 'text');
 
       expect(renderedLink).not.toBeNull();
-      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
+      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/123456789">text</a>');
     });
 
     it('should use a.anchor for render an anchor', () => {
@@ -159,7 +159,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/123456789">text</a>');
       });
 
       it('should find page by its name and file type', () => {
@@ -167,7 +167,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/myPage#SWAGGER', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=22">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/22">text</a>');
       });
 
       it('should find SWAGGER page by OPENAPI file reference', () => {
@@ -175,7 +175,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/myPage#OPENAPI', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=22">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/22">text</a>');
       });
 
       it('should find page by its name with spaces', () => {
@@ -183,7 +183,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/my%20Page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=33">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/33">text</a>');
       });
 
       it('should find page by its name and path', () => {
@@ -191,7 +191,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/parent/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=44">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/44">text</a>');
       });
 
       it('should find page with multi layer path with spaces', () => {
@@ -199,7 +199,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/grand%20parent/my%20parent/my%20page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=55">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/55">text</a>');
       });
 
       it('should find page with symbols its name', () => {
@@ -207,7 +207,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/my#$%^&*(){}?>.\\|éàêcrazy@%20page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=66">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/66">text</a>');
       });
 
       it('should return link with file name even if not found', () => {
@@ -215,7 +215,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/doesNotExist#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=doesNotExist">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/doesNotExist">text</a>');
       });
 
       it('should return link with file name even if parent id invalid', () => {
@@ -223,7 +223,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/api/doesNotExist/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=myPage">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation/myPage">text</a>');
       });
 
       it.each(['myPage#typeDoesNotExist', 'myPage', 'myPage#', '#MARKDOWN', '#', 'parent#FOLDER'])(
@@ -248,7 +248,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=123456789">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/123456789">text</a>');
       });
 
       it('should find page by its name and file type', () => {
@@ -256,7 +256,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/myPage#SWAGGER', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=22">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/22">text</a>');
       });
 
       it('should find SWAGGER page by OPENAPI file reference', () => {
@@ -264,7 +264,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/myPage#OPENAPI', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=22">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/22">text</a>');
       });
 
       it('should find page by its name with spaces', () => {
@@ -272,7 +272,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/my%20Page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=33">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/33">text</a>');
       });
 
       it('should find page by its name and path', () => {
@@ -280,7 +280,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/parent/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=44">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/44">text</a>');
       });
 
       it('should find page with multi layer path with spaces', () => {
@@ -288,7 +288,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/grand%20parent/my%20parent/my%20page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=55">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/55">text</a>');
       });
 
       it('should find page with symbols its name', () => {
@@ -296,7 +296,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/my#$%^&*(){}?>.\\|éàêcrazy@%20page#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=66">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/66">text</a>');
       });
 
       it('should return link with file name even if not found', () => {
@@ -304,7 +304,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/doesNotExist#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=doesNotExist">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/doesNotExist">text</a>');
       });
 
       it('should return link with file name even if parent id invalid', () => {
@@ -312,7 +312,7 @@ describe('MarkdownService', () => {
         const renderedLink = renderer.link('/#!/documentation/environment/doesNotExist/myPage#MARKDOWN', 'title', 'text');
 
         expect(renderedLink).not.toBeNull();
-        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=myPage">text</a>');
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides/myPage">text</a>');
       });
 
       it.each(['myPage#typeDoesNotExist', 'myPage', 'myPage#', '#MARKDOWN', '#', 'parent#FOLDER'])(

--- a/gravitee-apim-portal-webui-next/src/services/markdown.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/markdown.service.ts
@@ -90,7 +90,7 @@ export class MarkdownService {
         }
 
         if (pageBaseUrl && pageId) {
-          return `<a class="${INTERNAL_LINK_CLASSNAME}" href="${pageBaseUrl}?page=${pageId}">${text}</a>`;
+          return `<a class="${INTERNAL_LINK_CLASSNAME}" href="${pageBaseUrl}/${pageId}">${text}</a>`;
         }
 
         if (href.startsWith('#')) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11367

## Description

Allow users to navigate from a page to another using a link into an API document.
Allow user to refresh documentation page and stay on the selected document.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

