### PR TITLE
[CI] update bridge compatibility tests 4.8.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -329,7 +329,7 @@ workflows:
                 - graviteeio@4.7.0
                 - 4.6.x-latest
                 - graviteeio@4.6.0
-                - 4.5.x-latest
+                - graviteeio@4.5
                 - graviteeio@4.5.0
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -68,7 +68,7 @@ export class BridgeCompatibilityTestsWorkflow {
             'graviteeio@4.7.0',
             '4.6.x-latest',
             'graviteeio@4.6.0',
-            '4.5.x-latest',
+            'graviteeio@4.5',
             'graviteeio@4.5.0',
           ],
         },


### PR DESCRIPTION
## Description

4.5.x is no longer supported. So we force the bridge tests with latest 4.5 docker tag