### PR TITLE
fix: remove sensitive data from fetcher configuration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -73,6 +73,10 @@
 			<version>${project.version}</version>
 		</dependency>
         <dependency>
+            <groupId>io.gravitee.fetcher</groupId>
+            <artifactId>gravitee-fetcher-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
         </dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/PageSourceDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/PageSourceDomainService.java
@@ -26,4 +26,6 @@ public interface PageSourceDomainService {
     void setContentFromSource(Page page);
 
     void removeSensitiveData(Page page);
+
+    void mergeSensitiveData(Page oldPage, Page newPage);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCase.java
@@ -19,21 +19,25 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.PageSourceDomainService;
 import io.gravitee.apim.core.documentation.model.Page;
 
 @UseCase
 public class ApiGetDocumentationPageUseCase {
 
     private final ApiDocumentationDomainService apiDocumentationDomainService;
+    private final PageSourceDomainService pageSourceDomainService;
     private final ApiCrudService apiCrudService;
     private final PageCrudService pageCrudService;
 
     public ApiGetDocumentationPageUseCase(
         ApiDocumentationDomainService apiDocumentationDomainService,
+        PageSourceDomainService pageSourceDomainService,
         ApiCrudService apiCrudService,
         PageCrudService pageCrudService
     ) {
         this.apiDocumentationDomainService = apiDocumentationDomainService;
+        this.pageSourceDomainService = pageSourceDomainService;
         this.apiCrudService = apiCrudService;
         this.pageCrudService = pageCrudService;
     }
@@ -47,6 +51,8 @@ public class ApiGetDocumentationPageUseCase {
         page = page
             .withHidden(this.apiDocumentationDomainService.pageIsHidden(page))
             .withGeneralConditions(this.apiDocumentationDomainService.pageIsUsedAsGeneralConditions(page, api));
+
+        this.pageSourceDomainService.removeSensitiveData(page);
 
         return new Output(page);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.PageSourceDomainService;
 import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
 import io.gravitee.apim.core.documentation.model.Breadcrumb;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -29,15 +30,18 @@ import java.util.stream.Stream;
 public class ApiGetDocumentationPagesUseCase {
 
     private final ApiDocumentationDomainService apiDocumentationDomainService;
+    private final PageSourceDomainService pageSourceDomainService;
     private final ApiCrudService apiCrudService;
     private final PageCrudService pageCrudService;
 
     public ApiGetDocumentationPagesUseCase(
         ApiDocumentationDomainService apiDocumentationDomainService,
+        PageSourceDomainService pageSourceDomainService,
         ApiCrudService apiCrudService,
         PageCrudService pageCrudService
     ) {
         this.apiDocumentationDomainService = apiDocumentationDomainService;
+        this.pageSourceDomainService = pageSourceDomainService;
         this.apiCrudService = apiCrudService;
         this.pageCrudService = pageCrudService;
     }
@@ -73,6 +77,7 @@ public class ApiGetDocumentationPagesUseCase {
             )
             .toList();
 
+        pages.forEach(this.pageSourceDomainService::removeSensitiveData);
         return new Output(pages, breadcrumbList);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.DocumentationValidationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.HomepageDomainService;
+import io.gravitee.apim.core.documentation.domain_service.PageSourceDomainService;
 import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.model.AccessControl;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -45,6 +46,7 @@ public class ApiUpdateDocumentationPageUseCase {
     private final PageCrudService pageCrudService;
     private final PageQueryService pageQueryService;
     private final DocumentationValidationDomainService documentationValidationDomainService;
+    private final PageSourceDomainService pageSourceDomainService;
 
     public Output execute(Input input) {
         var api = this.apiCrudService.get(input.apiId);
@@ -76,6 +78,10 @@ public class ApiUpdateDocumentationPageUseCase {
         }
 
         var pageToUpdate = newPage.build();
+
+        if (pageToUpdate.getSource() != null && oldPage.getSource() != null) {
+            this.pageSourceDomainService.mergeSensitiveData(oldPage, pageToUpdate);
+        }
 
         if (!Objects.equals(oldPage.getContent(), input.content) || !Objects.equals(oldPage.getSource(), input.source)) {
             pageToUpdate = this.documentationValidationDomainService.validateAndSanitizeForUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.domain_service.documentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.documentation.domain_service.PageSourceDomainService;
 import io.gravitee.apim.core.documentation.exception.InvalidPageSourceException;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -23,14 +24,17 @@ import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.fetcher.api.Fetcher;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.Sensitive;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
@@ -41,7 +45,10 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @AllArgsConstructor
+@Slf4j
 public class PageSourceDomainServiceImpl implements PageSourceDomainService {
+
+    public static final String SENSITIVE_DATA_REPLACEMENT = "********";
 
     private final FetcherConfigurationFactory fetcherConfigurationFactory;
     private final PluginManager<FetcherPlugin<?>> pluginManager;
@@ -50,6 +57,27 @@ public class PageSourceDomainServiceImpl implements PageSourceDomainService {
     @Override
     public void setContentFromSource(Page page) {
         loadFetcher(page).ifPresentOrElse(fetcher -> fetchContent(fetcher, page), () -> page.setUseAutoFetch(false));
+    }
+
+    @Override
+    public void removeSensitiveData(Page page) {
+        loadFetcher(page).ifPresent(fetcher -> {
+            FetcherConfiguration fetcherConfiguration = fetcher.getConfiguration();
+            Field[] fields = fetcherConfiguration.getClass().getDeclaredFields();
+            for (Field field : fields) {
+                if (field.isAnnotationPresent(Sensitive.class)) {
+                    boolean accessible = field.isAccessible();
+                    field.setAccessible(true);
+                    try {
+                        field.set(fetcherConfiguration, SENSITIVE_DATA_REPLACEMENT);
+                    } catch (IllegalAccessException e) {
+                        log.error("Error while removing fetcher sensitive data", e);
+                    }
+                    field.setAccessible(accessible);
+                }
+            }
+            page.getSource().setConfiguration((new ObjectMapper().valueToTree(fetcherConfiguration).toString()));
+        });
     }
 
     private void fetchContent(Fetcher fetcher, Page page) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageSourceDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageSourceDomainServiceInMemory.java
@@ -18,6 +18,7 @@ package inmemory;
 import io.gravitee.apim.core.documentation.domain_service.PageSourceDomainService;
 import io.gravitee.apim.core.documentation.exception.InvalidPageSourceException;
 import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.infra.domain_service.documentation.PageSourceDomainServiceImpl;
 import java.util.Map;
 import org.springframework.scheduling.support.CronExpression;
 
@@ -33,6 +34,20 @@ public class PageSourceDomainServiceInMemory implements PageSourceDomainService 
     public void setContentFromSource(Page page) {
         if (page.getSource() != null) {
             page.setContent(MARKDOWN);
+        }
+    }
+
+    @Override
+    public void removeSensitiveData(Page page) {
+        if (page.getSource() != null && page.getSource().getConfiguration() != null) {
+            page
+                .getSource()
+                .setConfiguration(
+                    page
+                        .getSource()
+                        .getConfiguration()
+                        .replace("I'm a sensitive data", "\"" + PageSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT + "\"")
+                );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageSourceDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageSourceDomainServiceInMemory.java
@@ -50,4 +50,22 @@ public class PageSourceDomainServiceInMemory implements PageSourceDomainService 
                 );
         }
     }
+
+    @Override
+    public void mergeSensitiveData(Page oldPage, Page newPage) {
+        if (oldPage.getSource() == null || newPage.getSource() == null) {
+            return;
+        }
+        if (oldPage.getSource().getConfiguration() == null || newPage.getSource().getConfiguration() == null) {
+            return;
+        }
+
+        String newConfig = newPage.getSource().getConfiguration();
+        String oldConfig = oldPage.getSource().getConfiguration();
+        String sanitizedValue = "\"" + PageSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT + "\"";
+
+        if (newConfig.contains(sanitizedValue) && oldConfig.contains("I'm a sensitive data")) {
+            newPage.getSource().setConfiguration(newConfig.replace(sanitizedValue, "\"I'm a sensitive data\""));
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcher.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.documentation;
+
+import io.gravitee.fetcher.api.Fetcher;
+import io.gravitee.fetcher.api.FetcherConfiguration;
+import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.Resource;
+
+public class DummyFetcher implements Fetcher {
+
+    DummyFetcherConfiguration fetcherConfiguration;
+
+    public DummyFetcher(DummyFetcherConfiguration fetcherConfiguration) {
+        this.fetcherConfiguration = fetcherConfiguration;
+    }
+
+    @Override
+    public Resource fetch() throws FetcherException {
+        return null;
+    }
+
+    @Override
+    public FetcherConfiguration getConfiguration() {
+        return this.fetcherConfiguration;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcherConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcherConfiguration.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.documentation.domain_service;
+package io.gravitee.apim.infra.domain_service.documentation;
 
-import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.fetcher.api.FetcherConfiguration;
+import io.gravitee.fetcher.api.Sensitive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
-/**
- * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
- * @author GraviteeSource Team
- */
+@Getter
+@Setter
+@AllArgsConstructor
+public class DummyFetcherConfiguration implements FetcherConfiguration {
 
-public interface PageSourceDomainService {
-    void setContentFromSource(Page page);
+    private String nonSensitiveData;
 
-    void removeSensitiveData(Page page);
+    @Sensitive
+    private String sensitiveData;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImplTest.java
@@ -16,18 +16,18 @@
 package io.gravitee.apim.infra.domain_service.documentation;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.apim.core.documentation.exception.InvalidPageSourceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.documentation.model.PageSource;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
-import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +67,7 @@ class PageSourceDomainServiceImplTest {
     @Test
     void should_not_fetch_content_if_no_plugin() {
         when(pluginManager.get(any())).thenReturn(null);
-        cut.setContentFromSource(Page.builder().source(httpSource()).build());
+        cut.setContentFromSource(Page.builder().source(dummySource()).build());
         verifyNoInteractions(fetcherConfigurationFactory, applicationContext);
     }
 
@@ -75,21 +75,39 @@ class PageSourceDomainServiceImplTest {
     @SuppressWarnings("unchecked")
     void should_report_build_fetcher_error() {
         var error = assertThrows(TechnicalDomainException.class, () -> {
-            when(pluginManager.get("http-fetcher")).thenReturn(fetcherPlugin);
-            cut.setContentFromSource(Page.builder().source(httpSource()).build());
+            when(pluginManager.get("dummy-fetcher")).thenReturn(fetcherPlugin);
+            cut.setContentFromSource(Page.builder().source(dummySource()).build());
         });
         assertThat(error).hasMessage("unable to build fetcher instance");
     }
 
-    private static PageSource httpSource() {
+    @Test
+    void should_remove_sensitive_data() throws JsonProcessingException {
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(
+            mock(org.springframework.beans.factory.config.AutowireCapableBeanFactory.class)
+        );
+        when(fetcherPlugin.fetcher()).thenReturn(DummyFetcher.class);
+        when(fetcherPlugin.configuration()).thenReturn(DummyFetcherConfiguration.class);
+        when(fetcherPlugin.clazz()).thenReturn("io.gravitee.apim.infra.domain_service.documentation.DummyFetcher");
+        when(pluginManager.get("dummy-fetcher")).thenReturn(fetcherPlugin);
+        when(fetcherConfigurationFactory.create(any(), any())).thenReturn(
+            new DummyFetcherConfiguration("I'm not a sensitive data", "I'm a sensitive data, I should be masked")
+        );
+        Page page = Page.builder().source(dummySource()).build();
+        cut.removeSensitiveData(page);
+        JsonNode configuration = new ObjectMapper().readTree(page.getSource().getConfiguration());
+        assertThat(configuration.get("sensitiveData").textValue()).isEqualTo(PageSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT);
+        assertThat(configuration.get("nonSensitiveData").textValue()).isEqualTo("I'm not a sensitive data");
+    }
+
+    private static PageSource dummySource() {
         return PageSource.builder()
-            .type("http-fetcher")
+            .type("dummy-fetcher")
             .configuration(
                 """
                 {
-                   "autoFetch" : true,
-                   "fetchCron" : "*/10 * * * * *",
-                   "url" : "https://raw.githubusercontent.com/a-cordier/hands-on-gko/main/README.md"
+                   "sensitiveData" : I'm a sensitive data, I should be masked,
+                   "nonSensitiveData" : "I'm not a sensitive data"
                 }
                 """
             )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11405

## Description
This PR implements sensitive data sanitization for documentation pages in the V2 API by:

1. **Reimplementing `removeSensitiveData` method** in `PageSourceDomainService`:
   - Scans fetcher configuration fields annotated with `@Sensitive`
   - Replaces sensitive values with `********` before returning the page in API responses
   - Called in `ApiGetDocumentationPageUseCase` to ensure sensitive data is masked when retrieving pages

2. **Implementing `mergeSensitiveData` method** in `PageSourceDomainService`:
   - Preserves original sensitive data when updating pages
   - Prevents masked tokens (`********`) from overwriting actual credentials during updates
   - Called in `ApiUpdateDocumentationPageUseCase` to maintain data integrity



### Fixed version
https://github.com/user-attachments/assets/54851335-b048-4a95-9a9a-626813f1fe63


