### PR TITLE
fix: disabled Java Linker and Apache lucence lib warning logs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -96,6 +96,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 # Ensure UTF-8 encoding by default (e.g. filenames)
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
 
+# Add flags for Vector API and Native Access
+JAVA_OPTS="$JAVA_OPTS --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED"
+
 # Convert paths for Java on Windows
 if $cygwin; then
     GRAVITEE_BOOT_CLASSPATH=$(cygpath -w $GRAVITEE_BOOT_CLASSPATH)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -54,6 +54,9 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
 REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 
+REM Add flags to enable Vector API and Native Access
+set JAVA_OPTS=%JAVA_OPTS% --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED
+
 REM Display our environment
 echo "=============================================================="
 echo ""


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11304

## Description

During the startup of the Management API, multiple Java warnings are displayed related to restricted methods, native access, and the vector incubator module. While these warnings do not prevent the application from starting, they indicate potential misconfigurations or missing JVM options that could affect performance or stability.

https://lucene.apache.org/core/10_0_0/core/org/apache/lucene/store/MMapDirectory.html

enable --enable-native-access ======> to get high-speed file I/O, 
enable --add-modules jdk.incubator.vector ======>  to get speed-ups in vector math, 

https://lucene.apache.org/core/9_9_1/core/org/apache/lucene/util/VectorUtil.html



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-evtvtiqhlw.chromatic.com)
<!-- Storybook placeholder end -->
