### PR TITLE
fix: api count not updating after deletion for federated apis

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/federation/FederatedApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/federation/FederatedApiEntity.java
@@ -67,7 +67,7 @@ public class FederatedApiEntity implements GenericApiEntity {
 
     private Set<String> groups;
 
-    private Visibility visibility;
+    private Visibility visibility = Visibility.PRIVATE;
 
     private PrimaryOwnerEntity primaryOwner;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -19,6 +19,7 @@ import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static org.apache.lucene.document.Field.Store.NO;
 import static org.apache.lucene.document.Field.Store.YES;
 
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.listener.ListenerType;
@@ -126,9 +127,10 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
         if (api.getDefinitionVersion() == null && api.getName() == null) {
             return doc;
         }
-
-        doc.add(new StringField(FIELD_STATUS, api.getState().name(), Field.Store.NO));
-        doc.add(new SortedDocValuesField(FIELD_STATUS_SORTED, toSortedValue(api.getState().name())));
+        if (api.getDefinitionVersion() != DefinitionVersion.FEDERATED) {
+            doc.add(new StringField(FIELD_STATUS, api.getState().name(), Field.Store.NO));
+            doc.add(new SortedDocValuesField(FIELD_STATUS_SORTED, toSortedValue(api.getState().name())));
+        }
 
         String portalStatus = api.getLifecycleState() == ApiLifecycleState.PUBLISHED
             ? ApiLifecycleState.PUBLISHED.name()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -16,6 +16,9 @@
 package io.gravitee.rest.api.service.impl.search.lucene.transformer;
 
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_STATUS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_STATUS_SORTED;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_VISIBILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.definition.model.DefinitionContext;
@@ -165,6 +168,23 @@ class ApiDocumentTransformerTest {
         Document doc = cut.transform(api);
         assertThat(doc.get("id")).isEqualTo(api.getId());
         assertThat(doc.get(FIELD_API_TYPE)).isEqualTo("V4_HTTP_PROXY");
+    }
+
+    @Test
+    void transform_api_entity_federated_verify_api_type() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(DefinitionVersion.FEDERATED);
+        api.setType(ApiType.PROXY);
+        List<Listener> listeners = List.of(HttpListener.builder().paths(List.of()).build());
+        api.setListeners(listeners);
+        api.setVisibility(Visibility.PUBLIC);
+        Document doc = cut.transform(api);
+        assertThat(doc.get("id")).isEqualTo(api.getId());
+        assertThat(doc.get(FIELD_VISIBILITY)).isEqualTo("PUBLIC");
+        assertThat(doc.get(FIELD_API_TYPE)).isEqualTo("FEDERATED");
+        assertThat(doc.get(FIELD_STATUS)).isNull();
+        assertThat(doc.get(FIELD_STATUS_SORTED)).isNull();
     }
 
     @Test


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-11972

## Description

Removed fields Status and Status Sorted from Lucene Document for federated APIs as API States are null for federated APIs. 

Set the default value of Visibility for federated APIs to Private, as if it is null, during transformation it fails with exception.

If the above 2 cases are not handled, when we try to delete a federated API it fails with exception.


https://github.com/user-attachments/assets/0ab01a75-26d3-42f1-900b-5ae4cdf2b7d6



