### PR TITLE
fix: make updateEvent async to run all processing in another scheduler

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/pom.xml
@@ -158,6 +158,12 @@
             <artifactId>vertx-unit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- HTTP mock -->
         <dependency>
             <groupId>org.wiremock</groupId>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11571

## Description

Ensure the update of the DebugEvent is not executed in the event loop to prevent ThreadBlock occuring

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kokrxgmpao.chromatic.com)
<!-- Storybook placeholder end -->
