### PR TITLE
chore: bump gravitee-connector-http version to 5.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>5.0.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>5.0.7</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>5.2.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>3.0.2</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>3.0.0</gravitee-policy-assign-content.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11613

## Description

Bump connector-http to fix an issue with tracing in V2 APIs.

