### PR TITLE
Rename and relocate analytics filter decorator components

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -34,7 +34,7 @@ import inmemory.ParametersQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -37,7 +37,7 @@ import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -29,7 +29,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -28,7 +28,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryFilterDecorator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryFilterDecorator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.analytics.domain_service;
+package io.gravitee.apim.core.analytics_engine.domain_service;
 
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import java.util.List;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.core.analytics_engine.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AnalyticsQueryFilterDecoratorImpl.java
@@ -18,7 +18,7 @@ package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_ANALYTICS;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 
-import io.gravitee.apim.core.analytics.domain_service.AnalyticsQueryFilterDecorator;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryFilterDecorator;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.rest.api.model.permissions.RoleScope;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public class AnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilterDecorator {
+public class ApiAnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilterDecorator {
 
     private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AbstractPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/AbstractPermissionsTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractPermissionsTest {
     ApiAuthorizationService apiAuthorizationService;
 
     @Inject
-    AnalyticsQueryFilterDecoratorImpl analyticsQueryFilterDecorator;
+    ApiAnalyticsQueryFilterDecoratorImpl apiAnalyticsQueryFilterDecorator;
 
     static final Authentication authentication = mock(Authentication.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImplTest.java
@@ -37,14 +37,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.security.core.GrantedAuthority;
 
 /**
  * @author GraviteeSource Team
  */
-public class AnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
+public class ApiAnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTest {
 
     List<String> allApiIds = List.of(
         UUID.randomUUID().toString(),
@@ -64,7 +63,7 @@ public class AnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTe
         var EqualityFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.EQ, "43985673406573406");
         var filters = new ArrayList<>(Arrays.asList(EqualityFilter));
 
-        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(filters);
+        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(filters);
 
         assertThat(updatedFilters).isEqualTo(filters);
     }
@@ -77,7 +76,7 @@ public class AnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTe
         when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn(new HashSet<>(allApiIds));
 
         var emptyFilters = new ArrayList<Filter>();
-        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
 
         assertThat(updatedFilters).singleElement();
 
@@ -105,7 +104,7 @@ public class AnalyticsQueryFilterDecoratorImplTest extends AbstractPermissionsTe
         ).thenReturn(true);
 
         var emptyFilters = new ArrayList<Filter>();
-        var updatedFilters = analyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
+        var updatedFilters = apiAnalyticsQueryFilterDecorator.getUpdatedFilters(emptyFilters);
 
         assertThat(updatedFilters).singleElement();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
@@ -36,10 +36,10 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public AnalyticsQueryFilterDecoratorImpl analyticsQueryFilterDecorator(
+    public ApiAnalyticsQueryFilterDecoratorImpl apiAnalyticsQueryFilterDecorator(
         ApiAuthorizationService apiAuthorizationServiceV4,
         PermissionService permissionService
     ) {
-        return new AnalyticsQueryFilterDecoratorImpl(apiAuthorizationServiceV4, permissionService);
+        return new ApiAnalyticsQueryFilterDecoratorImpl(apiAuthorizationServiceV4, permissionService);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1611

## Description

- Renamed `AnalyticsQueryFilterDecoratorImpl` to `ApiAnalyticsQueryFilterDecoratorImpl` to clarify its purpose.

- Moved the `AnalyticsQueryFilterDecorator` interface under the `analytics_engine` package for consistency.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->