### PR TITLE
Update non-empty analytics API filters based on user permissions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryFilterDecorator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryFilterDecorator.java
@@ -22,5 +22,5 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface AnalyticsQueryFilterDecorator {
-    List<Filter> getUpdatedFilters(List<Filter> filters);
+    List<Filter> applyPermissionBasedFilters(List<Filter> filters);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
@@ -68,7 +68,7 @@ public class ComputeMeasuresUseCase {
     ) {
         var responses = new ArrayList<MeasuresResponse>();
         queryContext.forEach((queryService, request) -> {
-            List<Filter> updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(request.filters());
+            List<Filter> updatedFilters = analyticsQueryFilterDecorator.applyPermissionBasedFilters(request.filters());
             MeasuresRequest filteredRequest = new MeasuresRequest(request.timeRange(), updatedFilters, request.metrics());
             responses.add(queryService.searchMeasures(executionContext, filteredRequest));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/CollectionUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/CollectionUtils.java
@@ -27,6 +27,10 @@ public class CollectionUtils {
         return collection == null || collection.isEmpty();
     }
 
+    public static boolean isInitializedAndEmpty(Collection<?> collection) {
+        return collection != null && collection.isEmpty();
+    }
+
     public static boolean isNotEmpty(Collection<?> collection) {
         return !isEmpty(collection);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
@@ -22,6 +22,7 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
@@ -117,7 +118,7 @@ public class ApiAnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilte
     // If the wantedApiIds parameter is empty, an empty list will be returned.
     @NotNull
     private List<String> allowedApiIds(Set<String> wantedApiIds) {
-        if (wantedApiIds != null && wantedApiIds.isEmpty()) {
+        if (CollectionUtils.isInitializedAndEmpty(wantedApiIds)) {
             return List.of();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
@@ -47,6 +47,7 @@ import org.springframework.stereotype.Service;
 public class ApiAnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilterDecorator {
 
     private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
+    private static final String ENVIRONMENT_ADMIN = RoleScope.ENVIRONMENT.name() + ':' + SystemRole.ADMIN.name();
 
     private final ApiAuthorizationService apiAuthorizationService;
 
@@ -82,7 +83,7 @@ public class ApiAnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilte
     }
 
     protected boolean isAdmin() {
-        return isUserInRole(ORGANIZATION_ADMIN);
+        return isUserInRole(ORGANIZATION_ADMIN) || isUserInRole(ENVIRONMENT_ADMIN);
     }
 
     protected String getAuthenticatedUser() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Builder;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -191,6 +192,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
     @DisplayName("non-administrators see a subset of the metrics")
     class NonAdministratorUsers {
 
+        @Builder
         record EqTestArguments(
             String role,
             String wantedApiId,
@@ -310,9 +312,35 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         static Stream<EqTestArguments> eqTestParams() {
             return nonAdminRoles().mapMulti((role, consumer) -> {
-                consumer.accept(new EqTestArguments(role, apiId3, EQ, apiId3, "User has access to the ID requested"));
-                consumer.accept(new EqTestArguments(role, apiId7, IN, List.of(), "User doesn't have access to the ID requested"));
-                consumer.accept(new EqTestArguments(role, "invalid-api-id", IN, List.of(), "User requests invalid API ID"));
+                consumer.accept(
+                    EqTestArguments.builder()
+                        .description("User has access to the ID requested")
+                        .role(role)
+                        .wantedApiId(apiId3)
+                        .expectedOperator(EQ)
+                        .expectedApiIds(apiId3)
+                        .build()
+                );
+
+                consumer.accept(
+                    EqTestArguments.builder()
+                        .description("User doesn't have access to the API ID requested")
+                        .role(role)
+                        .wantedApiId(apiId7)
+                        .expectedOperator(IN)
+                        .expectedApiIds(List.of())
+                        .build()
+                );
+
+                consumer.accept(
+                    EqTestArguments.builder()
+                        .description("User requests an invalid API ID")
+                        .role(role)
+                        .wantedApiId("invalid-api-id")
+                        .expectedOperator(IN)
+                        .expectedApiIds(List.of())
+                        .build()
+                );
             });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -35,7 +35,6 @@ import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -201,6 +200,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
             String description
         ) {}
 
+        @Builder
         record InTestArguments(String role, List<String> wantedApiIds, List<String> expectedApiIds, String description) {}
 
         final String user = "testUser";
@@ -346,28 +346,40 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         static Stream<InTestArguments> inTestParams() {
             return nonAdminRoles().mapMulti((role, consumer) -> {
-                consumer.accept(new InTestArguments(role, List.of(), List.of(), "User requesting an empty list should get an empty list"));
                 consumer.accept(
-                    new InTestArguments(role, List.of(apiId3, apiId5), List.of(apiId3, apiId5), "User has access to the IDs requested")
+                    InTestArguments.builder()
+                        .description("User requesting an empty list should get an empty list")
+                        .role(role)
+                        .wantedApiIds(List.of())
+                        .expectedApiIds(List.of())
+                        .build()
                 );
+
                 consumer.accept(
-                    new InTestArguments(
-                        role,
-                        List.of(apiId7, apiId8),
-                        Collections.emptyList(),
-                        "User doesn't have access to the IDs requested"
-                    )
+                    InTestArguments.builder()
+                        .description("User has access to the API IDs requested")
+                        .role(role)
+                        .wantedApiIds(List.of(apiId3, apiId5))
+                        .expectedApiIds(List.of(apiId3, apiId5))
+                        .build()
                 );
+
                 consumer.accept(
-                    new InTestArguments(role, List.of(apiId3, apiId7), List.of(apiId3), "User has access to some if the IDs requested")
+                    InTestArguments.builder()
+                        .description("User doesn't have access to the API IDs requested")
+                        .role(role)
+                        .wantedApiIds(List.of(apiId7, apiId8))
+                        .expectedApiIds(List.of())
+                        .build()
                 );
+
                 consumer.accept(
-                    new InTestArguments(
-                        role,
-                        List.of(apiId3, apiId5, "invalid-api-id"),
-                        List.of(apiId3, apiId5),
-                        "User request some invalid IDs"
-                    )
+                    InTestArguments.builder()
+                        .description("User has access to some if the API IDs requested")
+                        .role(role)
+                        .wantedApiIds(List.of(apiId3, apiId5, "invalid-api-id"))
+                        .expectedApiIds(List.of(apiId3, apiId5))
+                        .build()
                 );
             });
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -56,7 +56,7 @@ import org.springframework.security.core.GrantedAuthority;
  * @author GraviteeSource Team
  */
 @DisplayName("analytics filters")
-public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
+class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
 
     static final String apiId1 = "api-id-1";
     static final String apiId2 = "api-id-2";
@@ -78,14 +78,14 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
     class AdministratorUsers {
 
         @BeforeEach
-        public void setUp() {
+        void setUp() {
             HashSet<String> set = new HashSet<>(allApiIds);
             when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn((Set<String>) set.clone(), (Set<String>) set.clone());
         }
 
         @ParameterizedTest
         @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
-        public void should_update_empty_filter_to_include_all_environment_ids(String role) {
+        void should_update_empty_filter_to_include_all_environment_ids(String role) {
             GrantedAuthority organizationAdmin = () -> role;
             setAuthorities(organizationAdmin);
 
@@ -105,7 +105,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
-        public void should_allow_access_to_single_api(String role) {
+        void should_allow_access_to_single_api(String role) {
             GrantedAuthority organizationAdmin = () -> role;
             setAuthorities(organizationAdmin);
 
@@ -119,7 +119,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
-        public void should_not_allow_access_to_unknown_api_id(String role) {
+        void should_not_allow_access_to_unknown_api_id(String role) {
             GrantedAuthority organizationAdmin = () -> role;
             setAuthorities(organizationAdmin);
 
@@ -134,7 +134,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
-        public void should_update_filter_list_to_include_only_valid_api_ids(String role) {
+        void should_update_filter_list_to_include_only_valid_api_ids(String role) {
             GrantedAuthority organizationAdmin = () -> role;
             setAuthorities(organizationAdmin);
 
@@ -155,7 +155,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
-        public void should_update_multiple_filters(String role) {
+        void should_update_multiple_filters(String role) {
             GrantedAuthority organizationAdmin = () -> role;
             setAuthorities(organizationAdmin);
 
@@ -173,7 +173,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
         }
 
         @Test
-        public void should_not_change_unsupported_filters() {
+        void should_not_change_unsupported_filters() {
             GrantedAuthority organizationAdmin = () -> environmentAdminRole;
             setAuthorities(organizationAdmin);
 
@@ -209,7 +209,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
         final List<String> apisUserCanRead = Arrays.asList(apiId3, apiId4, apiId5);
 
         @BeforeEach
-        public void setUp() {
+        void setUp() {
             setAuthenticatedUsername(user);
 
             when(permissionService.hasPermission(any(), eq(API_ANALYTICS), argThat(apisUserCanRead::contains), eq(READ))).thenReturn(true);
@@ -233,7 +233,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("nonAdminRoles")
-        public void should_update_empty_filter_to_include_allowed_ids(String role) {
+        void should_update_empty_filter_to_include_allowed_ids(String role) {
             GrantedAuthority environmentUser = () -> role;
             setAuthorities(environmentUser);
 
@@ -253,7 +253,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("eqTestParams")
-        public void should_allow_access_to_single_api(EqTestArguments args) {
+        void should_allow_access_to_single_api(EqTestArguments args) {
             GrantedAuthority environmentUser = () -> args.role;
             setAuthorities(environmentUser);
 
@@ -273,7 +273,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("inTestParams")
-        public void should_update_filter_list_to_include_only_valid_api_ids(InTestArguments args) {
+        void should_update_filter_list_to_include_only_valid_api_ids(InTestArguments args) {
             GrantedAuthority environmentUser = () -> args.role;
             setAuthorities(environmentUser);
 
@@ -293,7 +293,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("nonAdminRoles")
-        public void should_update_multiple_filters(String role) {
+        void should_update_multiple_filters(String role) {
             GrantedAuthority environmentUser = () -> role;
             setAuthorities(environmentUser);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -15,6 +15,11 @@
  */
 package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
 
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name.API;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.EQ;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.GTE;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.LTE;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_ANALYTICS;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,101 +31,326 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
 import org.springframework.security.core.GrantedAuthority;
 
 /**
  * @author GraviteeSource Team
  */
+@DisplayName("analytics filters")
 public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
 
-    List<String> allApiIds = List.of(
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString(),
-        UUID.randomUUID().toString()
-    );
+    static final String apiId1 = "api-id-1";
+    static final String apiId2 = "api-id-2";
+    static final String apiId3 = "api-id-3";
+    static final String apiId4 = "api-id-4";
+    static final String apiId5 = "api-id-5";
+    static final String apiId6 = "api-id-6";
+    static final String apiId7 = "api-id-7";
+    static final String apiId8 = "api-id-8";
+    static final String apiId9 = "api-id-9";
 
-    @Test
-    public void should_not_modify_non_enty_filter() {
-        var EqualityFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.EQ, "43985673406573406");
-        var filters = new ArrayList<>(Arrays.asList(EqualityFilter));
+    static final String organizationAdminRole = "ORGANIZATION:ADMIN";
+    static final String environmentAdminRole = "ENVIRONMENT:ADMIN";
 
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+    static List<String> allApiIds = List.of(apiId1, apiId2, apiId3, apiId4, apiId5, apiId6, apiId7, apiId8, apiId9);
 
-        assertThat(updatedFilters).isEqualTo(filters);
+    @Nested
+    @DisplayName("administrators can see all environment metrics")
+    class AdministratorUsers {
+
+        @BeforeEach
+        public void setUp() {
+            HashSet<String> set = new HashSet<>(allApiIds);
+            when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn((Set<String>) set.clone(), (Set<String>) set.clone());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
+        public void should_update_empty_filter_to_include_all_environment_ids(String role) {
+            GrantedAuthority organizationAdmin = () -> role;
+            setAuthorities(organizationAdmin);
+
+            var emptyFilters = new ArrayList<Filter>();
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+
+            assertThat(updatedFilters)
+                .singleElement()
+                .satisfies(filter -> {
+                    assertThat(filter.name()).isEqualTo(API);
+                    assertThat(filter.operator()).isEqualTo(IN);
+                    assertThat(filter.value())
+                        .asInstanceOf(InstanceOfAssertFactories.ITERABLE)
+                        .containsExactlyInAnyOrderElementsOf(allApiIds);
+                });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
+        public void should_allow_access_to_single_api(String role) {
+            GrantedAuthority organizationAdmin = () -> role;
+            setAuthorities(organizationAdmin);
+
+            var EqualityFilter = new Filter(API, EQ, apiId7);
+            List<Filter> filters = List.of(EqualityFilter);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            assertThat(updatedFilters).isEqualTo(filters);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
+        public void should_not_allow_access_to_unknown_api_id(String role) {
+            GrantedAuthority organizationAdmin = () -> role;
+            setAuthorities(organizationAdmin);
+
+            var EqualityFilter = new Filter(API, EQ, "invalid-api-id");
+            List<Filter> filters = List.of(EqualityFilter);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            var emptyFilter = new Filter(API, IN, List.of());
+            assertThat(updatedFilters).isEqualTo(List.of(emptyFilter));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
+        public void should_update_filter_list_to_include_only_valid_api_ids(String role) {
+            GrantedAuthority organizationAdmin = () -> role;
+            setAuthorities(organizationAdmin);
+
+            var filters = List.of(new Filter(API, IN, List.of(apiId1, apiId3, apiId7, "invalid-api-id")));
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            var allowedApiIds = List.of(apiId1, apiId3, apiId7);
+            assertThat(updatedFilters)
+                .singleElement()
+                .satisfies(filter -> {
+                    assertThat(filter.name()).isEqualTo(API);
+                    assertThat(filter.operator()).isEqualTo(IN);
+                    assertThat(filter.value())
+                        .asInstanceOf(InstanceOfAssertFactories.ITERABLE)
+                        .containsExactlyInAnyOrderElementsOf(allowedApiIds);
+                });
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { organizationAdminRole, environmentAdminRole })
+        public void should_update_multiple_filters(String role) {
+            GrantedAuthority organizationAdmin = () -> role;
+            setAuthorities(organizationAdmin);
+
+            var equalityFilter1 = new Filter(API, EQ, apiId5);
+            var equalityFilter2 = new Filter(API, EQ, "invalid-api-id");
+            var listFilter = new Filter(API, IN, List.of(apiId7, "invalid-api-id"));
+
+            List<Filter> filters = List.of(equalityFilter1, listFilter, equalityFilter2);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            assertThat(updatedFilters).size().isEqualTo(3);
+            assertThat(updatedFilters.get(0)).isEqualTo(equalityFilter1);
+            assertThat(updatedFilters.get(1)).isEqualTo(new Filter(API, IN, List.of(apiId7)));
+        }
+
+        @Test
+        public void should_not_change_unsupported_filters() {
+            GrantedAuthority organizationAdmin = () -> environmentAdminRole;
+            setAuthorities(organizationAdmin);
+
+            var filter1 = new Filter(API, LTE, "some-value");
+            var filter2 = new Filter(API, GTE, "other-value");
+            List<Filter> filters = List.of(filter1, filter2);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            assertThat(updatedFilters).isEqualTo(filters);
+        }
     }
 
-    @Test
-    public void should_modify_empty_filter_when_user_is_org_admin() {
-        GrantedAuthority organizationAdmin = () -> "ORGANIZATION:ADMIN";
-        setAuthorities(organizationAdmin);
+    @Nested
+    @DisplayName("non-administrators see a subset of the metrics")
+    class NonAdministratorUsers {
 
-        when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn(new HashSet<>(allApiIds));
+        record eqTestArguments(
+            String role,
+            String wantedApiId,
+            FilterSpec.Operator expectedOperator,
+            Object expectedApiIds,
+            String description
+        ) {}
 
-        var emptyFilters = new ArrayList<Filter>();
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+        record inTestArguments(String role, List<String> wantedApiIds, List<String> expectedApiIds, String description) {}
 
-        assertThat(updatedFilters).singleElement();
+        final String user = "testUser";
 
-        var filter = updatedFilters.get(0);
-        assertThat(filter.name()).isEqualByComparingTo(FilterSpec.Name.API);
-        assertThat(filter.operator()).isEqualByComparingTo(FilterSpec.Operator.IN);
-        assertThat((Iterable<String>) filter.value()).containsExactlyInAnyOrderElementsOf(allApiIds);
-    }
+        final List<String> apisUserIsAMemberOf = Arrays.asList(apiId1, apiId2, apiId3, apiId4, apiId5);
+        final List<String> apisUserCanRead = Arrays.asList(apiId3, apiId4, apiId5);
 
-    @ParameterizedTest
-    @MethodSource("nonAdminRoles")
-    public void should_modify_empty_filter_when_user_is_not_org_admin(String role) {
-        var user1 = "user1";
+        @BeforeEach
+        public void setUp() {
+            setAuthenticatedUsername(user);
 
-        setAuthenticatedUsername(user1);
-        GrantedAuthority environmentUser = () -> role;
-        setAuthorities(environmentUser);
+            when(permissionService.hasPermission(any(), eq(API_ANALYTICS), argThat(apisUserCanRead::contains), eq(READ))).thenReturn(true);
 
-        var user1ApiIds = allApiIds.subList(1, 6);
-        when(apiAuthorizationService.findIdsByUser(any(), eq(user1), anyBoolean())).thenReturn(new HashSet<>(user1ApiIds));
+            when(apiAuthorizationService.findIdsByUser(any(), eq(user), any(), anyBoolean())).thenAnswer(
+                (Answer<Set<String>>) invocation -> {
+                    var query = (ApiQuery) invocation.getArgument(2);
 
-        var apisUser1CanRead = user1ApiIds.subList(1, 3);
-        when(
-            permissionService.hasPermission(any(), eq(API_ANALYTICS), argThat(apiId -> apisUser1CanRead.contains(apiId)), eq(READ))
-        ).thenReturn(true);
+                    if (query.getIds() == null) {
+                        return new HashSet<>(apisUserIsAMemberOf);
+                    }
 
-        var emptyFilters = new ArrayList<Filter>();
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+                    if (query.getIds().isEmpty()) {
+                        return new HashSet<>();
+                    }
 
-        assertThat(updatedFilters).singleElement();
+                    return new HashSet<>(query.getIds());
+                }
+            );
+        }
 
-        var filter = updatedFilters.get(0);
-        assertThat(filter.name()).isEqualByComparingTo(FilterSpec.Name.API);
-        assertThat(filter.operator()).isEqualByComparingTo(FilterSpec.Operator.IN);
-        assertThat((Iterable<String>) filter.value()).containsExactlyInAnyOrderElementsOf(apisUser1CanRead);
-    }
+        @ParameterizedTest
+        @MethodSource("nonAdminRoles")
+        public void should_update_empty_filter_to_include_allowed_ids(String role) {
+            GrantedAuthority environmentUser = () -> role;
+            setAuthorities(environmentUser);
 
-    static Stream<String> nonAdminRoles() {
-        Set<String> roles = Arrays.stream(RolePermission.values())
-            .map(rolePermission -> String.format("%s:%s", rolePermission.getScope(), rolePermission.getPermission()))
-            .collect(Collectors.toSet());
+            var emptyFilters = new ArrayList<Filter>();
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
 
-        roles.add("ENVIRONMENT:ADMIN");
+            assertThat(updatedFilters)
+                .singleElement()
+                .satisfies(filter -> {
+                    assertThat(filter.name()).isEqualTo(API);
+                    assertThat(filter.operator()).isEqualTo(IN);
+                    assertThat(filter.value())
+                        .asInstanceOf(InstanceOfAssertFactories.ITERABLE)
+                        .containsExactlyInAnyOrderElementsOf(apisUserCanRead);
+                });
+        }
 
-        return roles.stream();
+        @ParameterizedTest
+        @MethodSource("eqTestParams")
+        public void should_allow_access_to_single_api(eqTestArguments args) {
+            GrantedAuthority environmentUser = () -> args.role;
+            setAuthorities(environmentUser);
+
+            var filter = new Filter(API, EQ, args.wantedApiId);
+            List<Filter> filters = List.of(filter);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            assertThat(updatedFilters)
+                .singleElement()
+                .satisfies(f -> {
+                    assertThat(f.name()).isEqualTo(API);
+                    assertThat(f.operator()).isEqualTo(args.expectedOperator);
+                    assertThat(f.value()).isEqualTo(args.expectedApiIds);
+                });
+        }
+
+        @ParameterizedTest
+        @MethodSource("inTestParams")
+        public void should_update_filter_list_to_include_only_valid_api_ids(inTestArguments args) {
+            GrantedAuthority environmentUser = () -> args.role;
+            setAuthorities(environmentUser);
+
+            var filter = new Filter(API, IN, args.wantedApiIds);
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(List.of(filter));
+
+            assertThat(updatedFilters)
+                .singleElement()
+                .satisfies(f -> {
+                    assertThat(f.name()).isEqualTo(API);
+                    assertThat(f.operator()).isEqualTo(IN);
+                    assertThat(f.value())
+                        .asInstanceOf(InstanceOfAssertFactories.ITERABLE)
+                        .containsExactlyInAnyOrderElementsOf(args.expectedApiIds);
+                });
+        }
+
+        @ParameterizedTest
+        @MethodSource("nonAdminRoles")
+        public void should_update_multiple_filters(String role) {
+            GrantedAuthority environmentUser = () -> role;
+            setAuthorities(environmentUser);
+
+            var equalityFilter1 = new Filter(API, EQ, apiId4);
+            var equalityFilter2 = new Filter(API, EQ, "invalid-api-id");
+            var listFilter = new Filter(API, IN, List.of(apiId3, apiId7));
+            List<Filter> filters = List.of(equalityFilter1, equalityFilter2, listFilter);
+
+            var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
+
+            assertThat(updatedFilters).size().isEqualTo(3);
+            assertThat(updatedFilters.get(0)).isEqualTo(equalityFilter1);
+            assertThat(updatedFilters.get(1)).isEqualTo(new Filter(API, IN, List.of()));
+            assertThat(updatedFilters.get(2)).isEqualTo(new Filter(API, IN, List.of(apiId3)));
+        }
+
+        static Stream<eqTestArguments> eqTestParams() {
+            return nonAdminRoles().mapMulti((role, consumer) -> {
+                consumer.accept(new eqTestArguments(role, apiId3, EQ, apiId3, "User has access to the ID requested"));
+                consumer.accept(new eqTestArguments(role, apiId7, IN, List.of(), "User doesn't have access to the ID requested"));
+                consumer.accept(new eqTestArguments(role, "invalid-api-id", IN, List.of(), "User requests invalid API ID"));
+            });
+        }
+
+        static Stream<inTestArguments> inTestParams() {
+            return nonAdminRoles().mapMulti((role, consumer) -> {
+                consumer.accept(new inTestArguments(role, List.of(), List.of(), "User requesting an empty list should get an empty list"));
+                consumer.accept(
+                    new inTestArguments(role, List.of(apiId3, apiId5), List.of(apiId3, apiId5), "User has access to the IDs requested")
+                );
+                consumer.accept(
+                    new inTestArguments(
+                        role,
+                        List.of(apiId7, apiId8),
+                        Collections.emptyList(),
+                        "User doesn't have access to the IDs requested"
+                    )
+                );
+                consumer.accept(
+                    new inTestArguments(role, List.of(apiId3, apiId7), List.of(apiId3), "User has access to some if the IDs requested")
+                );
+                consumer.accept(
+                    new inTestArguments(
+                        role,
+                        List.of(apiId3, apiId5, "invalid-api-id"),
+                        List.of(apiId3, apiId5),
+                        "User request some invalid IDs"
+                    )
+                );
+            });
+        }
+
+        // Returns all roles defined in RolePermission formated as SCOPE:PERMISSION
+        static Stream<String> nonAdminRoles() {
+            Set<String> roles = Arrays.stream(RolePermission.values())
+                .map(rolePermission -> String.format("%s:%s", rolePermission.getScope(), rolePermission.getPermission()))
+                .collect(Collectors.toSet());
+
+            return roles.stream();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -191,7 +191,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
     @DisplayName("non-administrators see a subset of the metrics")
     class NonAdministratorUsers {
 
-        record eqTestArguments(
+        record EqTestArguments(
             String role,
             String wantedApiId,
             FilterSpec.Operator expectedOperator,
@@ -199,7 +199,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
             String description
         ) {}
 
-        record inTestArguments(String role, List<String> wantedApiIds, List<String> expectedApiIds, String description) {}
+        record InTestArguments(String role, List<String> wantedApiIds, List<String> expectedApiIds, String description) {}
 
         final String user = "testUser";
 
@@ -251,7 +251,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("eqTestParams")
-        public void should_allow_access_to_single_api(eqTestArguments args) {
+        public void should_allow_access_to_single_api(EqTestArguments args) {
             GrantedAuthority environmentUser = () -> args.role;
             setAuthorities(environmentUser);
 
@@ -271,7 +271,7 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
 
         @ParameterizedTest
         @MethodSource("inTestParams")
-        public void should_update_filter_list_to_include_only_valid_api_ids(inTestArguments args) {
+        public void should_update_filter_list_to_include_only_valid_api_ids(InTestArguments args) {
             GrantedAuthority environmentUser = () -> args.role;
             setAuthorities(environmentUser);
 
@@ -308,22 +308,22 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
             assertThat(updatedFilters.get(2)).isEqualTo(new Filter(API, IN, List.of(apiId3)));
         }
 
-        static Stream<eqTestArguments> eqTestParams() {
+        static Stream<EqTestArguments> eqTestParams() {
             return nonAdminRoles().mapMulti((role, consumer) -> {
-                consumer.accept(new eqTestArguments(role, apiId3, EQ, apiId3, "User has access to the ID requested"));
-                consumer.accept(new eqTestArguments(role, apiId7, IN, List.of(), "User doesn't have access to the ID requested"));
-                consumer.accept(new eqTestArguments(role, "invalid-api-id", IN, List.of(), "User requests invalid API ID"));
+                consumer.accept(new EqTestArguments(role, apiId3, EQ, apiId3, "User has access to the ID requested"));
+                consumer.accept(new EqTestArguments(role, apiId7, IN, List.of(), "User doesn't have access to the ID requested"));
+                consumer.accept(new EqTestArguments(role, "invalid-api-id", IN, List.of(), "User requests invalid API ID"));
             });
         }
 
-        static Stream<inTestArguments> inTestParams() {
+        static Stream<InTestArguments> inTestParams() {
             return nonAdminRoles().mapMulti((role, consumer) -> {
-                consumer.accept(new inTestArguments(role, List.of(), List.of(), "User requesting an empty list should get an empty list"));
+                consumer.accept(new InTestArguments(role, List.of(), List.of(), "User requesting an empty list should get an empty list"));
                 consumer.accept(
-                    new inTestArguments(role, List.of(apiId3, apiId5), List.of(apiId3, apiId5), "User has access to the IDs requested")
+                    new InTestArguments(role, List.of(apiId3, apiId5), List.of(apiId3, apiId5), "User has access to the IDs requested")
                 );
                 consumer.accept(
-                    new inTestArguments(
+                    new InTestArguments(
                         role,
                         List.of(apiId7, apiId8),
                         Collections.emptyList(),
@@ -331,10 +331,10 @@ public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermission
                     )
                 );
                 consumer.accept(
-                    new inTestArguments(role, List.of(apiId3, apiId7), List.of(apiId3), "User has access to some if the IDs requested")
+                    new InTestArguments(role, List.of(apiId3, apiId7), List.of(apiId3), "User has access to some if the IDs requested")
                 );
                 consumer.accept(
-                    new inTestArguments(
+                    new InTestArguments(
                         role,
                         List.of(apiId3, apiId5, "invalid-api-id"),
                         List.of(apiId3, apiId5),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1611

## Description

Implemented code to update measures analytics requests with non-empty filters.
The following filters will be updated if:
- They are filtering by API ID
- AND, The filter is an `EQ` or `IN` filter. `LTE` or `GTE` filters are left as is.

This code will iterate over every filter, perform the checks mentioned above and update the filter as follows.
- If filter is `EQ` and the user doesn't have access to the API, the user should get no results.
- If filter is `EQ` and the user has access to the API, metrics will be returned.
- If filter is `IN` and it's empty, no metrics will be returned (user is asking for nothing).
- If filter is `IN` and has some IDs, metrics will be returned only for the IDs that the user is allowed to access.

**Questions:**
- Can users use `LTE` or `GTE` filters when filtering by API ID? I don't think this is valid since it doesn't make sense to compare IDs.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

