### PR TITLE
fix: disable DEPLOY_MODEL on API migrated from v2 to v4

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
@@ -21,10 +21,12 @@ import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.designer.DeployModelCommand;
 import io.gravitee.cockpit.api.command.v1.designer.DeployModelCommandPayload;
 import io.gravitee.cockpit.api.command.v1.designer.DeployModelReply;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntityResult;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.cockpit.model.DeploymentMode;
@@ -86,8 +88,15 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
                 executionContext.getEnvironmentId(),
                 apiCrossId
             );
+
             if (optApiId.isPresent()) {
                 final String apiId = optApiId.get();
+                final ApiEntity api = apiSearchService.findById(executionContext, apiId);
+
+                if (api.getDefinitionVersion() == DefinitionVersion.V4) {
+                    return Single.just(new DeployModelReply(command.getId(), "API migrated from v2 to v4. Update not yet supported."));
+                }
+
                 var message = permissionChecker.checkUpdatePermission(
                     executionContext,
                     user.getId(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3765

## Description

Adding validation to avoid issue if an API has been migrated from v2 from v4 on APIM side and this API is managed by API Designer.
This fix is needed only in 4.9.x, DEPLOY_MODEL has been updated in 4.10 to allow v4 push/create from API Designer

