### PR TITLE
fix: preserve generic notification data during upgrade

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcGenericNotificationConfigRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcGenericNotificationConfigRepositoryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.model.GenericNotificationConfig;
+import io.gravitee.repository.management.model.NotificationReferenceType;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.core.RowMapper;
+
+public class JdbcGenericNotificationConfigRepositoryTest {
+
+    private JdbcGenericNotificationConfigRepository repository = new JdbcGenericNotificationConfigRepository("table_prefix_");
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    @SneakyThrows
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        Field field = JdbcAbstractRepository.class.getDeclaredField("jdbcTemplate");
+        field.setAccessible(true);
+        field.set(repository, jdbcTemplate);
+        field.setAccessible(false);
+    }
+
+    @Test
+    void findAll_shouldLoadHooks() throws Exception {
+        GenericNotificationConfig config = GenericNotificationConfig.builder()
+            .id("config1")
+            .name("Config 1")
+            .notifier("email")
+            .referenceType(NotificationReferenceType.API)
+            .referenceId("api1")
+            .organizationId("org1")
+            .build();
+
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class))).thenReturn(List.of(config));
+        doAnswer(inv -> {
+            config.setHooks(List.of("HOOK_1"));
+            return null;
+        })
+            .when(jdbcTemplate)
+            .query(contains("generic_notification_config_hooks"), any(RowCallbackHandler.class));
+
+        Set<GenericNotificationConfig> result = repository.findAll();
+        assertThat(result).hasSize(1);
+        GenericNotificationConfig cfg = result.iterator().next();
+        assertThat(cfg.getHooks()).containsExactly("HOOK_1");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GenericNotificationConfigRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GenericNotificationConfigRepositoryTest.java
@@ -139,6 +139,25 @@ public class GenericNotificationConfigRepositoryTest extends AbstractManagementR
     }
 
     @Test
+    public void shouldFindAll() throws Exception {
+        var configs = genericNotificationConfigRepository.findAll();
+        assertNotNull(configs);
+        assertFalse(configs.isEmpty());
+        assertEquals(9, configs.size());
+
+        var notifToFind = configs
+            .stream()
+            .filter(c -> "notif-to-find".equals(c.getId()))
+            .findFirst()
+            .orElseThrow();
+
+        assertNotNull(notifToFind.getHooks());
+        assertEquals(2, notifToFind.getHooks().size());
+        assertTrue(notifToFind.getHooks().contains("A"));
+        assertTrue(notifToFind.getHooks().contains("B"));
+    }
+
+    @Test
     public void shouldFindByHookAndReference() throws Exception {
         List<GenericNotificationConfig> configs = genericNotificationConfigRepository.findByReferenceAndHook(
             "B",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11698

## Description

Notification data is split across two tables, but the upgrader still used a generic findAll() method that only fetched data from the parent table. Because it didn’t load the child table content, the upgrader processed incomplete entities and effectively erased the missing child data during update handling.

