### PR TITLE
fix(console): Updated API general information now visible without refreshing the page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -71,6 +71,7 @@ describe('ApiGeneralInfoComponent', () => {
           provide: ActivatedRoute,
           useValue: {
             params: of({ apiId: API_ID }),
+            snapshot: { params: { apiId: 'apiId' } },
           },
         },
         {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11288

## Description

When reimporting an API definition that contains a new picture field (base64-encoded image), the existing API image and background image is updated but to see the changes page needs to be refreshed. The old image remains visible even though the import payload contains a new image. This issue occurs both via the REST API (/apis/:api/import) and when performing an export–modify–reimport workflow through the APIM UI.

This ticket is connected to the ticket: [APIM-11026: Image not updated with rest-api](https://gravitee.atlassian.net/browse/APIM-11026) 
 

## Additional context

After fix video:

https://github.com/user-attachments/assets/fa490c66-31d1-482b-a5db-4c0401ef5d1e


The api export used:

[testapp-1 (1).json](https://github.com/user-attachments/files/22649683/testapp-1.1.json)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yvwvdbelzt.chromatic.com)
<!-- Storybook placeholder end -->
