### PR TITLE
fix: negotiate subprotocol to establish connection

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
@@ -84,6 +84,17 @@ public class WebSocketConnector extends HttpConnector {
                 .rxWebSocket(webSocketConnectOptions)
                 .flatMap(endpointWebSocket -> {
                     endpointWebSocket.pause();
+
+                    endpointWebSocket
+                        .headers()
+                        .forEach((name, value) -> {
+                            ctx.response().headers().add(name, value);
+                        });
+
+                    for (CharSequence header : hopHeaders()) {
+                        ctx.response().headers().remove(header.toString());
+                    }
+
                     return request
                         .webSocket()
                         .upgrade()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11990

## Description

- Select a supported subprotocol from client-requested options
- Ensure Sec-WebSocket-Protocol header is set in server response
- Connection now successfully establishes with proper protocol

Issue:


https://github.com/user-attachments/assets/1d8fa4cd-cb11-4fae-8ef1-b3541efbf2ad

Fix:


https://github.com/user-attachments/assets/b08764ff-562d-4b04-8cba-7eaf167a5598


New fix with the changes suggested by Archi Team:



https://github.com/user-attachments/assets/6bd9d3f6-7e08-4be2-9724-b872119cd44a


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

