### PR TITLE
ci: use medium resource for validation

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -41,6 +41,6 @@ export class ValidateJob {
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new reusable.ReusedCommand(saveMavenJobCacheCmd, { jobName: ValidateJob.jobName }),
     ];
-    return new Job(ValidateJob.jobName, OpenJdkExecutor.create('small'), steps);
+    return new Job(ValidateJob.jobName, OpenJdkExecutor.create('medium'), steps);
   }
 }

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -127,7 +127,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -171,7 +171,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -96,7 +96,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -147,7 +147,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -171,7 +171,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -147,7 +147,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -172,7 +172,7 @@ jobs:
   job-validate:
     docker:
       - image: cimg/openjdk:21.0.5
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## Description

Validation of backend is taking more and more time in CI.
Currently on master branch, the average time is around 6min
<img width="1224" height="83" alt="image" src="https://github.com/user-attachments/assets/c659553c-88a0-4c40-b8e0-f3bbbc217e26" />

Increasing resource from small to medium, increase he cost by 2, but divide the time by 3.
<img width="1224" height="276" alt="image" src="https://github.com/user-attachments/assets/21df82fc-0c11-41a7-b828-4397e0a529fb" />
