### PR TITLE
fix: propagate WS subprotocols from sec-websocket-protocol header for v4 APIs

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -82,8 +82,8 @@ public class HttpConnector implements ProxyConnector {
         UPGRADE
     );
     private final String relativeTarget;
-    private final String defaultHost;
-    private final int defaultPort;
+    protected final String defaultHost;
+    protected final int defaultPort;
     private final boolean defaultSsl;
     private final MultiValueMap<String, String> targetParameters;
     protected final HttpProxyEndpointConnectorConfiguration configuration;


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11807

## Description

- Ensure WebSocket subprotocols are set based on the sec-websocket-protocol header, mirroring V2 API behavior
- Fix endpoint value in v4-request log for better observability


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

