### PR TITLE
fix(console): mask privateToken in V2 API documentation page response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapperTest.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.rest.api.management.v2.rest.model.SourceConfiguration;
 import java.util.LinkedHashMap;
@@ -51,8 +49,8 @@ class PageMapperTest extends AbstractMapperTest {
 
         var pageSource = pageMapper.mapSourceConfigurationToPageSource(sourceConfiguration);
 
-        assertNotNull(pageSource);
-        assertEquals("http-fetcher", pageSource.getType());
+        assertThat(pageSource).isNotNull();
+        assertThat(pageSource.getType()).isEqualTo("http-fetcher");
 
         var expectedConfig = """
             {
@@ -60,7 +58,7 @@ class PageMapperTest extends AbstractMapperTest {
               "autoFetch" : false,
               "url" : "https://apim-master-api.team-apim.gravitee.dev/management/openapi.yaml"
             }""";
-        assertNotNull(pageSource.getConfiguration());
-        assertEquals(expectedConfig, pageSource.getConfiguration().toString());
+        assertThat(pageSource.getConfiguration()).isNotNull();
+        assertThat(pageSource.getConfiguration().toString()).isEqualTo(expectedConfig);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11405

## Description

Updated the V4 API endpoint logic to consistently mask sensitive fields like privateToken, aligning with the behaviour of the legacy endpoint.

## Additional context

### Before Fix
<img width="550" height="507" alt="Screenshot 2025-10-13 at 1 23 43 AM" src="https://github.com/user-attachments/assets/c8dfb137-de29-484c-8185-fe9641252096" />


### After Fix
<img width="1310" height="607" alt="Screenshot 2025-10-13 at 1 23 03 AM" src="https://github.com/user-attachments/assets/efcf634e-6122-485d-be23-3140be28e278" />
