### PR TITLE
[CJ-3841] allow delete organization command to remove environments

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -308,15 +308,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         var payload = command.getPayload();
 
         try {
-            log.info("Delete environment with id [{}]", payload.cockpitId());
-            var environment = environmentService.findByCockpitId(payload.cockpitId());
-            var executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
-            String resolvedUserId = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, payload.userId());
-
-            disableEnvironment(executionContext, resolvedUserId);
-            deleteEnvironment(executionContext, environment);
-
-            log.info("Environment [{}] with id [{}] has been deleted.", environment.getName(), environment.getId());
+            processDeletionWorkflow(payload.cockpitId(), payload.userId());
             return Single.just(new DeleteEnvironmentReply(command.getId()));
         } catch (EnvironmentNotFoundException e) {
             log.warn("Environment with cockpitId [{}] has not been found.", payload.cockpitId());
@@ -326,6 +318,16 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
             log.error(errorDetails, e);
             return Single.just(new DeleteEnvironmentReply(command.getId(), errorDetails));
         }
+    }
+
+    void processDeletionWorkflow(String environmentCockpitId, String userId) throws TechnicalException {
+        log.info("Delete environment with id [{}]", environmentCockpitId);
+        var environment = environmentService.findByCockpitId(environmentCockpitId);
+        var executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
+        String resolvedUserId = CockpitUserHelper.resolveApimUserId(userRepository, executionContext, userId);
+        disableEnvironment(executionContext, resolvedUserId);
+        deleteEnvironment(executionContext, environment);
+        log.info("Environment [{}] with id [{}] has been deleted.", environment.getName(), environment.getId());
     }
 
     private void disableEnvironment(ExecutionContext executionContext, String userId) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3841

## Description

Today, Cockpit is responsible for orchestrating data deletion on the APIM side. Our cloud product sends a batch of commands to APIM to remove environments and organizations. The main drawback of this approach is that the operations are executed asynchronously, which can lead to inconsistent states. For example, an organization deletion may be triggered while some of its environments are still being removed.

With this PR, Cockpit will instead send a single deletion command to APIM. APIM will then take full responsibility for performing all necessary cleanup in the correct order. This ensures better consistency, reduces the risk of failures, and centralizes the deletion logic where it belongs.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

