### PR TITLE
APIM-11923 fix new portal services with mapi-v2

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -197,10 +197,12 @@ describe('PortalNavigationItemsComponent', () => {
     httpTestingController.expectOne('assets/mocks/portal-menu-links.json').flush({ data: [] });
   }
   function expectGetNavigationItems(response: PortalNavigationItemsResponse = fakePortalNavigationItemsResponse()) {
-    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items` }).flush(response);
+    httpTestingController
+      .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR` })
+      .flush(response);
   }
   function expectCreateNavigationItem(requestBody: NewPortalNavigationItem, result: PortalNavigationItem) {
-    const req = httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items` });
+    const req = httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items` });
     expect(req.request.body).toEqual(requestBody);
     req.flush(result);
   }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -168,7 +168,7 @@ export class PortalNavigationItemsComponent implements OnInit {
   }
 
   private refreshList(): Observable<PortalNavigationItem[]> {
-    return this.portalNavigationItemsService.getNavigationItems().pipe(
+    return this.portalNavigationItemsService.getNavigationItems('TOP_NAVBAR').pipe(
       map(({ items }) => {
         this.menuLinks = items;
         this.isEmpty = !this.menuLinks?.length;

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -48,13 +48,13 @@ describe('PortalNavigationItemService', () => {
   describe('getNavigationItems', () => {
     it('should call the API', (done) => {
       const fakeResponse = fakePortalNavigationItemsResponse();
-      service.getNavigationItems().subscribe((response) => {
+      service.getNavigationItems('TOP_NAVBAR').subscribe((response) => {
         expect(response).toMatchObject(fakeResponse);
         done();
       });
 
       httpTestingController
-        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items` })
+        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR` })
         .flush(fakeResponse);
     });
   });
@@ -72,7 +72,7 @@ describe('PortalNavigationItemService', () => {
 
       const req = httpTestingController.expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items`,
       });
       expect(req.request.body).toEqual(newPageItem);
       req.flush(fakeCreatedItem);
@@ -90,7 +90,7 @@ describe('PortalNavigationItemService', () => {
 
       const req = httpTestingController.expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items`,
       });
       expect(req.request.body).toEqual(newFolderItem);
       req.flush(fakeCreatedItem);
@@ -108,7 +108,7 @@ describe('PortalNavigationItemService', () => {
 
       const req = httpTestingController.expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/portal-navigation-items`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items`,
       });
       expect(req.request.body).toEqual(newLinkItem);
       req.flush(fakeCreatedItem);

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -18,7 +18,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { NewPortalNavigationItem, PortalNavigationItem, PortalNavigationItemsResponse } from '../entities/management-api-v2';
+import { NewPortalNavigationItem, PortalArea, PortalNavigationItem, PortalNavigationItemsResponse } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -29,11 +29,11 @@ export class PortalNavigationItemService {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
-  public getNavigationItems(): Observable<PortalNavigationItemsResponse> {
-    return this.http.get<PortalNavigationItemsResponse>(`${this.constants.env.baseURL}/portal-navigation-items`);
+  public getNavigationItems(portalArea: PortalArea): Observable<PortalNavigationItemsResponse> {
+    return this.http.get<PortalNavigationItemsResponse>(`${this.constants.env.v2BaseURL}/portal-navigation-items?area=${portalArea}`);
   }
 
   public createNavigationItem(newPortalNavigationItem: NewPortalNavigationItem): Observable<PortalNavigationItem> {
-    return this.http.post<PortalNavigationItem>(`${this.constants.env.baseURL}/portal-navigation-items`, newPortalNavigationItem);
+    return this.http.post<PortalNavigationItem>(`${this.constants.env.v2BaseURL}/portal-navigation-items`, newPortalNavigationItem);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.spec.ts
@@ -48,7 +48,7 @@ describe('PortalPageContentService', () => {
       });
 
       httpTestingController
-        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal-page-contents/${contentId}` })
+        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}` })
         .flush(fakePageContent);
     });
   });
@@ -65,7 +65,7 @@ describe('PortalPageContentService', () => {
 
       const req = httpTestingController.expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/portal-page-contents`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents`,
       });
       expect(req.request.body).toEqual(newPageContent);
       req.flush(fakeCreatedContent);

--- a/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.ts
@@ -30,10 +30,10 @@ export class PortalPageContentService {
   ) {}
 
   public getPageContent(contentId: string): Observable<PortalPageContent> {
-    return this.http.get<PortalPageContent>(`${this.constants.env.baseURL}/portal-page-contents/${contentId}`);
+    return this.http.get<PortalPageContent>(`${this.constants.env.v2BaseURL}/portal-page-contents/${contentId}`);
   }
 
   public createPageContent(newPortalPageContent: NewPortalPageContent): Observable<PortalPageContent> {
-    return this.http.post<PortalPageContent>(`${this.constants.env.baseURL}/portal-page-contents`, newPortalPageContent);
+    return this.http.post<PortalPageContent>(`${this.constants.env.v2BaseURL}/portal-page-contents`, newPortalPageContent);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11923

## Description

- Use mapi-v2 instead of mapi-v1
- Incorporate query param for `GET /portal-navigation-items`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

