### PR TITLE
refactor: save the job before sending scoring API request

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_job/model/AsyncJob.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_job/model/AsyncJob.java
@@ -89,6 +89,10 @@ public class AsyncJob {
         return toBuilder().status(Status.TIMEOUT).updatedAt(TimeProvider.now()).build();
     }
 
+    public AsyncJob error(String errorMessage) {
+        return toBuilder().status(Status.ERROR).updatedAt(TimeProvider.now()).errorMessage(errorMessage).build();
+    }
+
     public boolean isTimedOut() {
         return !status.isFinal() && deadLine != null && deadLine.isBefore(TimeProvider.now());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringProviderInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringProviderInMemory.java
@@ -24,16 +24,25 @@ import java.util.List;
 
 public class ScoringProviderInMemory implements ScoringProvider {
 
+    /**
+     * If defined, this error will be thrown when a request is received.
+     */
+    public Throwable errorToThrow = null;
     List<ScoreRequest> pendingRequests = new ArrayList<>();
 
     @Override
     public Completable requestScore(ScoreRequest request) {
+        if (errorToThrow != null) {
+            return Completable.error(errorToThrow);
+        }
+
         pendingRequests.add(request);
         return Completable.complete();
     }
 
     public void reset() {
         pendingRequests.clear();
+        errorToThrow = null;
     }
 
     public List<ScoreRequest> pendingRequests() {


### PR DESCRIPTION
## Description

This change ensures the job is persisted to the database before calling the ScoringProvider. This is necessary to support future plugins that may offer alternative implementations of the ScoringProvider interface, allowing them to access a persistent job state.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

