### PR TITLE
Apim 11392 ng portal mobile catalog tiles

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
@@ -18,10 +18,12 @@
 <mat-card class="api-details" appearance="outlined">
   <mat-card-content>
     <div class="api-details__header">
-      <app-picture [picture]="api._links?.picture" [hashValue]="api.name + ' ' + api.version" [size]="40" />
-      <div class="api-details__header__content">
-        <div class="m3-headline-small">{{ api.name }}</div>
-        <div class="m3-body-medium">{{ api.version }}</div>
+      <div class="api-details__header__api-info">
+        <app-picture [picture]="api._links?.picture" [hashValue]="api.name + ' ' + api.version" [size]="40" />
+        <div class="api-details__header__content">
+          <div class="m3-headline-small">{{ api.name }}</div>
+          <div class="m3-body-medium">{{ api.version }}</div>
+        </div>
       </div>
       @if (!!api.mcp) {
         <mat-chip i18n="@@apiCardMcpEnabled" i18n-matTooltip matTooltip="MCP available for this API">

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.scss
@@ -18,8 +18,16 @@
 
   &__header {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: space-between;
     gap: 16px;
+
+    &__api-info {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
 
     &__content {
       display: flex;
@@ -41,7 +49,6 @@
   &__header-button {
     display: flex;
     align-items: center;
-    margin-left: auto;
     gap: 16px;
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<div class="api-details__tab">
+<div class="api-details__tab" [ngClass]="apiDetailsTabClasses()">
   <div class="api-details__tab-details-content">
     @if (homepageData$ | async; as homepageData) {
       @if (homepageData.result) {
@@ -31,23 +31,20 @@
       <app-loader />
     }
   </div>
-
-  <div>
-    <mat-card appearance="outlined" class="api-details__tab-details-info__card">
-      @if (apiInformation$ | async; as apiInformationList) {
-        @for (apiInformation of apiInformationList; track apiInformation.name) {
-          <div>
-            <div class="m3-body-large">{{ apiInformation.name }}</div>
-            <div class="m3-body-medium api-info-value">{{ apiInformation.value }}</div>
-          </div>
-        }
-      }
-      @if (categories$ | async; as categories) {
+  <mat-card appearance="outlined" class="api-details__tab-details-info__card">
+    @if (apiInformation$ | async; as apiInformationList) {
+      @for (apiInformation of apiInformationList; track apiInformation.name) {
         <div>
-          <div i18n="@@apiDetailsCategories" class="m3-body-large">Categories</div>
-          <div class="m3-body-medium">{{ categories }}</div>
+          <div class="m3-body-large">{{ apiInformation.name }}</div>
+          <div class="m3-body-medium api-info-value">{{ apiInformation.value }}</div>
         </div>
       }
-    </mat-card>
-  </div>
+    }
+    @if (categories$ | async; as categories) {
+      <div>
+        <div i18n="@@apiDetailsCategories" class="m3-body-large">Categories</div>
+        <div class="m3-body-medium">{{ categories }}</div>
+      </div>
+    }
+  </mat-card>
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.scss
@@ -32,11 +32,21 @@
       --mdc-elevated-card-container-color: #{m3-adapter.$surface-variant};
 
       display: flex;
-      width: 324px;
+      min-width: 324px;
       flex-direction: column;
       padding: 32px;
       gap: 32px;
     }
+  }
+}
+
+// MOBILE
+.api-details__tab--mobile {
+  flex-wrap: wrap-reverse;
+
+  .api-details__tab-details-info__card {
+    width: 100%;
+    min-width: 0;
   }
 }
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AsyncPipe } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
+import { AsyncPipe, NgClass } from '@angular/common';
+import { Component, computed, inject, Input, OnInit } from '@angular/core';
 import { MatCard } from '@angular/material/card';
 import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
 
@@ -24,6 +24,7 @@ import { Api } from '../../../../entities/api/api';
 import { ApiInformation } from '../../../../entities/api/api-information';
 import { Page } from '../../../../entities/page/page';
 import { CategoriesService } from '../../../../services/categories.service';
+import { ObservabilityBreakpointService } from '../../../../services/observability-breakpoint.service';
 import { PageService } from '../../../../services/page.service';
 import { PortalService } from '../../../../services/portal.service';
 
@@ -34,7 +35,7 @@ interface HomepageData {
 
 @Component({
   selector: 'app-api-tab-details',
-  imports: [AsyncPipe, PageComponent, LoaderComponent, MatCard],
+  imports: [AsyncPipe, PageComponent, LoaderComponent, MatCard, NgClass],
   templateUrl: './api-tab-details.component.html',
   styleUrl: './api-tab-details.component.scss',
 })
@@ -46,6 +47,11 @@ export class ApiTabDetailsComponent implements OnInit {
   homepageData$: Observable<HomepageData> = of();
   categories$: Observable<string> = of('');
   apiInformation$: Observable<ApiInformation[]> = of([]);
+
+  apiDetailsTabClasses = computed(() => ({
+    'api-details__tab--mobile': this.isMobile(),
+  }));
+  protected readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
 
   constructor(
     private pageService: PageService,

--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.html
@@ -29,7 +29,11 @@
       @if (applications.data.length === 0) {
         <p i18n="@@noAppsAvailable">Sorry, there are no applications yet.</p>
       } @else {
-        <div class="app-list__container" infiniteScroll (scrolled)="loadMoreApplications(applications)">
+        <div
+          class="app-list__container"
+          [ngClass]="appListContainerClasses()"
+          infiniteScroll
+          (scrolled)="loadMoreApplications(applications)">
           @for (application of applications.data; track application.id) {
             <app-application-card [application]="application" />
           }

--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.scss
@@ -30,6 +30,10 @@
   gap: 32px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 
+  &--mobile {
+    grid-template-columns: 1fr !important;
+  }
+
   > * {
     height: 256px;
   }

--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AsyncPipe } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { AsyncPipe, NgClass } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { BehaviorSubject, EMPTY, map, Observable, scan, switchMap, tap } from 'rxjs';
@@ -24,6 +24,7 @@ import { ApplicationCardComponent } from '../../components/application-card/appl
 import { LoaderComponent } from '../../components/loader/loader.component';
 import { Application } from '../../entities/application/application';
 import { ApplicationService } from '../../services/application.service';
+import { ObservabilityBreakpointService } from '../../services/observability-breakpoint.service';
 
 export interface ApplicationPaginatorVM {
   data: Application[];
@@ -33,7 +34,7 @@ export interface ApplicationPaginatorVM {
 
 @Component({
   selector: 'app-applications',
-  imports: [AsyncPipe, InfiniteScrollModule, LoaderComponent, MatCard, MatCardContent, ApplicationCardComponent],
+  imports: [AsyncPipe, InfiniteScrollModule, LoaderComponent, MatCard, MatCardContent, ApplicationCardComponent, NgClass],
   templateUrl: './applications.component.html',
   styleUrl: './applications.component.scss',
 })
@@ -41,6 +42,10 @@ export class ApplicationsComponent {
   applicationPaginator$: Observable<ApplicationPaginatorVM>;
   loadingPage$ = new BehaviorSubject(true);
 
+  appListContainerClasses = computed(() => ({
+    'app-list__container--mobile': this.isMobile(),
+  }));
+  protected readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
   private applicationService = inject(ApplicationService);
   private page$ = new BehaviorSubject(1);
 

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2025 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@
 
 @if (categories(); as categories) {
   @if (categories.length) {
-    <div class="categories-view__container">
+    <div class="categories-view__container" [ngClass]="categoriesViewContainerClasses()">
       @for (cat of categories; track $index) {
         <app-category-card [category]="cat" />
       }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,9 @@
 .categories-view {
   &__header {
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
     place-content: center space-between;
   }
 
@@ -29,5 +32,9 @@
     display: grid;
     gap: 32px;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+
+    &--mobile {
+      grid-template-columns: 1fr !important;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input, InputSignal } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, input, InputSignal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { RouterLink } from '@angular/router';
@@ -21,18 +22,24 @@ import { RouterLink } from '@angular/router';
 import { CategoryCardComponent } from '../../../components/category-card/category-card.component';
 import { Category } from '../../../entities/categories/categories';
 import { ConfigService } from '../../../services/config.service';
+import { ObservabilityBreakpointService } from '../../../services/observability-breakpoint.service';
 import { CatalogBannerComponent } from '../components/catalog-banner/catalog-banner.component';
 
 @Component({
   selector: 'app-categories-view',
   standalone: true,
-  imports: [CatalogBannerComponent, MatCardModule, CategoryCardComponent, MatButton, RouterLink],
+  imports: [CatalogBannerComponent, MatCardModule, CategoryCardComponent, MatButton, RouterLink, NgClass],
   templateUrl: './categories-view.component.html',
   styleUrl: './categories-view.component.scss',
 })
 export class CategoriesViewComponent {
   showBanner: boolean;
   categories: InputSignal<Category[]> = input<Category[]>([]);
+
+  categoriesViewContainerClasses = computed(() => ({
+    'categories-view__container--mobile': this.isMobile(),
+  }));
+  protected readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
 
   constructor(private readonly configService: ConfigService) {
     this.showBanner = !!this.configService.configuration?.portalNext?.banner?.enabled;

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.html
@@ -34,7 +34,7 @@
 
 @if (apiPaginator$ | async; as apis) {
   @if (apis.data.length > 0) {
-    <div class="api-list__container" infiniteScroll (scrolled)="loadMoreApis(apis)">
+    <div class="api-list__container" [ngClass]="apiListContainerClasses()" infiniteScroll (scrolled)="loadMoreApis(apis)">
       @for (api of apis.data; track api.id) {
         <app-api-card
           [id]="api.id"

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.scss
@@ -22,7 +22,10 @@
 .api-list {
   &__header {
     display: flex;
-    place-content: center space-between;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
 
     &__category-info {
       display: flex;
@@ -36,5 +39,9 @@
     display: grid;
     gap: 32px;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+
+    &--mobile {
+      grid-template-columns: 1fr !important;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AsyncPipe } from '@angular/common';
-import { Component, computed, effect, input, InputSignal, output } from '@angular/core';
+import { AsyncPipe, NgClass } from '@angular/common';
+import { Component, computed, effect, inject, input, InputSignal, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { isEqual } from 'lodash';
 import { InfiniteScrollDirective } from 'ngx-infinite-scroll';
@@ -27,6 +27,7 @@ import { SearchBarComponent } from '../../../../components/search-bar/search-bar
 import { ApisResponse } from '../../../../entities/api/apis-response';
 import { Category } from '../../../../entities/categories/categories';
 import { ApiService } from '../../../../services/api.service';
+import { ObservabilityBreakpointService } from '../../../../services/observability-breakpoint.service';
 
 interface ApiVM {
   id: string;
@@ -46,7 +47,7 @@ interface ApiPaginatorVM {
 @Component({
   selector: 'app-apis-list',
   standalone: true,
-  imports: [AsyncPipe, MatCardModule, ApiCardComponent, InfiniteScrollDirective, LoaderComponent, SearchBarComponent],
+  imports: [AsyncPipe, MatCardModule, ApiCardComponent, InfiniteScrollDirective, LoaderComponent, SearchBarComponent, NgClass],
   templateUrl: './apis-list.component.html',
   styleUrl: './apis-list.component.scss',
 })
@@ -59,6 +60,11 @@ export class ApisListComponent {
 
   apiPaginator$: Observable<ApiPaginatorVM> = of();
   loadingPage: boolean = true;
+
+  apiListContainerClasses = computed(() => ({
+    'api-list__container--mobile': this.isMobile(),
+  }));
+  protected readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
 
   private readonly page$ = new BehaviorSubject<number>(1);
 

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
@@ -15,6 +15,7 @@
  */
 :host {
   display: flex;
+  min-width: 0;
   min-height: 256px;
   flex-flow: column;
 }
@@ -27,6 +28,7 @@
 
   &__header {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 16px;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11392

## Description

- Handle single column grid for mobile for Category tiles, API Tiles and Application Tiles
- Handle mobile for API details --> Button and badges are moved below the header
- Handle mobile for API Description tab --> API Info displayed before homepage content


https://github.com/user-attachments/assets/8c5ca716-d365-405b-a3d7-cb803c46bc1f


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

