### PR TITLE
fix: handle null pagination parameters in latest event search query

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventLatestRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventLatestRepository.java
@@ -75,6 +75,9 @@ public class JdbcEventLatestRepository extends JdbcAbstractRepository<Event> imp
     public List<Event> search(EventCriteria criteria, Event.EventProperties group, Long page, Long size) {
         log.debug("JdbcEventLatestRepository.search({})", criteriaToString(criteria));
 
+        var pageNumber = page != null ? page : 0;
+        var pageSize = size != null ? size : 10;
+
         final List<Object> args = new ArrayList<>();
         var select = """
             WITH PagedEvents AS (%s)
@@ -86,7 +89,7 @@ public class JdbcEventLatestRepository extends JdbcAbstractRepository<Event> imp
                 LEFT JOIN %s evo ON evt.id = evo.event_id
             ORDER BY evt.updated_at ASC, evt.id ASC
             """.formatted(
-                buildSelectIn(criteria, group, page, size, args),
+                buildSelectIn(criteria, group, pageNumber, pageSize, args),
                 tableName,
                 EVENT_PROPERTIES,
                 EVENT_ENVIRONMENTS,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -245,7 +245,7 @@ public class ApiStateServiceImpl implements ApiStateService {
             .build();
 
         String lastDeployNumber = eventLatestRepository
-            .search(criteria, Event.EventProperties.DEPLOYMENT_NUMBER, 0L, 1L)
+            .search(criteria, Event.EventProperties.API_ID, 0L, 1L)
             .stream()
             .findFirst()
             .map(eventEntity -> eventEntity.getProperties().getOrDefault(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "0"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -1165,9 +1165,9 @@ public class ApiServiceImplTest {
         when(apiValidationService.canDeploy(any(), any())).thenReturn(true);
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(apiRepository.update(api)).thenReturn(api);
-        when(
-            eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.DEPLOYMENT_NUMBER), eq(0L), eq(1L))
-        ).thenReturn(List.of(previousPublishedEvent));
+        when(eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.API_ID), eq(0L), eq(1L))).thenReturn(
+            List.of(previousPublishedEvent)
+        );
 
         final ApiDeploymentEntity apiDeploymentEntity = new ApiDeploymentEntity();
         apiDeploymentEntity.setDeploymentLabel("deploy-label");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -223,9 +223,9 @@ public class ApiStateServiceImpl_DeployTest {
         when(apiValidationService.canDeploy(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(true);
         when(apiSearchService.findRepositoryApiById(any(), eq(API_ID))).thenReturn(api);
         when(apiRepository.update(api)).thenReturn(api);
-        when(
-            eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.DEPLOYMENT_NUMBER), eq(0L), eq(1L))
-        ).thenReturn(List.of(previousPublishedEvent));
+        when(eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.API_ID), eq(0L), eq(1L))).thenReturn(
+            List.of(previousPublishedEvent)
+        );
 
         final ApiDeploymentEntity apiDeploymentEntity = new ApiDeploymentEntity();
         apiDeploymentEntity.setDeploymentLabel("deploy-label");
@@ -267,9 +267,9 @@ public class ApiStateServiceImpl_DeployTest {
         when(apiValidationService.canDeploy(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(true);
         when(apiSearchService.findRepositoryApiById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(apiRepository.update(api)).thenReturn(api);
-        when(
-            eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.DEPLOYMENT_NUMBER), eq(0L), eq(1L))
-        ).thenReturn(List.of(previousPublishedEvent));
+        when(eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.API_ID), eq(0L), eq(1L))).thenReturn(
+            List.of(previousPublishedEvent)
+        );
 
         final ApiDeploymentEntity apiDeploymentEntity = new ApiDeploymentEntity();
         apiDeploymentEntity.setDeploymentLabel("deploy-label");
@@ -320,9 +320,9 @@ public class ApiStateServiceImpl_DeployTest {
         deploymentEntity.setDeploymentLabel("Release v1.0");
         Event mockEvent = new Event();
         mockEvent.setProperties(Map.of(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "5"));
-        when(
-            eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.DEPLOYMENT_NUMBER), eq(0L), eq(1L))
-        ).thenReturn(List.of(mockEvent));
+        when(eventLatestRepository.search(any(EventCriteria.class), eq(Event.EventProperties.API_ID), eq(0L), eq(1L))).thenReturn(
+            List.of(mockEvent)
+        );
         Map<String, String> props = new HashMap<>();
 
         ApiStateServiceImpl impl = new ApiStateServiceImpl(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11726

## Description

Ensure proper defaults are used when pagination parameters are not provided, this helps to have a query working for all DBs especially SQL Server to avoid

```
The ORDER BY clause is invalid in views, inline functions, derived
tables, subqueries, and common table expressions, unless TOP, OFFSET or
FOR XML is also specified.
```


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

