### PR TITLE
fix(sync): use the configmap revision number as a deployment number

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -40,6 +40,7 @@ import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -149,7 +150,9 @@ public class ApiManagerImpl implements ApiManager {
         // Keep the check of Sharding Tags for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
         if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
             boolean apiToDeploy = deployedApi == null || force;
-            boolean apiToUpdate = !apiToDeploy && deployedApi.getDeployedAt().before(api.getDeployedAt());
+            boolean apiToUpdate =
+                !apiToDeploy &&
+                (deployedApi.getDeployedAt().before(api.getDeployedAt()) || !Objects.equals(deployedApi.getRevision(), api.getRevision()));
 
             // if API will be deployed or updated
             if (apiToDeploy || apiToUpdate) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -154,6 +154,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-license</artifactId>
             <scope>provided</scope>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/fetcher/ConfigMapEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/fetcher/ConfigMapEventFetcher.java
@@ -16,8 +16,11 @@
 package io.gravitee.gateway.services.sync.process.kubernetes.fetcher;
 
 import static io.gravitee.repository.management.model.Event.EventProperties.API_ID;
+import static io.gravitee.repository.management.model.Event.EventProperties.DEPLOYMENT_NUMBER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.utils.IdGenerator;
+import io.gravitee.common.utils.UUID;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.kubernetes.client.KubernetesClient;
@@ -180,7 +183,13 @@ public class ConfigMapEventFetcher {
 
                 // Need to deserialize api definition in order to recreate a regular Event which can be handled by the ApiSynchronizer.
                 final io.gravitee.repository.management.model.Event event = new io.gravitee.repository.management.model.Event();
-                event.setProperties(Collections.singletonMap(API_ID.getValue(), apiId));
+                event.setProperties(
+                    Map.ofEntries(
+                        Map.entry(API_ID.getValue(), apiId),
+                        // simulate a deployment number to define a revision in the reactable
+                        Map.entry(DEPLOYMENT_NUMBER.getValue(), configMap.getMetadata().getResourceVersion())
+                    )
+                );
                 event.setCreatedAt(new Date());
 
                 final io.gravitee.repository.management.model.Api api = new io.gravitee.repository.management.model.Api();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11650
https://github.com/gravitee-io/issues/issues/10908

## Description

Ensure to have a revision when the API is deployed using Kubernetes synchronizer. 
Ensure to deploy the API when the revision is different

## Additional context

I will add unit tests covering this in another PR as I'd like to migrate the existing ones to JUnit5