### PR TITLE
fix: allow custom http2 windows on http-proxy endpoint

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/http/HttpClientOptions.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/http/HttpClientOptions.java
@@ -45,6 +45,15 @@ public class HttpClientOptions implements Serializable {
     private int http2MultiplexingLimit = -1;
 
     @Builder.Default
+    private int http2ConnectionWindowSize = -1;
+
+    @Builder.Default
+    private int http2StreamWindowSize = -1;
+
+    @Builder.Default
+    private int http2MaxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+
+    @Builder.Default
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
 
     @Builder.Default

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
@@ -84,6 +84,10 @@ The http proxy connector comes with default values regarding the connection pool
 |clearTextUpgrade | true     | No | No | No | Allows h2c Clear Text Upgrade. If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge).
 |pipelining | false     | No | No | No | Enable HTTP pipelining. When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
 |connectTimeout | 3000     | Yes | No | No | Maximum time to connect to the backend in milliseconds.
+|http2MultiplexingLimit | -1     | No | No | No | The maximum number of concurrent streams allowed for each HTTP/2 connection. The actual number of streams per connection is the minimum of this value and the server's initial settings. For example, if set to 10 and the server's initial setting is 1000, the max number of streams will be 10. If set to -1, the server's initial settings will be used. -1 is the default.
+|http2ConnectionWindowSize | -1     | No | No | No | Connection Window Size in bytes can be increased to a larger value such as 1MB (1048576 bytes) to improve throughput. If set to -1, the default HTTP/2 spec value is use (e.g., 65535 bytes). -1 is the default.
+|http2StreamWindowSize | -1     | No | No | No | Stream Window Size in bytes can be increased to a larger value such as 256KB (262144 bytes) to improve throughput (initial settings). If set to -1, the default HTTP/2 spec value is used (65535 bytes). -1 is the default.
+|http2MaxFrameSize | 16384     | No | No | No | Max frame size in bytes (initial settings). Default is the HTTP/2 spec default value (16384 bytes). Max value is 16777215.
 
 |===
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -130,6 +130,40 @@
                 }
             }
         },
+        "http2ConnectionWindowSize": {
+          "type": "integer",
+          "title": "Connection Window Size for an HTTP/2 connection",
+          "default": -1,
+          "gioConfig": {
+            "banner": {
+              "title": "Connection Window Size for an HTTP/2 connection",
+              "text": "Connection Window Size in bytes can be increased to a larger value such as 1MB (1048576 bytes) to improve throughput. If set to -1, the default HTTP/2 spec value is use (e.g., 65535 bytes). -1 is the default."
+            }
+          }
+        },
+        "http2StreamWindowSize": {
+          "type": "integer",
+          "title": "Stream initial window size for each HTTP/2 stream",
+          "default": -1,
+          "gioConfig": {
+            "banner": {
+              "title": "Stream initial window size for each HTTP/2 stream",
+              "text": "Stream Window Size in bytes can be increased to a larger value such as 256KB (262144 bytes) to improve throughput (initial settings). If set to -1, the default HTTP/2 spec value is used (65535 bytes). -1 is the default."
+            }
+          }
+        },
+        "http2MaxFrameSize": {
+          "type": "integer",
+          "title": "Max frame size for HTTP/2 stream data frame",
+          "default": 16384,
+          "maximum": 16777215,
+          "gioConfig": {
+            "banner": {
+              "title": "Max frame size for HTTP/2 stream data frame",
+              "text": "Max frame size in bytes (initial settings). Default is the HTTP/2 spec default value (16384 bytes). Max value is 16777215."
+            }
+          }
+        },
         "http": {
             "type": "object",
             "title": "Security configuration",
@@ -221,6 +255,15 @@
                         },
                         "http2MultiplexingLimit": {
                             "$ref": "#/definitions/http2MultiplexingLimit"
+                        },
+                        "http2ConnectionWindowSize": {
+                          "$ref": "#/definitions/http2ConnectionWindowSize"
+                        },
+                        "http2StreamWindowSize": {
+                          "$ref": "#/definitions/http2StreamWindowSize"
+                        },
+                        "http2MaxFrameSize": {
+                          "$ref": "#/definitions/http2MaxFrameSize"
                         }
                     },
                     "required": ["connectTimeout", "readTimeout", "idleTimeout", "maxConcurrentConnections"],

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -66,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -265,13 +266,53 @@ class HttpProxyEndpointConnectorTest {
 
             // We don't want to test the request itself just that the correct factory is used
             when(mockHttpClient.rxRequest(any())).thenThrow(new IllegalStateException());
-            cut
-                .connect(ctx)
-                .onErrorComplete(throwable -> throwable instanceof IllegalStateException)
-                .test()
-                .assertComplete();
-            verify(spyGrpcHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
+            cut.connect(ctx).onErrorComplete(IllegalStateException.class::isInstance).test().assertComplete();
+
+            ArgumentCaptor<HttpProxyEndpointConnectorSharedConfiguration> sharedConfigurationCaptor = ArgumentCaptor.forClass(
+                HttpProxyEndpointConnectorSharedConfiguration.class
+            );
+            verify(spyGrpcHttpClientFactory).getOrBuildHttpClient(any(), any(), sharedConfigurationCaptor.capture());
             verify(spyHttpClientFactory, never()).getOrBuildHttpClient(any(), any(), any());
+
+            HttpProxyEndpointConnectorSharedConfiguration config = sharedConfigurationCaptor.getValue();
+
+            // Check HTTP/2 default values.
+            assertThat(config.getHttpOptions().getHttp2MultiplexingLimit()).isEqualTo(-1);
+            assertThat(config.getHttpOptions().getHttp2ConnectionWindowSize()).isEqualTo(-1);
+            assertThat(config.getHttpOptions().getHttp2StreamWindowSize()).isEqualTo(-1);
+            assertThat(config.getHttpOptions().getHttp2MaxFrameSize()).isEqualTo(16384);
+        }
+
+        @Test
+        void should_use_grpc_client_factory_with_grpc_and_customize_http2_settings() {
+            // we nee to create a dedicated endpoint here as the evaluation of the configuration target
+            // to detect if the URL start by grpc is done once in the constructor
+            configuration.setTarget("grpc://target");
+            sharedConfiguration.getHttpOptions().setHttp2MultiplexingLimit(13);
+            sharedConfiguration.getHttpOptions().setHttp2ConnectionWindowSize(128000);
+            sharedConfiguration.getHttpOptions().setHttp2StreamWindowSize(72000);
+            sharedConfiguration.getHttpOptions().setHttp2MaxFrameSize(32000);
+
+            var cut = new HttpProxyEndpointConnector(configuration, sharedConfiguration);
+            injectSpyIntoEndpointConnector(cut);
+
+            // We don't want to test the request itself just that the correct factory is used
+            when(mockHttpClient.rxRequest(any())).thenThrow(new IllegalStateException());
+            cut.connect(ctx).onErrorComplete(IllegalStateException.class::isInstance).test().assertComplete();
+
+            ArgumentCaptor<HttpProxyEndpointConnectorSharedConfiguration> sharedConfigurationCaptor = ArgumentCaptor.forClass(
+                HttpProxyEndpointConnectorSharedConfiguration.class
+            );
+            verify(spyGrpcHttpClientFactory).getOrBuildHttpClient(any(), any(), sharedConfigurationCaptor.capture());
+            verify(spyHttpClientFactory, never()).getOrBuildHttpClient(any(), any(), any());
+
+            HttpProxyEndpointConnectorSharedConfiguration config = sharedConfigurationCaptor.getValue();
+
+            // Check HTTP/2 values have been taken into account when creating the client.
+            assertThat(config.getHttpOptions().getHttp2MultiplexingLimit()).isEqualTo(13);
+            assertThat(config.getHttpOptions().getHttp2ConnectionWindowSize()).isEqualTo(128000);
+            assertThat(config.getHttpOptions().getHttp2StreamWindowSize()).isEqualTo(72000);
+            assertThat(config.getHttpOptions().getHttp2MaxFrameSize()).isEqualTo(32000);
         }
 
         @Test

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.11.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.11.3.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.11.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.11.3.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.11.4.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.11.4.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.11.4.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.11.4.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,8 +473,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.11.3.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.11.3.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.11.4.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.11.4.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.0</gravitee-kubernetes.version>
-        <gravitee-node.version>7.11.3</gravitee-node.version>
+        <gravitee-node.version>7.11.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.8.0</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11272

## Description

This PR allows customizing the HTTP/2 settings (connection window size, stream window size, max frame size). 
This PR is considered a fix as we currently rely on the default from the HTTP/2 spec (64k). It can be too low for specific usage (high concurrency, large payloads, ...), and can introduce severe latencies or even timeouts for the end user application.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bilhwgqvad.chromatic.com)
<!-- Storybook placeholder end -->
