### PR TITLE
fix(console): mask privateToken in V2 API documentation page response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -70,6 +70,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.gravitee.fetcher</groupId>
+			<artifactId>gravitee-fetcher-api</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.gravitee.el</groupId>
 			<artifactId>gravitee-expression-language</artifactId>
 		</dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
@@ -1,42 +1,32 @@
-/*
- * Copyright © 2015 The Gravitee team (http://gravitee.io)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.fetcher.api.FetcherConfiguration;
+import io.gravitee.fetcher.api.Sensitive;
+import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
+import io.gravitee.rest.api.fetcher.impl.FetcherConfigurationFactoryImpl;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
-import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Mapper
-public interface ConfigurationSerializationMapper {
-    ConfigurationSerializationMapper INSTANCE = Mappers.getMapper(ConfigurationSerializationMapper.class);
-    Logger logger = LoggerFactory.getLogger(ConfigurationSerializationMapper.class);
+public abstract class ConfigurationSerializationMapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigurationSerializationMapper.class);
+    private static final String SENSITIVE_DATA_REPLACEMENT = "********";
 
     @Named("serializeConfiguration")
-    default String serializeConfiguration(Object configuration) {
+    public String serializeConfiguration(Object configuration) {
         if (Objects.isNull(configuration)) {
             return null;
         }
@@ -54,7 +44,7 @@ public interface ConfigurationSerializationMapper {
     }
 
     @Named("convertToMapConfiguration")
-    default Map<String, Object> convertToMapConfiguration(Object configuration) {
+    public Map<String, Object> convertToMapConfiguration(Object configuration) {
         if (Objects.isNull(configuration)) {
             return Map.of();
         }
@@ -66,7 +56,7 @@ public interface ConfigurationSerializationMapper {
     }
 
     @Named("deserializeConfiguration")
-    default Object deserializeConfiguration(String configuration) {
+    public Object deserializeConfiguration(String configuration) {
         if (Objects.isNull(configuration)) {
             return null;
         }
@@ -85,5 +75,125 @@ public interface ConfigurationSerializationMapper {
         }
 
         return configuration;
+    }
+
+    @Named("deserializeConfigurationWithSensitiveDataMasking")
+    public Object deserializeConfigurationWithSensitiveDataMasking(String configuration, String fetcherType) {
+        if (Objects.isNull(configuration)) {
+            return null;
+        }
+
+        ObjectMapper mapper = new GraviteeMapper();
+        try {
+            LinkedHashMap<String, Object> configMap = mapper.readValue(configuration, LinkedHashMap.class);
+
+            if (fetcherType != null) {
+                // Try annotation-based masking with FetcherConfigurationFactory
+                try {
+                    Class<? extends FetcherConfiguration> fetcherConfigClass = getFetcherConfigurationClass(fetcherType);
+                    if (fetcherConfigClass != null) {
+                        // Create factory instance
+                        FetcherConfigurationFactory factory = new FetcherConfigurationFactoryImpl();
+
+                        // Convert to actual configuration object
+                        FetcherConfiguration configObj = factory.create(fetcherConfigClass, configuration);
+
+                        if (configObj != null) {
+                            // Mask sensitive fields using annotations
+                            maskSensitiveFields(configObj);
+
+                            // Convert back to map
+                            String maskedJson = mapper.writeValueAsString(configObj);
+                            return mapper.readValue(maskedJson, LinkedHashMap.class);
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.debug("Annotation-based masking failed for fetcher type: " + fetcherType, e);
+                }
+            }
+
+            // Fallback to field name-based masking
+            maskSensitiveFieldsInMap(configMap);
+            return configMap;
+        } catch (JsonProcessingException e) {
+            logger.debug("Cannot parse configuration: " + e.getMessage());
+        }
+
+        return configuration;
+    }
+
+    /**
+     * Get the fetcher configuration class based on fetcher type.
+     */
+    private Class<? extends FetcherConfiguration> getFetcherConfigurationClass(String fetcherType) {
+        switch (fetcherType.toLowerCase()) {
+            case "github":
+                return getClassSafely("io.gravitee.fetcher.github.GitHubFetcherConfiguration");
+            case "gitlab":
+                return getClassSafely("io.gravitee.fetcher.gitlab.GitLabFetcherConfiguration");
+            case "git":
+                return getClassSafely("io.gravitee.fetcher.git.GitFetcherConfiguration");
+            case "http":
+            case "http-fetcher":
+                return getClassSafely("io.gravitee.fetcher.http.HttpFetcherConfiguration");
+            default:
+                logger.debug("Unknown fetcher type: " + fetcherType);
+                return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<? extends FetcherConfiguration> getClassSafely(String className) {
+        try {
+            Class<?> clazz = Class.forName(className);
+            if (FetcherConfiguration.class.isAssignableFrom(clazz)) {
+                return (Class<? extends FetcherConfiguration>) clazz;
+            }
+        } catch (ClassNotFoundException e) {
+            logger.debug("Fetcher configuration class not found: " + className);
+        }
+        return null;
+    }
+
+    /**
+     * Mask sensitive fields in a configuration object using @Sensitive annotations.
+     */
+    private void maskSensitiveFields(Object configuration) {
+        Class<?> configClass = configuration.getClass();
+        Field[] fields = configClass.getDeclaredFields();
+
+        for (Field field : fields) {
+            if (field.isAnnotationPresent(Sensitive.class)) {
+                try {
+                    field.setAccessible(true);
+                    field.set(configuration, SENSITIVE_DATA_REPLACEMENT);
+                } catch (IllegalAccessException e) {
+                    logger.debug("Could not mask sensitive field: " + field.getName(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Fallback method to mask sensitive fields by field name.
+     */
+    private void maskSensitiveFieldsInMap(LinkedHashMap<String, Object> configMap) {
+        String[] sensitiveFieldNames = {
+            "privateToken", // GitLab fetcher
+            "password", // HTTP, Git fetchers
+            "secret", // Various fetchers
+            "token", // Various fetchers
+            "apiKey", // API fetchers
+            "accessToken", // OAuth fetchers
+            "clientSecret", // OAuth fetchers
+            "personalAccessToken", // GitHub, GitLab
+            "authToken", // Generic auth tokens
+        };
+
+        for (String fieldName : sensitiveFieldNames) {
+            if (configMap.containsKey(fieldName)) {
+                configMap.put(fieldName, SENSITIVE_DATA_REPLACEMENT);
+            }
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
@@ -169,7 +169,7 @@ public interface PageMapper {
         }
 
         // Get the mapper instance and delegate to it
-        ConfigurationSerializationMapper configMapper = Mappers.getMapper(ConfigurationSerializationMapper.class);
+        ConfigurationSerializationMapper configMapper = ConfigurationSerializationMapper.INSTANCE;
         return configMapper.deserializeConfigurationWithSensitiveDataMasking(source.getConfiguration(), source.getType());
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11405

## Description

Updated the V4 API endpoint logic to consistently mask sensitive fields like privateToken, aligning with the behaviour of the legacy endpoint.

## Additional context

### Before Fix
<img width="550" height="507" alt="Screenshot 2025-10-13 at 1 23 43 AM" src="https://github.com/user-attachments/assets/c8dfb137-de29-484c-8185-fe9641252096" />


### After Fix
<img width="1310" height="607" alt="Screenshot 2025-10-13 at 1 23 03 AM" src="https://github.com/user-attachments/assets/efcf634e-6122-485d-be23-3140be28e278" />
