### PR TITLE
refactor: allow user to reject promotion when versions mismatch

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResource.java
@@ -46,7 +46,7 @@ public class PromotionsResource extends AbstractResource {
     @Path("{promotionId}/_process")
     @Produces(MediaType.APPLICATION_JSON)
     public Response processPromotion(@PathParam("promotionId") String promotionId, boolean isAccepted) {
-        var promotionContext = promotionContextDomainService.getPromotionContext(promotionId);
+        var promotionContext = promotionContextDomainService.getPromotionContext(promotionId, isAccepted);
         var expectedDefinitionVersion = promotionContext.expectedDefinitionVersion();
         var promotion = promotionContext.promotion();
         var existingPromotedApi = promotionContext.existingPromotedApi();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/domain_service/PromotionContextDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/domain_service/PromotionContextDomainService.java
@@ -65,20 +65,20 @@ public class PromotionContextDomainService {
      * Once all V2 APIs are migrated and V2 no longer supported, this validation step can be removed,
      * and the promotion can be applied directly through the corresponding UseCase.
      */
-    public PromotionContext getPromotionContext(String promotionId) {
+    public PromotionContext getPromotionContext(String promotionId, boolean isAccepted) {
         var promotion = promotionCrudService.getById(promotionId);
         var api = apiCrudService.get(promotion.getApiId());
         var environment = environmentCrudService.getByCockpitId(promotion.getTargetEnvCockpitId());
         var targetApiOpt = apiQueryService.findByEnvironmentIdAndCrossId(environment.getId(), api.getCrossId());
         var expectedDefinitionVersion = getPromotionDefinitionVersion(promotion);
 
-        targetApiOpt.ifPresent(targetApi -> {
-            if (targetApi.getDefinitionVersion() != expectedDefinitionVersion) {
+        if (isAccepted && targetApiOpt.isPresent()) {
+            if (targetApiOpt.get().getDefinitionVersion() != expectedDefinitionVersion) {
                 throw new IllegalStateException(
                     "An API with the same crossId already exists with a different definition version in the target environment"
                 );
             }
-        });
+        }
 
         return new PromotionContext(promotion, expectedDefinitionVersion, targetApiOpt.orElse(null), environment.getId());
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3861

## Description

Allow users to reject promotion when API version mismatch. This is mainly an edge case where you ask for a promotion and before processing it the target API has been migrated in the target env. It let the opportunity to the source API to migrate too and redo a promotion or to the target API to rollback to a V2 API

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

