### PR TITLE
Update filters on measures analytics requests with empty filters to account for user permissions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -34,6 +34,7 @@ import inmemory.ParametersQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
+import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -906,5 +907,10 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public AnalyticsQueryFilterDecorator analyticsQueryFilterDecorator() {
+        return mock(AnalyticsQueryFilterDecorator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -37,6 +37,7 @@ import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
+import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
@@ -926,5 +927,10 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public AnalyticsQueryFilterDecorator analyticsQueryFilterDecorator() {
+        return mock(AnalyticsQueryFilterDecorator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -29,6 +29,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
+import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -1045,5 +1046,10 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public AnalyticsQueryFilterDecorator analyticsQueryFilterDecorator() {
+        return mock(AnalyticsQueryFilterDecorator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -28,6 +28,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
+import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -1006,5 +1007,10 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public AnalyticsQueryFilterDecorator analyticsQueryFilterDecorator() {
+        return mock(AnalyticsQueryFilterDecorator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/domain_service/AnalyticsQueryFilterDecorator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/domain_service/AnalyticsQueryFilterDecorator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.domain_service;
+
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface AnalyticsQueryFilterDecorator {
+    List<Filter> getUpdatedFilters(List<Filter> filters);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
+
+import static io.gravitee.rest.api.model.permissions.RolePermission.API_ANALYTICS;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
+
+import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.security.Principal;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Service
+@RequiredArgsConstructor
+public class AnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilterDecorator {
+
+    private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
+
+    private final ApiAuthorizationService apiAuthorizationService;
+
+    private final PermissionService permissionService;
+
+    @Override
+    public List<Filter> getUpdatedFilters(@NotNull List<Filter> filters) {
+        if (!filters.isEmpty()) {
+            return filters;
+        }
+
+        List<String> apiIds = this.findApiIds();
+
+        Filter f = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, apiIds);
+        filters.add(f);
+
+        return filters;
+    }
+
+    @NotNull
+    private List<String> findApiIds() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        if (isAdmin()) {
+            Set<String> idsByEnvironment = apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId());
+            return idsByEnvironment.stream().toList();
+        }
+
+        return apiAuthorizationService
+            .findIdsByUser(executionContext, getAuthenticatedUser(), false)
+            .stream()
+            .filter(appId -> permissionService.hasPermission(executionContext, API_ANALYTICS, appId, READ))
+            .toList();
+    }
+
+    protected boolean isAdmin() {
+        return isUserInRole(ORGANIZATION_ADMIN);
+    }
+
+    protected String getAuthenticatedUser() {
+        return getUserPrincipal().getName();
+    }
+
+    protected boolean isUserInRole(final String role) {
+        return SecurityContextHolder.getContext()
+            .getAuthentication()
+            .getAuthorities()
+            .stream()
+            .anyMatch(
+                (Predicate<GrantedAuthority>) grantedAuthority -> {
+                    String authority = grantedAuthority.getAuthority();
+                    return authority.equalsIgnoreCase(role);
+                }
+            );
+    }
+
+    protected Principal getUserPrincipal() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return (authentication instanceof AnonymousAuthenticationToken) ? null : authentication;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AbstractPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AbstractPermissionsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ContextConfiguration(classes = { ResourceContextConfiguration.class })
+@ExtendWith(SpringExtension.class)
+public abstract class AbstractPermissionsTest {
+
+    @Inject
+    PermissionService permissionService;
+
+    @Inject
+    ApiAuthorizationService apiAuthorizationService;
+
+    @Inject
+    AnalyticsQueryFilterDecoratorImpl analyticsQueryFilterDecorator;
+
+    static final Authentication authentication = mock(Authentication.class);
+
+    @BeforeEach
+    public void setUp() {
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    }
+
+    void setAuthenticatedUsername(String username) {
+        when(authentication.getName()).thenReturn(username);
+    }
+
+    void setAuthorities(GrantedAuthority... authorities) {
+        Collection authorityList = new ArrayList<>(Arrays.stream(authorities).toList());
+        when(authentication.getAuthorities()).thenReturn(authorityList);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
+
+import static io.gravitee.rest.api.model.permissions.RolePermission.API_ANALYTICS;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class AnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
+
+    List<String> allApiIds = List.of(
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        UUID.randomUUID().toString()
+    );
+
+    @Test
+    public void should_not_modify_non_enty_filter() {
+        var EqualityFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.EQ, "43985673406573406");
+        var filters = new ArrayList<>(Arrays.asList(EqualityFilter));
+
+        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+        assertThat(updatedFilters).isEqualTo(filters);
+    }
+
+    @Test
+    public void should_modify_empty_filter_when_user_is_org_admin() {
+        GrantedAuthority organizationAdmin = () -> "ORGANIZATION:ADMIN";
+        setAuthorities(organizationAdmin);
+
+        when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn(new HashSet<>(allApiIds));
+
+        var emptyFilters = new ArrayList<Filter>();
+        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+
+        assertThat(updatedFilters).singleElement();
+
+        var filter = updatedFilters.get(0);
+        assertThat(filter.name()).isEqualByComparingTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualByComparingTo(FilterSpec.Operator.IN);
+        assertThat((Iterable<String>) filter.value()).containsExactlyInAnyOrderElementsOf(allApiIds);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonAdminRoles")
+    public void should_modify_empty_filter_when_user_is_not_org_admin(String role) {
+        var user1 = "user1";
+
+        setAuthenticatedUsername(user1);
+        GrantedAuthority environmentUser = () -> role;
+        setAuthorities(environmentUser);
+
+        var user1ApiIds = allApiIds.subList(1, 6);
+        when(apiAuthorizationService.findIdsByUser(any(), eq(user1), anyBoolean())).thenReturn(new HashSet<>(user1ApiIds));
+
+        var apisUser1CanRead = user1ApiIds.subList(1, 3);
+        when(
+            permissionService.hasPermission(any(), eq(API_ANALYTICS), argThat(apiId -> apisUser1CanRead.contains(apiId)), eq(READ))
+        ).thenReturn(true);
+
+        var emptyFilters = new ArrayList<Filter>();
+        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+
+        assertThat(updatedFilters).singleElement();
+
+        var filter = updatedFilters.get(0);
+        assertThat(filter.name()).isEqualByComparingTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualByComparingTo(FilterSpec.Operator.IN);
+        assertThat((Iterable<String>) filter.value()).containsExactlyInAnyOrderElementsOf(apisUser1CanRead);
+    }
+
+    static Stream<String> nonAdminRoles() {
+        Set<String> roles = Arrays.stream(RolePermission.values())
+            .map(rolePermission -> String.format("%s:%s", rolePermission.getScope(), rolePermission.getPermission()))
+            .collect(Collectors.toSet());
+
+        roles.add("ENVIRONMENT:ADMIN");
+
+        return roles.stream();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
+
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ResourceContextConfiguration {
+
+    @Bean
+    public ApiAuthorizationService apiAuthorizationServiceV4() {
+        return mock(ApiAuthorizationService.class);
+    }
+
+    @Bean
+    public PermissionService permissionService() {
+        return mock(PermissionService.class);
+    }
+
+    @Bean
+    public AnalyticsQueryFilterDecoratorImpl analyticsQueryFilterDecorator(
+        ApiAuthorizationService apiAuthorizationServiceV4,
+        PermissionService permissionService
+    ) {
+        return new AnalyticsQueryFilterDecoratorImpl(apiAuthorizationServiceV4, permissionService);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1611

## Description

Added functionality to filter measures requests based on user permissions. For now, only requests with empty filters are updated, and they are filtered by the API IDs that the user making the request has access to.

- If a user is an **organization** admin, they will have access to all APIs in the **environment**. This seems weird (why not give env admins access to the env APIs?), but I'm keeping the logic as it is defined in other places.  This can be easily changed later if wanted. 
- If the user is not an org admin, the user can see metrics for APIs if:
  - ~He/she is an API manager. i.e., Role is not `RATING` or `RATING_ANSWER`, and the user has create, edit, or delete permission.~
  - ~AND,~ user has `API_ANALYTICS`- `READ` permission

**Notes**:
- This filter is independent of the metrics being requested. i.e., The filter applied will be the same independently of the metric(s) being requested.
- This is still in progress, and I need to add tests.
- [This](https://github.com/gravitee-io/gravitee-api-management/blob/ebcd05cff065739e25c6459dd666671cb00e1f99/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilter.java#L71-L86) code was copied from the SecurityContextFilter class. I'll refactor this later to avoid duplication.
- I kept the permission validations consistent with existing code.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->