### PR TITLE
fix(logging) : Prevent endPointResponse showing 200 for failed request 502

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -77,7 +77,12 @@ public class LoggingHook implements InvokerHook {
             }
 
             if (log != null && loggingContext != null && loggingContext.endpointResponse()) {
-                ((LogEndpointResponse) log.getEndpointResponse()).capture();
+                final ExecutionFailure executionFailure = ctx.getInternalAttribute(
+                    InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE
+                );
+                if (executionFailure == null) {
+                    ((LogEndpointResponse) log.getEndpointResponse()).capture();
+                }
 
                 final HttpResponseInternal response = ((HttpExecutionContextInternal) ctx).response();
                 response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11609

## Description

Fixes endpoint-response logging to avoid default 200 when no response exists; only capture when a real response is present.

#### Why this change
- In cases like DNS resolution failure (502), the invoker's post() method in `LoggingHook.java` is called without a backend response, resulting in a default 200 status when capture() is invoked.
- For other errors (504, 500, 404) where no connection is established, post() is never called, and endpointResponse remains at its default value (0, initialized in `LogInitProcessor.java`).
- The capture() method is now gated by an ATTR_INTERNAL_ANALYTICS_CONTEXT check to prevent logging false 200 statuses.

Alternative approach
- Adding a 502 specific check in `LogResponseProcessor.java` with overriding capture() in `LogResponse.java`.
- Alternatively, adding the same check in `LoggingHook.java.`
- These approaches were avoided to prevent hardcoded, status-based logic

## Additional context

Before
<img width="1514" height="888" alt="image" src="https://github.com/user-attachments/assets/d24fadc2-e0b3-45ed-9ad8-c876f42c8df4" />

After

<img width="1606" height="897" alt="image" src="https://github.com/user-attachments/assets/87bec161-ca40-4cd8-a071-ad5a05b5db63" />


