### PR TITLE
Replace mongoTemplate `findDistinct` with `stream` since the application IDs are already different.

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
@@ -81,7 +81,7 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
     public Stream<String> searchIds(ApplicationCriteria criteria) {
         final Query query = buildSearchCriteria(criteria);
         query.fields().include("id");
-        return mongoTemplate.findDistinct(query, "id", ApplicationMongo.class, String.class).parallelStream();
+        return mongoTemplate.stream(query, ApplicationMongo.class).map(ApplicationMongo::getId);
     }
 
     Query buildSearchCriteria(ApplicationCriteria criteria) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1802

## Description

Replace call to `mongoTemplate.findDistinct` when finding application Ids with `mongoTemplate.stream`.
`findDistinct` is not necessary since it's trying to find unique application IDs in the applications collection, but IDs are already unique.

This is being done to improve performance. I ran some tests with ~250.000 applications and requests to get analytics were taking close to a second, and after this change, they take a little less than 700 mS.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

