### PR TITLE
chore(deps): update json-validation from 2.0.1 to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.11.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
-        <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
+        <gravitee-json-validation.version>2.1.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.6.1</gravitee-kubernetes.version>
         <gravitee-node.version>7.0.15</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11993

## Description

Introduced a caching mechanism within the JSON Schema Validator to significantly improve performance during API deployment and updates.

Previously, the validation process rebuilt the underlying JSON Schema object for every validation attempt. For APIs with complex configurations-specifically those containing a large number of Endpoint Groups (e.g., >900)-this resulted in excessive CPU usage and memory allocation. The validator now caches compiled schemas, eliminating redundant processing and drastically reducing the time required to validate complex API definitions.

## Additional context



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

