### PR TITLE
fix: allow group admin to edit/delete members

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.html
@@ -269,7 +269,7 @@
                       (click)="openDeleteMemberDialog(row)"
                       matTooltip="Remove member from group"
                       aria-hidden="false"
-                      aria-label="Click to delete group"
+                      aria-label="Click to delete group member"
                     >
                       <mat-icon svgIcon="gio:trash"></mat-icon>
                     </button>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -231,6 +231,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       expect(component.groupForm.getRawValue()).toEqual({
@@ -255,6 +256,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const nameInputHarness = await getNameInput();
@@ -269,6 +271,7 @@ describe('GroupComponent', () => {
         MatInputHarness.with({ selector: '[formControlName="maxNumberOfMembers"]' }),
       );
       expect(await maxNoOfMembersHarness.isDisabled()).toEqual(true);
+      expect(component.memberColumnDefs.length).toEqual(6);
     });
 
     it('should submit form to update group', async () => {
@@ -278,6 +281,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       await getNameInput().then((input) => input.setValue('Test Group 1'));
@@ -300,6 +304,7 @@ describe('GroupComponent', () => {
     it('should add group to existing APIs', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Add Group To Existing APIs' }));
@@ -318,6 +323,7 @@ describe('GroupComponent', () => {
     it('should add group to existing applications', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Add Group To Existing Applications' }));
@@ -345,6 +351,7 @@ describe('GroupComponent', () => {
     it('should display list of group members', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
@@ -358,6 +365,7 @@ describe('GroupComponent', () => {
     it('should delete member', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
@@ -374,6 +382,7 @@ describe('GroupComponent', () => {
     it('should update member', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
@@ -422,6 +431,7 @@ describe('GroupComponent', () => {
     it('should display list of invitations', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tabGroupHarness = await harnessLoader.getHarness(MatTabGroupHarness);
@@ -439,6 +449,7 @@ describe('GroupComponent', () => {
     it('should delete invitation', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tabGroupHarness = await harnessLoader.getHarness(MatTabGroupHarness);
@@ -468,6 +479,7 @@ describe('GroupComponent', () => {
     it('should display list of associated applications', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#groupApplicationsDataTable' }));
@@ -490,6 +502,7 @@ describe('GroupComponent', () => {
     it('should display list of associated APIs', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#groupApisDataTable' }));
@@ -521,6 +534,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -569,6 +583,7 @@ describe('GroupComponent', () => {
           },
         },
       ]);
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -583,6 +598,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -611,6 +627,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -642,6 +659,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -673,6 +691,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -710,6 +729,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -764,6 +784,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -803,6 +824,7 @@ describe('GroupComponent', () => {
       fixture.detectChanges();
       expectGetDefaultRoles();
       expectGetGroupMembers();
+      expectGetCurrentUser();
       expectGetGroupAPIs();
       expectGetGroupApplications();
       const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
@@ -949,5 +971,9 @@ describe('GroupComponent', () => {
       application_role: 'OWNER',
     };
     expect(req.request.body).toEqual(invitation);
+  }
+
+  function expectGetCurrentUser() {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.baseURL}/user`, method: 'GET' });
   }
 });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -64,6 +64,7 @@ import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { Group } from '../../../../entities/group/group';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { CurrentUserService } from '../../../../services-ngx/current-user.service';
 
 export interface EditMemberDialogData {
   group: Group;
@@ -230,6 +231,7 @@ export class GroupComponent implements OnInit {
     private router: Router,
     private permissionService: GioPermissionService,
     private matDialog: MatDialog,
+    private currentUserService: CurrentUserService,
   ) {}
 
   ngOnInit(): void {
@@ -243,7 +245,6 @@ export class GroupComponent implements OnInit {
         this.group.next(group);
         this.initializeForm(group);
         this.initialFormValues = this.groupForm.getRawValue();
-        this.hideActionsForReadOnlyUser();
         this.initializeDependents();
         this.disableForm();
       }),
@@ -299,10 +300,11 @@ export class GroupComponent implements OnInit {
     this.groupMembers$ = this.groupService.getMembers(this.groupId).pipe(
       tap((members) => {
         this.groupMembers.next(members.sort((a, b) => a.displayName.localeCompare(b.displayName)));
-        this.disableDeleteMember();
         this.maxInvitationsLimitReached = this.group.value.max_invitation <= this.groupMembers.value.length;
-        this.shouldAllowAddMembers();
         this.filterGroupMembers(this.membersDefaultFilters);
+        this.shouldAllowAddMembers();
+        this.hideActionsForReadOnlyUser();
+        this.disableDeleteMember();
       }),
       takeUntilDestroyed(this.destroyRef),
     );
@@ -351,9 +353,20 @@ export class GroupComponent implements OnInit {
   }
 
   private hideActionsForReadOnlyUser(): void {
-    if (!this.canUpdateGroup()) {
-      this.memberColumnDefs.pop();
-    }
+    const groupMembers = this.groupMembers.value;
+
+    this.currentUserService
+      .current()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((user) => {
+        if (user) {
+          const index = groupMembers.findIndex((member) => member.id === user.id && member.roles['GROUP'] === 'ADMIN');
+
+          if (!this.canUpdateGroup() && index === -1) {
+            this.memberColumnDefs.pop();
+          }
+        }
+      });
   }
 
   private updateEventRules(): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11182

## Description

Allow group admin to delete/edit group members.

## Test

<img width="1676" height="579" alt="Screenshot 2025-10-23 at 12 33 07 AM" src="https://github.com/user-attachments/assets/19dabfa2-7cc2-4aa4-9b1c-1f7db0a462cc" />

<img width="1672" height="729" alt="Screenshot 2025-10-23 at 12 37 31 AM" src="https://github.com/user-attachments/assets/cef1875a-35fe-4232-a5da-f46787130ea3" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

