### PR TITLE
reject an API promotion

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-promote-dialog/api-general-info-promote-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-promote-dialog/api-general-info-promote-dialog.component.html
@@ -32,7 +32,7 @@
 
       <mat-form-field class="promote__content__promotion-targets">
         <mat-label>Environment</mat-label>
-        <mat-select [formControl]="promoteControl">
+        <mat-select [formControl]="promoteControl" data-testid="promotion-dialog-target-environment">
           <mat-option *ngFor="let target of promotionTargets" [value]="target.id" [disabled]="target.promotionInProgress">
             {{ target.name }}{{ target.promotionInProgress ? ' (pending)' : '' }}
           </mat-option>
@@ -48,7 +48,15 @@
 
   <mat-dialog-actions align="end" class="actions">
     <button mat-flat-button [mat-dialog-close]="false">Cancel</button>
-    <button color="primary" mat-raised-button [disabled]="promotionTargets.length === 0" (click)="onPromote()">Promote</button>
+    <button
+      color="primary"
+      mat-raised-button
+      [disabled]="promotionTargets.length === 0"
+      (click)="onPromote()"
+      data-testid="promotion-dialog-confirm-button"
+    >
+      Promote
+    </button>
   </mat-dialog-actions>
 </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-promote-dialog/api-general-info-promote.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-promote-dialog/api-general-info-promote.component.spec.ts
@@ -132,7 +132,7 @@ describe('ApiPortalDetailsPromoteDialogComponent', () => {
   function expectPromotePostRequest(apiId: string) {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/_promote`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_promote`,
         method: 'POST',
       })
       .flush({});

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -186,7 +186,7 @@
           *gioPermission="{ anyOf: ['api-definition-u'] }"
           mat-button
           class="details-card__actions_btn"
-          [disabled]="cannotPromote || apiType === 'NATIVE'"
+          [disabled]="cannotPromote"
           data-testid="api_info_promote"
           (click)="promoteApi()"
         >

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -192,8 +192,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
           this.cannotPromote =
             !(this.dangerActions.canChangeApiLifecycle && api.lifecycleState !== 'DEPRECATED') ||
             this.isKubernetesOrigin ||
-            api.definitionVersion === 'V4' ||
-            api.definitionVersion === 'V1';
+            this.api.definitionVersion === 'V1';
 
           this.apiDetailsForm = new UntypedFormGroup({
             name: new UntypedFormControl(
@@ -417,11 +416,11 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
   }
 
   promoteApi() {
-    if (this.api.definitionVersion === 'V2')
+    if (!this.cannotPromote)
       this.matDialog
         .open<ApiGeneralInfoPromoteDialogComponent, ApiPortalDetailsPromoteDialogData>(ApiGeneralInfoPromoteDialogComponent, {
           data: {
-            api: this.api as ApiV2,
+            api: this.api,
           },
           role: 'alertdialog',
           id: 'promoteApiDialog',

--- a/gravitee-apim-console-webui/src/services-ngx/promotion.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/promotion.service.spec.ts
@@ -94,7 +94,7 @@ describe('PromotionService', () => {
 
       httpTestingController
         .expectOne(
-          `${CONSTANTS_TESTING.org.baseURL}/promotions/${promotion.id}/_process`,
+          `${CONSTANTS_TESTING.org.v2BaseURL}/promotions/${promotion.id}/_process`,
           // Need to cast because this function doesn't accept boolean
           isPromotionAccepted as any,
         )

--- a/gravitee-apim-console-webui/src/services-ngx/promotion.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/promotion.service.spec.ts
@@ -58,7 +58,7 @@ describe('PromotionService', () => {
   });
 
   describe('promote', () => {
-    it('should call the API', (done) => {
+    it('should ask for API promotion', (done) => {
       const promotionTarget = fakePromotionTarget({
         installationId: 'inst#1',
         id: 'env#1',
@@ -72,7 +72,7 @@ describe('PromotionService', () => {
 
       const req = httpTestingController.expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/apis/apiId/_promote`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/apiId/_promote`,
       });
       expect(req.request.body).toEqual({
         targetEnvCockpitId: 'env#1',

--- a/gravitee-apim-console-webui/src/services-ngx/promotion.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/promotion.service.ts
@@ -39,7 +39,8 @@ export class PromotionService {
       targetEnvCockpitId: promotionTarget.id,
       targetEnvName: promotionTarget.name,
     };
-    return this.http.post<Promotion>(`${this.constants.env.baseURL}/apis/${apiId}/_promote`, promotionRequest);
+
+    return this.http.post<Promotion>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_promote`, promotionRequest);
   }
 
   processPromotion(promotionId: string, isAccepted: boolean): Observable<Promotion> {

--- a/gravitee-apim-console-webui/src/services-ngx/promotion.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/promotion.service.ts
@@ -44,7 +44,7 @@ export class PromotionService {
   }
 
   processPromotion(promotionId: string, isAccepted: boolean): Observable<Promotion> {
-    return this.http.post<Promotion>(`${this.constants.org.baseURL}/promotions/${promotionId}/_process`, isAccepted);
+    return this.http.post<Promotion>(`${this.constants.org.v2BaseURL}/promotions/${promotionId}/_process`, isAccepted);
   }
 
   listPromotion(searchParams: PromotionSearchParams): Observable<Promotion[]> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EntrypointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.PoliciesResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.ResourcesResource;
+import io.gravitee.rest.api.management.v2.rest.resource.promotions.PromotionsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.ui.ManagementUIResource;
 import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
 import io.gravitee.rest.api.service.OrganizationService;
@@ -115,5 +116,10 @@ public class OrganizationResource extends AbstractResource {
     @Path("ui")
     public ManagementUIResource getManagementUIResource() {
         return resourceContext.getResource(ManagementUIResource.class);
+    }
+
+    @Path("promotions")
+    public PromotionsResource getOrganizationPromotionsResource() {
+        return resourceContext.getResource(PromotionsResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.promotions;
+
+import io.gravitee.apim.core.promotion.use_case.ProcessPromotionUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.PromotionMapper;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class PromotionsResource {
+
+    @Inject
+    private ProcessPromotionUseCase promotionUseCase;
+
+    @POST
+    @Path("{promotionId}/_process")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response processPromotion(@PathParam("promotionId") String promotionId, boolean isAccepted) {
+        var input = new ProcessPromotionUseCase.Input(promotionId, isAccepted, GraviteeContext.getCurrentOrganization());
+        var output = promotionUseCase.execute(input);
+        return Response.ok(PromotionMapper.INSTANCE.map(output.promotion())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
@@ -118,6 +118,41 @@ paths:
                                 $ref: "#/components/schemas/GraviteeLicense"
                 default:
                     $ref: "#/components/responses/Error"
+    /organizations/{orgId}/promotions/{promotionId}/_process:
+        servers:
+          - url: /management/v2
+            description: Gravitee.io APIM - Management API -v2
+        parameters:
+          - $ref: "#/components/parameters/orgIdParam"
+          - $ref: "#/components/parameters/promotionIdParam"
+        post:
+          tags:
+            - Promotions
+          summary: Process an API promotion.
+          description: |-
+            Accept or reject an API promotion.
+          operationId: processApiPromotion
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    accept:
+                      type: boolean
+                      description: Accept or reject the API promotion.
+                      example: true
+            required: true
+          responses:
+            "200":
+              description: The processed API promotion.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Promotion"
+            default:
+              $ref: "#/components/responses/Error"
+
 components:
     schemas:
         Environment:
@@ -248,6 +283,85 @@ components:
                     description: Organization's description. A short description of your Organization.
                     example: I can use many characters to describe this Organization.
                     minLength: 1
+        Promotion:
+          type: object
+          properties:
+            id:
+              type: string
+              description: The promotion id.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+            apiDefinition:
+              type: string
+              description: The api definition.
+            apiId:
+              type: string
+              description: The api id.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+            status:
+              type: string
+              description: The status of the promotion.
+              enum:
+                - CREATED
+                - TO_BE_VALIDATED
+                - ACCEPTED
+                - REJECTED
+                - ERROR
+            targetEnvCockpitId:
+              type: string
+              description: The target environment id where the promotion should be done.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+            targetEnvName:
+              type: string
+              description: The target environment name where the promotion should be done.
+              example: prod
+            sourceEnvCockpitId:
+              type: string
+              description: The source environment id where the promotion should come from.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+            sourceEnvName:
+              type: string
+              description: The source environment name where the promotion should come from.
+              example: dev
+            createdAt:
+              type: string
+              format: date-time
+              description: The datetime when the promotion was created.
+              example: 2023-05-25T12:40:46.184Z
+            updatedAt:
+              type: string
+              format: date-time
+              description: The datetime when the promotion was updated.
+              example: 2023-05-25T12:40:46.184Z
+            author:
+              $ref: "#/components/schemas/PromotionAuthor"
+            targetApiId:
+              type: string
+              description: The target api id.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+
+        PromotionAuthor:
+          type: object
+          properties:
+            userId:
+              type: string
+              description: The user id.
+              example: df83b2a4-cc3e-3f80-9f0d-c138c106c076
+            displayName:
+              type: string
+              description: The display name of the user who created the promotion.
+              example: John Doe
+            email:
+              type: string
+              description: The email of the user who created the promotion.
+              example: email@example.com
+            source:
+              type: string
+              description: The source of the use who created the promotion.
+              example: cockpit
+            sourceId:
+              type: string
+              description: The id of the user who created the promotion source.
+              example: 89eb0e39-1706-49c1-ab0e-391706d9c10a
     responses:
         EnvironmentsResponse:
             description: Page of environments
@@ -304,6 +418,13 @@ components:
             schema:
                 type: string
                 default: DEFAULT
+        promotionIdParam:
+          name: promotionId
+          in: path
+          required: true
+          description: Id of a promotion.
+          schema:
+            type: string
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/environment/crud_service/EnvironmentCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/environment/crud_service/EnvironmentCrudService.java
@@ -19,4 +19,5 @@ import io.gravitee.apim.core.environment.model.Environment;
 
 public interface EnvironmentCrudService {
     Environment get(String environmentId);
+    Environment getByCockpitId(String cockpitId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/crud_service/PromotionCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/crud_service/PromotionCrudService.java
@@ -20,4 +20,5 @@ import io.gravitee.apim.core.promotion.model.Promotion;
 public interface PromotionCrudService {
     Promotion create(Promotion promotion);
     Promotion update(Promotion promotion);
+    Promotion getById(String id);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/service_provider/CockpitPromotionServiceProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/service_provider/CockpitPromotionServiceProvider.java
@@ -22,4 +22,5 @@ import io.gravitee.apim.core.promotion.model.PromotionRequest;
 public interface CockpitPromotionServiceProvider {
     CockpitReplyStatus requestPromotion(String organizationId, String environmentId, Promotion promotion);
     Promotion createPromotion(String apiId, PromotionRequest promotionRequest, String userId);
+    Promotion process(String promotionId, boolean isAccepted);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.promotion.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.cockpit.model.CockpitReplyStatus;
+import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
+import io.gravitee.apim.core.promotion.crud_service.PromotionCrudService;
+import io.gravitee.apim.core.promotion.model.Promotion;
+import io.gravitee.apim.core.promotion.model.PromotionStatus;
+import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+
+@UseCase
+public class ProcessPromotionUseCase {
+
+    private final PromotionCrudService promotionCrudService;
+    private final ApiCrudService apiCrudService;
+    private final CockpitPromotionServiceProvider cockpitPromotionServiceProvider;
+    private final EnvironmentCrudService environmentCrudService;
+
+    public ProcessPromotionUseCase(
+        PromotionCrudService promotionCrudService,
+        ApiCrudService apiCrudService,
+        CockpitPromotionServiceProvider cockpitPromotionServiceProvider,
+        EnvironmentCrudService environmentCrudService
+    ) {
+        this.promotionCrudService = promotionCrudService;
+        this.apiCrudService = apiCrudService;
+        this.cockpitPromotionServiceProvider = cockpitPromotionServiceProvider;
+        this.environmentCrudService = environmentCrudService;
+    }
+
+    public record Input(String promotionId, boolean isAccepted, String organizationId) {}
+
+    public record Output(Promotion promotion) {}
+
+    public Output execute(Input input) {
+        var promotion = promotionCrudService.getById(input.promotionId);
+        var api = apiCrudService.get(promotion.getApiId());
+        var processedPromotion = switch (api.getDefinitionVersion()) {
+            case V2 -> cockpitPromotionServiceProvider.process(input.promotionId, input.isAccepted);
+            case V4 -> processPromotion(promotion, input.isAccepted, input.organizationId);
+            default -> throw new TechnicalManagementException("Only V2 and V4 API definition are supported");
+        };
+        return new Output(processedPromotion);
+    }
+
+    private Promotion processPromotion(Promotion promotion, boolean isAccepted, String organizationId) {
+        if (isAccepted) {
+            throw new TechnicalManagementException("Coming soon - V4 API promotion can only be rejected");
+        }
+
+        var environment = environmentCrudService.getByCockpitId(promotion.getTargetEnvCockpitId());
+        promotion.setStatus(PromotionStatus.REJECTED);
+
+        var cockpitReplyStatus = cockpitPromotionServiceProvider.requestPromotion(organizationId, environment.getId(), promotion);
+
+        if (cockpitReplyStatus != CockpitReplyStatus.SUCCEEDED) {
+            throw new TechnicalManagementException("An error occurs while sending promotion " + promotion.getId() + " request to cockpit");
+        }
+
+        return promotionCrudService.update(promotion);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/environment/EnvironmentCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/environment/EnvironmentCrudServiceImpl.java
@@ -48,4 +48,17 @@ public class EnvironmentCrudServiceImpl implements EnvironmentCrudService {
             throw new TechnicalManagementException(e);
         }
     }
+
+    @Override
+    public Environment getByCockpitId(String cockpitId) {
+        try {
+            log.debug("Find environment by cockpit id: {}", cockpitId);
+
+            return this.environmentRepository.findByCockpitId(cockpitId)
+                .map(EnvironmentAdapter.INSTANCE::toModel)
+                .orElseThrow(() -> new EnvironmentNotFoundException(cockpitId));
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(e);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/promotion/PromotionCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/promotion/PromotionCrudServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.crud_service.promotion;
 
+import io.gravitee.apim.core.exception.DbEntityNotFoundException;
 import io.gravitee.apim.core.promotion.crud_service.PromotionCrudService;
 import io.gravitee.apim.core.promotion.model.Promotion;
 import io.gravitee.apim.infra.adapter.PromotionAdapter;
@@ -52,6 +53,19 @@ public class PromotionCrudServiceImpl implements PromotionCrudService {
             return PromotionAdapter.INSTANCE.toCoreModel(updated);
         } catch (TechnicalException e) {
             throw TechnicalManagementException.ofTryingToUpdateWithId(Promotion.class, promotion.getId(), e);
+        }
+    }
+
+    @Override
+    public Promotion getById(String id) {
+        try {
+            log.debug("Get promotion by id : {}", id);
+            return promotionRepository
+                .findById(id)
+                .map(PromotionAdapter.INSTANCE::toCoreModel)
+                .orElseThrow(() -> new DbEntityNotFoundException(io.gravitee.repository.management.model.Promotion.class, id));
+        } catch (TechnicalException e) {
+            throw TechnicalManagementException.ofTryingToFindById(Promotion.class, id, e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/promotion/CockpitPromotionServiceProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/promotion/CockpitPromotionServiceProviderImpl.java
@@ -60,4 +60,10 @@ public class CockpitPromotionServiceProviderImpl implements CockpitPromotionServ
         );
         return PromotionAdapter.INSTANCE.toCoreModel(created);
     }
+
+    @Override
+    public Promotion process(String promotionId, boolean isAccepted) {
+        var processed = promotionService.processPromotion(GraviteeContext.getExecutionContext(), promotionId, isAccepted);
+        return PromotionAdapter.INSTANCE.toCoreModel(processed);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EnvironmentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EnvironmentCrudServiceInMemory.java
@@ -49,4 +49,13 @@ public class EnvironmentCrudServiceInMemory implements EnvironmentCrudService, I
             .findFirst()
             .orElseThrow(() -> new EnvironmentNotFoundException(environmentId));
     }
+
+    @Override
+    public Environment getByCockpitId(String cockpitId) {
+        return storage
+            .stream()
+            .filter(env -> cockpitId.equals(env.getCockpitId()))
+            .findFirst()
+            .orElseThrow(() -> new EnvironmentNotFoundException(cockpitId));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PromotionCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PromotionCrudServiceInMemory.java
@@ -15,8 +15,11 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.exception.DbEntityNotFoundException;
 import io.gravitee.apim.core.promotion.crud_service.PromotionCrudService;
 import io.gravitee.apim.core.promotion.model.Promotion;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,5 +59,17 @@ public class PromotionCrudServiceInMemory implements PromotionCrudService, InMem
         }
 
         throw new IllegalStateException("Promotion not found");
+    }
+
+    @Override
+    public Promotion getById(String id) {
+        if (id == null) {
+            throw new TechnicalManagementException("Promotion id should not be null");
+        }
+        return storage
+            .stream()
+            .filter(plan -> id.equals(plan.getId()))
+            .findFirst()
+            .orElseThrow(() -> new DbEntityNotFoundException(io.gravitee.repository.management.model.Promotion.class, id));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.promotion.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PromotionFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.EnvironmentCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PromotionCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.cockpit.model.CockpitReplyStatus;
+import io.gravitee.apim.core.environment.model.Environment;
+import io.gravitee.apim.core.promotion.model.Promotion;
+import io.gravitee.apim.core.promotion.model.PromotionStatus;
+import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProcessPromotionUseCaseTest {
+
+    private static final String API_ID = "api-id";
+    private static final String ORGANIZATION_ID = "DEFAULT";
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+    private static final Api API_V2 = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
+    private static final Promotion PROMOTION = PromotionFixtures.aPromotion()
+        .toBuilder()
+        .apiId(API_ID)
+        .status(PromotionStatus.TO_BE_VALIDATED)
+        .build();
+    private static final Environment ENVIRONMENT = Environment.builder()
+        .id(ENVIRONMENT_ID)
+        .cockpitId(PROMOTION.getTargetEnvCockpitId())
+        .organizationId(ORGANIZATION_ID)
+        .build();
+
+    private final PromotionCrudServiceInMemory promotionCrudService = new PromotionCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+    private final EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    private CockpitPromotionServiceProvider cockpitPromotionServiceProvider;
+    private ProcessPromotionUseCase useCase;
+
+    @BeforeEach
+    public void setUp() {
+        cockpitPromotionServiceProvider = mock(CockpitPromotionServiceProvider.class);
+        useCase = new ProcessPromotionUseCase(
+            promotionCrudService,
+            apiCrudServiceInMemory,
+            cockpitPromotionServiceProvider,
+            environmentCrudService
+        );
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        Stream.of(promotionCrudService, apiCrudServiceInMemory).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_process_v2_api_promotion() {
+        apiCrudServiceInMemory.initWith(List.of(API_V2));
+        promotionCrudService.initWith(List.of(PROMOTION));
+
+        when(cockpitPromotionServiceProvider.process(PROMOTION.getId(), true)).thenReturn(PROMOTION);
+        var result = useCase.execute(new ProcessPromotionUseCase.Input(PROMOTION.getId(), true, ORGANIZATION_ID));
+
+        verify(cockpitPromotionServiceProvider).process(eq(PROMOTION.getId()), eq(true));
+        assertThat(result.promotion()).isEqualTo(PROMOTION);
+    }
+
+    @Test
+    void should_throw_exception_when_api_definition_is_not_supported() {
+        var federatedApi = ApiFixtures.aFederatedApi().toBuilder().id(API_ID).build();
+        apiCrudServiceInMemory.initWith(List.of(federatedApi));
+        promotionCrudService.initWith(List.of(PROMOTION));
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(new ProcessPromotionUseCase.Input(PROMOTION.getId(), true, ORGANIZATION_ID))
+        );
+
+        assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessage("Only V2 and V4 API definition are supported");
+    }
+
+    @Test
+    void should_throw_exception_when_v4_api_promotion_is_accepted() {
+        var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        apiCrudServiceInMemory.initWith(List.of(v4proxyApi));
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(new ProcessPromotionUseCase.Input(PROMOTION.getId(), true, ORGANIZATION_ID))
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessage("Coming soon - V4 API promotion can only be rejected");
+    }
+
+    @Test
+    void should_reject_v4_api_promotion() {
+        var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        apiCrudServiceInMemory.initWith(List.of(v4proxyApi));
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        when(cockpitPromotionServiceProvider.requestPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
+            CockpitReplyStatus.SUCCEEDED
+        );
+
+        var result = useCase.execute(new ProcessPromotionUseCase.Input(PROMOTION.getId(), false, ORGANIZATION_ID));
+
+        assertThat(result).isNotNull();
+        assertThat(result.promotion()).isNotNull();
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.REJECTED);
+    }
+
+    @Test
+    void should_throw_exception_when_v4_api_promotion_command_fails() {
+        var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        apiCrudServiceInMemory.initWith(List.of(v4proxyApi));
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        when(cockpitPromotionServiceProvider.requestPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
+            CockpitReplyStatus.ERROR
+        );
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(new ProcessPromotionUseCase.Input(PROMOTION.getId(), false, ORGANIZATION_ID))
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessage("An error occurs while sending promotion promotion-id request to cockpit");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/environment/EnvironmentCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/environment/EnvironmentCrudServiceImplTest.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class EnvironmentCrudServiceImplTest {
@@ -41,25 +42,54 @@ class EnvironmentCrudServiceImplTest {
         service = new EnvironmentCrudServiceImpl(environmentRepository);
     }
 
-    @Test
-    void should_find_environment_by_id() {
-        Environment environment = anEnvironment();
-        givenEnvironment(environment);
+    @Nested
+    class Get {
 
-        assertThat(service.get(environment.getId())).isEqualTo(environment);
+        @Test
+        void should_find_environment_by_id() {
+            Environment environment = anEnvironment();
+            givenEnvironment(environment);
+
+            assertThat(service.get(environment.getId())).isEqualTo(environment);
+        }
+
+        @Test
+        void should_throw_exception_if_environment_not_found() {
+            var throwable = catchThrowable(() -> service.get("unknown"));
+            assertThat(throwable).isInstanceOf(EnvironmentNotFoundException.class);
+        }
+
+        @SneakyThrows
+        private void givenEnvironment(Environment environment) {
+            when(environmentRepository.findById(environment.getId())).thenReturn(
+                Optional.of(EnvironmentAdapter.INSTANCE.toRepository(environment))
+            );
+        }
     }
 
-    @Test
-    void should_throw_exception_if_environment_not_found() {
-        var throwable = catchThrowable(() -> service.get("unknown"));
-        assertThat(throwable).isInstanceOf(EnvironmentNotFoundException.class);
-    }
+    @Nested
+    class GetByCockpitId {
 
-    @SneakyThrows
-    private void givenEnvironment(Environment environment) {
-        when(environmentRepository.findById(environment.getId())).thenReturn(
-            Optional.of(EnvironmentAdapter.INSTANCE.toRepository(environment))
-        );
+        @Test
+        void should_find_environment_by_id() {
+            Environment environment = anEnvironment();
+            givenEnvironment(environment);
+
+            assertThat(service.getByCockpitId(environment.getId())).isEqualTo(environment);
+        }
+
+        @Test
+        void should_throw_exception_if_environment_not_found() {
+            var throwable = catchThrowable(() -> service.getByCockpitId("unknown"));
+            assertThat(throwable).isInstanceOf(EnvironmentNotFoundException.class);
+        }
+
+        @SneakyThrows
+        private void givenEnvironment(Environment environment) {
+            when(environmentRepository.findByCockpitId(environment.getId())).thenReturn(
+                Optional.of(EnvironmentAdapter.INSTANCE.toRepository(environment))
+            );
+        }
     }
 
     private Environment anEnvironment() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3713

## Description

- [x] Allow user to ask for V4 API promotion
- [x] use new MAPI V2 endpoint to process all APIs promotions. 
    - The `/management/v2/organizations/{orgId}/promotions/{promotionId}/_process` redirect the user to the legacy service for V2 APIs so the behaviour should not have changed
    - For the moment it's only possible to reject V4 APIs promotions. Acceptation will be part of my third PR
    
### Video
For V2 APIs
   
https://github.com/user-attachments/assets/3ab31d82-fa9e-4530-a034-36b7c8c6ea14

https://github.com/user-attachments/assets/65b1da7e-2165-4947-994f-70a41c41de04

For V4 APIs

https://github.com/user-attachments/assets/a5bbf1dd-2f98-478a-91f5-56186145d654


### Note

Waiting for https://github.com/gravitee-io/gravitee-api-management/pull/13754 to change the target branch

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

