### PR TITLE
fix(console): correct index calculation in analytics values in Hits by application charts

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
@@ -296,7 +296,21 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                 values[i] = 0;
             }
             for (Data data : dataBucket.getValue()) {
-                values[(int) ((data.timestamp() - from) / interval)] = data.value();
+                long index = Math.round((double) (data.timestamp() - from) / interval);
+                if (index >= 0 && index < timestamps.size()) {
+                    values[(int) index] = data.value();
+                } else {
+                    logger.warn(
+                        "Calculated index {} is out of bounds [0, {}) for timestamp {} (from: {}, interval: {}). " +
+                            "Skipping data point for bucket: {}",
+                        index,
+                        timestamps.size(),
+                        data.timestamp(),
+                        from,
+                        interval,
+                        dataBucket.getKey()
+                    );
+                }
             }
 
             analyticsDataBucket.setData(values);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11183

## Description

Fixes incorrect analytics values in "Hits by application" charts

## Additional context

### Before fix
<img width="1717" height="880" alt="Screenshot 2025-11-14 at 12 15 59 AM" src="https://github.com/user-attachments/assets/eef401cc-46f7-443b-a8b9-ceeac3dc3855" />

### After Fix
<img width="1728" height="919" alt="Screenshot 2025-11-14 at 12 26 08 AM" src="https://github.com/user-attachments/assets/18f00845-9735-4d86-ab96-adb66301cbc1" />

