### PR TITLE
fix: reset backend connection when client abort sse request

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -136,7 +136,13 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
                 if (proxyResponse != null) {
                     proxyResponse.cancel();
                 }
-                connection.end();
+                if (connection != null) {
+                    try {
+                        connection.cancel();
+                    } finally {
+                        connection.end();
+                    }
+                }
             }
         } catch (Exception e) {
             log.warn("Unable to properly cancel the proxy response.", e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -29,6 +29,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.AbstractVerticle;
 import io.vertx.rxjava3.core.RxHelper;
+import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServer;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
@@ -66,7 +67,7 @@ public class HttpProtocolVerticle extends AbstractVerticle {
     @Override
     public Completable rxStart() {
         // Set global error handler to catch everything that has not been properly caught.
-        RxJavaPlugins.setErrorHandler(throwable -> log.warn("An unexpected error occurred", throwable));
+        RxJavaPlugins.setErrorHandler(this::logGlobalErrors);
 
         // Reconfigure RxJava to use Vertx schedulers.
         RxJavaPlugins.setComputationSchedulerHandler(s -> RxHelper.scheduler(vertx));
@@ -74,6 +75,10 @@ public class HttpProtocolVerticle extends AbstractVerticle {
         RxJavaPlugins.setNewThreadSchedulerHandler(s -> RxHelper.scheduler(vertx));
 
         final List<VertxHttpServer> servers = this.serverManager.servers(VertxHttpServer.class);
+
+        // Some exceptions can be raised at the Vertx context level (outside the request flow). This is the case when the client
+        // closes the connection before the response is fully written. This one can be ignored as it's properly handled at the request level.
+        Vertx.currentContext().exceptionHandler(this::logGlobalErrors);
 
         return Flowable.fromIterable(servers)
             .concatMapCompletable(gioServer -> {
@@ -95,6 +100,14 @@ public class HttpProtocolVerticle extends AbstractVerticle {
                     .doOnError(throwable -> log.error("Unable to start HTTP server [{}]", gioServer.id(), throwable.getCause()));
             })
             .doOnSubscribe(disposable -> log.info("Starting HTTP servers..."));
+    }
+
+    private void logGlobalErrors(Throwable throwable) {
+        if (throwable instanceof IllegalStateException && "Response has already been written".equals(throwable.getMessage())) {
+            log.debug("Client has prematurely closed the connection before the response is fully written. Ignoring.");
+        } else {
+            log.warn("An unexpected error occurred.", throwable);
+        }
     }
 
     /**
@@ -160,8 +173,18 @@ public class HttpProtocolVerticle extends AbstractVerticle {
         request
             .connection()
             // Must be added to ensure closed connection or error disposes underlying subscription.
-            .exceptionHandler(event -> dispatchDisposable.dispose())
-            .closeHandler(event -> dispatchDisposable.dispose());
+            .exceptionHandler(event -> gracefulDispose(dispatchDisposable))
+            .closeHandler(event -> gracefulDispose(dispatchDisposable));
+    }
+
+    private void gracefulDispose(Disposable dispatchDisposable) {
+        if (!dispatchDisposable.isDisposed()) {
+            try {
+                dispatchDisposable.dispose();
+            } catch (Exception e) {
+                log.warn("Cannot graceful dispose request", e);
+            }
+        }
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -179,6 +179,7 @@ public class GatewayRunner {
     private VertxEmbeddedContainer vertxContainer;
     private Path tempDir;
     private boolean isRunning = false;
+    private GatewayDynamicConfig.GatewayDynamicConfigImpl gatewayDynamicConfig;
 
     record SharedPolicyGroupKey(String sharedPolicyGroupId, String environmentId) {}
 
@@ -276,7 +277,7 @@ public class GatewayRunner {
                 .flatMap(srv -> selectPort(srv, NetServer::actualPort))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-            var gatewayDynamicConfig = new GatewayDynamicConfig.GatewayDynamicConfigImpl(httpPorts, tcpPorts);
+            gatewayDynamicConfig = new GatewayDynamicConfig.GatewayDynamicConfigImpl(httpPorts, tcpPorts);
             isRunning = true;
 
             testInstance.init();
@@ -938,6 +939,13 @@ public class GatewayRunner {
         final AbstractGatewayTest.PlaceholderSymbols placeHolderSymbols = testInstance.configurePlaceHolder();
 
         final HashMap<String, String> variables = new HashMap<>();
+
+        gatewayDynamicConfig
+            .httpPorts()
+            .forEach((id, port) -> {
+                variables.put("GATEWAY_" + id.toUpperCase() + "_PORT", "" + port);
+            });
+
         testInstance.configurePlaceHolderVariables(variables);
 
         for (Map.Entry<String, String> entry : variables.entrySet()) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.micrometer.backends.BackendRegistries;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+abstract class SSEProxyIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("services.metrics.enabled", true);
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("sse", EntrypointBuilder.build("sse", SseEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        final CompositeMeterRegistry registry = (CompositeMeterRegistry) BackendRegistries.getDefaultNow();
+
+        // Initially, there is no active client connection (gateway to backend).
+        assertThat(Optional.ofNullable(registry.find("http.client.active.connections").gauge()).map(Gauge::value).orElse(0.0)).isEqualTo(
+            0.0
+        );
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .doOnSuccess(httpClientRequest -> httpClientRequest.headers().add("Accept", "text/event-stream"))
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response
+                    .toFlowable()
+                    .doOnNext(buffer -> {
+                        // Check the number of active client connections is 1 (gateway to sse mock backend) while consuming the SSE stream.
+                        assertThat(registry.get("http.client.active.connections").gauge().value()).isEqualTo(1.0);
+                    })
+                    // Keep the connection open for 1 second, then close it.
+                    .takeUntil(
+                        response
+                            .request()
+                            .connection()
+                            .rxClose()
+                            .toFlowable()
+                            .delaySubscription(1, TimeUnit.SECONDS)
+                            .doOnComplete(() -> log.info("Connection closed"))
+                    );
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Verify the gateway has properly closed the connection to the backend after client connection close.
+        await()
+            .atMost(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> {
+                // Check the number of active cleint connections is 0 after client connection close (gateway to sse mock backend)
+                double value = registry.get("http.client.active.connections").gauge().value();
+                assertThat(value).isEqualTo(0.0);
+            });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV3IntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.ExecutionMode;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+class SSEProxyV3IntegrationTest extends SSEProxyIntegrationTest {
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/http/sse/api-sse-proxy-v2.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4EmulationIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.micrometer.backends.BackendRegistries;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class SSEProxyV4EmulationIntegrationTest extends SSEProxyV3IntegrationTest {
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/http/sse/api-sse-proxy-v2.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/sse/SSEProxyV4IntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.sse;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class SSEProxyV4IntegrationTest extends SSEProxyV3IntegrationTest {
+
+    @Test
+    @Override
+    @DeployApi({ "/apis/v4/http/sse/api-sse-proxy.json", "/apis/v4/http/sse/api-mock-sse-backend.json" })
+    void should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(HttpClient httpClient) {
+        super.should_proxy_sse_and_close_backend_connection_when_client_closes_the_connection(httpClient);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/sse/api-sse-proxy-v2.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/sse/api-sse-proxy-v2.json
@@ -1,0 +1,18 @@
+{
+  "id": "api-sse-proxy-v2",
+  "name": "api-sse-proxy-v2",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:${GATEWAY_HTTP_PORT}/sse-mock-endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-mock-sse-backend.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-mock-sse-backend.json
@@ -1,0 +1,45 @@
+{
+  "id": "api-sse-mock-backend",
+  "name": "api-sse-mock-backend",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "Mock SSE API for testing purposes",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/sse-mock-endpoint"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "sse"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "mock data"
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-sse-proxy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/sse/api-sse-proxy.json
@@ -1,0 +1,63 @@
+{
+  "id": "api-sse-proxy-v4",
+  "name": "api-sse-proxy-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:${GATEWAY_HTTP_PORT}/sse-mock-endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11575
https://gravitee.atlassian.net/browse/APIM-10919

## Description

This PR fixes an issue when using a V4 HTTP proxy API or a V2 API with V4 emulation engine to perform SSE streaming (e.g., backend does SSE). 
SSE streaming is subject to never-ending. When the client was aborting the SSE stream, the gateway was unable to detect it and continued to consume the backend response under the hood. This led to resource exhaustion (CPU, Memory, ...).

The PR fixes the issue and introduces several logging improvements as well.

## Additional information

Tests have been conducted to validate that SSE requests still work the same for both V4 HTTP Proxy and V4 Protocol Mediation (SSE entrypoint). 

**For V4 Protocol Mediation**: the upstream (Kafka, MQTT, Mock, ...) stays properly cancelled when the client aborts the SSE stream.

**For V4 HTTP Proxy**: the upstream request is reset when the client aborts the SSE stream. This has been tested with both HTTP/1.1 and HTTP/2 with and without Keep Alive enabled: 
- HTTP1 Keep Alive disabled -> OK, connection is closed if SSE ends normally or is cancelled by the client
- HTTP1 Keep Alive enabled -> OK, connection kept if SSE ends normally (ex, finite stream), connection is reset and closed if SSE is cancelled by the client
- HTTP2 (note: there is no support for Keep alive, UI should not provide this option) -> OK, connection is kept if SSE ends normally, connection is also kept if SSE is cancelled by the client, but the HTTP2 stream is properly cancelled.

Tagging @jgiovaresco, @michel-barret, and @phiz71 as HttpConnector is also used in other areas in your scope (llm, mcp).
