### PR TITLE
fix: prevent 500 error on Developer Portal API search due to maxClauseCount issue

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -47,7 +47,7 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
 
     protected static void increaseMaxClauseCountIfNecessary(int size) {
         if (size > IndexSearcher.getMaxClauseCount()) {
-            IndexSearcher.setMaxClauseCount(size);
+            IndexSearcher.setMaxClauseCount(Math.min(size + 100, Integer.MAX_VALUE));
         }
     }
 


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11593

## Description

- Increase Elasticsearch maxClauseCount dynamically based on query size
- Add safety check to avoid exceeding Integer.MAX_VALUE
- Ensure exact API ID searches return results without errors

Issue:


https://github.com/user-attachments/assets/950a89c6-9a78-41b9-8235-068c73866e2d


Fix: 

https://github.com/user-attachments/assets/70191b62-20cf-4130-9601-c8aa798554f4



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

