### PR TITLE
fix: shared policies not executed in debug mode due to missing default constructor

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/policy/SharedPolicyGroupPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/policy/SharedPolicyGroupPolicy.java
@@ -39,6 +39,14 @@ public class SharedPolicyGroupPolicy implements HttpPolicy {
     private final String id;
     public final SharedPolicyGroupPolicyConfiguration policyConfiguration;
 
+    public SharedPolicyGroupPolicy() {
+        this(POLICY_ID, null);
+    }
+
+    public SharedPolicyGroupPolicy(SharedPolicyGroupPolicyConfiguration policyConfiguration) {
+        this(POLICY_ID, policyConfiguration);
+    }
+
     public SharedPolicyGroupPolicy(String id, SharedPolicyGroupPolicyConfiguration policyConfiguration) {
         this.id = id;
         this.policyConfiguration = policyConfiguration;


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11552

## Description

When running an API with Shared Policy Groups in Debug Mode, policies are not executed and a NoSuchMethodException is thrown for SharedPolicyGroupPolicy due to the absence of a default empty constructor. 

This commit ensures proper instantiation of SharedPolicyGroupPolicy during debug sessions so that shared policies execute correctly and appear in the debug trace.


Issue:


https://github.com/user-attachments/assets/ea963fd9-76bc-48e6-8609-839d96b2ab3e


Fix:


https://github.com/user-attachments/assets/de32e921-daa9-44ba-b0d0-d49f8a636e2e



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

