### PR TITLE
Update analytics API filters to always include the list of allowed APIs.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ApiAnalyticsQueryFilterDecoratorImpl.java
@@ -56,8 +56,8 @@ public class ApiAnalyticsQueryFilterDecoratorImpl implements AnalyticsQueryFilte
     private final PermissionService permissionService;
 
     @Override
-    public Map<String, AnalyticsQueryFilterDecorator.API> getAllowedApis() {
-        Map<String, API> allowedApis = new HashMap<>();
+    public Map<String, API> getAllowedApis() {
+        var allowedApis = new HashMap<String, API>();
 
         var executionContext = GraviteeContext.getExecutionContext();
         if (isEnvironmentAdmin()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ListAllowedApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ListAllowedApisTest.java
@@ -65,7 +65,7 @@ class ListAllowedApisTest extends AbstractTest {
     static final String apiId3 = "api-id-3";
     static final String apiId4 = "api-id-4";
 
-    static List<String> environmentIds = List.of(apiId1, apiId2, apiId3, apiId4);
+    static List<String> environmentApiIds = List.of(apiId1, apiId2, apiId3, apiId4);
 
     @BeforeEach
     public void setUp() {
@@ -76,7 +76,7 @@ class ListAllowedApisTest extends AbstractTest {
     void should_allow_administrators_access_to_all_environment_APIs() {
         var environmentAdminRole = "ENVIRONMENT:ADMIN";
 
-        when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn(Set.copyOf(environmentIds));
+        when(apiAuthorizationService.findIdsByEnvironment("DEFAULT")).thenReturn(Set.copyOf(environmentApiIds));
 
         GrantedAuthority organizationAdmin = () -> environmentAdminRole;
         setAuthorities(organizationAdmin);
@@ -84,7 +84,7 @@ class ListAllowedApisTest extends AbstractTest {
         var allowedApis = apiAnalyticsQueryFilterDecorator.getAllowedApis();
 
         var apiIds = allowedApis.keySet();
-        assertThat(apiIds).containsExactlyInAnyOrderElementsOf(environmentIds);
+        assertThat(apiIds).containsExactlyInAnyOrderElementsOf(environmentApiIds);
     }
 
     @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/PermissionBasedFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/PermissionBasedFilterTest.java
@@ -16,45 +16,47 @@
 package io.gravitee.apim.infra.domain_service.analytics_engine.permissions;
 
 import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name.API;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.EQ;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.GTE;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.LTE;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name.APPLICATION;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.apim.core.analytics_engine.model.Filter;
-import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
-import lombok.Builder;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author GraviteeSource Team
  */
 class PermissionBasedFilterTest extends AbstractTest {
 
-    static final String apiId1 = "api-id-1";
-    static final String apiId2 = "api-id-2";
-    static final String apiId11 = "api-id-11";
-    static final String apiId12 = "api-id-12";
+    static final String allowedApi1 = "api-id-1";
+    static final String allowedApi2 = "api-id-2";
+    static final String forbiddenApi1 = "api-id-11";
+    static final String forbiddenApi2 = "api-id-12";
 
-    static Set<String> allowedApiIds = Set.of(apiId1, apiId2);
-
-    @Builder
-    record EqTestArguments(String wantedApiId, FilterSpec.Operator expectedOperator, Object expectedApiIds) {}
-
-    @Builder
-    record InTestArguments(List<String> wantedApiIds, List<String> expectedApiIds) {}
+    static Set<String> allowedApiIds = Set.of(allowedApi1, allowedApi2);
 
     @Test
-    void should_update_empty_filter_to_include_all_allowed_ids() {
+    void usrers_without_API_access_should_not_see_any_data() {
+        var filter = new Filter(API, EQ, forbiddenApi2);
+
+        var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(List.of(filter), Collections.emptySet());
+
+        assertThat(updatedFilters).size().isEqualTo(2);
+        assertThat(updatedFilters).contains(filter);
+        assertThat(updatedFilters.getLast()).satisfies(f -> {
+            assertThat(f.name()).isEqualTo(API);
+            assertThat(f.operator()).isEqualTo(IN);
+            assertThat(f.value()).asInstanceOf(InstanceOfAssertFactories.ITERABLE).containsExactlyInAnyOrderElementsOf(List.of());
+        });
+    }
+
+    @Test
+    void should_update_empty_API_filter_to_include_all_allowed_ids() {
         var emptyFilters = new ArrayList<Filter>();
         var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(emptyFilters, allowedApiIds);
 
@@ -71,106 +73,23 @@ class PermissionBasedFilterTest extends AbstractTest {
 
     @Test
     void should_update_multiple_filters() {
-        var equalityFilter1 = new Filter(API, EQ, apiId1);
-        var listFilter = new Filter(API, IN, List.of(apiId2, apiId11, "invalid-api-id"));
-        var equalityFilter2 = new Filter(API, EQ, "invalid-api-id");
+        var equalityFilter1 = new Filter(API, EQ, allowedApi1);
+        var listFilter = new Filter(API, IN, List.of(allowedApi2, forbiddenApi1));
+        var equalityFilter2 = new Filter(API, EQ, forbiddenApi2);
+        var lteFilter = new Filter(API, LTE, "some-value");
+        var gteFilter = new Filter(API, GTE, "other-value");
+        var appplicationFilter = new Filter(APPLICATION, EQ, "some-app");
 
-        var filters = List.of(equalityFilter1, listFilter, equalityFilter2);
-
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(filters, allowedApiIds);
-
-        assertThat(updatedFilters).containsExactly(equalityFilter1, new Filter(API, IN, List.of(apiId2)), new Filter(API, IN, List.of()));
-    }
-
-    @Test
-    void should_not_change_unsupported_filters() {
-        var filter1 = new Filter(API, LTE, "some-value");
-        var filter2 = new Filter(API, GTE, "other-value");
-
-        var filters = List.of(filter1, filter2);
+        var filters = List.of(equalityFilter1, listFilter, equalityFilter2, lteFilter, gteFilter, appplicationFilter);
 
         var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(filters, allowedApiIds);
 
-        assertThat(updatedFilters).isEqualTo(filters);
-    }
-
-    @ParameterizedTest
-    @MethodSource("eqTestParams")
-    void should_allow_access_to_single_api(EqTestArguments args) {
-        var filter = new Filter(API, EQ, args.wantedApiId);
-
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(List.of(filter), allowedApiIds);
-
-        assertThat(updatedFilters)
-            .singleElement()
-            .satisfies(f -> {
-                assertThat(f.name()).isEqualTo(API);
-                assertThat(f.operator()).isEqualTo(args.expectedOperator);
-                assertThat(f.value()).isEqualTo(args.expectedApiIds);
-            });
-    }
-
-    @ParameterizedTest
-    @MethodSource("inTestParams")
-    void should_update_filter_list_to_include_only_valid_api_ids(InTestArguments args) {
-        var filter = new Filter(API, IN, args.wantedApiIds);
-
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(List.of(filter), allowedApiIds);
-
-        assertThat(updatedFilters)
-            .singleElement()
-            .satisfies(f -> {
-                assertThat(f.name()).isEqualTo(API);
-                assertThat(f.operator()).isEqualTo(IN);
-                assertThat(f.value())
-                    .asInstanceOf(InstanceOfAssertFactories.ITERABLE)
-                    .containsExactlyInAnyOrderElementsOf(args.expectedApiIds);
-            });
-    }
-
-    @Test
-    void should_throw_exception_when_IN_filter_is_not_an_iterable() {
-        var filters = List.of(new Filter(API, IN, 1));
-
-        assertThatThrownBy(() -> apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(filters, allowedApiIds))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Filter value must be an Iterable");
-    }
-
-    @Test
-    void should_handle_non_string_values_in_IN_filter() {
-        var filters = List.of(new Filter(API, IN, List.of(apiId2, true, 6)));
-
-        var updatedFilters = apiAnalyticsQueryFilterDecorator.applyPermissionBasedFilters(filters, allowedApiIds);
-
-        var expectedFilter = new Filter(API, IN, List.of(apiId2));
-        assertThat(updatedFilters).containsExactly(expectedFilter);
-    }
-
-    static Stream<EqTestArguments> eqTestParams() {
-        return Stream.of(
-            // User has access to the ID requested
-            EqTestArguments.builder().wantedApiId(apiId1).expectedOperator(EQ).expectedApiIds(apiId1).build(),
-            // User doesn't have access to the API ID requested
-            EqTestArguments.builder().wantedApiId(apiId11).expectedOperator(IN).expectedApiIds(List.of()).build(),
-            // User requests an invalid API ID
-            EqTestArguments.builder().wantedApiId("invalid-api-id").expectedOperator(IN).expectedApiIds(List.of()).build()
-        );
-    }
-
-    static Stream<InTestArguments> inTestParams() {
-        return Stream.of(
-            // User requesting an empty list should get an empty list
-            InTestArguments.builder().wantedApiIds(List.of()).expectedApiIds(List.of()).build(),
-            // User has access to the API IDs requested
-            InTestArguments.builder().wantedApiIds(List.of(apiId1)).expectedApiIds(List.of(apiId1)).build(),
-            // User doesn't have access to the API IDs requested
-            InTestArguments.builder().wantedApiIds(List.of(apiId11, apiId12)).expectedApiIds(List.of()).build(),
-            // User has access to some if the API IDs requested
-            InTestArguments.builder()
-                .wantedApiIds(List.of(apiId1, apiId2, apiId11, "invalid-api-id"))
-                .expectedApiIds(List.of(apiId1, apiId2))
-                .build()
-        );
+        assertThat(updatedFilters).size().isEqualTo(filters.size() + 1);
+        assertThat(updatedFilters).containsAll(filters);
+        assertThat(updatedFilters.getLast()).satisfies(f -> {
+            assertThat(f.name()).isEqualTo(API);
+            assertThat(f.operator()).isEqualTo(IN);
+            assertThat(f.value()).asInstanceOf(InstanceOfAssertFactories.ITERABLE).containsExactlyInAnyOrderElementsOf(allowedApiIds);
+        });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/permissions/ResourceContextConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 public class ResourceContextConfiguration {
 
     @Bean
-    public ApiAuthorizationService apiAuthorizationServiceV4() {
+    public ApiAuthorizationService apiAuthorizationService() {
         return mock(ApiAuthorizationService.class);
     }
 
@@ -37,9 +37,9 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ApiAnalyticsQueryFilterDecoratorImpl apiAnalyticsQueryFilterDecorator(
-        ApiAuthorizationService apiAuthorizationServiceV4,
+        ApiAuthorizationService applicationService,
         PermissionService permissionService
     ) {
-        return new ApiAnalyticsQueryFilterDecoratorImpl(apiAuthorizationServiceV4, permissionService);
+        return new ApiAnalyticsQueryFilterDecoratorImpl(applicationService, permissionService);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1611

## Description

Update analytics request filter to always have a filter `API in [allowed API IDs]`

This will ensure that, independently of what the user requests, only metrics for allowed APIs are returned.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->