### PR TITLE
fix(console): overlapping of buttons on mat-card-header

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.scss
@@ -9,6 +9,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    min-width: max-content;
 
     &__title {
       width: 50%;

--- a/gravitee-apim-console-webui/src/management/clusters/details/user-permissions/cluster-user-permissions.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/details/user-permissions/cluster-user-permissions.component.scss
@@ -9,6 +9,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    min-width: max-content;
 
     &__actions {
       display: flex;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11550

## Description

The button text "Manage groups transfer ownership Add members" overflows its container and appears visually broken in the User Permissions tab.

## Additional context

**To replicate:**

Navigate to:
Kafka Clusters → Select a cluster → User Permissions tab
(URL pattern: /clusters/:clusterId/user-permissions)

OR Navigate to: 
APIs → Select an API → User Permissions tab
(URL pattern: /clusters/:clusterId/user-permissions)

Observe the action buttons above the members table to have text overflowing the containers when i open network tab.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->


Before fix:
<img width="2732" height="1798" alt="image" src="https://github.com/user-attachments/assets/f70d984b-c031-4915-9c40-e2c22c0ebc0d" />

<img width="1920" height="1247" alt="image" src="https://github.com/user-attachments/assets/3cd543d3-083d-40d1-bfd7-7cc2c991a843" />

After fix:

https://github.com/user-attachments/assets/b33bd2f7-64da-471e-9338-6c0c50e1045b


