### PR TITLE
fix(portal-next): add markdown support to API description

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
@@ -43,7 +43,7 @@
       <app-banner class="api-details__banner">
         <div class="api-details__banner-content">
           <mat-icon class="api-details__banner-content__icon" aria-hidden="false" aria-label="Light-bulb icon">lightbulb</mat-icon>
-          <div class="m3-body-large">{{ api.description }}</div>
+          <div class="m3-body-large" [innerHTML]="(api | markdownDescription).description"></div>
         </div>
       </app-banner>
     }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.ts
@@ -28,6 +28,7 @@ import { ApiCardComponent } from '../../../components/api-card/api-card.componen
 import { BannerComponent } from '../../../components/banner/banner.component';
 import { BreadcrumbNavigationComponent } from '../../../components/breadcrumb-navigation/breadcrumb-navigation.component';
 import { PictureComponent } from '../../../components/picture/picture.component';
+import { MarkdownDescriptionPipe } from '../../../components/pipe/markdown-description.pipe';
 import { Api } from '../../../entities/api/api';
 import { Plan } from '../../../entities/plan/plan';
 import { CurrentUserService } from '../../../services/current-user.service';
@@ -48,6 +49,7 @@ import { PlanService } from '../../../services/plan.service';
     RouterModule,
     BreadcrumbNavigationComponent,
     FormsModule,
+    MarkdownDescriptionPipe,
   ],
   templateUrl: './api-details.component.html',
   styleUrl: './api-details.component.scss',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11784

## Description

Add markdown processing to API details component description field,
following the same pattern used in PageMarkdownComponent. This allows
API descriptions to support markdown formatting such as bold text,
links, lists, and other markdown features.

## Additional context

### Before Fix
<img width="1728" height="919" alt="Screenshot 2025-11-05 at 8 38 40 AM" src="https://github.com/user-attachments/assets/e8652764-70a7-4dee-9d48-a63f506b4534" />

### After Fix
<img width="1728" height="919" alt="Screenshot 2025-11-05 at 8 37 07 AM" src="https://github.com/user-attachments/assets/72cdc4f2-7f12-4b1d-b1de-f0bf84fec2d3" />


