### PR TITLE
APIM-11416 configure the header name to read api key from plans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>5.0.6</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>5.0.1</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>5.2.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.4</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.1</gravitee-policy-assign-content.version>
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11416

## Description

This PR follows a similar one on the API key policy plugin : https://github.com/gravitee-io/gravitee-policy-apikey/pull/97
It makes sure that for older version (from 4.6) we can use api key custom headers that have been configured in plans.