### PR TITLE
feat(console): handle folder section creation from nav item list

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -39,6 +39,7 @@
         <mat-menu #addSectionMenu="matMenu">
           <button mat-menu-item (click)="onAddSection('PAGE')"><mat-icon svgIcon="gio:page"></mat-icon> Add Page</button>
           <button mat-menu-item (click)="onAddSection('LINK')"><mat-icon svgIcon="gio:link"></mat-icon> Add Link</button>
+          <button mat-menu-item (click)="onAddSection('FOLDER')"><mat-icon svgIcon="gio:folder"></mat-icon> Add Folder</button>
         </mat-menu>
       </div>
     </header>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -31,6 +31,7 @@ import { GioTestingPermissionProvider } from '../../shared/components/gio-permis
 import {
   fakeNewLinkPortalNavigationItem,
   fakeNewPagePortalNavigationItem,
+  fakePortalNavigationFolder,
   fakePortalNavigationItemsResponse,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
@@ -154,6 +155,37 @@ describe('PortalNavigationItemsComponent', () => {
             configuration: {
               url,
             },
+          }),
+        );
+        expectGetNavigationItems();
+      });
+    });
+    describe('adding a folder', () => {
+      beforeEach(async () => {
+        await harness.clickFolderMenuItem();
+        dialogHarness = await rootLoader.getHarness(SectionEditorDialogHarness);
+      });
+      it('opens the dialog when the Add button is clicked and Folder is selected', async () => {
+        expect(dialogHarness).toBeTruthy();
+      });
+      it('should not create the folder when the dialog is cancelled', async () => {
+        await dialogHarness.clickCancelButton();
+      });
+      it('should create the folder when the dialog is submitted', async () => {
+        const title = 'New Folder Title';
+        await dialogHarness.setTitleInputValue(title);
+        await dialogHarness.clickAddButton();
+
+        expectCreateNavigationItem(
+          {
+            title,
+            area: 'TOP_NAVBAR',
+            type: 'FOLDER',
+          },
+          fakePortalNavigationFolder({
+            title,
+            area: 'TOP_NAVBAR',
+            type: 'FOLDER',
           }),
         );
         expectGetNavigationItems();

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -42,6 +42,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     return menu.getHarness(MatMenuItemHarness.with({ text: /Add Link/i }));
   }
 
+  async getFolderMenuItem(): Promise<MatMenuItemHarness> {
+    const menu = await this.getMenu();
+    return menu.getHarness(MatMenuItemHarness.with({ text: /Add Folder/i }));
+  }
+
   async clickPageMenuItem(): Promise<void> {
     const menuItem = await this.getPageMenuItem();
     return menuItem.click();
@@ -49,6 +54,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
 
   async clickLinkMenuItem(): Promise<void> {
     const menuItem = await this.getLinkMenuItem();
+    return menuItem.click();
+  }
+
+  async clickFolderMenuItem(): Promise<void> {
+    const menuItem = await this.getFolderMenuItem();
     return menuItem.click();
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -163,5 +163,41 @@ describe('SectionEditorDialogComponent', () => {
         });
       });
     });
+    describe('when adding a folder', () => {
+      beforeEach(() => {
+        fixture.componentRef.setInput('type', 'FOLDER');
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+      });
+      it('should not allow empty title', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+        expect(await titleInput.getValue()).toBe('');
+        expect(await dialog.isAddButtonDisabled()).toEqual(true);
+      });
+      it('should save the title', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+
+        await titleInput.setValue('My new folder');
+
+        await dialog.clickAddButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual({
+          title: 'My new folder',
+        });
+      });
+      it('should close the dialog when canceling', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+        await titleInput.setValue('My new folder');
+        await dialog.clickCancelButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toBeUndefined();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11514

## Description

Add a folder section to the portal navigation item list

https://github.com/user-attachments/assets/22683c50-1ff1-4c9a-984c-ced3992711b8

**Next PRs**

- Edit GMD Page, link and folder

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

