### PR TITLE
fix: handle unexpected CLUSTER audit property for audit logs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
@@ -76,6 +76,7 @@ public class Audit {
         USER_FIELD,
         NOTIFICATION_TEMPLATE,
         SHARED_POLICY_GROUP,
+        CLUSTER,
     }
 
     private String id;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11977

## Description

After upgrading to 4.9.3, the Audit UI fails with a 500 error: `No enum constant io.gravitee.repository.management.model.Audit.AuditProperties.CLUSTER`.

The backend returns an audit entry containing the `CLUSTER` property, which is not declared in the AuditProperties enum. This causes enum parsing to throw an IllegalArgumentException, preventing the Audit API from responding correctly.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

