### PR TITLE
fix(console): make all the titles uniform for home dashboard

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-requests-stats/api-analytics-request-stats.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-requests-stats/api-analytics-request-stats.component.html
@@ -16,7 +16,9 @@
 
 -->
 <mat-card class="card">
-  <div class="title">{{ title }}</div>
+  <mat-card-header class="title">
+    <mat-card-title>{{ title }}</mat-card-title>
+  </mat-card-header>
   <div class="list">
     @for (requestStat of requestsStats; track requestStat.label) {
       <div class="list__row">

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-requests-stats/api-analytics-request-stats.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-requests-stats/api-analytics-request-stats.component.scss
@@ -5,8 +5,7 @@
 $typography: map.get(gio.$mat-theme, typography);
 
 .title {
-  @include mat.m2-typography-level($typography, 'body-1');
-  padding: 16px;
+  padding-bottom: 12px;
   border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
 }
 

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.html
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.html
@@ -16,10 +16,11 @@
 
 -->
 <mat-card class="card">
-  <div class="title">
-    API Request Stats
-    <mat-icon class="title__tooltip" svgIcon="gio:info" matTooltip="Excluding Websocket, Webhook and SSE" />
-  </div>
+  <mat-card-header>
+    <mat-card-title class="title"
+      >API Request Stats <mat-icon class="title__tooltip" svgIcon="gio:info" matTooltip="Excluding Websocket, Webhook and SSE"
+    /></mat-card-title>
+  </mat-card-header>
   @if (data) {
     <div class="stats">
       <div class="stats__body">

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.scss
@@ -15,22 +15,18 @@ $typography: map.get(gio.$mat-theme, typography);
 }
 
 .title {
-  @include mat.m2-typography-level($typography, 'body-1');
-  padding: 16px;
-  border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
 
   &__tooltip {
-    height: 16px;
-    width: 16px;
+    width: 18px;
+    height: 18px;
   }
 }
 
-.subtitle {
-  @include mat.m2-typography-level($typography, 'caption');
-  padding: 8px;
+mat-card-header {
+  padding-bottom: 12px;
   border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
 }
 

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.ts
@@ -17,7 +17,7 @@ import { Component, Input } from '@angular/core';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CommonModule, DecimalPipe } from '@angular/common';
 import { GioLoaderModule } from '@gravitee/ui-particles-angular';
-import { MatCard } from '@angular/material/card';
+import { MatCardModule } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
 
 import { GioShortNumberPipeModule } from '../../../../shared/utils/shortNumber.pipe.module';
@@ -32,7 +32,7 @@ export type v4ApisRequestStats = {
 
 @Component({
   selector: 'dashboard-api-request-stats',
-  imports: [CommonModule, MatTooltip, MatCard, MatIcon, DecimalPipe, GioShortNumberPipeModule, GioLoaderModule],
+  imports: [CommonModule, MatTooltip, MatCardModule, MatIcon, DecimalPipe, GioShortNumberPipeModule, GioLoaderModule],
   templateUrl: './dashboard-api-request-stats.component.html',
   styleUrls: ['./dashboard-api-request-stats.component.scss'],
 })

--- a/gravitee-apim-console-webui/src/management/home/components/top-applications-by-requests/top-applications-by-requests.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/components/top-applications-by-requests/top-applications-by-requests.component.scss
@@ -1,3 +1,7 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
 .top-applications-card {
   height: 100%;
 }
@@ -12,4 +16,14 @@ gio-loader {
 
 tr.mat-mdc-row {
   height: 28px;
+}
+
+mat-card-header {
+  padding-bottom: 12px;
+  border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+}
+
+gio-table-wrapper {
+  margin-top: 0;
+  border-top: none;
 }

--- a/gravitee-apim-console-webui/src/management/home/components/top-failed-apis/top-failed-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/home/components/top-failed-apis/top-failed-apis.component.html
@@ -18,7 +18,7 @@
 
 <mat-card class="top-failed-apis-card">
   <mat-card-header>
-    <mat-card-title class="mat-h4 card-title">Top failed APIs</mat-card-title>
+    <mat-card-title>Top failed APIs</mat-card-title>
   </mat-card-header>
 
   @if (isLoading) {

--- a/gravitee-apim-console-webui/src/management/home/components/top-failed-apis/top-failed-apis.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/components/top-failed-apis/top-failed-apis.component.scss
@@ -1,9 +1,19 @@
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'sass:map';
+@use '@angular/material' as mat;
+
 .top-failed-apis-card {
   height: 100%;
 }
 
-.card-title {
-  margin: 0;
+mat-card-header {
+  padding-bottom: 12px;
+  border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+}
+
+gio-table-wrapper {
+  margin-top: 0;
+  border-top: none;
 }
 
 tr.mat-mdc-row {

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -22,7 +22,9 @@
 
   <div class="row-cards">
     <mat-card class="card flex">
-      <div class="card__header">Summary</div>
+      <mat-card-header>
+        <mat-card-title>Summary</mat-card-title>
+      </mat-card-header>
       <mat-card-content class="card__content">
         <div *ngIf="apiNb !== undefined && applicationNb !== undefined; else loader" class="card__list">
           <div class="card__list__row">
@@ -37,7 +39,9 @@
       </mat-card-content>
     </mat-card>
     <mat-card class="card">
-      <div class="card__header">API Lifecycle State</div>
+      <mat-card-header>
+        <mat-card-title>API Lifecycle State</mat-card-title>
+      </mat-card-header>
       <mat-card-content class="card__content">
         <ng-container *ngIf="apiLifecycleState; else loader">
           <gio-api-lifecycle-state [data]="apiLifecycleState"></gio-api-lifecycle-state>
@@ -45,7 +49,9 @@
       </mat-card-content>
     </mat-card>
     <mat-card class="card">
-      <div class="card__header">API State</div>
+      <mat-card-header>
+        <mat-card-title>API State</mat-card-title>
+      </mat-card-header>
       <mat-card-content class="card__content">
         <ng-container *ngIf="apiState; else loader">
           <gio-api-state [data]="apiState"></gio-api-state>

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.scss
@@ -28,14 +28,17 @@ $typography: map.get(gio.$mat-theme, typography);
   gap: 14px;
 }
 
+mat-card-header {
+  padding-bottom: 12px;
+  border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+}
+
 .card {
   width: 100%;
   flex: 1 1 100%;
   min-height: 250px;
 
   &__header {
-    @include mat.m2-typography-level($typography, 'body-1');
-    border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
     padding: 16px;
     display: flex;
     align-items: center;

--- a/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.html
@@ -16,7 +16,9 @@
 
 -->
 <mat-card class="card">
-  <div class="title">{{ title }}</div>
+  <mat-card-header>
+    <mat-card-title>{{ title }}</mat-card-title>
+  </mat-card-header>
 
   @if (!responseStatusRanges || responseStatusRanges.isLoading) {
     <div class="card__loader">

--- a/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.scss
@@ -8,9 +8,8 @@ $typography: map.get(gio.$mat-theme, typography);
   display: block;
 }
 
-.title {
-  @include mat.m2-typography-level($typography, 'body-1');
-  padding: 16px;
+mat-card-header {
+  padding-bottom: 12px;
   border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
 }
 

--- a/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { MatCard } from '@angular/material/card';
+import { MatCard, MatCardHeader, MatCardTitle } from '@angular/material/card';
 import { GioLoaderModule } from '@gravitee/ui-particles-angular';
 
 import { GioChartPieModule } from '../gio-chart-pie/gio-chart-pie.module';
@@ -27,7 +27,7 @@ export type ApiAnalyticsResponseStatusRanges = {
 
 @Component({
   selector: 'api-analytics-response-status-ranges',
-  imports: [MatCard, GioChartPieModule, GioLoaderModule],
+  imports: [MatCard, GioChartPieModule, GioLoaderModule, MatCardTitle, MatCardHeader],
   templateUrl: './api-analytics-response-status-ranges.component.html',
   styleUrl: './api-analytics-response-status-ranges.component.scss',
 })

--- a/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.html
@@ -17,10 +17,16 @@
 -->
 
 <mat-card class="top-apis-card">
-  <div class="title">
-    Top APIs
-    <mat-icon class="title__tooltip" svgIcon="gio:info" matTooltip="Ordered by API calls"></mat-icon>
-  </div>
+  <mat-card-header>
+    <mat-card-title class="title">
+      Top APIs
+      <mat-icon
+        class="title__tooltip"
+        svgIcon="gio:info"
+        matTooltip="This table shows the top APIs based on the number of hits they have received. It provides insights into which APIs are most frequently accessed, helping you understand usage patterns and prioritize API management efforts."
+      ></mat-icon>
+    </mat-card-title>
+  </mat-card-header>
 
   @if (data) {
     <gio-table-wrapper

--- a/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.scss
@@ -10,15 +10,13 @@ $typography: map.get(gio.$mat-theme, typography);
 }
 
 .title {
-  @include mat.m2-typography-level($typography, 'body-1');
-  padding: 16px;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
 
   &__tooltip {
-    height: 16px;
-    width: 16px;
+    width: 18px;
+    height: 18px;
   }
 }
 
@@ -26,8 +24,14 @@ tr.mat-mdc-row {
   height: 28px;
 }
 
+mat-card-header {
+  padding-bottom: 12px;
+  border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+}
+
 .top-apis-table {
   margin-top: 0 !important;
+  border-top: none;
 }
 
 gio-loader {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Matching headers for the home dashboards:

https://github.com/user-attachments/assets/2f66ca78-143f-4715-b86c-43351de0d8af


Adjustments to the message dashboard to match the UI changes to the homepage:

<img width="1457" height="855" alt="Screenshot 2025-10-07 at 17 59 24" src="https://github.com/user-attachments/assets/dbb6b0ef-8d2f-4850-9bfd-135b9c5655b5" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ugiqtlxqtt.chromatic.com)
<!-- Storybook placeholder end -->
