### PR TITLE
fix: always consume the request body to update the metrics

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -142,7 +142,9 @@ public class HttpConnector implements ProxyConnector {
                                 .map(buffer -> new io.vertx.rxjava3.core.buffer.Buffer(BufferImpl.buffer(buffer.getNativeBuffer())))
                         );
                     } else {
-                        return httpClientRequest.rxSend();
+                        // Consume the empty body from the downstream and send the request to the upstream.
+                        // This ensures that any resources associated with the downstream request body are properly released and metrics are kept up to date.
+                        return request.chunks().ignoreElements().andThen(httpClientRequest.rxSend());
                     }
                 })
                 .doOnSuccess(endpointResponse -> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12021

## Description

This PR ensures that, even in the case of an empty body request, the flow is still consumed so every resource is properly released and metrics updated.
