### PR TITLE
fix: add username support for Redis authentication

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -412,6 +412,7 @@ ratelimit:
   mongodb:
     uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 #  redis:
+#    username: # Optional: Redis username for ACL authentication
 #    password:
 #    # Redis Standalone settings
 #    host: localhost

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
@@ -264,4 +264,29 @@ public class RedisConnectionFactoryTest {
         assertThat(options.getNetClientOptions().getConnectTimeout()).isEqualTo(1234);
         assertThat(options.getNetClientOptions().getIdleTimeout()).isEqualTo(5678);
     }
+
+    @Test
+    void shouldReturnRedisOptionsWithUsernameAndPassword() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.username", "testuser");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.password", "testpass");
+
+        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+
+        assertThat(options).isNotNull();
+        assertThat(options.getEndpoint()).isEqualTo("redis://testuser:testpass@redis:6379");
+    }
+
+    @Test
+    void shouldReturnRedisOptionsWithOnlyPassword() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.password", "testpass");
+
+        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+
+        assertThat(options).isNotNull();
+        assertThat(options.getEndpoint()).isEqualTo("redis://:testpass@redis:6379");
+    }
 }

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.9.5
+- Improve redis rate limit configuration to allow username for acl configuration [issues/10966](https://github.com/gravitee-io/issues/issues/10966).
 
 ### 4.9.0
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,9 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: 'allow redis rate limit configuration to use username for acl configuration'
+      links:
+        - name: Github Issue
+          url: https://github.com/gravitee-io/issues/issues/10966

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -435,6 +435,9 @@ data:
       redis:
         host: {{ .Values.gateway.ratelimit.redis.host }}
         port: {{ .Values.gateway.ratelimit.redis.port }}
+        {{- if .Values.gateway.ratelimit.redis.username }}
+        username: {{ .Values.gateway.ratelimit.redis.username }}
+        {{- end }}
         {{- if .Values.gateway.ratelimit.redis.password }}
         password: {{ .Values.gateway.ratelimit.redis.password }}
         {{- end }}

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -19,6 +19,27 @@ tests:
             \s redis:
             \s   host: redis
             \s   port: 6379
+  - it: Set host and port with username and password for ACL authentication
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: redis
+      gateway:
+        ratelimit:
+          redis:
+            host: redis
+            port: 6379
+            username: myuser
+            password: mypassword
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s redis:
+            \s   host: redis
+            \s   port: 6379
+            \s   username: myuser
+            \s   password: mypassword
   - it: Set host and port with password and ssl enabled
     template: gateway/gateway-configmap.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1218,6 +1218,7 @@ gateway:
     # redis:
     #   host: redis
     #   port: 6379
+    #   username: # Optional: Redis username for ACL authentication
     #   password:
     #   ssl: false
     #   hostnameVerificationAlgorithm: NONE


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11913

## Description

Currently, the Redis configuration only supports password-based authentication. This change adds username support to enable Redis ACL authentication with username and password pairs.

Changes:
- Added username property to RedisConnectionFactory
- Updated connection string format to support redis://username:password@host:port
- Added backward compatibility for password-only authentication redis://password@host:port
- Added test cases for authentication scenarios
- Updated Helm charts to support username configuration
- Added Helm unit tests for Redis username authentication

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

