### PR TITLE
fix(gateway): forward sse(v2+v4) closing request to sse backend server on client disconnect

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -136,7 +136,13 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
                 if (proxyResponse != null) {
                     proxyResponse.cancel();
                 }
-                connection.end();
+                if (connection != null) {
+                    try {
+                        connection.cancel();
+                    } finally {
+                        connection.end();
+                    }
+                }
             }
         } catch (Exception e) {
             log.warn("Unable to properly cancel the proxy response.", e);

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.node.monitoring.metrics.Metrics;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+abstract class SSEProxyIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("services.metrics.enabled", true);
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("sse", EntrypointBuilder.build("sse", SseEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        final MeterRegistry registry = Metrics.getDefaultRegistry();
+
+        // Initially, there is no active client connection (gateway to backend).
+        assertThat(Optional.ofNullable(registry.find("http.client.active.connections").gauge()).map(Gauge::value).orElse(0.0)).isEqualTo(
+            0.0
+        );
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .doOnSuccess(httpClientRequest -> httpClientRequest.headers().add("Accept", "text/event-stream"))
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response
+                    .toFlowable()
+                    .doOnNext(buffer -> {
+                        // Check the number of active client connections is 1 (gateway to sse mock backend) while consuming the SSE stream.
+                        assertThat(registry.get("http.client.active.connections").gauge().value()).isEqualTo(1.0);
+                    })
+                    // Keep the connection open for 1 second, then close it.
+                    .takeUntil(
+                        response
+                            .request()
+                            .connection()
+                            .rxClose()
+                            .toFlowable()
+                            .delaySubscription(1, TimeUnit.SECONDS)
+                            .doOnComplete(() -> log.info("Connection closed"))
+                    );
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Verify the gateway has properly closed the connection to the backend after client connection close.
+        await()
+            .atMost(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> {
+                // Check the number of active cleint connections is 0 after client connection close (gateway to sse mock backend)
+                double value = registry.get("http.client.active.connections").gauge().value();
+                assertThat(value).isEqualTo(0.0);
+            });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV3IntegrationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.ExecutionMode;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+class SSEProxyV3IntegrationTest extends SSEProxyIntegrationTest {
+
+    @Override
+    public void configurePlaceHolderVariables(Map<String, String> variables) {
+        variables.put("GATEWAY_HTTP_PORT", String.valueOf(gatewayPort()));
+    }
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/http/sse/api-sse-proxy-v2.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4EmulationIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class SSEProxyV4EmulationIntegrationTest extends SSEProxyV3IntegrationTest {
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/http/sse/api-sse-proxy-v2.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4IntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class SSEProxyV4IntegrationTest extends SSEProxyV3IntegrationTest {
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/v4/http/sse/api-sse-proxy.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/sse/api-sse-proxy-v2.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/sse/api-sse-proxy-v2.json
@@ -1,0 +1,18 @@
+{
+  "id": "api-sse-proxy-v2",
+  "name": "api-sse-proxy-v2",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:${GATEWAY_HTTP_PORT}/sse-mock-endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-mock-sse-backend.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-mock-sse-backend.json
@@ -1,0 +1,45 @@
+{
+  "id": "api-sse-mock-backend",
+  "name": "api-sse-mock-backend",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "Mock SSE API for testing purposes",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/sse-mock-endpoint"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "sse"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "mock data"
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-sse-proxy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-sse-proxy.json
@@ -1,0 +1,63 @@
+{
+  "id": "api-sse-proxy-v4",
+  "name": "api-sse-proxy-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:${GATEWAY_HTTP_PORT}/sse-mock-endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -48,24 +48,31 @@ import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.client.UriHelper;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
+import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.impl.BufferImpl;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.StreamResetException;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class HttpConnector implements ProxyConnector {
 
     /**
@@ -130,7 +137,9 @@ public class HttpConnector implements ProxyConnector {
                     observableHttpClientRequest.httpClientRequest(httpClientRequest.getDelegate());
                     if (requestWithBody(request)) {
                         return httpClientRequest.rxSend(
-                            request.chunks().map(buffer -> io.vertx.rxjava3.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
+                            request
+                                .chunks()
+                                .map(buffer -> new io.vertx.rxjava3.core.buffer.Buffer(BufferImpl.buffer(buffer.getNativeBuffer())))
                         );
                     } else {
                         // Consume the empty body from the downstream and send the request to the upstream.
@@ -148,15 +157,10 @@ public class HttpConnector implements ProxyConnector {
                             ((VertxHttpServerResponse) response).getNativeResponse().writeCustomFrame(frame)
                         );
                     }
-                    response.chunks(
-                        endpointResponse
-                            .toFlowable()
-                            .map(Buffer::buffer)
-                            .doOnComplete(() ->
-                                // Write trailers when chunks are completed
-                                copyHeaders(endpointResponse.trailers(), response.trailers())
-                            )
-                    );
+
+                    // Assign the response chunks from the endpoint's response to the gateway response.
+                    response.chunks(getEndpointResponseChunks(endpointResponse, response, absoluteUri));
+
                     ObservableHttpClientResponse observableHttpClientResponse = new ObservableHttpClientResponse(
                         endpointResponse.getDelegate()
                     );
@@ -167,6 +171,39 @@ public class HttpConnector implements ProxyConnector {
         } catch (Exception e) {
             return Completable.error(e);
         }
+    }
+
+    private @NonNull Flowable<Buffer> getEndpointResponseChunks(
+        HttpClientResponse endpointResponse,
+        HttpResponse response,
+        String absoluteUri
+    ) {
+        return endpointResponse
+            .toFlowable()
+            .map(Buffer::buffer)
+            .doOnComplete(() ->
+                // Write trailers when chunks are completed
+                copyHeaders(endpointResponse.trailers(), response.trailers())
+            )
+            .onErrorResumeNext(throwable -> {
+                if (throwable instanceof StreamResetException) {
+                    // Means that we have manually reset the stream because the downstream request has been cancelled (see doOnCancel).
+                    log.debug("Stream reset to the backend [{}]", absoluteUri);
+                } else {
+                    log.error("Exception occurred while handling response chunk from upstream [{}]", absoluteUri, throwable);
+                }
+                return Flowable.empty();
+            })
+            .doOnCancel(() -> {
+                try {
+                    log.debug("Downstream request has been cancelled, cancelling upstream request to [{}]", absoluteUri);
+
+                    // Reset forces the upstream connection to be closed and avoid consuming the response while downstream is already gone.
+                    endpointResponse.request().reset();
+                } catch (Exception e) {
+                    log.debug("Can't properly reset endpoint request to backend [{}]", absoluteUri, e);
+                }
+            });
     }
 
     protected HttpClientRequest customizeHttpClientRequest(final HttpClientRequest httpClientRequest) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11575
https://gravitee.atlassian.net/browse/APIM-10919

Base PR : https://github.com/gravitee-io/gravitee-api-management/pull/14020
Changes in this PR is merged to master and verified by perf team for v4 and v2(+ V4 emulation)

Ps :   [GatewayRunner.java](https://github.com/gravitee-io/gravitee-api-management/pull/14020/files#diff-423256c18ebc5747b23938bf905b56085abff6d77ad61fd976020ac806b712b2) changes are not present as in version 4.8.x, the GategatewayDynamicConfig doesnt exist

## Additional context (video)

working v2 and v4 

https://github.com/user-attachments/assets/d9a1c2d0-ea34-4d9c-8fd3-155f41b9f1a0

-----------------

PS : Perf team made an extra test for the V2 + V3 engine (so no V4 emulation), and they noticed the issue is also present. So need to fix this issue separately. 



