### PR TITLE
[CI] update bridge compatibility tests 4.7.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -324,9 +324,10 @@ workflows:
                 - bridge
               apim_client_tag:
                 - 4.7.x-latest
+                - graviteeio@4.7.0
                 - 4.6.x-latest
                 - graviteeio@4.6.0
-                - 4.5.x-latest
+                - graviteeio@4.5
                 - graviteeio@4.5.0
                 - graviteeio@4.4
                 - graviteeio@4.4.2

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -63,9 +63,10 @@ export class BridgeCompatibilityTestsWorkflow {
           database: ['bridge'],
           apim_client_tag: [
             '4.7.x-latest',
+            'graviteeio@4.7.0',
             '4.6.x-latest',
             'graviteeio@4.6.0',
-            '4.5.x-latest',
+            'graviteeio@4.5',
             'graviteeio@4.5.0',
             'graviteeio@4.4',
             'graviteeio@4.4.2',


### PR DESCRIPTION
## Description

4.5.x is no longer supported. So we force the bridge tests with latest 4.5 docker tag
Also adding a missing 4.7.0 test