### PR TITLE
fix(helm): retain SSL password field when empty string is provided

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -132,7 +132,7 @@ data:
           {{- if .Values.gateway.ssl.keystore.path }}
           path: {{ .Values.gateway.ssl.keystore.path }}
           {{- end }}
-          {{- if .Values.gateway.ssl.keystore.password }}
+          {{- if hasKey .Values.gateway.ssl.keystore "password" }}
           password: {{ .Values.gateway.ssl.keystore.password | quote }}
           {{- end }}
           {{- if .Values.gateway.ssl.keystore.kubernetes }}

--- a/helm/tests/gateway/configmap_ssl_test.yaml
+++ b/helm/tests/gateway/configmap_ssl_test.yaml
@@ -98,3 +98,31 @@ tests:
             \s ssl:
             \s   keystore:
             \s     secret: secret://kubernetes/my-secret
+
+  - it: Keystore with empty password should render password field
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          keystore:
+            type: pkcs12
+            path: ${gravitee.home}/security/internal-cert.pfx
+            password: ""
+          sni: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s secured: true
+            \s ssl:
+            \s   keystore:
+            \s     type: pkcs12
+            \s     path: \$\{gravitee\.home\}/security/internal-cert\.pfx
+            \s     password: ""
+            \s   clientAuth: false
+            \s   sni: true


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11301

## Description

When configuring Gravitee APIM Gateway via Helm, if `gateway.ssl.keystore.password` is explicitly set to an empty string (""), the generated configuration omitted the `password` field entirely due to a truthy check in the template.

This caused issues for systems or validation tools expecting the field to exist, and diverged from Gravitee AM Helm behavior where empty passwords are preserved.

This commit updates the Helm template to use `hasKey` instead of a truthy check for `password`, ensuring the field is rendered even when empty. A Helm unit test has been added to verify that `password: ""` appears in the rendered output.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

