### PR TITLE
fix: make search case-insensitive for ownerName, accessPath

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -62,25 +62,18 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
 
     public static final String FIELD_API_TYPE_VALUE = "api";
 
-    private static final Map<String, Float> API_FIELD_BOOST = Map.of(
-        FIELD_NAME,
-        20.0f,
-        FIELD_NAME_LOWERCASE,
-        20.0f,
-        FIELD_NAME_SPLIT,
-        18.0f,
-        FIELD_PATHS,
-        10.0f,
-        FIELD_HOSTS,
-        10.0f,
-        FIELD_LABELS,
-        8.0f,
-        FIELD_DESCRIPTION,
-        5.0f,
-        FIELD_METADATA,
-        4.0f,
-        FIELD_TAGS,
-        1.0f
+    private static final Map<String, Float> API_FIELD_BOOST = Map.ofEntries(
+        Map.entry(FIELD_NAME, 20.0f),
+        Map.entry(FIELD_NAME_LOWERCASE, 20.0f),
+        Map.entry(FIELD_NAME_SPLIT, 18.0f),
+        Map.entry(FIELD_PATHS, 10.0f),
+        Map.entry(FIELD_PATHS_LOWERCASE, 10.0f),
+        Map.entry(FIELD_HOSTS, 10.0f),
+        Map.entry(FIELD_HOSTS_LOWERCASE, 10.0f),
+        Map.entry(FIELD_LABELS, 8.0f),
+        Map.entry(FIELD_DESCRIPTION, 5.0f),
+        Map.entry(FIELD_METADATA, 4.0f),
+        Map.entry(FIELD_TAGS, 1.0f)
     );
 
     private static final String[] API_FIELD_SEARCH = new String[] {
@@ -93,6 +86,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_DESCRIPTION_LOWERCASE,
         FIELD_DESCRIPTION_SPLIT,
         FIELD_OWNER,
+        FIELD_OWNER_LOWERCASE,
         FIELD_LABELS,
         FIELD_LABELS_SPLIT,
         FIELD_TAGS,
@@ -100,8 +94,10 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_CATEGORIES,
         FIELD_CATEGORIES_SPLIT,
         FIELD_PATHS,
+        FIELD_PATHS_LOWERCASE,
         FIELD_PATHS_SPLIT,
         FIELD_HOSTS,
+        FIELD_HOSTS_LOWERCASE,
         FIELD_HOSTS_SPLIT,
         FIELD_METADATA,
         FIELD_METADATA_SPLIT,
@@ -400,7 +396,6 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         if (FIELD_CATEGORIES.equals(term.field())) {
             text = formatCategoryField(term.text());
         } else if (
-            !FIELD_PATHS.equals(term.field()) &&
             !FIELD_TAGS.equals(term.field()) &&
             !FIELD_ORIGIN.equals(term.field()) &&
             !FIELD_HAS_HEALTH_CHECK.equals(term.field()) &&
@@ -446,10 +441,15 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
                 .add(new BoostQuery(toWildcard(FIELD_NAME, token), 12.0f), BooleanClause.Occur.SHOULD)
                 .add(new BoostQuery(toWildcard(FIELD_NAME_LOWERCASE, token.toLowerCase()), 10.0f), BooleanClause.Occur.SHOULD)
                 .add(new BoostQuery(toWildcard(FIELD_PATHS, token), 8.0f), BooleanClause.Occur.SHOULD)
+                .add(new BoostQuery(toWildcard(FIELD_PATHS_LOWERCASE, token.toLowerCase()), 7.0f), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_DESCRIPTION, token), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_DESCRIPTION_LOWERCASE, token.toLowerCase()), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_HOSTS, token), BooleanClause.Occur.SHOULD)
+                .add(toWildcard(FIELD_HOSTS_LOWERCASE, token.toLowerCase()), BooleanClause.Occur.SHOULD)
+                .add(toWildcard(FIELD_OWNER, token), BooleanClause.Occur.SHOULD)
+                .add(toWildcard(FIELD_OWNER_LOWERCASE, token.toLowerCase()), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_LABELS, token), BooleanClause.Occur.SHOULD)
+                .add(toWildcard(FIELD_LABELS_LOWERCASE, token.toLowerCase()), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_CATEGORIES, token), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_TAGS, token), BooleanClause.Occur.SHOULD)
                 .add(toWildcard(FIELD_METADATA, token), BooleanClause.Occur.SHOULD);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -86,7 +86,9 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
     public static final String FIELD_CREATED_AT = "createdAt";
     public static final String FIELD_UPDATED_AT = "updatedAt";
     public static final String FIELD_PATHS = "paths";
+    public static final String FIELD_PATHS_LOWERCASE = "paths_lowercase";
     public static final String FIELD_HOSTS = "hosts";
+    public static final String FIELD_HOSTS_LOWERCASE = "hosts_lowercase";
     public static final String FIELD_PATHS_SORTED = "paths_sorted";
     public static final String FIELD_PATHS_SPLIT = "paths_split";
     public static final String FIELD_HOSTS_SPLIT = "hosts_split";
@@ -272,9 +274,11 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
 
     private void appendPath(final Document doc, final int[] pathIndex, final String host, final String path) {
         doc.add(new StringField(FIELD_PATHS, path, NO));
+        doc.add(new StringField(FIELD_PATHS_LOWERCASE, path.toLowerCase(), NO));
         doc.add(new TextField(FIELD_PATHS_SPLIT, path, NO));
         if (host != null && !host.isEmpty()) {
             doc.add(new StringField(FIELD_HOSTS, host, NO));
+            doc.add(new StringField(FIELD_HOSTS_LOWERCASE, host.toLowerCase(), NO));
             doc.add(new TextField(FIELD_HOSTS_SPLIT, host, NO));
         }
         if (pathIndex[0]++ == 0) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -234,6 +234,7 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
 
     private void appendPath(final Document doc, final int[] pathIndex, final String path) {
         doc.add(new StringField(FIELD_PATHS, path, Field.Store.NO));
+        doc.add(new StringField(FIELD_PATHS_LOWERCASE, path.toLowerCase(), Field.Store.NO));
         doc.add(new TextField(FIELD_PATHS_SPLIT, path, Field.Store.NO));
         if (pathIndex[0]++ == 0) {
             doc.add(new SortedDocValuesField(FIELD_PATHS_SORTED, toSortedValue(path)));
@@ -243,6 +244,7 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
     private void appendHost(Document doc, String host) {
         if (host != null && !host.isEmpty()) {
             doc.add(new StringField(FIELD_HOSTS, host, Field.Store.NO));
+            doc.add(new StringField(FIELD_HOSTS_LOWERCASE, host.toLowerCase(), Field.Store.NO));
             doc.add(new TextField(FIELD_HOSTS_SPLIT, host, Field.Store.NO));
         }
     }
@@ -316,9 +318,11 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
 
     private void appendPath(final Document doc, final int[] pathIndex, final String host, final String path) {
         doc.add(new StringField(FIELD_PATHS, path, Field.Store.NO));
+        doc.add(new StringField(FIELD_PATHS_LOWERCASE, path.toLowerCase(), Field.Store.NO));
         doc.add(new TextField(FIELD_PATHS_SPLIT, path, Field.Store.NO));
         if (host != null && !host.isEmpty()) {
             doc.add(new StringField(FIELD_HOSTS, host, Field.Store.NO));
+            doc.add(new StringField(FIELD_HOSTS_LOWERCASE, host.toLowerCase(), Field.Store.NO));
             doc.add(new TextField(FIELD_HOSTS_SPLIT, host, Field.Store.NO));
         }
         if (pathIndex[0]++ == 0) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
@@ -176,8 +176,10 @@ public class SearchEngineServiceTest {
             GraviteeContext.getExecutionContext(),
             QueryBuilder.create(ApiEntity.class).setQuery("Owner 3").setFilters(filters).build()
         );
-        assertThat(matches.getHits()).isEqualTo(2);
-        assertThat(matches.getDocuments()).containsExactly("api-3", "api-4");
+        assertThat(matches.getHits()).isEqualTo(5);
+        List<String> results = new ArrayList<>(matches.getDocuments());
+        assertThat(results.get(0)).isIn("api-3", "api-4");
+        assertThat(results.get(1)).isIn("api-3", "api-4");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
@@ -53,7 +53,7 @@ public class ApiDocumentSearcherTest {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         assertThat(searcher.completeQueryWithFilters(query, builder)).isEmpty();
         assertThat(builder.build()).hasToString(
-            "#(+(categories:\"sports\" categories:sports)) +(+((name:*Cycling*)^20.0 (name_lowercase:*cycling*)^18.0 (name_sorted:*cycling*)^15.0 (name:*Cycling*)^12.0 (name_lowercase:*cycling*)^10.0 (paths:*Cycling*)^8.0 description:*Cycling* description_lowercase:*cycling* hosts:*Cycling* labels:*Cycling* categories:*Cycling* tags:*Cycling* metadata:*Cycling*))"
+            "#(+(categories:\"sports\" categories:sports)) +(+((name:*Cycling*)^20.0 (name_lowercase:*cycling*)^18.0 (name_sorted:*cycling*)^15.0 (name:*Cycling*)^12.0 (name_lowercase:*cycling*)^10.0 (paths:*Cycling*)^8.0 (paths_lowercase:*cycling*)^7.0 description:*Cycling* description_lowercase:*cycling* hosts:*Cycling* hosts_lowercase:*cycling* ownerName:*Cycling* ownerName_lowercase:*cycling* labels:*Cycling* labels_lowercase:*cycling* categories:*Cycling* tags:*Cycling* metadata:*Cycling*))"
         );
     }
 
@@ -71,5 +71,37 @@ public class ApiDocumentSearcherTest {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         assertThat(searcher.completeQueryWithFilters(query, builder)).isEmpty();
         assertThat(builder.build()).hasToString("#(has_health_check:\"true\" has_health_check:true)");
+    }
+
+    @Test
+    public void should_convert_description_to_lowercase() {
+        var query = QueryBuilder.create(ApiEntity.class).setQuery("description:TestValue").build();
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        assertThat(searcher.completeQueryWithFilters(query, builder)).isEmpty();
+        assertThat(builder.build()).hasToString("#(description_lowercase:\"testvalue\" description_lowercase:testvalue)");
+    }
+
+    @Test
+    public void should_convert_owner_to_lowercase() {
+        var query = QueryBuilder.create(ApiEntity.class).setQuery("ownerName:JohnDoe").build();
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        assertThat(searcher.completeQueryWithFilters(query, builder)).isEmpty();
+        assertThat(builder.build()).hasToString("#(ownerName_lowercase:\"johndoe\" ownerName_lowercase:johndoe)");
+    }
+
+    @Test
+    public void should_convert_labels_to_lowercase() {
+        var query = QueryBuilder.create(ApiEntity.class).setQuery("labels:MyLabel").build();
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        assertThat(searcher.completeQueryWithFilters(query, builder)).isEmpty();
+        assertThat(builder.build()).hasToString("#(labels_lowercase:\"mylabel\" labels_lowercase:mylabel)");
+    }
+
+    @Test
+    public void should_include_paths_lowercase_in_text_search() {
+        var query = QueryBuilder.create(ApiEntity.class).setQuery("TestPath").build();
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        String remaining = searcher.completeQueryWithFilters(query, builder);
+        assertThat(remaining).isEqualTo("TestPath");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -195,6 +195,24 @@ class ApiDocumentTransformerTest {
         assertThat(doc.get(FIELD_API_TYPE)).isEqualTo("V2");
     }
 
+    @Test
+    void transform_v4_api_should_index_paths_and_hosts_lowercase() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setType(ApiType.PROXY);
+        api.setVisibility(Visibility.PUBLIC);
+
+        io.gravitee.definition.model.v4.listener.http.Path path = new io.gravitee.definition.model.v4.listener.http.Path();
+        path.setPath("/TestPath");
+        path.setHost("api.TestHost.com");
+
+        api.setListeners(List.of(HttpListener.builder().paths(List.of(path)).build()));
+        Document doc = cut.transform(api);
+        assertThat(doc.getFields("paths_lowercase")[0].stringValue()).isEqualTo("/testpath");
+        assertThat(doc.getFields("hosts_lowercase")[0].stringValue()).isEqualTo("api.testhost.com");
+    }
+
     @Nested
     class HasHealthCheck {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -333,6 +333,36 @@ public class IndexableApiDocumentTransformerTest {
     }
 
     @Test
+    void should_index_v4_api_paths_and_hosts_lowercase() {
+        var api = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id(API_ID)
+            .apiDefinitionHttpV4(
+                io.gravitee.definition.model.v4.Api.builder()
+                    .listeners(
+                        List.of(
+                            io.gravitee.definition.model.v4.listener.http.HttpListener.builder()
+                                .paths(
+                                    List.of(
+                                        io.gravitee.definition.model.v4.listener.http.Path.builder()
+                                            .path("/TestPath")
+                                            .host("api.TestHost.com")
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                    )
+                    .build()
+            )
+            .build();
+        var indexable = new IndexableApi(api, PRIMARY_OWNER, Map.of(), Set.of());
+        var result = cut.transform(indexable);
+        assertThat(result.getFields("paths_lowercase")[0].stringValue()).isEqualTo("/testpath");
+        assertThat(result.getFields("hosts_lowercase")[0].stringValue()).isEqualTo("api.testhost.com");
+    }
+
+    @Test
     void should_sort_names_by_bytesref() throws Exception {
         List<String> names = List.of("Nano", "zorro", "äther", "Vem", "épée", "épona", "Öko", "bns");
         List<String> expectedSorted = List.of("äther", "bns", "épée", "épona", "Nano", "Öko", "Vem", "zorro");


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-11931

## Description

The API search was failing when queries were entered in a different case (e.g. uppercase vs lowercase). Updated search logic to perform case-insensitive matching for ownerName, accessPath, and pathName fields.

Also added tests to validate case-insensitive behavior.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

