### PR TITLE
fix: ensure API creation respects the visibility flag (public/private) as defined

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3127,6 +3127,8 @@ components:
                     type: string
                     description: API's description. A short description of your API.
                     example: I can use many characters to describe this API.
+                visibility:
+                    $ref: "#/components/schemas/Visibility"
                 definitionVersion:
                     $ref: "#/components/schemas/DefinitionVersion"
                 groups:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -19,23 +19,28 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import fixtures.ApiFixtures;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
+import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.FailoverV4;
 import io.gravitee.rest.api.management.v2.rest.model.IntegrationOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.KubernetesOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.ManagementOriginContext;
+import io.gravitee.rest.api.management.v2.rest.model.Visibility;
 import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.federation.FederatedApiEntity;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mapstruct.factory.Mappers;
 
@@ -116,6 +121,39 @@ public class ApiMapperTest {
         assertThat(updateApiEntity.getLifecycleState().name()).isEqualTo(updateApi.getLifecycleState().name());
         assertThat(updateApiEntity.isDisableMembershipNotifications()).isEqualTo(updateApi.getDisableMembershipNotifications());
         assertThat(updateApiEntity.getExecutionMode().name()).isEqualTo(updateApi.getExecutionMode().getValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Visibility.class)
+    void shouldMapCreateApiV4Visibility(Visibility visibility) {
+        CreateApiV4 newApi = CreateApiV4.builder()
+            .name("Test API")
+            .apiVersion("1.0.0")
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .type(io.gravitee.rest.api.management.v2.rest.model.ApiType.PROXY)
+            .visibility(visibility)
+            .tags(Set.of("tag1"))
+            .build();
+        var mapped = apiMapper.mapToNewHttpApi(newApi);
+        assertThat(mapped).isNotNull();
+        assertThat(mapped.getVisibility()).isEqualTo(Api.Visibility.valueOf(visibility.name()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Visibility.class)
+    void shouldMapCreateNativeApiV4Visibility(Visibility visibility) {
+        CreateApiV4 newApi = CreateApiV4.builder()
+            .name("Test Native API")
+            .apiVersion("1.0.0")
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .type(io.gravitee.rest.api.management.v2.rest.model.ApiType.NATIVE)
+            .visibility(visibility)
+            .tags(Set.of("tag2"))
+            .build();
+
+        var mapped = apiMapper.mapToNewNativeApi(newApi);
+        assertThat(mapped).isNotNull();
+        assertThat(mapped.getVisibility()).isEqualTo(Api.Visibility.valueOf(visibility.name()));
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
@@ -72,6 +73,9 @@ public class NewApiEntity {
     @JsonProperty(value = "gravitee")
     @Schema(description = "API's gravitee definition version")
     private String graviteeDefinitionVersion;
+
+    @Schema(description = "API's visibility. Can be PUBLIC or PRIVATE.", example = "PUBLIC", allowableValues = { "PUBLIC", "PRIVATE" })
+    private Visibility visibility;
 
     public String getName() {
         return name;
@@ -153,6 +157,14 @@ public class NewApiEntity {
         this.graviteeDefinitionVersion = graviteeDefinitionVersion;
     }
 
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
     @Override
     public String toString() {
         return (
@@ -177,6 +189,9 @@ public class NewApiEntity {
             '\'' +
             ", flowMode='" +
             flowMode +
+            '\'' +
+            ", visibility='" +
+            visibility +
             '\'' +
             '}'
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractNewApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractNewApi.java
@@ -45,6 +45,8 @@ public abstract class AbstractNewApi {
     @Builder.Default
     protected Set<String> groups = Set.of();
 
+    private Api.Visibility visibility;
+
     /**
      * @return An instance of {@link Api.ApiBuilder} based on the current state of this NewApi.
      */
@@ -56,6 +58,7 @@ public abstract class AbstractNewApi {
             .type(type)
             .definitionVersion(definitionVersion)
             .description(description)
+            .visibility(visibility)
             .groups(groups);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -422,6 +422,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
 
         apiEntity.setPathMappings(new HashSet<>(declaredPaths));
+        apiEntity.setVisibility(newApiEntity.getVisibility());
 
         return createFromUpdateApiEntity(executionContext, apiEntity, userId, null);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
@@ -15,6 +15,7 @@
  */
 package fixtures.core.model;
 
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.NewNativeApi;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -46,6 +47,7 @@ public class NewApiFixtures {
         return BASE_HTTP.get()
             .definitionVersion(DefinitionVersion.V4)
             .type(ApiType.PROXY)
+            .visibility(Api.Visibility.PRIVATE)
             .listeners(
                 List.of(
                     HttpListener.builder()
@@ -80,6 +82,7 @@ public class NewApiFixtures {
         return BASE_NATIVE.get()
             .definitionVersion(DefinitionVersion.V4)
             .type(ApiType.NATIVE)
+            .visibility(Api.Visibility.PRIVATE)
             .listeners(
                 List.of(
                     KafkaListener.builder()


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11604

## Description

- Corrected mapping logic to honour the visibility flag during API creation for all definition versions.
- Added/updated tests for Create API workflows to verify public/private visibility.
- Verified export/import flow reflects the correct visibility.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

