### PR TITLE
fix: ensure payload filter returns all request results

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -155,7 +155,7 @@ public class LogsServiceImpl implements LogsService {
             logResponse.setLogs(response.getLogs().stream().map(this::toApiRequestItem).collect(Collectors.toList()));
 
             // Add metadata (only if they are results)
-            if (response.getSize() > 0) {
+            if (response.getLogs() != null && !response.getLogs().isEmpty()) {
                 Map<String, Map<String, String>> metadata = new HashMap<>();
 
                 logResponse


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10781

## Description

This PR fixes a bug where using the payload/body filter in v2 API logs returned an incorrect total when matching log entries spanned multiple pages.

**Root cause**
The repository previously only gathered the set of log `_id`s from a single page of LOG results (aligned to the user page), then applied that subset to filter REQUEST documents. When matching logs were spread across multiple pages, many matching request IDs were omitted and the total returned was incorrect.


https://github.com/user-attachments/assets/ace6ef13-d2df-48b3-a1c8-25501a8ba899



**Fix**
- Enumerate matching LOG hits using `search_after` (iterative paging) and collect `_id`s up to a configurable cap (`max_result_window`) rather than relying on a single page.
- Use the collected `_id` set to filter the REQUEST index, and then apply the original pagination (`page`, `size`) to the REQUEST query.

https://github.com/user-attachments/assets/b10399be-1450-443c-a26d-f53a8f41507a




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

