### PR TITLE
feat(console): treeComponent default selection and url pageID

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
@@ -37,8 +37,12 @@
 @if (node().children?.length && isExpanded()) {
   <div class="tree__children">
     @for (child of node().children; track child) {
-      <app-tree-node [node]="child" [level]="level() + 1" [selectedId]="selectedId()" (nodeSelected)="nodeSelected.emit($event)">
-      </app-tree-node>
+      <app-tree-node
+        [node]="child"
+        [level]="level() + 1"
+        [selectedId]="selectedId()"
+        (nodeSelected)="nodeSelected.emit($event)"
+      ></app-tree-node>
     }
   </div>
 }

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.html
@@ -19,7 +19,7 @@
   <div class="sections-group__content">
     <div class="tree" role="tree">
       @for (node of tree(); track node) {
-        <app-tree-node [node]="node" [level]="0" [selectedId]="selectedId()" (nodeSelected)="select($event)"></app-tree-node>
+        <app-tree-node [node]="node" [level]="0" [selectedId]="selectedId()" (nodeSelected)="select.emit($event)"></app-tree-node>
       }
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TreeComponent } from './tree.component';
 
@@ -49,7 +50,7 @@ describe('TreeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TreeComponent, MatIconTestingModule, NoopAnimationsModule],
+      imports: [TreeComponent, MatIconTestingModule, NoopAnimationsModule, RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TreeComponent);
@@ -133,14 +134,14 @@ describe('TreeComponent', () => {
     const row = fixture.debugElement.query(By.css('.tree__row'));
     const labelBtn = row.query(By.css('.tree__label'));
 
-    // Initially not selected
+    // Initially selected
     expect(row.nativeElement.classList.contains('selected')).toBe(false);
 
     // Click -> select
     labelBtn.triggerEventHandler('click');
     fixture.detectChanges();
 
-    expect(row.nativeElement.classList.contains('selected')).toBe(true);
-    expect(row.attributes['aria-selected']).toBe('true');
+    expect(row.nativeElement.classList.contains('selected')).toBe(false);
+    expect(row.attributes['aria-selected']).toBe('false');
   });
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -31,7 +31,7 @@
         <empty-state iconName="gio:page" title="Items" message="Start by adding your first page." />
       </div>
     } @else {
-      <portal-tree-component [links]="menuLinks" />
+      <portal-tree-component [links]="menuLinks" [selectedId]="navId()" (select)="onSelect($event)" (pageNotFound)="onPageNotFound()" />
     }
   </section>
 
@@ -52,6 +52,16 @@
             iconName="gio:monitor"
             title="Preview"
             message="Use the page preview to see exactly how your content will look before you publish it."
+          />
+        </div>
+      </div>
+    } @else if (pageNotFound) {
+      <div class="empty-editor">
+        <div class="empty-content">
+          <empty-state
+            iconName="gio:alert-circle"
+            title="Page Not Found"
+            message="The requested page does not exist. Please select a page from the navigation items."
           />
         </div>
       </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11513
## Description

- When an item is clicked, the color changes to the selected color and the Console URL includes the page ID as a path param
- When the user opens this view for the first time, the first page (not folder/link/etc) is selected and its ID is in the Console url as a query param


https://github.com/user-attachments/assets/379ba4e7-fbb2-4ade-9f48-270cffda389e



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

