### PR TITLE
fix(analytics): fix incorrect curve rendering with scale differences in hits chart

### DIFF
--- a/gravitee-apim-console-webui/src/components/dashboard/widget/line/widget-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/components/dashboard/widget/line/widget-chart-line.component.ts
@@ -126,11 +126,21 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
           value.legendIndex = orderedBucketNames.indexOf(value.name);
         });
 
+        const stackedValue = this.parent.widget.chart.stacked;
+        let stacking: string | boolean | null = null;
+        if (stackedValue != null) {
+          if (stackedValue) {
+            stacking = 'normal';
+          } else {
+            stacking = false;
+          }
+        }
+
         this.options = {
           labelPrefix: 'HTTP Status',
           pointStart: timestamp.from,
           pointInterval: timestamp.interval,
-          stacking: this.parent.widget.chart.stacked ? 'normal' : null,
+          stacking,
           plotLines: (this.events || []).map((event) => {
             return {
               color: 'rgba(223, 169, 65, 0.4)',

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/dashboards/api_global.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/dashboards/api_global.json
@@ -240,7 +240,7 @@
     "chart": {
       "type": "line",
       "selectable": true,
-      "stacked": true,
+      "stacked": false,
       "request": {
         "type": "date_histo",
         "aggs": "field:application"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11183

## Description
Previously, when stacked was explicitly set to false in the dashboard configuration, the stacking property was incorrectly set to null instead of false. This fix ensures that explicit false values are properly handled, allowing charts to correctly disable stacking when configured.

## Additional context

### Before Fix
<img width="1350" height="441" alt="Screenshot 2025-11-18 at 10 45 07 AM" src="https://github.com/user-attachments/assets/075076dc-d642-4979-a88b-e0891663d194" />


### After Fix
<img width="1722" height="895" alt="Screenshot 2025-11-18 at 10 43 38 AM" src="https://github.com/user-attachments/assets/0afc7688-516e-4017-b274-fdb924f9aa34" />


