### PR TITLE
APIM-11554 - Add GMD Page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -114,8 +114,6 @@ export function fakeNewPagePortalNavigationItem(overrides?: Partial<NewPagePorta
     title: 'New Page',
     type: 'PAGE',
     area: 'HOMEPAGE',
-    order: 1,
-    contentId: 'content-1',
   };
 
   if (isFunction(overrides)) {
@@ -133,7 +131,6 @@ export function fakeNewFolderPortalNavigationItem(overrides?: Partial<NewFolderP
     title: 'New Folder',
     type: 'FOLDER',
     area: 'HOMEPAGE',
-    order: 1,
   };
 
   if (isFunction(overrides)) {
@@ -151,7 +148,6 @@ export function fakeNewLinkPortalNavigationItem(overrides?: Partial<NewLinkPorta
     title: 'New Link',
     type: 'LINK',
     area: 'HOMEPAGE',
-    order: 1,
     url: 'https://example.com',
   };
 

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -43,24 +43,21 @@ export interface PortalNavigationLink extends BasePortalNavigationItem {
 
 export type PortalNavigationItem = PortalNavigationPage | PortalNavigationFolder | PortalNavigationLink;
 
-interface BaseNewPortalNavigationItem {
+interface BaseNewPortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;
+  type: T;
   area: PortalArea;
   parentId?: string;
   order?: number;
 }
 
-export interface NewPagePortalNavigationItem extends BaseNewPortalNavigationItem {
-  type: 'PAGE';
-  contentId: string;
+export interface NewPagePortalNavigationItem extends BaseNewPortalNavigationItem<'PAGE'> {
+  contentId?: string;
 }
 
-export interface NewFolderPortalNavigationItem extends BaseNewPortalNavigationItem {
-  type: 'FOLDER';
-}
+export interface NewFolderPortalNavigationItem extends BaseNewPortalNavigationItem<'FOLDER'> {}
 
-export interface NewLinkPortalNavigationItem extends BaseNewPortalNavigationItem {
-  type: 'LINK';
+export interface NewLinkPortalNavigationItem extends BaseNewPortalNavigationItem<'LINK'> {
   url: string;
 }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -21,8 +21,24 @@
   <section class="panel sections-panel">
     <header class="panel-header sections-panel__header">
       <h3>Navigation items</h3>
-      <div class="panel-header__actions">
-        <button mat-flat-button disabled>Add</button>
+      <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-c'] }">
+        <button
+          mat-stroked-button
+          type="button"
+          aria-label="Add new section"
+          [matMenuTriggerFor]="addSectionMenu"
+          (menuClosed)="addSectionMenuOpen = false"
+          (menuOpened)="addSectionMenuOpen = true"
+        >
+          <span class="panel-header__actions__add__label"
+            >Add
+            <mat-icon svgIcon="gio:nav-arrow-down" class="panel-header__actions__add__label__icon" [class.opened]="addSectionMenuOpen">
+            </mat-icon>
+          </span>
+        </button>
+        <mat-menu #addSectionMenu="matMenu">
+          <button mat-menu-item (click)="onAddPageSectionClick()"><mat-icon svgIcon="gio:page"></mat-icon> Add Page</button>
+        </mat-menu>
       </div>
     </header>
 
@@ -37,7 +53,7 @@
 
   <section class="panel editor-panel">
     <header class="panel-header editor-panel__header">
-      <div class="panel-header__actions">
+      <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">
         <button mat-flat-button disabled>Save</button>
       </div>
     </header>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -50,6 +50,22 @@
 
   &__actions {
     margin-left: auto;
+
+    &__add {
+      &__label {
+        display: flex;
+        gap: 8px;
+
+        &__icon {
+          transition: transform 0.15s ease-out;
+          backface-visibility: hidden;
+
+          &.opened {
+            transform: rotate(-180deg);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+
+import SpyInstance = jest.SpyInstance;
+
+import { PortalNavigationItemsComponent } from './portal-navigation-items.component';
+import { PortalNavigationItemsHarness } from './portal-navigation-items.harness';
+import { SectionEditorDialogHarness } from './section-editor-dialog/section-editor-dialog.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
+import { GioTestingPermissionProvider } from '../../shared/components/gio-permission/gio-permission.service';
+import {
+  fakeNewPagePortalNavigationItem,
+  fakePortalNavigationItemsResponse,
+  fakePortalNavigationPage,
+  NewPortalNavigationItem,
+  PortalNavigationItem,
+  PortalNavigationItemsResponse,
+} from '../../entities/management-api-v2';
+
+describe('PortalNavigationItemsComponent', () => {
+  let fixture: ComponentFixture<PortalNavigationItemsComponent>;
+  let harness: PortalNavigationItemsHarness;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let routerSpy: SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, PortalNavigationItemsComponent],
+      providers: [
+        {
+          provide: GioTestingPermissionProvider,
+          useValue: ['environment-documentation-c'],
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PortalNavigationItemsComponent);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PortalNavigationItemsHarness);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    const router = TestBed.inject(Router);
+    routerSpy = jest.spyOn(router, 'navigate');
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  describe('adding a section', () => {
+    describe('adding a page', () => {
+      let dialogHarness: SectionEditorDialogHarness;
+      beforeEach(async () => {
+        expectGetMenuLinks();
+        await harness.clickAddButton();
+        await harness.clickPageMenuItem();
+        dialogHarness = await rootLoader.getHarness(SectionEditorDialogHarness);
+      });
+      it('opens the dialog when the Add button is clicked and Page is selected', async () => {
+        expect(dialogHarness).toBeTruthy();
+      });
+
+      it('should not create the page when the dialog is cancelled', async () => {
+        await dialogHarness.clickCancelButton();
+      });
+
+      it('should create the page when the dialog is submitted', async () => {
+        const title = 'New Page Title';
+        await dialogHarness.setTitleInputValue(title);
+        await dialogHarness.clickAddButton();
+
+        expectCreateNavigationItem(
+          fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE' }),
+          fakePortalNavigationPage({
+            title,
+            area: 'TOP_NAVBAR',
+            type: 'PAGE',
+            configuration: {
+              portalPageContentId: 'content-id',
+            },
+          }),
+        );
+        expectGetNavigationItems();
+      });
+      it('should navigate to the created page after creation', async () => {
+        const title = 'New Page Title';
+        await dialogHarness.setTitleInputValue(title);
+        await dialogHarness.clickAddButton();
+
+        const createdItem = fakePortalNavigationPage({
+          title,
+          area: 'TOP_NAVBAR',
+          type: 'PAGE',
+          configuration: {
+            portalPageContentId: 'content-id',
+          },
+        });
+        expectCreateNavigationItem(fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE' }), createdItem);
+        expectGetNavigationItems();
+
+        expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdItem.id } }));
+      });
+    });
+  });
+
+  function expectGetMenuLinks() {
+    httpTestingController.expectOne('assets/mocks/portal-menu-links.json').flush({ data: [] });
+  }
+  function expectGetNavigationItems(response: PortalNavigationItemsResponse = fakePortalNavigationItemsResponse()) {
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items` }).flush(response);
+  }
+  function expectCreateNavigationItem(requestBody: NewPortalNavigationItem, result: PortalNavigationItem) {
+    const req = httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items` });
+    expect(req.request.body).toEqual(requestBody);
+    req.flush(result);
+  }
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
+
+export class PortalNavigationItemsHarness extends ComponentHarness {
+  static hostSelector = 'portal-navigation-items';
+
+  private getAddButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add new section"]' }));
+  private getMenu = this.locatorFor(MatMenuHarness);
+
+  async getAddButtonHarness(): Promise<MatButtonHarness> {
+    return this.getAddButton();
+  }
+
+  async clickAddButton(): Promise<void> {
+    const button = await this.getAddButton();
+    return button.click();
+  }
+
+  async getPageMenuItem(): Promise<MatMenuItemHarness> {
+    const menu = await this.getMenu();
+    return menu.getHarness(MatMenuItemHarness.with({ text: /Add Page/i }));
+  }
+
+  async clickPageMenuItem(): Promise<void> {
+    const menuItem = await this.getPageMenuItem();
+    return menuItem.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div mat-dialog-title class="title">
+  {{ title }}
+</div>
+
+<form [formGroup]="form">
+  <mat-dialog-content>
+    <div class="form-field-title">Title</div>
+    <mat-form-field>
+      <mat-label>{{ type | titlecase }} Title</mat-label>
+      <input matInput formControlName="title" required />
+      @if (form.controls.title.hasError('required')) {
+        <mat-error>Title is required</mat-error>
+      }
+    </mat-form-field>
+
+    <gio-banner-info type="info">
+      This change will not be visible in the Developer Portal until you publish the {{ type | lowercase }}.
+    </gio-banner-info>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button (click)="onCancel()">Cancel</button>
+    <button mat-flat-button color="primary" (click)="onSubmit()" [disabled]="!form.valid">Add</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
@@ -1,0 +1,20 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'sass:map';
+
+$typography: map.get(gio.$mat-theme, typography);
+
+mat-dialog-content {
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+}
+
+.title {
+  @include mat.m2-typography-level($typography, headline-6);
+}
+
+.form-field-title {
+  @include mat.m2-typography-level($typography, subtitle-2);
+  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, inject, input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SectionEditorDialogHarness } from './section-editor-dialog.harness';
+import {
+  SectionEditorDialogComponent,
+  SectionEditorDialogData,
+  SectionEditorDialogMode,
+  SectionEditorDialogResult,
+} from './section-editor-dialog.component';
+
+import { GioTestingModule } from '../../../shared/testing';
+import { PortalNavigationItemType } from '../../../entities/management-api-v2';
+
+@Component({
+  selector: 'test-host-component',
+  template: `<button (click)="clicked()">Click me</button>`,
+})
+class TestHostComponent {
+  mode = input<SectionEditorDialogMode>('create');
+  type = input<PortalNavigationItemType>('PAGE');
+
+  dialogValue: SectionEditorDialogResult;
+  private matDialog = inject(MatDialog);
+
+  public clicked(): void {
+    this.matDialog
+      .open<SectionEditorDialogComponent, SectionEditorDialogData>(SectionEditorDialogComponent, {
+        width: '500px',
+        data: {
+          mode: this.mode(),
+          type: this.type(),
+        },
+      })
+      .afterClosed()
+      .subscribe({
+        next: (result) => {
+          this.dialogValue = result;
+        },
+      });
+  }
+}
+
+describe('SectionEditorDialogComponent', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let rootLoader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, GioTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    fixture.detectChanges();
+  });
+
+  describe('when in create mode', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('mode', 'create');
+    });
+    describe('when adding a page', () => {
+      beforeEach(() => {
+        fixture.componentRef.setInput('type', 'PAGE');
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+      });
+      it('should not allow empty title', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+        expect(await titleInput.getValue()).toBe('');
+        expect(await dialog.isAddButtonDisabled()).toEqual(true);
+      });
+      it('should save the title', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+
+        await titleInput.setValue('My new page');
+
+        await dialog.clickAddButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual({
+          title: 'My new page',
+        });
+      });
+      it('should close the dialog when canceling', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+        await titleInput.setValue('My new page');
+        await dialog.clickCancelButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toBeUndefined();
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { LowerCasePipe, TitleCasePipe } from '@angular/common';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+
+import { PortalNavigationItemType } from '../../../entities/management-api-v2';
+
+export type SectionEditorDialogMode = 'create';
+
+export interface SectionEditorDialogData {
+  mode: SectionEditorDialogMode;
+  type: PortalNavigationItemType;
+}
+
+export interface SectionEditorDialogResult {
+  title: string;
+  settings?: {
+    url: string;
+  };
+}
+
+interface SectionFormControls {
+  title: FormControl<string>;
+  settings?: FormGroup<{
+    // Optional for 'LINK' type
+    url: FormControl<string>;
+  }>;
+}
+
+type SectionForm = FormGroup<SectionFormControls>;
+
+@Component({
+  selector: 'section-editor-dialog',
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatSlideToggleModule,
+    MatInputModule,
+    TitleCasePipe,
+    GioBannerModule,
+    LowerCasePipe,
+  ],
+  templateUrl: './section-editor-dialog.component.html',
+  styleUrls: ['./section-editor-dialog.component.scss'],
+})
+export class SectionEditorDialogComponent implements OnInit {
+  form: SectionForm = new FormGroup<SectionFormControls>({
+    title: new FormControl<string>('', { validators: [Validators.required], nonNullable: true }),
+  });
+
+  public type: PortalNavigationItemType;
+  public mode: SectionEditorDialogMode;
+  public title: string;
+
+  private readonly dialogRef = inject(MatDialogRef<SectionEditorDialogComponent, SectionEditorDialogResult>);
+  private readonly data: SectionEditorDialogData = inject(MAT_DIALOG_DATA);
+
+  constructor() {
+    this.type = this.data.type;
+    this.mode = this.data.mode;
+    this.title = `Add ${this.type.toLowerCase()}`;
+  }
+
+  ngOnInit(): void {
+    this.addTypeSpecificControls();
+  }
+
+  private addTypeSpecificControls(): void {
+    if (this.type === 'LINK') {
+      // Add link specific settings here
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.valid) {
+      this.dialogRef.close({ ...this.form.getRawValue() });
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class SectionEditorDialogHarness extends ComponentHarness {
+  static hostSelector = 'section-editor-dialog';
+  private locateTitleInput = this.locatorFor(MatInputHarness.with({ selector: '[formcontrolname="title"]' }));
+  private locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  private locateAddButton = this.locatorFor(MatButtonHarness.with({ text: 'Add' }));
+
+  async getTitleInput(): Promise<MatInputHarness> {
+    return this.locateTitleInput();
+  }
+  async setTitleInputValue(value: string): Promise<void> {
+    const titleInput = await this.locateTitleInput();
+    return titleInput.setValue(value);
+  }
+  async getTitleInputValue(): Promise<string> {
+    const titleInput = await this.locateTitleInput();
+    return titleInput.getValue();
+  }
+  async clickCancelButton(): Promise<void> {
+    const cancelButton = await this.locateCancelButton();
+    return cancelButton.click();
+  }
+  async isAddButtonDisabled(): Promise<boolean> {
+    const addButton = await this.locateAddButton();
+    return await addButton.isDisabled();
+  }
+  async clickAddButton(): Promise<void> {
+    const addButton = await this.locateAddButton();
+    return addButton.click();
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11554

## Description

This Pull Request introduces updates to the navigation items feature in the Gravitee API Management Console. It modifies existing navigation structures, improves component behaviors with new menu and dialog functionalities, and adds tests to support these enhancements.

**Main Changes:**
- Removed unnecessary fields (order, contentId) from portalNavigationItem.fixture.ts to simplify test data.
- Modified TypeScript interfaces in portalNavigationItem.ts to enforce stricter typing and adjust optional contentId.
- Enhanced portal-navigation-items.component.html with permission-based dynamic buttons and a dropdown menu for navigation item creation.
- Updated SASS styles in portal-navigation-items.component.scss to include styles for new menu and button elements.
- Added a new unit testing file, portal-navigation-items.component.spec.ts, to validate interactions with the new dropdown menu.
- Extended logic in portal-navigation-items.component.ts to support dialog-based navigation item creation using Angular Material dialog.
- Introduced a new component, section-editor-dialog, including its HTML, SCSS, TypeScript, and testing files, to manage navigation item creation (supports a form for entering a title).
- Created harness classes for testing UI logic for both portal-navigation-items and section-editor-dialog.


https://github.com/user-attachments/assets/8c9d94e2-cec2-476f-94dd-096a548a1b25



**Next PRs**
- Refactor menu items to truly reflect what is coming from the back and then refresh list
- Add link
- Add folder
- Edit GMD Page, link and folder

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

