### PR TITLE
fix(console): Handle async overlay rendering when groups are loaded on scroll

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
@@ -127,7 +127,7 @@ describe('ApplicationGeneralGroupsComponent', () => {
       expect(new Set(idsInOrder).size).toBe(idsInOrder.length);
     });
 
-    it('should attach scroll listener on open and call load when threshold reached', () => {
+    it('should attach scroll listener on open and call load when threshold reached', async () => {
       const app = fakeApplication({ id: APPLICATION_ID, groups: ['g1'] } as any);
       httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' }).flush(app);
 
@@ -156,6 +156,7 @@ describe('ApplicationGeneralGroupsComponent', () => {
       const loadSpy = jest.spyOn(comp, 'loadGroups').mockReturnValue(of([]));
 
       comp.onSelectToggle(true);
+      await Promise.resolve();
       scrollDiv.dispatchEvent(new Event('scroll'));
 
       expect(loadSpy).toHaveBeenCalledWith(comp.page);

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
@@ -15,10 +15,10 @@
  */
 import { Group } from 'src/entities/group/group';
 
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
-import { catchError, map, takeUntil, tap, switchMap } from 'rxjs/operators';
+import { catchError, map, takeUntil, tap, switchMap, take } from 'rxjs/operators';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatSelect } from '@angular/material/select';
 
@@ -62,6 +62,8 @@ export class ApplicationGeneralGroupsComponent implements OnInit, OnDestroy {
     private readonly applicationService: ApplicationService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly snackBarService: SnackBarService,
+    private readonly ngZone: NgZone,
+    private readonly cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {
@@ -161,16 +163,19 @@ export class ApplicationGeneralGroupsComponent implements OnInit, OnDestroy {
 
   onSelectToggle(opened: boolean): void {
     if (opened) {
-      const panelElement = this.groupMatSelect?.panel?.nativeElement as HTMLElement | null;
+      this.ngZone.onStable.pipe(take(1)).subscribe(() => {
+        this.cdr.detectChanges();
 
-      if (!panelElement) {
-        return;
-      }
+        const panelElement = this.groupMatSelect?.panel?.nativeElement as HTMLElement | null;
+        if (!panelElement) {
+          return;
+        }
 
-      this.scrollContainer = panelElement;
-      const boundScrollHandler = this.onScroll.bind(this);
-      panelElement.addEventListener('scroll', boundScrollHandler);
-      this.scrollListener = () => panelElement.removeEventListener('scroll', boundScrollHandler);
+        this.scrollContainer = panelElement;
+        const boundScrollHandler = this.onScroll.bind(this);
+        panelElement.addEventListener('scroll', boundScrollHandler);
+        this.scrollListener = () => panelElement.removeEventListener('scroll', boundScrollHandler);
+      });
     } else {
       this.cleanupScrollListener();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10518

## Description

In the APIM UI, the User & Group Access tab within an application takes up long time to load. This performance degradation appears to be linked to the high number of groups and group memberships configured in the environment.

What the PR is doing (strengths):

1. The PR addresses performance: instead of fetching all groups (e.g. list(1, 9999)), it moves to paginated loading and selective fetching.
2. It introduces listById use for fetching only relevant groups (selected ones) rather than always loading full dataset.
3. It retains backward compatibility by deduplicating, merging, and ordering selected groups first, then others.
4. It correctly reads pagination metadata (pageCount, pagination) to stop infinite scroll at the right point.

Request URL 1: 

management/v2/environments/DEFAULT/groups?page=1&perPage=9999

Request URL 2: 

management/organizations/DEFAULT/environments/DEFAULT/configuration/groups

## Additional context

Problem video:

https://github.com/user-attachments/assets/bd07698e-0427-4d6b-a30e-2f006a30203e

After fix video:

https://github.com/user-attachments/assets/55ca0da1-39f6-42c9-a8aa-59b455e5619e