### PR TITLE
feat(console): don't display technical error message

### DIFF
--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -98,8 +98,7 @@ function fetchData(): Promise<{ constants: Constants; build: any }> {
     })
     .catch((error) => {
       document.getElementById('gravitee-error').style.display = 'block';
-      document.getElementById('gravitee-error-banner-message').innerText =
-        error.message ?? 'Management API unreachable or error occurs, please check logs';
+      document.getElementById('gravitee-error-banner-message').innerText = 'Management API unreachable or error occurs, please check logs';
       document.getElementById('loader').style.display = 'none';
       throw error;
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11794

## Description

When console is started and the mAPI is not reachable, we display a hardcoded message instead of an unclear technical error message "Failed to fetch" 