### PR TITLE
fix: hints in subscription form in portal next

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.html
@@ -29,7 +29,7 @@
     <div>
       @switch (keyStoreForm.controls.type.value) {
         @case ('JKS') {
-          <mat-form-field appearance="outline" class="form__field form__field--margin">
+          <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field form__field--margin">
             <mat-label i18n="@@sslKeyStorePassword">Password</mat-label>
             <input matInput formControlName="jksPassword" type="password" name="jksPassword" autocomplete="off" required />
             <mat-hint i18n="@@sslKeyStorePasswordHint">
@@ -42,7 +42,7 @@
           </mat-form-field>
 
           <div class="path-or-content">
-            <mat-form-field appearance="outline" class="form__field">
+            <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
               <mat-label i18n="@@sslKeyStorePath">Path</mat-label>
               <input matInput formControlName="jksPath" name="jksPath" autocomplete="off" />
               <mat-hint i18n="@@sslKeyStorePathHint">Path to the trust store file</mat-hint>
@@ -53,7 +53,7 @@
 
             <span i18n="@@sslKeyStoreOr">or</span>
 
-            <mat-form-field appearance="outline" class="form__field">
+            <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
               <mat-label i18n="@@sslKeyStoreContent">Content</mat-label>
               <textarea matInput formControlName="jksContent" rows="1" name="jksContent"></textarea>
               <mat-hint i18n="@@sslKeyStoreContentHint">Binary content as Base64</mat-hint>
@@ -63,13 +63,13 @@
             </mat-form-field>
           </div>
 
-          <mat-form-field appearance="outline" class="form__field">
+          <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
             <mat-label i18n="@@sslKeyStoreAlias">Alias</mat-label>
             <input matInput formControlName="jksAlias" name="jksAlias" autocomplete="off" />
             <mat-hint i18n="@@sslKeyStoreAliasHint">Alias of the key to use in case the key store contains more than one key.</mat-hint>
           </mat-form-field>
 
-          <mat-form-field appearance="outline" class="form__field">
+          <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
             <mat-label i18n="@@sslKeyStoreKeyPassword">Key password</mat-label>
             <input matInput formControlName="jksKeyPassword" name="jksKeyPassword" autocomplete="off" />
             <mat-hint i18n="@@sslKeyStoreKeyPasswordHint"
@@ -100,7 +100,7 @@
 
             <span i18n="@@sslKeyStoreOr">or</span>
 
-            <mat-form-field appearance="outline" class="form__field">
+            <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
               <mat-label i18n="@@sslKeyStoreContent">Content</mat-label>
               <textarea matInput formControlName="pkcs12Content" rows="1" name="pkcs12Content"></textarea>
               <mat-hint i18n="@@sslKeyStoreContentHint">Binary content as Base64</mat-hint>
@@ -110,13 +110,13 @@
             </mat-form-field>
           </div>
 
-          <mat-form-field appearance="outline" class="form__field">
+          <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
             <mat-label i18n="@@sslKeyStoreAlias">Alias</mat-label>
             <input matInput formControlName="pkcs12Alias" name="pkcs12Alias" autocomplete="off" />
             <mat-hint i18n="@@sslKeyStoreAliasHint">Alias of the key to use in case the key store contains more than one key.</mat-hint>
           </mat-form-field>
 
-          <mat-form-field appearance="outline" class="form__field">
+          <mat-form-field subscriptSizing="dynamic" appearance="outline" class="form__field">
             <mat-label i18n="@@sslKeyStoreKeyPassword">Key password</mat-label>
             <input matInput formControlName="pkcs12KeyPassword" name="pkcs12KeyPassword" autocomplete="off" />
             <mat-hint i18n="@@sslKeyStoreKeyPasswordHint"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11731

## Description

Fix mat-hint elements overlapping elements in mobile view in subscription form.


<img width="1082" height="956" alt="Screenshot 2025-11-04 at 13 15 04" src="https://github.com/user-attachments/assets/32ed376d-e59b-426b-adea-509ac237d2a1" />
<img width="996" height="949" alt="Screenshot 2025-11-04 at 13 14 54" src="https://github.com/user-attachments/assets/a8ffcdf8-de3c-4c67-9c6c-bc662e431ac4" />
<img width="1098" height="949" alt="Screenshot 2025-11-04 at 13 14 41" src="https://github.com/user-attachments/assets/dbe7f704-5527-4a68-b933-5401c96025fd" />
<img width="1011" height="940" alt="Screenshot 2025-11-04 at 13 14 29" src="https://github.com/user-attachments/assets/0e86e32c-014d-41ce-80a1-5f4a6fc5fae2" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

