### PR TITLE
fix: jdbc repository return latest event with all their properties

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -52,3 +52,10 @@ tasks:
     cmds:
       - docker build -t ${DOCKER_REGISTRY}/apim-management-ui:$DOCKER_TAG -f gravitee-apim-console-webui/docker/Dockerfile ./gravitee-apim-console-webui
       - docker build -t ${DOCKER_REGISTRY}/apim-portal-ui:$DOCKER_TAG -f gravitee-apim-portal-webui/docker/Dockerfile ./gravitee-apim-portal-webui
+
+  postgres-driver:
+    desc: "Download postgres jdbc driver"
+    cmds:
+      - curl https://jdbc.postgresql.org/download/postgresql-42.4.0.jar --create-dirs -o /tmp/postgresql-42.4.0.jar
+      - cp /tmp/postgresql-42.4.0.jar $APIM_GW_DISTRIBUTION_PATH/plugins/ext/repository-jdbc
+      - cp /tmp/postgresql-42.4.0.jar $APIM_MAPI_DISTRIBUTION_PATH/plugins/ext/repository-jdbc

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Event.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Event.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -37,6 +38,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode
+@ToString
 public class Event implements Serializable {
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-latest-tests/events.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-latest-tests/events.json
@@ -57,7 +57,8 @@
     "payload": "{}",
     "parentId": null,
     "properties": {
-      "api_id": "api-4"
+      "api_id": "api-4",
+      "deployment_number": "1"
     },
     "createdAt": 1464739200000,
     "updatedAt": 1464739200000

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
@@ -7,8 +7,10 @@
     "payload": "{}",
     "parentId": null,
     "properties": {
-      "api_id": "api-1"
+      "api_id": "api-1",
+      "deployment_number": "1"
     },
+    "createdAt": 1451606400000,
     "updatedAt": 1451606400000
   },
   {
@@ -44,8 +46,10 @@
     "payload": "{}",
     "parentId": null,
     "properties": {
-      "api_id": "api-3"
+      "api_id": "api-3",
+      "deployment_number": "1"
     },
+    "createdAt": 1459468800000,
     "updatedAt": 1459468800000
   },
   {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11726

## Description

JDBC repository that fetches the latest events, where we are building an Event without all its properties. Therefore, when the API was synchronized on the Gateway, the revision was not defined, and when an update was deployed, it was ignored because the revision number was the same.

The fix was not straightforward and may not be efficient. If we notice performance issues during the sync, we may need to investigate more on how we can improve this `JdbcEventLatestRepository`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

