### PR TITLE
fix: regression in CRD export

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -237,17 +237,7 @@ public interface ApiMapper {
             return List.of();
         }
 
-        return apiCRD
-            .getPlans()
-            .entrySet()
-            .stream()
-            .sorted(comparingInt(p -> p.getValue().getOrder()))
-            .map(entry -> {
-                PlanV4 planV4 = map(entry.getValue());
-                planV4.setHrid(entry.getKey());
-                return planV4;
-            })
-            .toList();
+        return apiCRD.getPlans().values().stream().sorted(comparingInt(PlanCRD::getOrder)).map(this::map).toList();
     }
 
     default Map<String, PageCRD> mapApiV4SpecPages(ApiV4Spec apiV4Spec) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/PlanCRD.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/PlanCRD.java
@@ -33,6 +33,8 @@ public class PlanCRD {
     @NotEmpty
     private String id;
 
+    private String hrid;
+
     private String crossId;
 
     private String name;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
@@ -103,12 +103,8 @@ public interface ApiCRDAdapter {
             .filter(plan -> !plan.isClosed())
             .toList();
         for (var plan : nonClosedPlans) {
-            if (plan.getHrid() == null) {
-                var key = plansMap.containsKey(plan.getName()) ? randomize(plan.getName()) : plan.getName();
-                plansMap.put(key, toCRDPlan(plan));
-            } else {
-                plansMap.put(plan.getHrid(), toCRDPlan(plan));
-            }
+            var key = plansMap.containsKey(plan.getName()) ? randomize(plan.getName()) : plan.getName();
+            plansMap.put(key, toCRDPlan(plan));
         }
         return plansMap;
     }
@@ -135,7 +131,7 @@ public interface ApiCRDAdapter {
             ? definition
                 .getMembers()
                 .stream()
-                .map(me -> new MemberCRD(me.getId(), null, null, me.getRoles().get(0).getName()))
+                .map(me -> new MemberCRD(me.getId(), null, null, me.getRoles().getFirst().getName()))
                 .collect(Collectors.toSet())
             : null;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiCRDAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiCRDAdapterTest.java
@@ -61,7 +61,7 @@ class ApiCRDAdapterTest {
             soft.assertThat(spec.getListeners()).hasSize(1);
             soft.assertThat(spec.getEndpointGroups()).hasSize(1);
             soft.assertThat(spec.getPlans()).hasSize(1);
-            soft.assertThat(spec.getPlans()).containsKey("plan-hrid");
+            soft.assertThat(spec.getPlans()).containsKey("plan-name");
         });
     }
 
@@ -92,7 +92,7 @@ class ApiCRDAdapterTest {
             soft.assertThat(spec.getListeners()).hasSize(1);
             soft.assertThat(spec.getEndpointGroups()).hasSize(1);
             soft.assertThat(spec.getPlans()).hasSize(1);
-            soft.assertThat(spec.getPlans()).containsKey("plan-hrid");
+            soft.assertThat(spec.getPlans()).containsKey("plan-name");
         });
     }
 
@@ -149,7 +149,7 @@ class ApiCRDAdapterTest {
         export.setPlans(plansWithConflictingNames);
         var spec = ApiCRDAdapter.INSTANCE.toCRDSpec(export, export.getApiEntity());
         assertThat(spec.getPlans()).hasSize(3);
-        assertThat(spec.getPlans()).containsKey("plan-1");
+        assertThat(spec.getPlans()).containsKey("api key");
     }
 
     private static ExportApiEntity exportEntity(boolean withHrid) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
@@ -127,7 +127,7 @@ class ApiCRDExportDomainServiceImplTest {
             soft.assertThat(spec.getListeners()).hasSize(1);
             soft.assertThat(spec.getEndpointGroups()).hasSize(1);
             soft.assertThat(spec.getPlans()).hasSize(1);
-            soft.assertThat(spec.getPlans()).containsKey("plan-hrid");
+            soft.assertThat(spec.getPlans()).containsKey("plan-name");
         });
     }
 
@@ -152,7 +152,7 @@ class ApiCRDExportDomainServiceImplTest {
             soft.assertThat(spec.getListeners()).hasSize(1);
             soft.assertThat(spec.getEndpointGroups()).hasSize(1);
             soft.assertThat(spec.getPlans()).hasSize(1);
-            soft.assertThat(spec.getPlans()).containsKey("plan-hrid");
+            soft.assertThat(spec.getPlans()).containsKey("plan-name");
         });
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1880
https://gravitee.atlassian.net/browse/GKO-1883

## Description

### GKO CRD API Layer
* Stop using `hrid` in CRD export in GKO layer.
* Test that plan name is used instead of hrid in tests 

### Automation API related changes
* Map `hrid` in all `PlanCRD` class in GKO layer
* Use `PlanCRD.hrid` instead of the map key from the GKO mapper

## Additional context

Regression was due to an adaptation done when fixing issues in Automation API. Plan mapping got changed in GKO layer where it should have remained untouched.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

