### PR TITLE
fix: respect disabled state for resources

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
@@ -63,9 +63,10 @@ public class ResourceManagerImpl extends LegacyResourceManagerImpl {
         if (legacyMode) {
             super.initialize();
         } else {
-            // Unlike v4 resource, v2 Resource enabled flag has never been used. Keep this unchanged to avoid unexpected behavior or breaking changes.
             reactable
                 .dependencies(Resource.class)
+                .stream()
+                .filter(Resource::isEnabled)
                 .forEach(resource -> {
                     log.debug("Loading resource {} for {}", resource.getName(), reactable);
                     final io.gravitee.resource.api.Resource resourceInstance = resourceLoader.load(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/ResourceManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/ResourceManagerImplTest.java
@@ -156,14 +156,11 @@ class ResourceManagerImplTest {
         final ResourcePlugin resourcePlugin = mock(ResourcePlugin.class);
         resource.setEnabled(false);
 
-        when(resourcePlugin.resource()).thenReturn(Fake.class);
         when(reactable.dependencies(Resource.class)).thenReturn(Set.of(resource));
-        when(resourcePluginManager.get(resource.getType())).thenReturn(resourcePlugin);
-
         cut.initialize();
 
-        assertThat(cut.containsResource(resource.getName())).isTrue();
-        assertThat(cut.getResource(resource.getName())).isExactlyInstanceOf(Fake.class);
+        assertThat(cut.containsResource(resource.getName())).isFalse();
+        assertThat(cut.getResource(resource.getName())).isNull();
     }
 
     @Test
@@ -238,6 +235,46 @@ class ResourceManagerImplTest {
         assertThat(r).isExactlyInstanceOf(FakeWithDeploymentContext.class);
 
         assertThat(((FakeWithDeploymentContext) r).getDeploymentContext()).isNotNull().isSameAs(deploymentContext);
+    }
+
+    @Test
+    void should_initialize_enabled_resource_and_not_load_disabled_resource() {
+        final Resource enabledResource = buildResource();
+        enabledResource.setName("enabled-resource");
+        enabledResource.setEnabled(true);
+
+        final Resource disabledResource = buildResource();
+        disabledResource.setName("disabled-resource");
+        disabledResource.setType("test-disabled");
+        disabledResource.setEnabled(false);
+
+        final FakeConfiguration fakeConfiguration = new FakeConfiguration();
+        final ResourcePlugin resourcePlugin = mock(ResourcePlugin.class);
+
+        when(resourcePlugin.resource()).thenReturn(Fake.class);
+        when(reactable.dependencies(Resource.class)).thenReturn(Set.of(enabledResource, disabledResource));
+        when(resourcePluginManager.get(anyString())).thenReturn(resourcePlugin);
+        when(resourcePlugin.configuration()).thenReturn(FakeConfiguration.class);
+        when(resourceConfigurationFactory.create(FakeConfiguration.class, enabledResource.getConfiguration())).thenReturn(
+            fakeConfiguration
+        );
+
+        cut.initialize();
+
+        // Only enabled resource should be loaded due to .filter(Resource::isEnabled)
+        assertThat(cut.containsResource(enabledResource.getName())).isTrue();
+        assertThat(cut.containsResource(disabledResource.getName())).isFalse();
+
+        final Object enabledR = cut.getResource(enabledResource.getName());
+        assertThat(enabledR).isExactlyInstanceOf(Fake.class);
+        assertThat(((Fake) enabledR).configuration()).isSameAs(fakeConfiguration);
+
+        final Object disabledR = cut.getResource(disabledResource.getName());
+        assertThat(disabledR).isNull();
+
+        // Verify only the enabled resource was loaded
+        verify(resourcePluginManager).get(enabledResource.getType());
+        verify(resourcePluginManager, never()).get(disabledResource.getType());
     }
 
     private Resource buildResource() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11119

## Description

Disabled OAuth2 resources now properly block token validation. Previously, disabling a OAuth2 resource had no effect, allowing OAuth2 plans to continue validating tokens and granting access.

Changes:
- Filter out disabled resources during initialization using Resource::isEnabled
- OAuth2 plans linked to disabled resources now return 401 Unauthorized
- Added test coverage for enabled/disabled resource filtering

Before: Disabling OAuth2 resource → tokens still validated → 200 OK
After: Disabling OAuth2 resource → token validation blocked → 401 Unauthorized

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

