### PR TITLE
fix(portal-next): fix documentation content going out of frame

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
@@ -26,7 +26,11 @@
     </app-drawer>
   </div>
   @if (apiId && pageId(); as pageId) {
-    <app-api-documentation [apiId]="apiId" [pages]="pages" [pageId]="pageId"></app-api-documentation>
+    <app-api-documentation
+      [apiId]="apiId"
+      [pages]="pages"
+      [pageId]="pageId"
+      class="api-tab-documentation__page-content"></app-api-documentation>
   }
 } @else {
   <div i18n="@@apiDocumentationEmpty" class="api-tab-documentation__empty">Documentation for this API is missing.</div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11797

## Description

Fixed The documentation page content was incorrectly aligned, causing horizontal
shifts due to left navigation panel 

## Additional context

### Before Fix
https://github.com/user-attachments/assets/ec192d31-0583-433a-b4c8-6a8a237cbdaa


### After Fix
https://github.com/user-attachments/assets/b6ef0cec-64e1-43f5-a7d3-b3f4f337c322
