### PR TITLE
fix: escape regex metacharacters to prevent PatternSyntaxException during OData YAML import

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/PathMapping.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/PathMapping.java
@@ -26,7 +26,17 @@ public class PathMapping {
     private PathMapping() {}
 
     public static Pattern buildPattern(String mappingExpression) {
-        var regex = mappingExpression.replaceAll(":[^/]*", "[^/]*") + "/*";
+        if (mappingExpression == null || mappingExpression.isBlank()) return Pattern.compile(".*");
+
+        var regex =
+            mappingExpression
+                .replaceAll("([+?^$\\[\\]{}|])", "\\\\$1")
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+                .replaceAll("\\.(?!\\*)", "\\\\.")
+                .replaceAll(":[^/]*", "[^/]*") +
+            "/*";
+
         return Pattern.compile(regex);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11651

## Description

The API import process fails when OData-style OpenAPI definitions include paths with regex-like characters such as parentheses, brackets, or asterisks.
This leads to PatternSyntaxException ("Unclosed group near index ...") when compiling the path mapping regex.

Summary -
Path mappings containing regex metacharacters (e.g., parentheses in Pbx.ExportTrunk()) caused Pattern.compile to throw PatternSyntaxException: Unclosed group. We now safely escape mapping literals while still supporting :param placeholders and trailing-slash behavior.
Background
- Before: mappingExpression was used directly to build a regex, so characters like (, ), [, ], {, }, +, ?, ^, $, | were interpreted as regex operators.
- Issue: When a mapping contained unbalanced or unintended regex constructs (e.g., “(” or “)”), Pattern.compile failed with Unclosed group.
- Example error:
    - Input: /Trunks/:tenant/Pbx.ExportTrunk()
    - Failure: PatternSyntaxException due to unescaped parentheses.

 - Fix:
 - Input: /Trunks/:tenant/Pbx.ExportTrunk()
    - After escaping and placeholder expansion:
        - /Trunks/[^/]_/Pbx.ExportTrunk()/_

    - Compiles without error and matches:
        - /Trunks/acme/Pbx.ExportTrunk()  
        - /Trunks/acme/Pbx.ExportTrunk()/


What changed
- Escape regex metacharacters in the literal parts of mappingExpression to ensure they’re treated as plain text.
- Convert :param placeholders (colon followed by non-slash chars) into a safe “match a path segment” regex: [^/]*.
- Preserve previous behavior for trailing slashes by appending /* at the end.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

