### PR TITLE
APIM 11507 add detailed policy tracing via OpenTelemetry events

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -248,6 +248,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
         ctx.setAttribute(ContextAttributes.ATTR_CONTEXT_PATH, ctx.request().contextPath());
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT, analyticsContext);
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ENABLED, analyticsContext.isTracingEnabled());
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED, tracingContext.isVerbose());
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_VALIDATE_SUBSCRIPTION, validateSubscriptionEnabled);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
@@ -104,6 +104,7 @@ public class TcpApiReactor extends AbstractApiReactor {
     public Completable handle(MutableExecutionContext ctx) {
         prepareCommonAttributes(ctx);
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ENABLED, analyticsContext.isTracingEnabled());
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED, tracingContext.isVerbose());
 
         // TODO specific Tcp API Request processor chain factory that contains SubscriptionProcessor in beforeApi chain
         return new CompletableReactorChain(handleEntrypointRequest(ctx))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
@@ -16,10 +16,15 @@
 package io.gravitee.gateway.reactive.policy.tracing;
 
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.hook.PolicyHook;
 import io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook;
+import io.gravitee.node.api.opentelemetry.Span;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -27,11 +32,59 @@ import java.util.Map;
  */
 public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook {
 
-    public static final String SPAN_POLICY_ATTR = "policy";
+    private static final String HOOK_ID = "hook-tracing-policy";
+
+    private static final String ATTR_SPAN_POLICY = "gravitee.policy";
+    private static final String ATTR_SPAN_POLICY_TRIGGER_EXECUTED = "gravitee.policy.trigger.executed";
+    private static final String ATTR_SPAN_POLICY_TRIGGER_CONDITION = "gravitee.policy.trigger.condition";
+    public static final String ATTR_POLICY_TRIGGER_CONDITION_PREFIX = "gravitee.policy.trigger.condition.";
+    private static final String EVENT_POLICY_PRE = "gravitee.policy.pre";
+    private static final String EVENT_POLICY_POST = "gravitee.policy.post";
+    private static final String ATTR_HTTP_REQUEST_HEADER_PREFIX = "http.request.header.";
+    private static final String ATTR_HTTP_RESPONSE_HEADER_PREFIX = "http.response.header.";
 
     @Override
     public String id() {
-        return "hook-tracing-policy";
+        return HOOK_ID;
+    }
+
+    @Override
+    public Completable pre(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
+        return super
+            .pre(id, ctx, executionPhase)
+            .doOnComplete(() -> {
+                if (isVerboseEnabled(ctx)) {
+                    addPreExecutionEvent(id, ctx, executionPhase);
+                }
+            });
+    }
+
+    @Override
+    public Completable post(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
+        return Completable.fromRunnable(() -> {
+            addTriggerAttributes(id, ctx);
+
+            if (isVerboseEnabled(ctx)) {
+                addPostExecutionEvent(id, ctx, executionPhase);
+            }
+            endSpan(id, ctx);
+        });
+    }
+
+    /**
+     * Add policy.trigger.condition and policy.trigger.executed attributes to the span.
+     * These must be added in post() because HttpConditionalPolicy stores the condition
+     * in the context during policy execution, after the span is created.
+     */
+    private void addTriggerAttributes(final String id, final HttpExecutionContext ctx) {
+        Span span = getSpan(ctx, id);
+        if (span != null) {
+            String triggerCondition = ctx.getInternalAttribute(ATTR_POLICY_TRIGGER_CONDITION_PREFIX + id);
+            if (triggerCondition != null && !triggerCondition.isBlank()) {
+                span.withAttribute(ATTR_SPAN_POLICY_TRIGGER_CONDITION, triggerCondition);
+            }
+            span.withAttribute(ATTR_SPAN_POLICY_TRIGGER_EXECUTED, "true");
+        }
     }
 
     @Override
@@ -50,7 +103,81 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
     @Override
     protected Map<String, String> spanAttributes(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
         Map<String, String> spanAttributes = super.spanAttributes(id, ctx, executionPhase);
-        spanAttributes.put(SPAN_POLICY_ATTR, id);
+        spanAttributes.put(ATTR_SPAN_POLICY, id);
         return spanAttributes;
+    }
+
+    private boolean isVerboseEnabled(final HttpExecutionContext ctx) {
+        Boolean verbose = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED);
+        return verbose != null && verbose;
+    }
+
+    private void addPreExecutionEvent(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
+        Span span = getSpan(ctx, id);
+        if (span != null) {
+            Map<String, Object> eventAttributes = captureEventAttributes(ctx, executionPhase);
+            span.addEvent(EVENT_POLICY_PRE, eventAttributes);
+        }
+    }
+
+    private void addPostExecutionEvent(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
+        Span span = getSpan(ctx, id);
+        if (span != null) {
+            Map<String, Object> eventAttributes = captureEventAttributes(ctx, executionPhase);
+            span.addEvent(EVENT_POLICY_POST, eventAttributes);
+        }
+    }
+
+    private Map<String, Object> captureEventAttributes(final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
+        Map<String, Object> eventAttributes = new LinkedHashMap<>();
+
+        if (executionPhase == ExecutionPhase.REQUEST && ctx.request() != null && ctx.request().headers() != null) {
+            Map<String, String> headers = captureHeaders(ctx.request().headers().toSingleValueMap());
+            headers.forEach((key, value) -> eventAttributes.put(ATTR_HTTP_REQUEST_HEADER_PREFIX + key, value));
+        } else if (executionPhase == ExecutionPhase.RESPONSE && ctx.response() != null && ctx.response().headers() != null) {
+            Map<String, String> headers = captureHeaders(ctx.response().headers().toSingleValueMap());
+            headers.forEach((key, value) -> eventAttributes.put(ATTR_HTTP_RESPONSE_HEADER_PREFIX + key, value));
+        }
+
+        if (ctx.getAttributes() != null) {
+            Map<String, String> attributes = captureContextAttributes(ctx);
+            attributes.forEach(eventAttributes::put);
+        }
+
+        return eventAttributes;
+    }
+
+    Map<String, String> captureHeaders(final Map<String, String> headers) {
+        Map<String, String> captured = new LinkedHashMap<>();
+        if (headers == null) {
+            return captured;
+        }
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String name = entry.getKey();
+            String value = entry.getValue();
+
+            if (value != null) {
+                captured.put(name, value);
+            }
+        }
+        return captured;
+    }
+
+    Map<String, String> captureContextAttributes(final HttpExecutionContext ctx) {
+        Map<String, String> captured = new LinkedHashMap<>();
+        Set<String> attributeNames = ctx.getAttributeNames();
+        if (attributeNames == null) {
+            return captured;
+        }
+
+        for (String name : attributeNames) {
+            Object value = ctx.getAttribute(name);
+            if (value != null) {
+                captured.put(name, String.valueOf(value));
+            }
+        }
+
+        return captured;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.policy.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
+import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TracingPolicyHookTest {
+
+    @Mock
+    private HttpExecutionContext ctx;
+
+    @Mock
+    private Tracer tracer;
+
+    @Mock
+    private Span span;
+
+    @Mock
+    private HttpRequest request;
+
+    @Mock
+    private HttpHeaders httpHeaders;
+
+    private TracingPolicyHook hook;
+
+    @BeforeEach
+    void setUp() {
+        hook = new TracingPolicyHook();
+    }
+
+    @Test
+    void shouldHaveCorrectId() {
+        assertThat(hook.id()).isEqualTo("hook-tracing-policy");
+    }
+
+    @Test
+    void shouldExecutePreHookWithoutVerbose() {
+        String policyId = "test-policy";
+        when(ctx.getTracer()).thenReturn(tracer);
+        when(tracer.startSpanFrom(any(InternalRequest.class))).thenReturn(span);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+
+        hook.pre(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(tracer).startSpanFrom(any(InternalRequest.class));
+        verify(span, never()).addEvent(anyString(), anyMap());
+    }
+
+    @Test
+    void shouldExecutePreHookWithVerbose() {
+        String policyId = "test-policy";
+        Map<String, String> singleValueMap = Map.of("content-type", "application/json");
+
+        when(ctx.getTracer()).thenReturn(tracer);
+        when(tracer.startSpanFrom(any(InternalRequest.class))).thenReturn(span);
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(httpHeaders);
+        when(httpHeaders.toSingleValueMap()).thenReturn(singleValueMap);
+        when(ctx.getAttributeNames()).thenReturn(Set.of("api.id"));
+        when(ctx.getAttribute("api.id")).thenReturn("test-api");
+
+        hook.pre(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(tracer).startSpanFrom(any(InternalRequest.class));
+        verify(span).addEvent(eq("gravitee.policy.pre"), anyMap());
+    }
+
+    @Test
+    void shouldExecutePostHookWithTriggerAttributes() {
+        String policyId = "test-policy";
+        String condition = "{#request.headers['x-test'] != null}";
+
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(condition);
+        lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+        when(ctx.getTracer()).thenReturn(tracer);
+
+        hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(span).withAttribute("gravitee.policy.trigger.condition", condition);
+        verify(span).withAttribute("gravitee.policy.trigger.executed", "true");
+        verify(tracer).end(span);
+    }
+
+    @Test
+    void shouldExecutePostHookWithVerbose() {
+        String policyId = "test-policy";
+        Map<String, String> headers = Map.of("header1", "value1", "header2", "value2");
+
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
+        lenient().when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(null);
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(httpHeaders);
+        when(httpHeaders.toSingleValueMap()).thenReturn(headers);
+        when(ctx.getAttributeNames()).thenReturn(Set.of("api.id"));
+        when(ctx.getAttribute("api.id")).thenReturn("test-api");
+        when(ctx.getTracer()).thenReturn(tracer);
+
+        hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(span).addEvent(eq("gravitee.policy.post"), anyMap());
+        verify(tracer).end(span);
+    }
+
+    @Test
+    void shouldNotAddTriggerConditionWhenBlank() {
+        String policyId = "test-policy";
+
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn("");
+        lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+        when(ctx.getTracer()).thenReturn(tracer);
+        hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(span, never()).withAttribute(eq("gravitee.policy.trigger.condition"), anyString());
+        verify(span).withAttribute("gravitee.policy.trigger.executed", "true");
+    }
+
+    @Test
+    void shouldCaptureAllHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("host", "localhost");
+        headers.put("authorization", "Bearer secret-token-12345");
+        headers.put("x-api-key", "secret-api-key-12345");
+        headers.put("content-type", "application/json");
+
+        Map<String, String> captured = hook.captureHeaders(headers);
+
+        assertEquals("hook-tracing-policy", hook.id());
+        assertEquals(4, captured.size());
+        assertEquals("localhost", captured.get("host"));
+        assertEquals("Bearer secret-token-12345", captured.get("authorization"));
+        assertEquals("secret-api-key-12345", captured.get("x-api-key"));
+        assertEquals("application/json", captured.get("content-type"));
+    }
+
+    @Test
+    void shouldHandleNullOrEmptyHeaders() {
+        Map<String, String> capturedFromNull = hook.captureHeaders(null);
+        assertNotNull(capturedFromNull);
+        assertTrue(capturedFromNull.isEmpty());
+
+        Map<String, String> capturedFromEmpty = hook.captureHeaders(new HashMap<>());
+        assertNotNull(capturedFromEmpty);
+        assertTrue(capturedFromEmpty.isEmpty());
+    }
+
+    @Test
+    void shouldSkipNullHeaderValues() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("valid-header", "value");
+        headers.put("null-header", null);
+
+        Map<String, String> captured = hook.captureHeaders(headers);
+
+        assertEquals(1, captured.size());
+        assertEquals("value", captured.get("valid-header"));
+        assertFalse(captured.containsKey("null-header"));
+    }
+
+    @Test
+    void shouldPreserveHeaderOrder() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("header-1", "value-1");
+        headers.put("header-2", "value-2");
+        headers.put("header-3", "value-3");
+
+        Map<String, String> captured = hook.captureHeaders(headers);
+        List<String> keys = new ArrayList<>(captured.keySet());
+
+        assertEquals("header-1", keys.get(0));
+        assertEquals("header-2", keys.get(1));
+        assertEquals("header-3", keys.get(2));
+    }
+
+    @Test
+    void shouldHandleDifferentTypeOfHeaders() {
+        String longValue = "x".repeat(1000);
+        Map<String, String> headers = Map.of(
+            "Content-Type",
+            "application/json",
+            "special-header",
+            "value with spaces & special @#$ chars",
+            "long-header",
+            longValue
+        );
+
+        Map<String, String> captured = hook.captureHeaders(headers);
+
+        assertEquals("application/json", captured.get("Content-Type"));
+        assertEquals("value with spaces & special @#$ chars", captured.get("special-header"));
+        assertEquals(longValue, captured.get("long-header"));
+    }
+
+    @Test
+    void shouldCaptureAllContextAttributes() {
+        when(ctx.getAttributeNames()).thenReturn(Set.of("user.password", "api.id", "app.secret", "user.id"));
+        when(ctx.getAttribute("user.password")).thenReturn("secret123");
+        when(ctx.getAttribute("api.id")).thenReturn("abc-123");
+        when(ctx.getAttribute("app.secret")).thenReturn("my-secret");
+        when(ctx.getAttribute("user.id")).thenReturn("user123");
+
+        Map<String, String> captured = hook.captureContextAttributes(ctx);
+
+        assertEquals("hook-tracing-policy", hook.id());
+        assertEquals(4, captured.size());
+        assertEquals("secret123", captured.get("user.password"));
+        assertEquals("abc-123", captured.get("api.id"));
+        assertEquals("my-secret", captured.get("app.secret"));
+        assertEquals("user123", captured.get("user.id"));
+    }
+
+    @Test
+    void shouldHandleNullAttributeNames() {
+        when(ctx.getAttributeNames()).thenReturn(null);
+
+        Map<String, String> captured = hook.captureContextAttributes(ctx);
+
+        assertNotNull(captured);
+        assertTrue(captured.isEmpty());
+    }
+
+    @Test
+    void shouldHandleEmptyAttributeNames() {
+        when(ctx.getAttributeNames()).thenReturn(Collections.emptySet());
+
+        Map<String, String> captured = hook.captureContextAttributes(ctx);
+
+        assertNotNull(captured);
+        assertTrue(captured.isEmpty());
+    }
+
+    @Test
+    void shouldSkipNullAttributeValue() {
+        when(ctx.getAttributeNames()).thenReturn(Set.of("null-attr", "valid-attr"));
+        when(ctx.getAttribute("null-attr")).thenReturn(null);
+        when(ctx.getAttribute("valid-attr")).thenReturn("value");
+
+        Map<String, String> captured = hook.captureContextAttributes(ctx);
+
+        assertEquals(1, captured.size());
+        assertFalse(captured.containsKey("null-attr"));
+        assertEquals("value", captured.get("valid-attr"));
+    }
+
+    @Test
+    void shouldHandleDifferentTypeOfAttributes() {
+        String longValue = "y".repeat(1000);
+        when(ctx.getAttribute("obj-attr")).thenReturn(new Object());
+        when(ctx.getAttributeNames()).thenReturn(Set.of("int-attr", "bool-attr", "obj-attr", "long-attr"));
+        when(ctx.getAttribute("int-attr")).thenReturn(123);
+        when(ctx.getAttribute("bool-attr")).thenReturn(true);
+        when(ctx.getAttribute("obj-attr")).thenReturn(new Object());
+        when(ctx.getAttribute("long-attr")).thenReturn(longValue);
+
+        Map<String, String> captured = hook.captureContextAttributes(ctx);
+
+        assertEquals("123", captured.get("int-attr"));
+        assertEquals("true", captured.get("bool-attr"));
+        assertNotNull(captured.get("obj-attr"));
+        assertEquals(longValue, captured.get("long-attr"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-exchange.version>1.9.1</gravitee-exchange.version>
         <gravitee-expression-language.version>4.2.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>4.1.0-alpha.6</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>4.1.0-APIM-11507-add-tracing-verbose-attribute-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.1.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.0</gravitee-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-exchange.version>1.9.1</gravitee-exchange.version>
         <gravitee-expression-language.version>4.2.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>4.1.0-APIM-11507-add-tracing-verbose-attribute-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>4.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.1.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.0</gravitee-kubernetes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11507

## Description

- Create OTel Span Events that display headers & attributes before & after a policy. (Payload not included)
- Includes message & proxy API types
- Includes all context attributes
- Span events (pre and post) for headers and selected context
- Span attributes for compact, filterable details such as the policy ID, the trigger condition, the execution status, etc.
- Follows OTel Naming conventions:
    - Prefix with "gravitee."
    - Custom attributes (for example added via assign attributes) remain same without any prefix/alteration
    - Headers are prefixed with http.request or http.response based on execution phase. This is also same as done in Kong/Tyk.

## Example Screenshots

### Consider below policy studio configuration:

- In Request phase: First assign attribute policy sets Attribute Customer to 1 based on a condition and second sets Customer to 2
- In Response Phase: Another attribute is added with Name Florent and value Remi

<img width="1646" height="887" alt="image" src="https://github.com/user-attachments/assets/b3ee4e56-61ba-484d-b8e5-8fb1bf81cfbd" />

### Trace:

<img width="701" height="566" alt="image" src="https://github.com/user-attachments/assets/37537ebe-d3d9-445a-ba03-bf05b7fc0d11" />

### Request Phase: First Assign Attribute policy: 
**Tags**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/640703f0-c9a0-4334-9b61-de2f12d45a17" />

**Pre:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/8f8c9c6f-3133-4d0f-9355-1858e6f34be0" />

**Post:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/18278e6e-d45b-4b2c-9fb7-b1b8454877d0" />

### Request Phase: Second Assign Attribute policy: 
**Tags**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/0d76a83f-e860-40d9-ab36-a99e9c0b3ac7" />

**Pre:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/e5e2f244-ec5a-4b0e-af99-b9a10702ee78" />

**Post:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/64d35961-4ddb-44fc-bb26-2792f51afb5c" />

### Response Phase:
**Tags**

<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/efd2412e-71f8-4d7d-814a-349812956428" />

**Pre:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/edf1cec1-bb1b-44d5-8dc6-91b0df40b615" />

**Post:**


<img width="1915" height="782" alt="image" src="https://github.com/user-attachments/assets/0d73028e-2fcd-4731-a98b-bd2a50cd5394" />

### The Gravitee headers vs headers from request look like:

<img width="921" height="219" alt="image" src="https://github.com/user-attachments/assets/d419b7a6-001f-4260-b93f-aaa703318606" />

### Similar for Message API as well

<img width="1910" height="791" alt="image" src="https://github.com/user-attachments/assets/ad077618-23e4-42af-a56c-2c70dbdd2a89" />

