### PR TITLE
feat(rest-api): support new MCP_PROXY phases

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PolicyPluginMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PolicyPluginMapper.java
@@ -64,6 +64,10 @@ public interface PolicyPluginMapper {
         if (flowPhaseCompatibility.get(ApiProtocolType.NATIVE_KAFKA) != null) {
             policyPluginAllOfFlowPhaseCompatibility.NATIVE_KAFKA(mapToFlowPhase(flowPhaseCompatibility.get(ApiProtocolType.NATIVE_KAFKA)));
         }
+        var httpMcpProxyPhases = flowPhaseCompatibility.get(ApiProtocolType.HTTP_MCP_PROXY);
+        if (httpMcpProxyPhases != null) {
+            policyPluginAllOfFlowPhaseCompatibility.HTTP_MCP_PROXY(mapToFlowPhase(httpMcpProxyPhases));
+        }
         return policyPluginAllOfFlowPhaseCompatibility;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -389,6 +389,7 @@ paths:
                           - HTTP_PROXY
                           - HTTP_MESSAGE
                           - NATIVE_KAFKA
+                          - HTTP_MCP_PROXY
             tags:
                 - Plugins - Policies
             summary: Get a policy schema
@@ -528,6 +529,11 @@ components:
                                   items:
                                       $ref: "#/components/schemas/FlowPhase"
                               NATIVE_KAFKA:
+                                  type: array
+                                  uniqueItems: true
+                                  items:
+                                      $ref: "#/components/schemas/FlowPhase"
+                              HTTP_MCP_PROXY:
                                   type: array
                                   uniqueItems: true
                                   items:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
@@ -100,7 +100,9 @@ class PoliciesResourceTest extends AbstractResourceTest {
                             ApiProtocolType.HTTP_MESSAGE,
                             Set.of(FlowPhase.PUBLISH),
                             ApiProtocolType.NATIVE_KAFKA,
-                            Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE, FlowPhase.PUBLISH)
+                            Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE, FlowPhase.PUBLISH),
+                            ApiProtocolType.HTTP_MCP_PROXY,
+                            Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE)
                         )
                     )
                     .deployed(true)
@@ -140,6 +142,12 @@ class PoliciesResourceTest extends AbstractResourceTest {
                                 io.gravitee.rest.api.management.v2.rest.model.FlowPhase.REQUEST,
                                 io.gravitee.rest.api.management.v2.rest.model.FlowPhase.RESPONSE,
                                 io.gravitee.rest.api.management.v2.rest.model.FlowPhase.PUBLISH
+                            )
+                        )
+                        .HTTP_MCP_PROXY(
+                            Set.of(
+                                io.gravitee.rest.api.management.v2.rest.model.FlowPhase.REQUEST,
+                                io.gravitee.rest.api.management.v2.rest.model.FlowPhase.RESPONSE
                             )
                         )
                 ),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/ApiProtocolType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/ApiProtocolType.java
@@ -19,4 +19,5 @@ public enum ApiProtocolType {
     HTTP_PROXY,
     HTTP_MESSAGE,
     NATIVE_KAFKA,
+    HTTP_MCP_PROXY,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/FlowPhase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/FlowPhase.java
@@ -25,8 +25,8 @@ public enum FlowPhase {
     CONNECT(ApiProtocolType.NATIVE_KAFKA),
     PUBLISH(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
     SUBSCRIBE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
-    REQUEST(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE),
-    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE);
+    REQUEST(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE, ApiProtocolType.HTTP_MCP_PROXY),
+    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE, ApiProtocolType.HTTP_MCP_PROXY);
 
     private final List<ApiProtocolType> apiProtocolType;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
@@ -98,6 +98,7 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
         var httpProxyFlowPhase = getFlowPhase(plugin, ApiProtocolType.HTTP_PROXY);
         var httpMessageFlowPhase = getFlowPhase(plugin, ApiProtocolType.HTTP_MESSAGE);
         var nativeKafkaFlowPhase = getFlowPhase(plugin, ApiProtocolType.NATIVE_KAFKA);
+        var httpMcpProxyFlowPhase = getFlowPhase(plugin, ApiProtocolType.HTTP_MCP_PROXY);
         if (httpProxyFlowPhase.isEmpty()) {
             httpProxyFlowPhase = getDeprecatedFlowPhase(plugin, "proxy");
         }
@@ -108,6 +109,7 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
         entity.putFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY, httpProxyFlowPhase);
         entity.putFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE, httpMessageFlowPhase);
         entity.putFlowPhaseCompatibility(ApiProtocolType.NATIVE_KAFKA, nativeKafkaFlowPhase);
+        entity.putFlowPhaseCompatibility(ApiProtocolType.HTTP_MCP_PROXY, httpMcpProxyFlowPhase);
 
         return entity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -135,7 +135,16 @@ public class PolicyPluginServiceImplTest {
         when(mockPlugin.manifest()).thenReturn(mockPluginManifest);
         when(pluginManager.findAll(true)).thenReturn(List.of(mockPlugin));
         when(mockPluginManifest.properties()).thenReturn(
-            Map.of("http_proxy", "REQUEST,RESPONSE", "http_message", "PUBLISH", "native_kafka", "PUBLISH, SUBSCRIBE")
+            Map.of(
+                "http_proxy",
+                "REQUEST,RESPONSE",
+                "http_message",
+                "PUBLISH",
+                "native_kafka",
+                "PUBLISH, SUBSCRIBE",
+                "http_mcp_proxy",
+                "REQUEST,RESPONSE"
+            )
         );
         Set<PolicyPluginEntity> result = cut.findAll();
 
@@ -146,6 +155,7 @@ public class PolicyPluginServiceImplTest {
         assertEquals(Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY));
         assertEquals(Set.of(FlowPhase.PUBLISH), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE));
         assertEquals(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.NATIVE_KAFKA));
+        assertEquals(Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_MCP_PROXY));
     }
 
     @Nested


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11427

## Description

We can now activate the policies on MCP API by adding this into policy plugin.properties file:
```
http_mcp_proxy=REQUEST,RESPONSE
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

