### PR TITLE
fix: remove api stop notification during delete environment command

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -319,7 +319,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
                 new ApiCriteria.Builder().state(LifecycleState.STARTED).environmentId(executionContext.getEnvironmentId()).build(),
                 new ApiFieldFilter.Builder().excludeDefinition().excludePicture().build()
             )
-            .forEach(api -> apiStateService.stop(executionContext, api.getId(), userId));
+            .forEach(api -> apiStateService.stopWithoutNotification(executionContext, api.getId(), userId));
 
         // Delete related access points
         this.accessPointService.deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, executionContext.getEnvironmentId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
@@ -82,7 +82,7 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
                     new ApiCriteria.Builder().state(LifecycleState.STARTED).environmentId(environment.getId()).build(),
                     new ApiFieldFilter.Builder().excludeDefinition().excludePicture().build()
                 )
-                .forEach(api -> apiStateService.stop(executionContext, api.getId(), payload.userId()));
+                .forEach(api -> apiStateService.stopWithoutNotification(executionContext, api.getId(), payload.userId()));
 
             // Delete related access points
             this.accessPointService.deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, environment.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiStateService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiStateService.java
@@ -64,6 +64,8 @@ public interface ApiStateService {
 
     GenericApiEntity stop(ExecutionContext executionContext, String apiId, String userId);
 
+    GenericApiEntity stopWithoutNotification(ExecutionContext executionContext, String apiId, String userId);
+
     boolean stopV2DynamicProperties(String apiId);
 
     boolean stopV4DynamicProperties(String apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -558,8 +558,8 @@ public class DeleteEnvironmentCommandHandlerTest {
     }
 
     private void verifyDisableEnvironment(ExecutionContext executionContext) {
-        verify(apiStateService).stop(executionContext, API_ID_1, USER_ID);
-        verify(apiStateService).stop(executionContext, API_ID_2, USER_ID);
+        verify(apiStateService).stopWithoutNotification(executionContext, API_ID_1, USER_ID);
+        verify(apiStateService).stopWithoutNotification(executionContext, API_ID_2, USER_ID);
         verify(dictionaryService).stop(executionContext, DICTIONARY_ID);
         verify(identityProviderActivationService).removeAllIdpsFromTarget(
             executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandlerTest.java
@@ -115,7 +115,7 @@ class DisableEnvironmentCommandHandlerTest {
             .awaitDone(1, TimeUnit.SECONDS)
             .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
-        verify(apiStateService).stop(eq(context), eq(API_ID), eq(USER_ID));
+        verify(apiStateService).stopWithoutNotification(eq(context), eq(API_ID), eq(USER_ID));
         verify(accessPointService).deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, ENV_APIM_ID);
         verify(dictionaryService).stop(context, DICTIONARY_ID);
         verify(idpActivationService).removeAllIdpsFromTarget(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3681

## Description

Desired outcome: remove user notifications when disabling/deleting an environment or organization through command handler. 

I believe API stop is the only notificaiton the commands currently cause (most deletion actions use the repository directly, skipping triggering notificaitons) so added method allowing stopping APIs without triggering notification and updated command handler usages to this. 