### PR TITLE
[CI] update bridge compatibility tests 4.6.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -328,7 +328,7 @@ workflows:
               apim_client_tag:
                 - 4.6.x-latest
                 - graviteeio@4.6.0
-                - 4.5.x-latest
+                - graviteeio@4.5
                 - graviteeio@4.5.0
                 - graviteeio@4.4
                 - graviteeio@4.4.2

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -64,7 +64,7 @@ export class BridgeCompatibilityTestsWorkflow {
           apim_client_tag: [
             '4.6.x-latest',
             'graviteeio@4.6.0',
-            '4.5.x-latest',
+            'graviteeio@4.5',
             'graviteeio@4.5.0',
             'graviteeio@4.4',
             'graviteeio@4.4.2',


### PR DESCRIPTION
## Description

4.5.x is no longer supported. So we force the bridge tests with latest 4.5 docker tag