### PR TITLE
fix(portal-next): fix documentation content going out of frame

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.scss
@@ -20,7 +20,7 @@
 
 .api-tab-documentation {
   &__side-bar {
-    min-width: 276px;
+    min-width: 276px; // 276px (side bar)
 
     &__tree {
       position: sticky;
@@ -29,9 +29,9 @@
   }
 
   &__page-content {
-    width: 100%;
+    min-width: 0;
+    flex: 1;
     overflow-wrap: break-word;
-    word-wrap: break-word;
 
     &__container {
       min-width: 0;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11797

## Description

Fixed The documentation page content was incorrectly aligned, causing horizontal
shifts due to left navigation panel 

## Additional context

### Before Fix
https://github.com/user-attachments/assets/ec192d31-0583-433a-b4c8-6a8a237cbdaa


### After Fix
https://github.com/user-attachments/assets/b6ef0cec-64e1-43f5-a7d3-b3f4f337c322
