### PR TITLE
fix: kafka console image unavailable in docker hub

### DIFF
--- a/docker/quick-setup/kafka-console/README.md
+++ b/docker/quick-setup/kafka-console/README.md
@@ -26,7 +26,7 @@ Up docker-compose :
 
 To be sure to fetch last version of images, you can do
 `export APIM_VERSION={APIM_VERSION} && docker-compose down -v && docker-compose pull && docker-compose up`
-Or you can do `export APIM_REGISTRY=graviteeio.azurecr.io  && export APIM_VERSION=master-latest && docker-compose up -d` to use the latest version. but you need to have access to the internal registry.
+Or you can do `export APIM_REGISTRY=graviteeio.azurecr.io  && export APIM_VERSION=master-latest && export APIM_KAFKA_CONSOLE_VERSION=4.9.0-alpha.3 && docker-compose up -d` to use the latest version. but you need to have access to the internal registry.
 
 
 

--- a/docker/quick-setup/kafka-console/docker-compose.yml
+++ b/docker/quick-setup/kafka-console/docker-compose.yml
@@ -179,7 +179,7 @@ services:
       - email
 
   kafkaConsole:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-kafka-console:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-kafka-console:${APIM_KAFKA_CONSOLE_VERSION:-latest}
     container_name: gio_apim_kafka_console
     networks:
       - kafkaConsole
@@ -194,7 +194,7 @@ services:
       - KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINPASSWORD=admin
 
   kafka:
-    image: docker.io/bitnami/kafka:3.9
+    image: docker.io/bitnamilegacy/kafka:3.9
     container_name: gio_apim_kafka
     volumes:
       - data-kafka:/bitnami/kafka

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2018,12 +2018,15 @@ ui:
   #    secret:
   #      secretName: gravitee-config-secret-name
 
+# NOTE: Kafka Console is in tech preview and requires a private image.
+# Contact your technical account manager for access and the correct image reference.
 kafkaConsole:
   enabled: false
   name: kafkaConsole
   replicaCount: 1
   image:
-    repository: graviteeio/apim-kafka-console
+    repository: graviteeio/apim-kafka-console # Update with your private registry
+    # tag: latest
     pullPolicy: Always
 
   lifecycle:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11725

## Description

Update registry and version to fetch Kafka Console image from private ACR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

