### PR TITLE
feat: allow readonly users to view endpoint configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -1163,7 +1163,7 @@ const apisRoutes: Routes = [
         component: ApiEndpointComponent,
         data: {
           permissions: {
-            anyOf: ['api-definition-u'],
+            anyOf: ['api-definition-r'],
           },
           docs: {
             page: 'management-api-proxy-endpoints',

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
@@ -153,12 +153,10 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
         value: this.endpointGroup.services?.healthCheck?.enabled ?? false,
         disabled: this.isReadOnly,
       }),
-      configuration: new FormControl(
-        {
-          value: this.endpointGroup.services?.healthCheck?.configuration ?? {},
-          disabled: this.isReadOnly,
-        } ?? {},
-      ),
+      configuration: new FormControl({
+        value: this.endpointGroup.services?.healthCheck?.configuration ?? {},
+        disabled: this.isReadOnly,
+      }),
     });
 
     if (this.isHttpProxyApi) {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
@@ -125,7 +125,7 @@
           <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef id="actions">Actions</th>
             <td mat-cell *matCellDef="let element; let j = index">
-              <div class="endpoint-group-card__table__actions" *gioPermission="{ anyOf: ['api-definition-u'] }">
+              <div class="endpoint-group-card__table__actions">
                 <a
                   mat-icon-button
                   [attr.aria-label]="isReadOnly ? 'View endpoint' : 'Edit endpoint'"
@@ -137,6 +137,7 @@
                 <button
                   mat-icon-button
                   aria-label="Delete endpoint"
+                  *gioPermission="{ anyOf: ['api-definition-u'] }"
                   (click)="deleteEndpoint(group.name, element.name)"
                   [disabled]="isReadOnly || (groupsTableData?.length === 1 && group.endpoints.length === 1)"
                 >

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
@@ -467,6 +467,7 @@ describe('ApiEndpointGroupsComponent', () => {
       expect(await componentHarness.isEndpointDeleteButtonVisible()).toEqual(false);
       expect(await componentHarness.isAddEndpointButtonVisible()).toEqual(false);
       expect(await componentHarness.isEditEndpointButtonVisible()).toEqual(false);
+      expect(await componentHarness.isViewEndpointButtonVisible()).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
@@ -19,7 +19,7 @@ import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operato
 import { find, remove } from 'lodash';
 import { combineLatest, EMPTY, Observable, Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { EndpointGroup, toEndpoints } from './api-endpoint-groups.adapter';
 
@@ -31,6 +31,7 @@ import { IconService } from '../../../../services-ngx/icon.service';
 import { ApimFeature, UTMTags } from '../../../../shared/components/gio-license/gio-license-data';
 import { disableDlqEntrypoint, getMatchingDlqEntrypoints, getMatchingDlqEntrypointsForGroup } from '../api-endpoint-v4-matching-dlq';
 import { AGENT_TO_AGENT } from '../../../../entities/management-api-v2/api/v4/agentToAgent';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'api-endpoint-groups',
@@ -62,7 +63,7 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   };
 
   constructor(
-    private readonly router: Router,
+    private permissionService: GioPermissionService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly matDialog: MatDialog,
     private readonly apiService: ApiV2Service,
@@ -80,8 +81,8 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
           this.isA2ASelcted = this.api.listeners?.some((listener) => listener.entrypoints?.some((ep) => ep.type === AGENT_TO_AGENT.id));
           this.groupsTableData = toEndpoints(apiV4);
 
-          this.isReadOnly = this.api.definitionContext?.origin === 'KUBERNETES';
-
+          const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
+          this.isReadOnly = this.api.definitionContext?.origin === 'KUBERNETES' || !canUpdate;
           this.plugins = new Map(
             plugins.map((plugin) => [
               plugin.id,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.harness.ts
@@ -26,6 +26,7 @@ export class ApiEndpointGroupsHarness extends ComponentHarness {
   private getDeleteEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
   private getAddEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add endpoint"]' }));
   private getEditEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint"]' }));
+  private getViewEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="View endpoint"]' }));
   private getEditEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint group"]' }));
   private getAddEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add endpoint group"]' }));
   public getWarningFailoverBanner = this.locatorForAll(DivHarness.with({ selector: '.banner__wrapper__title' }));
@@ -81,6 +82,10 @@ export class ApiEndpointGroupsHarness extends ComponentHarness {
 
   public async isEditEndpointButtonVisible(): Promise<boolean> {
     return this.getEditEndpointButtons().then((buttons) => buttons?.length > 0);
+  }
+
+  public async isViewEndpointButtonVisible(): Promise<boolean> {
+    return this.getViewEndpointButtons().then((buttons) => buttons?.length > 0);
   }
 
   public async moveGroupUp(index: number) {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -78,7 +78,7 @@ describe('ApiEndpointComponent', () => {
   let componentHarness: ApiEndpointHarness;
   let routerNavigationSpy: jest.SpyInstance;
 
-  const initComponent = async (api: ApiV4, routerParams: unknown = { apiId: API_ID, groupIndex: 0 }) => {
+  const initComponent = async (api: ApiV4, routerParams: unknown = { apiId: API_ID, groupIndex: 0 }, canUpdate: boolean = true) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [NoopAnimationsModule, GioTestingModule, ApiEndpointModule, MatIconTestingModule],
@@ -87,7 +87,7 @@ describe('ApiEndpointComponent', () => {
         {
           provide: GioPermissionService,
           useValue: {
-            hasAnyMatching: Boolean,
+            hasAnyMatching: () => canUpdate,
           },
         },
       ],
@@ -210,6 +210,22 @@ describe('ApiEndpointComponent', () => {
     });
 
     describe('should update endpoint', () => {
+      it('should disable general components', async () => {
+        const apiV4 = fakeApiV4({ id: API_ID });
+
+        await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 }, false);
+
+        const formGroup = fixture.componentInstance.apiEndpoint.formGroup;
+        const name = formGroup.get('name');
+        const targetUrl = formGroup.get('configuration');
+        const weight = formGroup.get('weight');
+        const tenants = formGroup.get('tenants');
+        expect(name?.disabled).toBe(true);
+        expect(targetUrl?.disabled).toBe(true);
+        expect(weight?.disabled).toBe(true);
+        expect(tenants?.disabled).toBe(true);
+      });
+
       it('should edit and save an existing endpoint', async () => {
         const apiV4 = fakeApiV4({
           id: API_ID,
@@ -402,9 +418,9 @@ describe('ApiEndpointComponent', () => {
                   configuration: {
                     bootstrapServers: undefined,
                   },
-                  inheritConfiguration: null,
-                  weight: null,
-                  tenants: null,
+                  inheritConfiguration: undefined,
+                  weight: undefined,
+                  tenants: undefined,
                 },
               ],
             },

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -47,6 +47,7 @@ import {
   PlanV4,
 } from '../../../../entities/management-api-v2';
 import { expectGetSharedPolicyGroupPolicyPluginRequest } from '../../../../services-ngx/shared-policy-groups.service.spec';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 describe('ApiV4PolicyStudioDesignComponent', () => {
   const API_ID = 'api-id';
@@ -58,6 +59,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
     snapshot: { params: { apiId: API_ID } },
     params: routeParams$.asObservable(),
   };
+  const permissions = ['api-definition-u'];
 
   let fixture: ComponentFixture<ApiV4PolicyStudioDesignComponent>;
   let component: ApiV4PolicyStudioDesignComponent;
@@ -68,7 +70,14 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiV4PolicyStudioModule, MatIconTestingModule, GioLicenseTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: activatedRouteStub }, importProvidersFrom(GioFormJsonSchemaModule)],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRouteStub,
+        },
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        importProvidersFrom(GioFormJsonSchemaModule),
+      ],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -42,6 +42,7 @@ import { ResourceTypeService } from '../../../../shared/components/form-json-sch
 import { ApimFeature, UTMTags } from '../../../../shared/components/gio-license/gio-license-data';
 import { SharedPolicyGroupsService } from '../../../../services-ngx/shared-policy-groups.service';
 import { getApiProtocolTypeFromApi } from '../../../../entities/management-api-v2/plugin/apiProtocolType';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 export type FlowSelection = { planIndex: number; flowIndex: number };
 
@@ -86,6 +87,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
     private readonly resourceTypeService: ResourceTypeService,
     private readonly gioLicenseService: GioLicenseService,
     private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly permissionsService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
@@ -181,7 +183,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
         this.selectedFlowIndexes.planIndex = Number(params['planIndex'] ?? 0);
         this.selectedFlowIndexes.flowIndex = Number(params['flowIndex'] ?? 0);
         this.checkAndAdjustIndexes();
-        this.isReadOnly = api.definitionContext.origin === 'KUBERNETES';
+        this.isReadOnly = !this.permissionsService.hasAnyMatching(['api-definition-u']) || api.definitionContext.origin === 'KUBERNETES';
         this.isLoading = false;
       });
     this.trialURL = this.gioLicenseService.getTrialURL({ feature: ApimFeature.APIM_DEBUG_MODE, context: UTMTags.CONTEXT_API_V4 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11120

## Description

This feature allows users with read only permission on API definitions to view necessary API configuration details.

## Test

<img width="1187" height="443" alt="Screenshot 2025-10-16 at 6 29 30 PM" src="https://github.com/user-attachments/assets/86cc0e79-e7ac-409d-b6e4-fbca8b4d2acb" />


<img width="1682" height="1045" alt="Screenshot 2025-10-16 at 6 05 58 PM" src="https://github.com/user-attachments/assets/b01bf88a-7d03-4bf3-8796-88df062af26e" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ypwbeyzepa.chromatic.com)
<!-- Storybook placeholder end -->
