### PR TITLE
fix: make sure that page is published and present when used as general conditions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.core.api.use_case;
 
 import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.oneShotIndexation;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
@@ -275,6 +274,10 @@ public class ImportApiCRDUseCase {
                     .build()
             );
 
+            // Pages
+            createOrUpdatePages(input.spec.getPages(), updatedApi.getId(), input.auditInfo);
+            deleteRemovedPages(input.spec.getPages(), updatedApi.getId());
+
             // Plans
             Map<String, String> planKeyIdMapping = handlePlanUpdate(input, api);
 
@@ -283,10 +286,6 @@ public class ImportApiCRDUseCase {
 
             // Members
             membersDomainService.updateApiMembers(input.auditInfo, updatedApi.getId(), input.spec().getMembers());
-
-            // Pages
-            createOrUpdatePages(input.spec.getPages(), updatedApi.getId(), input.auditInfo);
-            deleteRemovedPages(input.spec.getPages(), updatedApi.getId());
 
             // Metadata
             apiMetadataDomainService.importApiMetadata(api.getId(), input.spec.getMetadata(), input.auditInfo);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ValidatePagesDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ValidatePagesDomainService.java
@@ -66,6 +66,7 @@ public class ValidatePagesDomainService implements Validator<ValidatePagesDomain
                 page.setReferenceId(input.apiId());
                 if (page.getId() == null) {
                     page.setId(IdBuilder.builder(input.auditInfo, input.apiHrid).withExtraId(k).buildId());
+                    v.setId(page.getId());
                 }
                 page.setHrid(k);
                 if (v.getParentId() == null && v.getParentHrid() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
@@ -144,7 +144,7 @@ class ValidateApiCRDDomainServiceTest {
             pagesValidator.validateAndSanitize(new ValidatePagesDomainService.Input(AUDIT_INFO, spec.getId(), spec.getHrid(), any()))
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(planValidator.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, any()))).thenAnswer(call ->
+        when(planValidator.validateAndSanitize(any(ValidatePlanDomainService.Input.class))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
         );
 
@@ -195,7 +195,7 @@ class ValidateApiCRDDomainServiceTest {
             pagesValidator.validateAndSanitize(new ValidatePagesDomainService.Input(AUDIT_INFO, spec.getId(), spec.getHrid(), any()))
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(planValidator.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, any()))).thenAnswer(call ->
+        when(planValidator.validateAndSanitize(any(ValidatePlanDomainService.Input.class))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
         );
 
@@ -245,7 +245,7 @@ class ValidateApiCRDDomainServiceTest {
             pagesValidator.validateAndSanitize(new ValidatePagesDomainService.Input(AUDIT_INFO, spec.getId(), spec.getHrid(), any()))
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(planValidator.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, any()))).thenAnswer(call ->
+        when(planValidator.validateAndSanitize(any(ValidatePlanDomainService.Input.class))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
         );
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1598 
https://gravitee.atlassian.net/browse/GKO-1602

## Description

* Enhanced Plan Validation: Introduced a new validation mechanism to ensure that any page referenced as 'general conditions' by a plan within an API CRD is both present and published. This prevents plans from being configured with non-existent or unpublished general conditions.
* Improved Page ID Mapping: Refined the process of ID mapping for pages defined in CRDs, ensuring that generated IDs are consistently applied to both the internal Page model and the PageCRD object. This helps maintain data integrity when handling pages via CRDs.
* Streamlined CRD Processing Order: Adjusted the order of operations during API CRD import, specifically moving the creation and update of pages to occur before plan processing. This ensures that all necessary page information is available and consistent when plans are being validated against them.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ihxivijbrt.chromatic.com)
<!-- Storybook placeholder end -->
