### PR TITLE
fix: portal link points to classic portal when nextPortal is disabled

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { GioLicenseService } from '@gravitee/ui-particles-angular';
+
+import { GioTopNavComponent } from './gio-top-nav.component';
+
+import { Constants } from '../../entities/Constants';
+import { TaskService } from '../../services-ngx/task.service';
+import { UiCustomizationService } from '../../services-ngx/ui-customization.service';
+import { EnvironmentSettingsService } from '../../services-ngx/environment-settings.service';
+
+declare global {
+  interface Window {
+    pendo?: { isReady: () => boolean };
+  }
+}
+
+const taskServiceMock = {
+  getTasksAutoFetch: jest.fn(() => of({ page: { total_elements: 0 } })),
+};
+
+const uiCustomizationServiceMock = {
+  getConsoleCustomization: jest.fn(() => of(undefined)),
+};
+
+const licenseServiceMock = {
+  isOEM$: jest.fn(() => of(false)),
+};
+
+const environmentSettingsServiceMock = {
+  get: jest.fn(),
+};
+
+const buildConstants = (overrides?: Partial<Constants>): Constants =>
+  ({
+    env: {
+      // base URL pattern where {:envId} should be replaced
+      baseURL: '/organizations/DEFAULT/environments/{:envId}',
+    },
+    org: {
+      currentEnv: {
+        id: 'DEFAULT',
+      },
+      settings: {
+        management: {
+          support: { enabled: true },
+        },
+      },
+    },
+    isOEM: false,
+    customization: undefined as any,
+    ...((overrides as any) ?? {}),
+  }) as unknown as Constants;
+
+describe('GioTopNavComponent', () => {
+  let component: GioTopNavComponent;
+  let fixture: ComponentFixture<GioTopNavComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GioTopNavComponent],
+      providers: [
+        { provide: Constants, useValue: buildConstants() },
+        { provide: TaskService, useValue: taskServiceMock },
+        { provide: UiCustomizationService, useValue: uiCustomizationServiceMock },
+        { provide: GioLicenseService, useValue: licenseServiceMock },
+        { provide: EnvironmentSettingsService, useValue: environmentSettingsServiceMock },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GioTopNavComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should compute portalUrl without classic query when Portal Next is enabled', () => {
+    // Given Portal Next enabled in environment settings
+    environmentSettingsServiceMock.get.mockReturnValue(
+      of({ portal: { url: 'https://portal.company.tld' }, portalNext: { access: { enabled: true } } }),
+    );
+
+    fixture.detectChanges();
+
+    const constants = TestBed.inject(Constants);
+    const expectedBase = constants.env.baseURL.replace('{:envId}', constants.org.currentEnv.id) + '/portal/redirect';
+    expect(component.portalUrl).toBe(expectedBase);
+    expect(component.isPortalNextEnabled).toBe(true);
+  });
+
+  it('should compute portalUrl and append ?version=classic when Portal Next is disabled', () => {
+    // Given Portal Next disabled in environment settings
+    environmentSettingsServiceMock.get.mockReturnValue(
+      of({ portal: { url: 'https://portal.company.tld' }, portalNext: { access: { enabled: false } } }),
+    );
+
+    fixture.detectChanges();
+
+    const constants = TestBed.inject(Constants);
+    const expectedBase = constants.env.baseURL.replace('{:envId}', constants.org.currentEnv.id) + '/portal/redirect';
+    expect(component.isPortalNextEnabled).toBe(false);
+    expect(component.portalUrl).toBe(expectedBase + '?version=classic');
+  });
+
+  it('should keep portalUrl undefined if portal url is missing in settings', () => {
+    // Given settings with no portal url
+    environmentSettingsServiceMock.get.mockReturnValue(of({ portal: { url: '' }, portalNext: { access: { enabled: false } } }));
+
+    fixture.detectChanges();
+
+    // Then - despite Portal Next disabled, base portalUrl is undefined
+    expect(component.portalUrl).toBeUndefined();
+  });
+});

--- a/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.ts
@@ -48,6 +48,7 @@ export class GioTopNavComponent implements OnInit, OnDestroy {
   public customLogo: string;
   public isOEM: boolean;
   public portalUrl?: string;
+  isPortalNextEnabled = false;
 
   constructor(
     @Inject(Constants) public readonly constants: Constants,
@@ -94,6 +95,11 @@ export class GioTopNavComponent implements OnInit, OnDestroy {
         this.portalUrl = isEmpty(settings?.portal?.url)
           ? undefined
           : this.constants.env.baseURL.replace('{:envId}', this.constants.org.currentEnv.id) + '/portal/redirect';
+
+        this.isPortalNextEnabled = settings?.portalNext?.access?.enabled;
+        if (!this.isPortalNextEnabled && this.portalUrl) {
+          this.portalUrl = this.portalUrl + '?version=classic';
+        }
       });
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalRedirectResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalRedirectResource.java
@@ -49,6 +49,8 @@ public class PortalRedirectResource extends AbstractAuthenticationResource {
     public static final String PROPERTY_HTTP_API_PORTAL_ENTRYPOINT = "http.api.portal.entrypoint";
     private static final String PORTAL_NEXT_VERSION = "next";
     private static final String PORTAL_NEXT_QUERY_PARAM = "version=next&";
+    private static final String PORTAL_CLASSIC_VERSION = "classic";
+    private static final String PORTAL_CLASSIC_QUERY_PARAM = "version=classic&";
 
     @Autowired
     private InstallationAccessQueryService installationAccessQueryService;
@@ -73,7 +75,15 @@ public class PortalRedirectResource extends AbstractAuthenticationResource {
                     .build();
                 url = uriComponents.toUriString();
             }
-            var versionQueryParam = version != null && version.equals(PORTAL_NEXT_VERSION) ? PORTAL_NEXT_QUERY_PARAM : "";
+            var versionQueryParam = "";
+            if (version != null) {
+                if (version.equals(PORTAL_NEXT_VERSION)) {
+                    versionQueryParam = PORTAL_NEXT_QUERY_PARAM;
+                } else if (version.equals(PORTAL_CLASSIC_VERSION)) {
+                    versionQueryParam = PORTAL_CLASSIC_QUERY_PARAM;
+                }
+            }
+
             // Redirect the user.
             URI location = new URI(
                 "%s/environments/%s/auth/console?%stoken=%s".formatted(url, environmentId, versionQueryParam, tokenEntity.getToken())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalRedirectResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalRedirectResourceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author Gaurav SHARMA (gaurav.sharma at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PortalRedirectResourceTest {
+
+    private PortalRedirectResource resource;
+    private InstallationAccessQueryService installationAccessQueryService;
+    private UserService userService;
+    private MembershipService membershipService;
+    private MockEnvironment environment;
+
+    @Before
+    public void setUp() throws Exception {
+        // Prepare SecurityContext with a Gravitee UserDetails principal
+        var principal = new UserDetails("UnitTests", "", Collections.emptyList());
+        principal.setOrganizationId("DEFAULT");
+        principal.setId("UnitTests");
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(principal, "n/a"));
+
+        // Instantiate resource and mocks
+        resource = new PortalRedirectResource();
+        installationAccessQueryService = mock(InstallationAccessQueryService.class);
+        userService = mock(UserService.class);
+        membershipService = mock(MembershipService.class);
+        environment = new MockEnvironment();
+        environment.setProperty("jwt.secret", "unit-test-secret");
+        environment.setProperty("jwt.issuer", "unit-test-issuer");
+        environment.setProperty(PortalRedirectResource.PROPERTY_HTTP_API_PORTAL_ENTRYPOINT, "/portal");
+
+        inject(resource, "installationAccessQueryService", installationAccessQueryService);
+        inject(resource, "userService", userService);
+        inject(resource, "membershipService", membershipService);
+        inject(resource, "environment", environment);
+
+        when(installationAccessQueryService.getPortalAPIUrl(anyString())).thenReturn("https://portal.example");
+        when(userService.findById(any(), anyString())).thenAnswer(invocation -> {
+            var u = new io.gravitee.rest.api.model.UserEntity();
+            u.setId("UnitTests");
+            u.setEmail("unit@test.local");
+            u.setFirstname("Unit");
+            u.setLastname("Tests");
+            u.setOrganizationId("DEFAULT");
+            return u;
+        });
+        when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Set.of());
+
+        GraviteeContext.cleanContext();
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void redirect_should_not_include_version_param_when_null() throws Exception {
+        var httpRequest = new MockHttpServletRequest();
+        Response response = resource.redirectToPortal(httpRequest, null);
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertTrue(location.startsWith("https://portal.example/environments/DEFAULT/auth/console?"));
+        assertTrue(location.contains("token="));
+        assertFalse(location.contains("version="));
+    }
+
+    @Test
+    public void redirect_should_include_version_next() throws Exception {
+        var httpRequest = new MockHttpServletRequest();
+        Response response = resource.redirectToPortal(httpRequest, "next");
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertTrue(location.startsWith("https://portal.example/environments/DEFAULT/auth/console?"));
+        assertTrue(location.contains("version=next&"));
+        assertTrue(location.contains("token="));
+    }
+
+    @Test
+    public void redirect_should_include_version_classic() throws Exception {
+        var httpRequest = new MockHttpServletRequest();
+        Response response = resource.redirectToPortal(httpRequest, "classic");
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertTrue(location.startsWith("https://portal.example/environments/DEFAULT/auth/console?"));
+        assertTrue(location.contains("version=classic&"));
+        assertTrue(location.contains("token="));
+    }
+
+    @Test
+    public void redirect_should_ignore_unknown_version() throws Exception {
+        var httpRequest = new MockHttpServletRequest();
+        Response response = resource.redirectToPortal(httpRequest, "foobar");
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertTrue(location.startsWith("https://portal.example/environments/DEFAULT/auth/console?"));
+        assertTrue(location.contains("token="));
+        assertFalse(location.contains("version="));
+    }
+
+    private static void inject(Object target, String fieldName, Object value) throws Exception {
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field f = type.getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException ex) {
+                type = type.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/ConsoleAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/ConsoleAuthenticationResource.java
@@ -47,6 +47,8 @@ public class ConsoleAuthenticationResource extends AbstractAuthenticationResourc
 
     private static final String PORTAL_NEXT_VERSION = "next";
     private static final String PORTAL_NEXT_PATH = "/next";
+    private static final String PORTAL_CLASSIC_VERSION = "classic";
+    private static final String PORTAL_CLASSIC_PATH = "/classic";
 
     @Autowired
     private InstallationAccessQueryService installationAccessQueryService;
@@ -89,7 +91,14 @@ public class ConsoleAuthenticationResource extends AbstractAuthenticationResourc
             // connect the user
             super.connectUser(jwt.getSubject(), httpResponse);
             String url = installationAccessQueryService.getPortalUrl(environmentId);
-            var versionQueryParam = version != null && version.equals(PORTAL_NEXT_VERSION) ? PORTAL_NEXT_PATH : "";
+            var versionQueryParam = ""; // Default to no Version path
+            if (version != null) {
+                if (version.equals(PORTAL_NEXT_VERSION)) {
+                    versionQueryParam = PORTAL_NEXT_PATH;
+                } else if (version.equals(PORTAL_CLASSIC_VERSION)) {
+                    versionQueryParam = PORTAL_CLASSIC_PATH;
+                }
+            }
             url += versionQueryParam;
             // Redirect the user.
             return Response.temporaryRedirect(new URI(url)).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/ConsoleAuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/ConsoleAuthenticationResourceTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.auth;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.JWTHelper;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * @author Gaurav SHARMA (gaurav.sharma at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ConsoleAuthenticationResourceTest {
+
+    private ConsoleAuthenticationResource resource;
+    private InstallationAccessQueryService installationAccessQueryService;
+    private AuthoritiesProvider authoritiesProvider;
+    private UserService userService;
+    private MockEnvironment environment;
+
+    private static final String ORG_ID = "DEFAULT";
+    private static final String USER_ID = "UnitTests";
+
+    @Before
+    public void setUp() throws Exception {
+        resource = spy(new ConsoleAuthenticationResource());
+        installationAccessQueryService = mock(InstallationAccessQueryService.class);
+        authoritiesProvider = mock(AuthoritiesProvider.class);
+        userService = mock(UserService.class);
+        environment = new MockEnvironment();
+        environment.setProperty("jwt.secret", "unit-test-secret");
+
+        inject(resource, "installationAccessQueryService", installationAccessQueryService);
+        inject(resource, "authoritiesProvider", authoritiesProvider);
+        inject(resource, "userService", userService);
+        inject(resource, "environment", environment);
+
+        // Avoid executing parent connectUser logic (cookie/session), not relevant for this test
+        doNothing().when(resource).connectUser(anyString(), any());
+
+        when(installationAccessQueryService.getPortalUrl(anyString())).thenReturn("https://portal.example");
+        when(authoritiesProvider.retrieveAuthorities(anyString(), anyString(), anyString())).thenReturn(Set.<GrantedAuthority>of());
+        when(userService.findById(any(), anyString())).thenAnswer(
+            (Answer<UserEntity>) invocation -> {
+                UserEntity u = new UserEntity();
+                u.setId(USER_ID);
+                u.setOrganizationId(ORG_ID);
+                u.setEmail("unit@test.local");
+                return u;
+            }
+        );
+
+        GraviteeContext.cleanContext();
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void redirect_should_not_append_version_path_when_null() throws Exception {
+        String token = buildJwtToken();
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+
+        Response response = resource.redirectTo(null, token, httpResponse);
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertEquals("https://portal.example", location);
+    }
+
+    @Test
+    public void redirect_should_append_next_path() throws Exception {
+        String token = buildJwtToken();
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+
+        Response response = resource.redirectTo("next", token, httpResponse);
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertEquals("https://portal.example/next", location);
+    }
+
+    @Test
+    public void redirect_should_append_classic_path() throws Exception {
+        String token = buildJwtToken();
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+
+        Response response = resource.redirectTo("classic", token, httpResponse);
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertEquals("https://portal.example/classic", location);
+    }
+
+    @Test
+    public void redirect_should_ignore_unknown_version() throws Exception {
+        String token = buildJwtToken();
+        MockHttpServletResponse httpResponse = new MockHttpServletResponse();
+
+        Response response = resource.redirectTo("foobar", token, httpResponse);
+
+        assertEquals(307, response.getStatus());
+        String location = ((URI) response.getLocation()).toString();
+        assertEquals("https://portal.example", location);
+    }
+
+    private String buildJwtToken() {
+        Algorithm alg = Algorithm.HMAC256(environment.getProperty("jwt.secret"));
+        return JWT.create().withSubject(USER_ID).withClaim(JWTHelper.Claims.ORG, ORG_ID).sign(alg);
+    }
+
+    private static void inject(Object target, String fieldName, Object value) throws Exception {
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field f = type.getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException ex) {
+                type = type.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11798

## Description

The link to the developer portal in the top left corner of the console is not working when new developer portal is disabled. Sometimes it points to 404 page.

**Expected behaviour :**

On clicking of the Developer Portal: 

1. When New Portal is enabled: New portal page should open
2. When New Portal is disabled: Old/classic portal page should open

**Current behaviour :**

1. On clicking of the Developer Portal: When New Portal is enabled: New portal page is opening
2. When New Portal is disabled: Old/classic portal page is not working.



## Additional context

To Reproduce:

Enable and disable the now developer portal in 4.7.x or any greater environment.

