### PR TITLE
feat(portal-next): remove showing company title in nav bar

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.html
@@ -15,12 +15,7 @@
     limitations under the License.
 
 -->
-<app-nav-bar
-  [currentUser]="currentUser()"
-  [siteTitle]="siteTitle"
-  [logo]="logo()"
-  [customLinks]="customLinks()"
-  [forceLogin]="forceLogin()" />
+<app-nav-bar [currentUser]="currentUser()" [logo]="logo()" [customLinks]="customLinks()" [forceLogin]="forceLogin()" />
 <div class="main-container-wrapper">
   <router-outlet />
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/app.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.spec.ts
@@ -21,11 +21,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { AppComponent } from './app.component';
-import { CompanyTitleHarness } from '../components/company-title/company-title.harness';
-import { Configuration } from '../entities/configuration/configuration';
-import { ConfigService } from '../services/config.service';
 import { PortalMenuLinksService } from '../services/portal-menu-links.service';
-import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+import { AppTestingModule } from '../testing/app-testing.module';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -44,49 +41,6 @@ describe('AppComponent', () => {
     it('should create the app', () => {
       const app = fixture.componentInstance;
       expect(app).toBeTruthy();
-    });
-
-    it(`should have the 'Developer Portal' title`, async () => {
-      const companyTitleComponent = await harnessLoader.getHarness(CompanyTitleHarness);
-      expect(companyTitleComponent).toBeTruthy();
-
-      expect(await companyTitleComponent.getTitle()).toEqual('Developer Portal');
-    });
-  });
-
-  describe('custom configuration', () => {
-    @Injectable()
-    class CustomConfigurationServiceStub {
-      get baseURL(): string {
-        return TESTING_BASE_URL;
-      }
-      get configuration(): Configuration {
-        return {
-          portalNext: {
-            siteTitle: 'My custom title',
-          },
-        };
-      }
-    }
-
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [AppComponent, AppTestingModule],
-        providers: [
-          {
-            provide: ConfigService,
-            useClass: CustomConfigurationServiceStub,
-          },
-        ],
-      }).compileComponents();
-      fixture = TestBed.createComponent(AppComponent);
-      harnessLoader = TestbedHarnessEnvironment.loader(fixture);
-    });
-    it('should show configured title', async () => {
-      const companyTitleComponent = await harnessLoader.getHarness(CompanyTitleHarness);
-      expect(companyTitleComponent).toBeTruthy();
-
-      expect(await companyTitleComponent.getTitle()).toEqual('My custom title');
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/app.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.ts
@@ -36,7 +36,7 @@ export class AppComponent {
   logo = inject(ThemeService).logo;
   favicon = inject(ThemeService).favicon;
   customLinks = inject(PortalMenuLinksService).links;
-  siteTitle: string;
+  private siteTitle: string;
 
   constructor(
     private configService: ConfigService,

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
@@ -18,4 +18,3 @@
 <a class="company-logo" [routerLink]="['']">
   <img i18n-alt="@@logo" [src]="logo" alt="Company logo" (error)="updateLogo()" />
 </a>
-<div class="m3-title-small">{{ title }}</div>

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.ts
@@ -24,8 +24,6 @@ import { RouterLink } from '@angular/router';
 })
 export class CompanyTitleComponent {
   @Input()
-  title: string = 'Developer Portal';
-  @Input()
   logo!: string;
 
   updateLogo() {

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="nav-bar__container">
-  <app-company-title [title]="siteTitle" [logo]="logo()" />
+  <app-company-title [logo]="logo()" />
   @if (!forceLogin() || isLoggedIn()) {
     @if (isMobile()) {
       <app-mobile-nav-bar [currentUser]="currentUser()" [customLinks]="customLinks()" />

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
@@ -34,5 +34,5 @@
   border-bottom: 1px solid app-theme.$nav-bar-border-color;
   background: app-theme.$nav-bar-background-color;
   box-shadow: app-theme.$nav-bar-elevation;
-  gap: 16px;
+  gap: 24px;
 }

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, inject, Input, input, InputSignal } from '@angular/core';
+import { Component, computed, inject, input, InputSignal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { isEmpty } from 'lodash';
 
@@ -31,9 +31,6 @@ import { MobileNavBarComponent } from './mobile-nav-bar/mobile-nav-bar.component
   styleUrls: ['./nav-bar.component.scss'],
 })
 export class NavBarComponent {
-  @Input()
-  siteTitle!: string;
-
   customLinks: InputSignal<PortalMenuLink[]> = input<PortalMenuLink[]>([]);
   currentUser: InputSignal<User> = input({});
   forceLogin: InputSignal<boolean> = input(false);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11822

## Description

Remove company title text from desktop nav bar in the NextGen Portal.
Note: the company title is still set in the `Title` object for Angular. This improves SEO performance and is non-visible.

Desktop:

<img width="1384" height="959" alt="Screenshot 2025-11-19 at 11 04 12" src="https://github.com/user-attachments/assets/4d0cba61-5744-4991-9be8-0baf29dbf2d3" />

Mobile:

<img width="421" height="700" alt="Screenshot 2025-11-19 at 10 40 29" src="https://github.com/user-attachments/assets/e16c32a7-4e96-49fd-b86a-e7c5e8bfb291" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

