### PR TITLE
fix(test): truncate TimeProvider to fix flaky tests

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TimeProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TimeProvider.java
@@ -45,7 +45,7 @@ public class TimeProvider {
     private final String yesterdayWithDot;
 
     public TimeProvider() {
-        now = Instant.now().minus(30, ChronoUnit.MINUTES);
+        now = Instant.now().minus(30, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
         final Instant yesterday = now.minus(1, ChronoUnit.DAYS);
 
         dateToday = DATE_FORMATTER_WITH_DASH.format(now);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11969

## Description

Truncate TimeProvider timestamp to fix flaky test.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

