### PR TITLE
docs: use only on tag for API promotion request endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -622,7 +622,6 @@ paths:
       post:
         tags:
           - APIs
-          - Promotions
         summary: Promote an API
         description: |-
           Promote the API to another environment.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3712

## Description

Using multiple tags on APIs endpoint break the e2e tests https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/64882/workflows/e3238984-32eb-47e1-9cab-3a87a197777b/jobs/1305303

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

