### PR TITLE
fix: apim user id on stop API event if available

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/CockpitUserHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/CockpitUserHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CockpitUserHelper {
+
+    public static final String COCKPIT_SOURCE = "cockpit";
+
+    /**
+     * Resolves the apim user ID from a cockpit user ID by looking up the user in the repository.
+     * Falls back to the provided userId if not found (cockpit system user is an expected example) or if an error occurs.
+     *
+     * @param userRepository the user repository to search in
+     * @param executionContext the execution context containing organization information
+     * @param cockpitUserId the cockpit user ID to resolve
+     * @return the resolved user ID or the original cockpit user ID as fallback
+     */
+    public static String resolveApimUserId(UserRepository userRepository, ExecutionContext executionContext, String cockpitUserId) {
+        try {
+            return userRepository
+                .findBySource(COCKPIT_SOURCE, cockpitUserId, executionContext.getOrganizationId())
+                .map(User::getId)
+                .orElse(cockpitUserId);
+        } catch (TechnicalException ex) {
+            return cockpitUserId;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -69,6 +69,7 @@ import io.gravitee.repository.management.api.SharedPolicyGroupRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.ThemeRepository;
 import io.gravitee.repository.management.api.TicketRepository;
+import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.WorkflowRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -168,6 +169,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final TicketRepository ticketRepository;
     private final WorkflowRepository workflowRepository;
     private final ClusterRepository clusterRepository;
+    private final UserRepository userRepository;
 
     public DeleteEnvironmentCommandHandler(
         @Lazy AccessPointRepository accessPointRepository,
@@ -224,7 +226,8 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         DictionaryService dictionaryService,
         EnvironmentService environmentService,
         IdentityProviderActivationService identityProviderActivationService,
-        SearchEngineService searchEngineService
+        SearchEngineService searchEngineService,
+        UserRepository userRepository
     ) {
         this.accessPointRepository = accessPointRepository;
         this.accessPointService = accessPointService;
@@ -281,6 +284,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.ticketRepository = ticketRepository;
         this.workflowRepository = workflowRepository;
         this.clusterRepository = clusterRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -296,8 +300,9 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
             log.info("Delete environment with id [{}]", payload.cockpitId());
             var environment = environmentService.findByCockpitId(payload.cockpitId());
             var executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
+            String resolvedUserId = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, payload.userId());
 
-            disableEnvironment(executionContext, payload.userId());
+            disableEnvironment(executionContext, resolvedUserId);
             deleteEnvironment(executionContext, environment);
 
             log.info("Environment [{}] with id [{}] has been deleted.", environment.getName(), environment.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
@@ -22,6 +22,7 @@ import io.gravitee.cockpit.api.command.v1.environment.DisableEnvironmentCommand;
 import io.gravitee.cockpit.api.command.v1.environment.DisableEnvironmentReply;
 import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -46,6 +47,7 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
     private final AccessPointCrudService accessPointService;
     private final IdentityProviderActivationService identityProviderActivationService;
     private final DictionaryService dictionaryService;
+    private final UserRepository userRepository;
 
     public DisableEnvironmentCommandHandler(
         EnvironmentService environmentService,
@@ -53,7 +55,8 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
         @Lazy ApiRepository apiRepository,
         AccessPointCrudService accessPointService,
         IdentityProviderActivationService identityProviderActivationService,
-        DictionaryService dictionaryService
+        DictionaryService dictionaryService,
+        UserRepository userRepository
     ) {
         this.environmentService = environmentService;
         this.apiStateService = apiStateService;
@@ -61,6 +64,7 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
         this.accessPointService = accessPointService;
         this.identityProviderActivationService = identityProviderActivationService;
         this.dictionaryService = dictionaryService;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -75,6 +79,7 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
         try {
             var environment = environmentService.findByCockpitId(payload.cockpitId());
             var executionContext = new ExecutionContext(environment);
+            String userId = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, payload.userId());
 
             // Stop all Environment APIs
             apiRepository
@@ -82,7 +87,7 @@ public class DisableEnvironmentCommandHandler implements CommandHandler<DisableE
                     new ApiCriteria.Builder().state(LifecycleState.STARTED).environmentId(environment.getId()).build(),
                     new ApiFieldFilter.Builder().excludeDefinition().excludePicture().build()
                 )
-                .forEach(api -> apiStateService.stopWithoutNotification(executionContext, api.getId(), payload.userId()));
+                .forEach(api -> apiStateService.stopWithoutNotification(executionContext, api.getId(), userId));
 
             // Delete related access points
             this.accessPointService.deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, environment.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/CockpitUserHelperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/CockpitUserHelperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CockpitUserHelperTest {
+
+    private static final String ORGANIZATION_ID = "org-123";
+    private static final String COCKPIT_USER_ID = "cockpit-user-456";
+    private static final String APIM_USER_ID = "apim-user-789";
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @BeforeEach
+    void setUp() {
+        when(executionContext.getOrganizationId()).thenReturn(ORGANIZATION_ID);
+    }
+
+    @Test
+    void should_resolve_apim_user_id_when_user_found_in_repository() throws TechnicalException {
+        // Given
+        User user = User.builder().id(APIM_USER_ID).build();
+        when(userRepository.findBySource(CockpitUserHelper.COCKPIT_SOURCE, COCKPIT_USER_ID, ORGANIZATION_ID)).thenReturn(Optional.of(user));
+
+        // When
+        String result = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, COCKPIT_USER_ID);
+
+        // Then
+        assertThat(result).isEqualTo(APIM_USER_ID);
+    }
+
+    @Test
+    void should_return_cockpit_user_id_when_user_not_found_in_repository() throws TechnicalException {
+        // Given
+        when(userRepository.findBySource(CockpitUserHelper.COCKPIT_SOURCE, COCKPIT_USER_ID, ORGANIZATION_ID)).thenReturn(Optional.empty());
+
+        // When
+        String result = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, COCKPIT_USER_ID);
+
+        // Then
+        assertThat(result).isEqualTo(COCKPIT_USER_ID);
+    }
+
+    @Test
+    void should_return_cockpit_user_id_when_technical_exception_occurs() throws TechnicalException {
+        // Given
+        when(userRepository.findBySource(CockpitUserHelper.COCKPIT_SOURCE, COCKPIT_USER_ID, ORGANIZATION_ID)).thenThrow(
+            new TechnicalException("Database error")
+        );
+
+        // When
+        String result = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, COCKPIT_USER_ID);
+
+        // Then
+        assertThat(result).isEqualTo(COCKPIT_USER_ID);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3702

## Description

Use apim user id if present rather than cockpit user id for calling api stop during disable/delete environment. 

Delete/disable environments can now either be called by a user (through cockpit UI or API) or through cockpit customer management API internally on behalf of a customer. If called by a user then should be able to find corresponding apim user and use that user id for correctness instead of cockpit user id. If set to non-synced cockpit system user when called from customer management api then it will continue to save with that Id as it does now (which shouldn't cause any issues). 