### PR TITLE
Replace unmaintained Bitnami Legacy Kafka with secure SolDevelo alternative

### DIFF
--- a/docker/quick-setup/kafka-console/docker-compose.yml
+++ b/docker/quick-setup/kafka-console/docker-compose.yml
@@ -194,7 +194,7 @@ services:
       - KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINPASSWORD=admin
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     container_name: gio_apim_kafka
     volumes:
       - data-kafka:/bitnami/kafka

--- a/docker/quick-setup/native-kafka/docker-compose.yml
+++ b/docker/quick-setup/native-kafka/docker-compose.yml
@@ -201,7 +201,7 @@ services:
       - email
 
   kafka:
-    image: docker.io/bitnamilegacy/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     container_name: gio_apim_kafka
     volumes:
       - data-kafka:/bitnami/kafka
@@ -275,7 +275,7 @@ services:
       - kafka
 
   kafka-client:
-    image: docker.io/bitnamilegacy/kafka:3.9
+    image: docker.io/soldevelo/kafka:3.9
     container_name: gio_apim_kafka-client
     volumes:
       - ./.kafka-client-config:/app/config


### PR DESCRIPTION
## Description

This PR updates the Docker Compose configurations in `docker/quick-setup/` to replace the deprecated `bitnamilegacy/kafka:3.9` image with `soldevelo/kafka:3.9`.

### Context
The current configuration uses `bitnamilegacy` images. As these images are hosted in a legacy repository, they are effectively frozen and **no longer receive security updates or maintenance**, posing a security risk for users deploying these quick-setup environments.

### Solution
I have switched the image references to **`soldevelo/kafka:3.9`**.

This image serves as a secure, actively maintained drop-in replacement.
**Crucially for this project**, it preserves the `/opt/bitnami/kafka` directory structure. This ensures that the existing volume mapping in `kafka-console/docker-compose.yml` continues to work without modification.