### PR TITLE
fix: Optimised permissions resource which causes delay on portal when having large app list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
@@ -19,12 +19,16 @@ import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -50,16 +54,39 @@ public class PermissionsResourceTest extends AbstractResourceTest {
     public void init() {
         resetAllMocks();
         when(accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API)).thenReturn(true);
+        when(accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), "fake")).thenReturn(false);
+
+        GenericApiEntity genericApiEntity = mock(GenericApiEntity.class);
+        doReturn(genericApiEntity).when(apiSearchService).findGenericById(GraviteeContext.getExecutionContext(), API);
+        Map<String, char[]> apiPermissions = new HashMap<>();
+        apiPermissions.put("API", new char[] { 'R' });
+        doReturn(apiPermissions)
+            .when(membershipService)
+            .getUserMemberPermissions(eq(GraviteeContext.getExecutionContext()), eq(genericApiEntity), any());
 
         ApplicationListItem mockAppListItem = new ApplicationListItem();
         mockAppListItem.setId(APPLICATION);
-        Set<ApplicationListItem> mockApps = new HashSet<>(Arrays.asList(mockAppListItem));
-        doReturn(mockApps).when(applicationService).findByUser(eq(GraviteeContext.getExecutionContext()), any());
+        Set<ApplicationListItem> activeApps = new HashSet<>(Arrays.asList(mockAppListItem));
+        doReturn(activeApps)
+            .when(applicationService)
+            .findByIdsAndStatus(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Collections.singleton(APPLICATION)),
+                eq(ApplicationStatus.ACTIVE)
+            );
+        doReturn(Collections.emptySet())
+            .when(applicationService)
+            .findByIdsAndStatus(eq(GraviteeContext.getExecutionContext()), eq(Collections.singleton("fake")), eq(ApplicationStatus.ACTIVE));
 
         ApplicationEntity mockAppEntity = new ApplicationEntity();
         mockAppEntity.setId(APPLICATION);
+        doReturn(mockAppEntity).when(applicationService).findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION));
 
-        doReturn(mockAppEntity).when(applicationService).findById(eq(GraviteeContext.getExecutionContext()), any());
+        Map<String, char[]> appPermissions = new HashMap<>();
+        appPermissions.put("APPLICATION", new char[] { 'R' });
+        doReturn(appPermissions)
+            .when(membershipService)
+            .getUserMemberPermissions(eq(GraviteeContext.getExecutionContext()), eq(mockAppEntity), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10970

## Description

Impossible to use the Dev Portal with so many apps when logged in through the admin user. 
Sometimes a few customers are facing: "Une erreur est inattendue survenue"

Fix explanation:
Permission api took around more than 30seconds on local to provide the response.
So, to fix this we optimised the app search and reduced the response time

## Additional context

Before fix:
Time taken ~30seconds
<img width="1920" height="1241" alt="image" src="https://github.com/user-attachments/assets/be1b95a4-a553-4007-a4e6-c81b7f27ce2a" />

After fix:
Time taken ~30milliseconds
<img width="1920" height="1241" alt="image" src="https://github.com/user-attachments/assets/cbadc870-dadd-4d3c-b185-38299f7362b0" />


