### PR TITLE
refractor(analytics): Add v2 prefix to tabs name

### DIFF
--- a/gravitee-apim-console-webui/src/management/analytics/env-analytics-layout.component.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-analytics-layout.component.ts
@@ -20,13 +20,13 @@ import { Component } from '@angular/core';
   template: `
     <nav mat-tab-nav-bar class="navigation-tabs" [tabPanel]="tabPanel">
       <a mat-tab-link routerLinkActive #rla1="routerLinkActive" [active]="rla1.isActive" routerLink="dashboard"
-        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:dashboard-dots"></mat-icon> Dashboard</a
+        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:dashboard-dots"></mat-icon> V2 Dashboard</a
       >
       <a mat-tab-link routerLinkActive #rla2="routerLinkActive" [active]="rla2.isActive" routerLink="logs"
-        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:table-rows"></mat-icon> Logs</a
+        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:table-rows"></mat-icon> V2 Logs</a
       >
       <a mat-tab-link routerLinkActive #rla3="routerLinkActive" [active]="rla3.isActive" routerLink="dashboard-v4"
-        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:dashboard-dots"></mat-icon> Analytics (beta)</a
+        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:dashboard-dots"></mat-icon> V4 Dashboard</a
       >
     </nav>
     <mat-tab-nav-panel #tabPanel>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1592

## Description

Add v2 suffixe to analytics tab

## Additional context
 
<img width="2036" height="1010" alt="Screenshot 2025-11-25 at 14 56 27" src="https://github.com/user-attachments/assets/acfa89b1-718b-4d19-95ba-76f3fbc6c340" />


