### PR TITLE
chore: bump gravitee-cloud-initializer version to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <gravitee-bom.version>8.3.41</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.0</gravitee-cockpit-api.version>
-        <gravitee-cloud-initializer.version>2.1.1</gravitee-cloud-initializer.version>
+        <gravitee-cloud-initializer.version>2.2.0</gravitee-cloud-initializer.version>
         <gravitee-common.version>4.7.3</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.9.1</gravitee-exchange.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-534

## Description

Bump cloud-initializer to add new hybrid gateway monitoring feature.

