### PR TITLE
fix: ensure ipv4 backward compatibility in docker images

### DIFF
--- a/gravitee-apim-console-webui/docker/config/default.conf
+++ b/gravitee-apim-console-webui/docker/config/default.conf
@@ -1,8 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
-    listen [::]:$HTTP_PORT;
-    listen [::]:$HTTPS_PORT;
+    listen [::]:$HTTP_PORT ipv6only=off;
+    listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/gravitee-apim-portal-webui/docker/config/default-next.conf
+++ b/gravitee-apim-portal-webui/docker/config/default-next.conf
@@ -1,8 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
-    listen [::]:$HTTP_PORT;
-    listen [::]:$HTTPS_PORT;
+    listen [::]:$HTTP_PORT ipv6only=off;
+    listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
     add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -1,8 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
-    listen [::]:$HTTP_PORT;
-    listen [::]:$HTTPS_PORT;
+    listen [::]:$HTTP_PORT ipv6only=off;
+    listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
     add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;

--- a/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
@@ -26,7 +26,7 @@ server {
         try_files $uri $uri/ =404;
         error_page 404 /;
         root /rw.mount/www;
-        sub_filter '<base href="/"' '<base href="$CONSOLE_BASE_HREF"';
+        sub_filter '<base href="/"' '<base href="$PORTAL_BASE_HREF"';
         sub_filter_once on;
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11292
https://gravitee.atlassian.net/browse/APIM-11640

## Description

- Ensure IPv4 backward compatibility in docker images.
- Also, PORTAL_BASE_HREF is not used when using IP_V4 images


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iefbjtrzmz.chromatic.com)
<!-- Storybook placeholder end -->
