### PR TITLE
feat(dashboard-lib): Add new stories (storybook)

### DIFF
--- a/gravitee-apim-portal-webui-next/.storybook/main.ts
+++ b/gravitee-apim-portal-webui-next/.storybook/main.ts
@@ -5,6 +5,7 @@ const config: StorybookConfig = {
     '../src/**/*.mdx',
     '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../projects/gravitee-markdown/src/**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    '../projects/gravitee-dashboard/src/**/*.stories.@(js|jsx|ts|tsx|mdx)',
   ],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@chromatic-com/storybook', '@storybook/addon-interactions'],
   framework: {

--- a/gravitee-apim-portal-webui-next/.storybook/tsconfig.json
+++ b/gravitee-apim-portal-webui-next/.storybook/tsconfig.json
@@ -6,6 +6,6 @@
     "resolveJsonModule": true
   },
   "exclude": ["../**/*.spec.ts"],
-  "include": ["../src/**/*.stories.*", "./preview.ts", "../projects/gravitee-markdown/src/**/*"],
+  "include": ["../src/**/*.stories.*", "./preview.ts", "../projects/gravitee-markdown/src/**/*", "../projects/gravitee-dashboard/src/**/*"],
   "files": ["./typings.d.ts"]
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.stories.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+
+import { PieChartComponent, PieType } from './pie-chart.component';
+
+interface PieChartStoryArgs {
+  storyId?: string;
+  type: PieType;
+  data: {
+    labels: string[];
+    datasets: Array<{
+      data: number[];
+    }>;
+  };
+}
+
+export default {
+  title: 'Gravitee Dashboard/Components/Chart/Pie Chart',
+  component: PieChartComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [PieChartComponent],
+    }),
+    applicationConfig({
+      providers: [
+        // Register Chart.js controllers for pie charts
+        provideCharts(withDefaultRegisterables()),
+      ],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A pie chart component built with Chart.js that displays data in a circular chart format.',
+      },
+    },
+  },
+  argTypes: {
+    storyId: {
+      table: { disable: true },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['pie', 'doughnut', 'polarArea'],
+      description: 'Type of pie chart to display',
+    },
+    data: {
+      description: 'Chart data containing labels and datasets',
+    },
+  },
+  render: args => ({
+    template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-pie-chart [type]="type" [data]="data" />
+        </div>
+    `,
+    props: {
+      type: args.type,
+      data: args.data,
+    },
+  }),
+} satisfies Meta<PieChartStoryArgs>;
+
+export const Default: StoryObj<PieChartStoryArgs> = {
+  args: {
+    storyId: 'default',
+    type: 'pie' as PieType,
+    data: {
+      labels: ['North America', 'Europe', 'Asia Pacific', 'South America', 'Africa', 'Middle East', 'Oceania'],
+      datasets: [
+        {
+          data: [35, 28, 20, 8, 5, 3, 1],
+        },
+      ],
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.ts
@@ -40,8 +40,8 @@ export class PieChartComponent<T extends PieType> {
 
   private getDataMock(): ChartData<T> {
     return {
-      labels: ['Download Sales', 'In-Store Sales', 'Mail-Order Sales'],
-      datasets: [{ data: [350, 450, 100] }],
+      labels: ['North America', 'Europe', 'Asia Pacific', 'South America', 'Africa', 'Middle East', 'Oceania'],
+      datasets: [{ data: [35, 28, 20, 8, 5, 3, 1] }],
     } as ChartData<T>;
   }
 

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.html
@@ -19,7 +19,7 @@
 <gridster [options]="options()" class="grid">
   @for (item of items(); track item) {
     <gridster-item [item]="item.layout">
-      <gd-widget [item]="item">
+      <gd-widget [isDraggable]="options().draggable?.enabled ?? false">
         <gd-widget-title>{{ item.label }}</gd-widget-title>
 
         <gd-widget-body>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.scss
@@ -39,3 +39,7 @@ gridster-item {
   border-radius: 7px;
   background: white;
 }
+
+.widget-title.is-draggable {
+  cursor: move;
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.stories.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+
+import { GridComponent } from './grid.component';
+import { Widget } from '../widget/widget';
+
+interface GridStoryArgs {
+  items: Widget[];
+}
+
+// Common widget items to avoid duplication
+const commonItems: Widget[] = [
+  {
+    id: 'widget-1',
+    label: 'API Calls',
+    type: 'pie',
+    layout: { cols: 2, rows: 1, x: 0, y: 0 },
+  },
+  {
+    id: 'widget-2',
+    label: 'Database Queries',
+    type: 'doughnut',
+    layout: { cols: 1, rows: 1, x: 2, y: 0 },
+  },
+  {
+    id: 'widget-3',
+    label: 'Cache Hits',
+    type: 'kpi',
+    layout: { cols: 1, rows: 1, x: 3, y: 0 },
+  },
+  {
+    id: 'widget-4',
+    label: 'Error Rate',
+    type: 'pie',
+    layout: { cols: 1, rows: 3, x: 0, y: 1 },
+  },
+  {
+    id: 'widget-5',
+    label: 'Response Time',
+    type: 'doughnut',
+    layout: { cols: 3, rows: 3, x: 1, y: 1 },
+  },
+  {
+    id: 'widget-6',
+    label: 'User Activity',
+    type: 'polarArea',
+    layout: { cols: 2, rows: 2, x: 4, y: 1 },
+  },
+];
+
+export default {
+  title: 'Gravitee Dashboard/Components/Grid',
+  component: GridComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GridComponent],
+    }),
+    applicationConfig({
+      providers: [
+        // Register Chart.js controllers for pie charts
+        provideCharts(withDefaultRegisterables()),
+      ],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A grid component built with Angular Gridster2 that displays widgets in a draggable and resizable layout. The grid options can be configured to customize the grid behavior. More info: https://tiberiuzuld.github.io/angular-gridster2/api',
+      },
+    },
+  },
+  argTypes: {
+    items: {
+      description: 'Array of widgets to display in the grid',
+    },
+  },
+  render: args => ({
+    template: `
+          <gd-grid [items]="items" />
+    `,
+    props: {
+      items: args.items,
+    },
+  }),
+} as Meta<GridStoryArgs>;
+
+export const Default: StoryObj<GridStoryArgs> = {
+  args: {
+    items: commonItems,
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.ts
@@ -33,15 +33,13 @@ export class GridComponent {
   private getGridsterOptions(): GridsterConfig {
     return {
       gridType: GridType.VerticalFixed,
-      maxCols: 6,
-      minCols: 6,
-      minRows: 8,
-      itemAspectRatio: 4 / 3,
       compactType: CompactType.None,
       displayGrid: DisplayGrid.None,
+      itemAspectRatio: 4 / 3,
       pushItems: true,
       draggable: {
         enabled: true,
+        dragHandleClass: '.widget-title-container',
       },
       resizable: {
         enabled: true,

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2025 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,11 @@
 
 -->
 <div class="widget-container">
-  <span class="widget-title">
+  <span class="widget-title-container" [class.is-draggable]="isDraggable()">
     <ng-content select="gd-widget-title" />
   </span>
 
-  <span class="widget-content gridster-item-content">
+  <span class="widget-body-container gridster-item-content">
     <ng-content select="gd-widget-body" />
   </span>
 </div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,19 +19,22 @@
   flex-flow: column;
 }
 
-.widget-title {
+.widget-title-container {
   display: flex;
   height: 50px;
   flex-shrink: 0;
   align-items: center;
   padding: 0 15px;
   border-bottom: 1px solid #eee;
-  cursor: move;
 }
 
-.widget-content {
+.widget-body-container {
   overflow: hidden;
   height: 80%;
   min-height: 0;
   flex-grow: 1;
+}
+
+.widget-title-container.is-draggable {
+  cursor: move;
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.stories.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+
+import { Widget } from './widget';
+import { WidgetComponent, WidgetTitleComponent, WidgetBodyComponent } from './widget.component';
+import { PieChartComponent } from '../chart/pie-chart/pie-chart.component';
+
+interface WidgetStoryArgs {
+  storyId: string;
+  widgetTitle: string;
+  widgetBody: string;
+  isDraggable: boolean;
+  item: Widget;
+}
+
+export default {
+  title: 'Gravitee Dashboard/Components/Widget',
+  component: WidgetComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [WidgetComponent, WidgetTitleComponent, WidgetBodyComponent, PieChartComponent],
+    }),
+    applicationConfig({
+      providers: [
+        // Register Chart.js controllers for pie charts
+        provideCharts(withDefaultRegisterables()),
+      ],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A widget component that displays data in a container with title and body sections. Supports different widget types including charts, Plain text and KPIs.',
+      },
+    },
+  },
+  argTypes: {
+    storyId: {
+      table: { disable: true },
+    },
+    item: {
+      description: 'Widget configuration object',
+      if: { arg: 'storyId', neq: 'default' },
+    },
+    widgetTitle: {
+      control: { type: 'text' },
+      description: 'Custom title for the widget',
+      defaultValue: 'Custom Widget Title',
+    },
+    widgetBody: {
+      control: { type: 'text' },
+      description: 'Custom body content for the widget',
+      defaultValue: 'This is custom body content that can be edited by the user.',
+    },
+    isDraggable: {
+      control: { type: 'boolean' },
+      description: 'Custom body content for the widget',
+      defaultValue: 'This is custom body content that can be edited by the user.',
+    },
+  },
+};
+
+export const Default: StoryObj<WidgetStoryArgs> = {
+  args: {
+    storyId: 'default',
+    widgetTitle: 'Custom Widget Title',
+    widgetBody: 'This is custom body content that can be edited by the user.',
+  },
+  render: args => {
+    const typedArgs = args;
+    return {
+      template: `
+            <gd-widget [isDraggable]="isDraggable">
+              <gd-widget-title>{{ widgetTitle }}
+              </gd-widget-title>
+              <gd-widget-body >
+                  {{ widgetBody }}
+              </gd-widget-body>
+            </gd-widget>
+      `,
+      props: {
+        widgetTitle: typedArgs.widgetTitle,
+        widgetBody: typedArgs.widgetBody,
+        isDraggable: typedArgs.isDraggable,
+      },
+    };
+  },
+};
+
+export const WidgetWithPieChart: StoryObj<WidgetStoryArgs> = {
+  args: {
+    widgetTitle: '{{item.label}}',
+    widgetBody: '<gd-pie-chart type="pie" />',
+    item: {
+      id: 'widget-custom',
+      label: 'Custom Analytics',
+      type: 'pie',
+      filter: 'last-30-days',
+      layout: { cols: 3, rows: 3, x: 0, y: 0 },
+    },
+  },
+  render: args => {
+    const typedArgs = args;
+    return {
+      template: `
+            <gd-widget [isDraggable]="isDraggable">
+              <gd-widget-title>{{item.label}}</gd-widget-title>
+              <gd-widget-body>
+                <gd-pie-chart type="pie" />
+              </gd-widget-body>
+            </gd-widget>
+      `,
+      props: {
+        item: args.item,
+        widgetTitle: typedArgs.widgetTitle,
+        widgetBody: typedArgs.widgetBody,
+        isDraggable: typedArgs.isDraggable,
+      },
+    };
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/widget/widget.component.ts
@@ -15,8 +15,6 @@
  */
 import { Component, input } from '@angular/core';
 
-import { Widget } from './widget';
-
 @Component({
   selector: 'gd-widget-title',
   template: `<ng-content>widget-title</ng-content>`,
@@ -38,5 +36,5 @@ export class WidgetBodyComponent {}
   styleUrl: './widget.component.scss',
 })
 export class WidgetComponent {
-  item = input<Widget>();
+  isDraggable = input<boolean>(false);
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1803

## Description

Add new stories (storybook) for dashboard-lib components.
Grid + Widget + Chart

## Additional context

<img width="2543" height="1297" alt="Screenshot 2025-10-29 at 16 16 50" src="https://github.com/user-attachments/assets/ee9c079c-e7bb-424d-aa4e-0324b3a86b98" />
<img width="2552" height="1251" alt="Screenshot 2025-10-29 at 16 16 35" src="https://github.com/user-attachments/assets/6d55cd3c-c195-49d2-9b96-0edabee4fa0f" />
<img width="2546" height="1233" alt="Screenshot 2025-10-29 at 16 16 23" src="https://github.com/user-attachments/assets/cf6a8dad-9eac-4b2e-9152-464217b39343" />