### PR TITLE
fix: preserve API notification data during upgrade

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepositoryTest.java
@@ -16,14 +16,43 @@
 package io.gravitee.repository.jdbc.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.PortalNotificationCriteria;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import io.gravitee.repository.management.model.PortalNotificationConfig;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.core.RowMapper;
 
 public class JdbcPortalNotificationConfigRepositoryTest {
 
     private JdbcPortalNotificationConfigRepository repository = new JdbcPortalNotificationConfigRepository("table_prefix_");
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    @SneakyThrows
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        Field field = JdbcAbstractRepository.class.getDeclaredField("jdbcTemplate");
+        field.setAccessible(true);
+        field.set(repository, jdbcTemplate);
+        field.setAccessible(false);
+    }
 
     @Test
     public void generateQuery_withHookAndOrgId() {
@@ -51,5 +80,37 @@ public class JdbcPortalNotificationConfigRepositoryTest {
             "pnc.reference_type = pnch.reference_type and pnc.reference_id = pnch.reference_id and pnc.`user` = pnch.`user` " +
             "where 1=1 and pnc.reference_type = ? and pnc.reference_id = ? and pnch.hook = ?";
         assertThat(query).isEqualTo(expectedQuery);
+    }
+
+    @Test
+    void findAll_shouldLoadHooksAndGroups() throws Exception {
+        PortalNotificationConfig config = PortalNotificationConfig.builder()
+            .user("user1")
+            .referenceType(NotificationReferenceType.API)
+            .referenceId("api1")
+            .build();
+
+        when(jdbcTemplate.query(contains("FROM table_prefix_portal_notification_configs"), any(RowMapper.class))).thenReturn(
+            List.of(config)
+        );
+        doAnswer(inv -> {
+            config.setHooks(List.of("H1"));
+            return null;
+        })
+            .when(jdbcTemplate)
+            .query(contains("portal_notification_config_hooks"), any(RowCallbackHandler.class));
+
+        doAnswer(inv -> {
+            config.setGroups(Set.of("G1"));
+            return null;
+        })
+            .when(jdbcTemplate)
+            .query(contains("portal_notification_config_groups"), any(RowCallbackHandler.class));
+
+        Set<PortalNotificationConfig> result = repository.findAll();
+        PortalNotificationConfig cfg = result.iterator().next();
+
+        assertThat(cfg.getHooks()).containsExactly("H1");
+        assertThat(cfg.getGroups()).containsExactly("G1");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11698

## Description

Notification data is split across two tables, but the upgrader still used a generic findAll() method that only fetched data from the parent table. Because it didn’t load the child table content, the upgrader processed incomplete entities and effectively erased the missing child data during update handling.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

