### PR TITLE
fix: remove openapi-analytics.yaml symlink

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/openapi-analytics.yaml
@@ -1,1 +1,0 @@
-/Users/antoine.cordier/src/gravitee/gravitee-api-management/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description
I may be wrong but I think this symlink should not be here

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

