### PR TITLE
fix: ensure consistent policy display names between OpenAPI imports and policy catalog

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SwaggerServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SwaggerServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.swagger.OAIDescriptor;
 import io.gravitee.rest.api.service.swagger.SwaggerDescriptor;
+import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import java.net.MalformedURLException;
@@ -71,6 +72,9 @@ public class SwaggerServiceImpl implements SwaggerService {
     @Autowired
     private TagService tagService;
 
+    @Autowired
+    private PolicyPluginService policyPluginService;
+
     @Override
     public SwaggerApiEntity createAPI(ExecutionContext executionContext, ImportSwaggerDescriptorEntity swaggerDescriptor) {
         return this.createAPI(executionContext, swaggerDescriptor, DefinitionVersion.V1);
@@ -95,10 +99,13 @@ public class SwaggerServiceImpl implements SwaggerService {
 
         if (descriptor != null) {
             if (definitionVersion.equals(DefinitionVersion.V2)) {
-                return new OAIToAPIV2Converter(swaggerDescriptor, policyOperationVisitorManager, groupService, tagService).convert(
-                    executionContext,
-                    (OAIDescriptor) descriptor
-                );
+                return new OAIToAPIV2Converter(
+                    swaggerDescriptor,
+                    policyOperationVisitorManager,
+                    groupService,
+                    tagService,
+                    policyPluginService
+                ).convert(executionContext, (OAIDescriptor) descriptor);
             } else {
                 return new OAIToAPIConverter(swaggerDescriptor, policyOperationVisitorManager, groupService, tagService).convert(
                     executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
@@ -28,30 +28,38 @@ import io.gravitee.definition.model.flow.Step;
 import io.gravitee.policy.api.swagger.Policy;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.model.api.SwaggerApiEntity;
+import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.TagService;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.gravitee.rest.api.service.impl.swagger.visitor.v3.OAIOperationVisitor;
+import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class OAIToAPIV2Converter extends OAIToAPIConverter {
+
+    private final PolicyPluginService policyPluginService;
 
     public OAIToAPIV2Converter(
         ImportSwaggerDescriptorEntity swaggerDescriptor,
         PolicyOperationVisitorManager policyOperationVisitorManager,
         GroupService groupService,
-        TagService tagService
+        TagService tagService,
+        PolicyPluginService policyPluginService
     ) {
         super(swaggerDescriptor, policyOperationVisitorManager, groupService, tagService);
+        this.policyPluginService = policyPluginService;
     }
 
     @Override
@@ -80,8 +88,21 @@ public class OAIToAPIV2Converter extends OAIToAPIConverter {
                                     Optional<Policy> policy = (Optional<Policy>) oaiOperationVisitor.visit(oai, operation);
                                     if (policy.isPresent()) {
                                         final Step step = new Step();
-                                        step.setName(policy.get().getName());
+                                        String policyId = policy.get().getName(); // actually the plugin ID
+                                        step.setPolicy(policyId);
                                         step.setEnabled(true);
+                                        try {
+                                            PolicyPluginEntity plugin = policyPluginService.findById(policyId);
+                                            step.setName(plugin != null ? plugin.getName() : policyId);
+                                        } catch (RuntimeException e) {
+                                            log.warn(
+                                                "An error occurred while trying to retrieve the policy plugin '{}' for API '{}'. Falling back to policy id.",
+                                                policyId,
+                                                apiEntity.getName(),
+                                                e
+                                            );
+                                            step.setName(policyId);
+                                        }
                                         step.setDescription(
                                             operation.getSummary() == null
                                                 ? (operation.getOperationId() == null
@@ -90,7 +111,6 @@ public class OAIToAPIV2Converter extends OAIToAPIConverter {
                                                 : operation.getSummary()
                                         );
 
-                                        step.setPolicy(policy.get().getName());
                                         String configuration = clearNullValues(policy.get().getConfiguration());
                                         step.setConfiguration(configuration);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2ConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2ConverterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.swagger.converter.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Step;
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.model.api.SwaggerApiEntity;
+import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
+import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.TagService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitor;
+import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.impl.swagger.visitor.v3.OAIOperationVisitor;
+import io.gravitee.rest.api.service.swagger.OAIDescriptor;
+import io.gravitee.rest.api.service.v4.PolicyPluginService;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Info;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OAIToAPIV2ConverterTest {
+
+    private PolicyPluginService policyPluginService;
+    private PolicyOperationVisitorManagerImpl policyOperationVisitorManager;
+    private OAIToAPIV2Converter converter;
+
+    @BeforeEach
+    void setup() {
+        policyPluginService = mock(PolicyPluginService.class);
+        policyOperationVisitorManager = mock(PolicyOperationVisitorManagerImpl.class);
+    }
+
+    @Test
+    @DisplayName("Should set plugin name and policyId correctly")
+    void shouldSetMockPluginNameAndPolicyId() {
+        ImportSwaggerDescriptorEntity descriptor = new ImportSwaggerDescriptorEntity();
+        descriptor.setWithPolicyPaths(true);
+        descriptor.setWithPathMapping(true);
+        descriptor.setWithPolicies(List.of("json-validation"));
+
+        OAIOperationVisitor visitor = mock(OAIOperationVisitor.class);
+        Policy policy = new Policy();
+        policy.setName("json-validation");
+        policy.setConfiguration("{}");
+        when(visitor.visit(any(OpenAPI.class), any(Operation.class))).thenReturn(Optional.of(policy));
+
+        PolicyOperationVisitor policyVisitor = mock(PolicyOperationVisitor.class);
+        when(policyVisitor.getId()).thenReturn("json-validation");
+
+        when(policyOperationVisitorManager.getPolicyVisitors()).thenReturn(List.of(policyVisitor));
+        when(policyOperationVisitorManager.getOAIOperationVisitor("json-validation")).thenReturn(visitor);
+
+        PolicyPluginEntity plugin = new PolicyPluginEntity();
+        plugin.setName("JSON Validation");
+        when(policyPluginService.findById("json-validation")).thenReturn(plugin);
+
+        converter = new OAIToAPIV2Converter(
+            descriptor,
+            policyOperationVisitorManager,
+            mock(GroupService.class),
+            mock(TagService.class),
+            policyPluginService
+        );
+
+        OpenAPI openAPI = new OpenAPI()
+            .info(new Info().title("Mock API").version("1.0"))
+            .paths(new Paths().addPathItem("/pets", new PathItem().get(new Operation().operationId("listPets"))))
+            .servers(List.of());
+
+        SwaggerApiEntity api = converter.convert(new ExecutionContext("DEFAULT", "DEFAULT"), new OAIDescriptor(openAPI));
+
+        assertThat(api).isNotNull();
+        assertThat(api.getFlows()).isNotNull();
+        assertThat(api.getFlows().size()).isEqualTo(1);
+
+        Flow flow = api.getFlows().get(0);
+        Step step = flow.getPre().get(0);
+
+        assertThat(step.getPolicy()).isEqualTo("json-validation");
+        assertThat(step.getName()).isEqualTo("JSON Validation");
+    }
+}


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11020

## Description

Policies created automatically during API import from an OpenAPI specification used different display names (e.g., "json-validation") compared to the standard catalog name ("JSON Validation"). 

This change aligns the naming convention so that all policies use the same human-readable name across the platform, improving consistency and reducing confusion.

Issue: (policy name = mock)


https://github.com/user-attachments/assets/0e09c871-04ba-4b93-b030-21b7b6851718


Fix: (policy name = Mock)

https://github.com/user-attachments/assets/f1815d24-324f-497b-a1dc-755d32157890



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

