### PR TITLE
fix: reflow api analytics charts when menu is collapsed or expanded

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.scss
@@ -31,4 +31,8 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  box-sizing: border-box;
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-chart-abstract/gio-chart-abstract.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-chart-abstract/gio-chart-abstract.component.ts
@@ -13,26 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Directive, effect, inject, signal, WritableSignal } from '@angular/core';
+import { DestroyRef, Directive, inject, signal, WritableSignal } from '@angular/core';
 import * as Highcharts from 'highcharts';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { GioMenuService } from '@gravitee/ui-particles-angular';
+import { tap } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive()
 export abstract class GioChartAbstractComponent {
-  private reduced = toSignal(inject(GioMenuService).reduced$);
-
   Highcharts: typeof Highcharts = Highcharts;
   private chart: WritableSignal<Highcharts.Chart | undefined> = signal<Highcharts.Chart>(undefined);
 
   constructor() {
-    effect(() => {
-      if (this.reduced() && this.chart()) {
-        setTimeout(() => {
-          this.chart().reflow();
-        }, 0);
-      }
-    });
+    inject(GioMenuService)
+      .reduced$.pipe(
+        tap(() => {
+          if (this.chart()) {
+            setTimeout(() => {
+              this.chart().reflow();
+            }, 0);
+          }
+        }),
+        takeUntilDestroyed(inject(DestroyRef)),
+      )
+      .subscribe();
   }
 
   protected chartInstance(chart: Highcharts.Chart) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10875

## Description

Before:

https://github.com/user-attachments/assets/d7f0dfbe-5838-495d-96e1-79d93ebfefa2

After:

https://github.com/user-attachments/assets/225595fc-b4d2-42f0-a76e-4cd376bf1fda


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vxqflphzwo.chromatic.com)
<!-- Storybook placeholder end -->
