### PR TITLE
fix: adding policy on the org level causes '404 Not Found'

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
@@ -65,7 +65,7 @@ export class OrgSettingsPlatformPoliciesService {
   }
 
   getDocumentation(policyId: string): Observable<PolicyDocumentation> {
-    return this.http.get<PolicyDocumentation>(`${this.constants.env.baseURL}/policies/${policyId}/documentation-ext`);
+    return this.http.get<PolicyDocumentation>(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/documentation-ext`);
   }
 
   getFlowSchemaForm(): Observable<FlowSchema> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10253

## Description

URL was not updated for org level policies for documentation.

Old path:
{basePath}/management/organizations/DEFAULT/environments/DEFAULT/policies/mock/documentation-ext

https://github.com/user-attachments/assets/9e734802-d9aa-4d8d-b8b5-51eb1e8bca6b




New path:
{basePath}/management/v2/organizations/DEFAULT/plugins/policies/mock/documentation-ext


https://github.com/user-attachments/assets/f36f8c89-417f-4e71-bb4d-04395ce69315


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kjrluozsdy.chromatic.com)
<!-- Storybook placeholder end -->
