### PR TITLE
feat: windowed sampling added to APIs

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/sampling/Sampling.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/sampling/Sampling.java
@@ -15,15 +15,15 @@
  */
 package io.gravitee.definition.model.v4.analytics.sampling;
 
+import com.google.common.base.Splitter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nonnull;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import java.time.Duration;
+import java.util.List;
+import lombok.*;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -43,4 +43,22 @@ public class Sampling implements Serializable {
     @NotEmpty
     @NotNull
     private String value;
+
+    public record WindowedCount(int count, Duration window) {
+        public String encode() {
+            return count + "/" + window;
+        }
+
+        public double ratePerSeconds() {
+            return (double) count / window.toSeconds();
+        }
+    }
+
+    public static WindowedCount parseWindowedCount(@Nonnull String value) {
+        List<String> parts = List.of(value.split("/"));
+        if (parts.size() != 2) {
+            throw new IllegalArgumentException("Invalid windowed count value: " + value + ", must be of the form <count>/<duration>");
+        }
+        return new WindowedCount(Integer.parseInt(parts.getFirst()), Duration.parse(parts.getLast()));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1907,12 +1907,15 @@ components:
             The type of the sampling:
 
             `PROBABILITY`: based on a specified probability,
-            `TEMPORAL`: all messages for on time duration,
-            `COUNT`: for every number of specified messages
+            `TEMPORAL`: report one message at least every,
+            `COUNT`: for every number of specified messages,
+            `WINDOWED_COUNT`: x number of messages on a time windows,
+            
           enum:
             - PROBABILITY
             - TEMPORAL
             - COUNT
+            - WINDOWED_COUNT
         value:
           type: string
           description: |
@@ -1921,6 +1924,7 @@ components:
             `PROBABILITY`: between `0.01` and `0.5`,
             `TEMPORAL`: ISO-8601 duration format, 1 second minimum (PT1S)
             `COUNT`: greater than `1`,
+            `WINDOWED_COUNT`: x/<ISO-8601 duration> cannot exceed 1 message per second
       required:
         - type
     MembershipMemberType:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
@@ -15,12 +15,9 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
-import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
-import io.gravitee.rest.api.management.v2.rest.model.Sampling;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.ValueMapping;
 
 @Mapper
 public interface AnalyticsMapper {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5826,18 +5826,33 @@ components:
                 propagateErrorKeyToLogs:
                     type: boolean
         Sampling:
+            description: API analytics sampling (message API only). This is meant to log only a portion to avoid overflowing the log sink.
             type: object
             properties:
                 type:
                     type: string
-                    description: The type of the sampling
+                    description: |
+                        The type of the sampling:
+
+                        `PROBABILITY`: based on a specified probability,
+                        `TEMPORAL`: report one message at least every duration,
+                        `COUNT`: for every number of specified messages,
+                        `WINDOWED_COUNT`: x number of messages on a time window,
+                        
                     enum:
                         - PROBABILITY
                         - TEMPORAL
                         - COUNT
+                        - WINDOWED_COUNT
                 value:
                     type: string
-                    description: The value of the sampling
+                    description: |
+                        The value of the sampling:
+
+                        `PROBABILITY`: between `0.01` and `0.5`,
+                        `TEMPORAL`: ISO-8601 duration format, 1 second minimum (PT1S)
+                        `COUNT`: greater than `1`,
+                        `WINDOWED_COUNT`: x/<ISO-8601 duration> cannot exceed 1 message per second
             required:
                 - type
         MembershipMemberType:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -50,7 +52,7 @@ public enum Key {
     PORTAL_RATING_ENABLED("portal.rating.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_RATING_COMMENT_MANDATORY(
         "portal.rating.comment.mandatory",
-        "false",
+        Boolean.FALSE.toString(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
     PORTAL_USERCREATION_ENABLED("portal.userCreation.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
@@ -59,12 +61,16 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    PORTAL_ANALYTICS_ENABLED("portal.analytics.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    PORTAL_ANALYTICS_ENABLED(
+        "portal.analytics.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
     PORTAL_ANALYTICS_TRACKINGID("portal.analytics.trackingId", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_APIS_TILESMODE_ENABLED("portal.apis.tilesMode.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_APIS_DOCUMENTATIONONLYMODE_ENABLED(
         "portal.apis.documentationOnlyMode.enabled",
-        "false",
+        Boolean.FALSE.toString(),
         Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)
     ),
     PORTAL_APIS_CATEGORY_ENABLED(
@@ -83,7 +89,11 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    PORTAL_UPLOAD_MEDIA_ENABLED("portal.uploadMedia.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    PORTAL_UPLOAD_MEDIA_ENABLED(
+        "portal.uploadMedia.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
     PORTAL_UPLOAD_MEDIA_MAXSIZE(
         "portal.uploadMedia.maxSizeInOctet",
         "1000000",
@@ -116,7 +126,7 @@ public enum Key {
         "portal.next.banner.secondaryButton.visibility",
         new HashSet<>(singletonList(ENVIRONMENT))
     ),
-    PORTAL_NEXT_ACCESS_ENABLED("portal.next.access.enabled", "false", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_ACCESS_ENABLED("portal.next.access.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_COLOR_PRIMARY("portal.next.theme.color.primary", "#275CF6", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_COLOR_SECONDARY("portal.next.theme.color.secondary", "#2051B1", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_COLOR_TERTIARY("portal.next.theme.color.tertiary", "#275CF6", new HashSet<>(singletonList(ENVIRONMENT))),
@@ -140,7 +150,7 @@ public enum Key {
 
     PORTAL_AUTHENTICATION_FORCELOGIN_ENABLED(
         "portal.authentication.forceLogin.enabled",
-        "false",
+        Boolean.FALSE.toString(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
     PORTAL_AUTHENTICATION_LOCALLOGIN_ENABLED(
@@ -166,10 +176,10 @@ public enum Key {
     PLAN_SECURITY_APIKEY_ENABLED("plan.security.apikey.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_APIKEY_CUSTOM_ALLOWED(
         "plan.security.apikey.allowCustom.enabled",
-        "false",
+        Boolean.FALSE.toString(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    PLAN_SECURITY_APIKEY_SHARED_ALLOWED("plan.security.apikey.allowShared.enabled", "false", Set.of(ENVIRONMENT, SYSTEM)),
+    PLAN_SECURITY_APIKEY_SHARED_ALLOWED("plan.security.apikey.allowShared.enabled", Boolean.FALSE.toString(), Set.of(ENVIRONMENT, SYSTEM)),
     PLAN_SECURITY_KEYLESS_ENABLED("plan.security.keyless.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_SUBSCRIPTION_ENABLED(
         "plan.security.subscription.enabled",
@@ -190,8 +200,12 @@ public enum Key {
     ),
     OPEN_API_DOC_TYPE_DEFAULT("open.api.doc.type.default", "Swagger", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
-    API_SCORE_ENABLED("api.score.enabled", "false", new HashSet<>(singletonList(ENVIRONMENT))),
-    API_QUALITY_METRICS_ENABLED("api.quality.metrics.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    API_SCORE_ENABLED("api.score.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
+    API_QUALITY_METRICS_ENABLED(
+        "api.quality.metrics.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
     API_QUALITY_METRICS_FUNCTIONAL_DOCUMENTATION_WEIGHT(
         "api.quality.metrics.functional.documentation.weight",
         "0",
@@ -236,9 +250,13 @@ public enum Key {
     ALERT_ENABLED("alert.enabled", "true", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
 
     LOGGING_DEFAULT_MAX_DURATION("logging.default.max.duration", "0", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
-    LOGGING_AUDIT_ENABLED("logging.audit.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
-    LOGGING_AUDIT_TRAIL_ENABLED("logging.audit.trail.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
-    LOGGING_USER_DISPLAYED("logging.user.displayed", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
+    LOGGING_AUDIT_ENABLED("logging.audit.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
+    LOGGING_AUDIT_TRAIL_ENABLED(
+        "logging.audit.trail.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))
+    ),
+    LOGGING_USER_DISPLAYED("logging.user.displayed", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     LOGGING_MESSAGE_SAMPLING_COUNT_DEFAULT("logging.messageSampling.count.default", "100", Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)),
     LOGGING_MESSAGE_SAMPLING_COUNT_LIMIT("logging.messageSampling.count.limit", "10", Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)),
     LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_DEFAULT(
@@ -257,6 +275,16 @@ public enum Key {
         Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)
     ),
     LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT("logging.messageSampling.temporal.limit", "PT1S", Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)),
+    LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_DEFAULT(
+        "logging.messageSampling.windowed_count.default",
+        "1/PT10S",
+        Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)
+    ),
+    LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT(
+        "logging.messageSampling.windowed_count.limit",
+        "1/PT1S",
+        Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)
+    ),
 
     ANALYTICS_CLIENT_TIMEOUT("analytics.client.timeout", "30000", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
@@ -283,15 +311,19 @@ public enum Key {
     ),
     APPLICATION_REGISTRATION_ENABLED(
         "application.registration.enabled",
-        "false",
+        Boolean.FALSE.toString(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
 
-    API_REVIEW_ENABLED("api.review.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
-    MAINTENANCE_MODE_ENABLED("maintenance.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
+    API_REVIEW_ENABLED("api.review.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    MAINTENANCE_MODE_ENABLED("maintenance.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     NEWSLETTER_ENABLED("newsletter.enabled", "true", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
 
-    PORTAL_RECAPTCHA_ENABLED("portal.reCaptcha.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    PORTAL_RECAPTCHA_ENABLED(
+        "portal.reCaptcha.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
     PORTAL_RECAPTCHA_SITE_KEY("portal.reCaptcha.siteKey", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
     PORTAL_HTTP_CORS_ALLOW_ORIGIN(
@@ -320,7 +352,7 @@ public enum Key {
     ),
     PORTAL_HTTP_CORS_MAX_AGE("http.api.portal.cors.max-age", "1728000", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
-    EMAIL_ENABLED("email.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
+    EMAIL_ENABLED("email.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_HOST("email.host", "smtp.my.domain", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_PORT("email.port", "587", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_USERNAME("email.username", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
@@ -350,7 +382,7 @@ public enum Key {
     ),
     CONSOLE_SCHEDULER_TASKS("console.scheduler.tasks", "10", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     CONSOLE_SCHEDULER_NOTIFICATIONS("console.scheduler.notifications", "10", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
-    CONSOLE_RECAPTCHA_ENABLED("console.reCaptcha.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
+    CONSOLE_RECAPTCHA_ENABLED("console.reCaptcha.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     CONSOLE_RECAPTCHA_SITE_KEY("console.reCaptcha.siteKey", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     CONSOLE_HTTP_CORS_ALLOW_ORIGIN(
         "http.api.management.cors.allow-origin",
@@ -389,9 +421,9 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    CONSOLE_SYSTEM_ROLE_EDITION_ENABLED("console.systemRoleEdition.enabled", "false", Set.of(SYSTEM)),
+    CONSOLE_SYSTEM_ROLE_EDITION_ENABLED("console.systemRoleEdition.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
 
-    CONSOLE_ANALYTICS_PENDO_ENABLED("console.analytics.pendo.enabled", "false", Set.of(SYSTEM)),
+    CONSOLE_ANALYTICS_PENDO_ENABLED("console.analytics.pendo.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
     CONSOLE_ANALYTICS_PENDO_API_KEY("console.analytics.pendo.apiKey", "", Set.of(SYSTEM)),
     CONSOLE_ANALYTICS_PENDO_ACCOUNT_ID("console.analytics.pendo.account.id", (String) null, Set.of(SYSTEM)),
     CONSOLE_ANALYTICS_PENDO_ACCOUNT_HRID("console.analytics.pendo.account.hrid", (String) null, Set.of(SYSTEM)),
@@ -419,25 +451,30 @@ public enum Key {
 
     V4_EMULATION_ENGINE_DEFAULT("api.v2.emulateV4Engine.default", "yes", Set.of(SYSTEM)),
 
-    ALERT_ENGINE_ENABLED("alerts.alert-engine.enabled", "false", Set.of(SYSTEM)),
-    FEDERATION_ENABLED("integration.enabled", "false", Set.of(SYSTEM)),
-    NEWTAI_ELGEN_ENABLED("newtai.elgen.enabled", "false", Set.of(SYSTEM)),
+    ALERT_ENGINE_ENABLED("alerts.alert-engine.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
+    FEDERATION_ENABLED("integration.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
+    NEWTAI_ELGEN_ENABLED("newtai.elgen.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
-    TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
-    CLOUD_HOSTED_ENABLED("cloud-hosted.enabled", "false", Set.of(SYSTEM)),
+    TRIAL_INSTANCE("trialInstance.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
+    CLOUD_HOSTED_ENABLED("cloud-hosted.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
 
-    EXTERNAL_AUTH_ENABLED("auth.external.enabled", "false", Set.of(SYSTEM)),
+    EXTERNAL_AUTH_ENABLED("auth.external.enabled", Boolean.FALSE.toString(), Set.of(SYSTEM)),
     EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED("auth.external.allowAccountDeletion", "true", Set.of(SYSTEM)),
-    USER_GROUP_REQUIRED_ENABLED("userGroup.required.enabled", "false", Set.of(ORGANIZATION, ENVIRONMENT)),
+    USER_GROUP_REQUIRED_ENABLED("userGroup.required.enabled", Boolean.FALSE.toString(), Set.of(ORGANIZATION, ENVIRONMENT)),
 
-    KAFKA_CONSOLE_ENABLED("kafka.console.enabled", "false", Set.of(KeyScope.SYSTEM));
+    KAFKA_CONSOLE_ENABLED("kafka.console.enabled", Boolean.FALSE.toString(), Set.of(KeyScope.SYSTEM));
 
     final String key;
     String defaultValue;
     Class<?> type;
+
+    @Getter
     boolean isOverridable = true;
+
     final Set<KeyScope> scopes;
+
+    @Getter
     boolean isHiddenForTrial = false;
 
     Key(String key, Set<KeyScope> scopes) {
@@ -503,14 +540,6 @@ public enum Key {
 
     public Class<?> type() {
         return type;
-    }
-
-    public boolean isOverridable() {
-        return isOverridable;
-    }
-
-    public boolean isHiddenForTrial() {
-        return isHiddenForTrial;
     }
 
     public Set<KeyScope> scopes() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/logging/MessageSampling.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/logging/MessageSampling.java
@@ -49,6 +49,11 @@ public class MessageSampling {
     @Builder.Default
     private MessageSampling.Temporal temporal = Temporal.builder().build();
 
+    @Valid
+    @NotNull
+    @Builder.Default
+    private MessageSampling.WindowedCount windowedCount = WindowedCount.builder().build();
+
     @Data
     @Builder
     @NoArgsConstructor
@@ -99,5 +104,21 @@ public class MessageSampling {
         @Builder.Default
         @ParameterKey(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT)
         private String limit = "PT1S";
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WindowedCount {
+
+        @Builder.Default
+        @JsonProperty("default")
+        @ParameterKey(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_DEFAULT)
+        private String defaultValue = "1/PT10S";
+
+        @Builder.Default
+        @ParameterKey(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT)
+        private String limit = "1/PT1S";
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/logging/MessageSamplingSettingsValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/logging/MessageSamplingSettingsValidatorTest.java
@@ -25,9 +25,10 @@ import jakarta.validation.ConstraintValidatorContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,6 +56,7 @@ class MessageSamplingSettingsValidatorTest {
             .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
             .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
             .temporal(MessageSampling.Temporal.builder().defaultValue("PT5S").limit("PT2S").build())
+            .windowedCount(MessageSampling.WindowedCount.builder().limit("2/PT1S").defaultValue("1/PT1M").build())
             .build();
 
         assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isTrue();
@@ -101,68 +103,57 @@ class MessageSamplingSettingsValidatorTest {
             .hasToString("Invalid probabilistic default value, 'default' should be lower than 'limit'");
     }
 
-    @Nested
-    class Temporal {
-
-        @Test
-        void should_fail_when_temporal_settings_default_is_not_iso_8601() {
-            final MessageSampling messageSampling = MessageSampling.builder()
-                .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
-                .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
-                .temporal(MessageSampling.Temporal.builder().defaultValue("PT-five-seconds").limit("PT2S").build())
-                .build();
-
-            ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
-            when(constraintValidatorContext.buildConstraintViolationWithTemplate(violationCaptor.capture())).thenReturn(
-                constraintViolationBuilder
-            );
-            assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
-            verify(constraintViolationBuilder).addConstraintViolation();
-            assertThat(violationCaptor.getAllValues())
-                .hasSize(1)
-                .first()
-                .hasToString("Invalid temporal default value, 'default' should be a valid ISO-8601 date");
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = ";",
+        value = {
+            "PT-five-seconds;   PT2S;             Invalid temporal default value, 'default' should be a valid ISO-8601 date",
+            "PT5S;              PT-two-seconds;   Invalid temporal limit value, 'limit' should be a valid ISO-8601 date",
+            "PT5S;              PT20S;            Invalid temporal default value, 'default' should be greater than 'limit'",
         }
+    )
+    void should_fail_when_temporal_settings_are_badly_configured(String defaultValue, String limit, String expectedMessage) {
+        final MessageSampling messageSampling = MessageSampling.builder()
+            .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
+            .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
+            .temporal(MessageSampling.Temporal.builder().defaultValue(defaultValue).limit(limit).build())
+            .build();
 
-        @Test
-        void should_fail_when_temporal_settings_limit_is_not_iso_8601() {
-            final MessageSampling messageSampling = MessageSampling.builder()
-                .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
-                .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
-                .temporal(MessageSampling.Temporal.builder().defaultValue("PT5S").limit("PT-two-seconds").build())
-                .build();
+        ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
+        when(constraintValidatorContext.buildConstraintViolationWithTemplate(violationCaptor.capture())).thenReturn(
+            constraintViolationBuilder
+        );
+        assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
+        verify(constraintViolationBuilder).addConstraintViolation();
+        assertThat(violationCaptor.getAllValues()).hasSize(1).first().hasToString(expectedMessage);
+    }
 
-            ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
-            when(constraintValidatorContext.buildConstraintViolationWithTemplate(violationCaptor.capture())).thenReturn(
-                constraintViolationBuilder
-            );
-            assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
-            verify(constraintViolationBuilder).addConstraintViolation();
-            assertThat(violationCaptor.getAllValues())
-                .hasSize(1)
-                .first()
-                .hasToString("Invalid temporal limit value, 'limit' should be a valid ISO-8601 date");
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = ";",
+        value = {
+            "invalid;   2/PT1S;     Invalid windowed count 'default' value: cannot parse",
+            "-1/PT1S;   2/PT1S;     Invalid windowed count 'default' value: count must be positive",
+            "2/PT1S;    invalid;    Invalid windowed count 'limit' value: cannot parse",
+            "1/PT1M;    -1/PT1S;    Invalid windowed count 'limit' value: count must be positive",
+            "10/PT1S;   1/PT1S;     Invalid windowed count default value, 'default' should have a lower rate than 'limit'",
         }
+    )
+    void should_fail_when_windowed_count_settings_are_badly_configured(String defaultValue, String limit, String expectedMessage) {
+        final MessageSampling messageSampling = MessageSampling.builder()
+            .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
+            .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
+            .temporal(MessageSampling.Temporal.builder().defaultValue("PT5S").limit("PT2S").build())
+            .windowedCount(MessageSampling.WindowedCount.builder().defaultValue(defaultValue).limit(limit).build())
+            .build();
 
-        @Test
-        void should_fail_when_temporal_settings_default_lower_than_limit() {
-            final MessageSampling messageSampling = MessageSampling.builder()
-                .count(MessageSampling.Count.builder().defaultValue(40).limit(15).build())
-                .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(0.25).limit(0.75).build())
-                .temporal(MessageSampling.Temporal.builder().defaultValue("PT5S").limit("PT20S").build())
-                .build();
-
-            ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
-            when(constraintValidatorContext.buildConstraintViolationWithTemplate(violationCaptor.capture())).thenReturn(
-                constraintViolationBuilder
-            );
-            assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
-            verify(constraintViolationBuilder).addConstraintViolation();
-            assertThat(violationCaptor.getAllValues())
-                .hasSize(1)
-                .first()
-                .hasToString("Invalid temporal default value, 'default' should be greater than 'limit'");
-        }
+        ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
+        when(constraintValidatorContext.buildConstraintViolationWithTemplate(violationCaptor.capture())).thenReturn(
+            constraintViolationBuilder
+        );
+        assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
+        verify(constraintViolationBuilder).addConstraintViolation();
+        assertThat(violationCaptor.getAllValues()).hasSize(1).first().hasToString(expectedMessage);
     }
 
     @Test
@@ -171,6 +162,7 @@ class MessageSamplingSettingsValidatorTest {
             .count(MessageSampling.Count.builder().defaultValue(40).limit(105).build())
             .probabilistic(MessageSampling.Probabilistic.builder().defaultValue(1.0).limit(0.75).build())
             .temporal(MessageSampling.Temporal.builder().defaultValue("PT5S").limit("PT20S").build())
+            .windowedCount(MessageSampling.WindowedCount.builder().defaultValue("-1/PT1S").limit("2/PT1S").build())
             .build();
 
         ArgumentCaptor<String> violationCaptor = ArgumentCaptor.forClass(String.class);
@@ -178,13 +170,14 @@ class MessageSamplingSettingsValidatorTest {
             constraintViolationBuilder
         );
         assertThat(cut.isValid(messageSampling, constraintValidatorContext)).isFalse();
-        verify(constraintViolationBuilder, times(3)).addConstraintViolation();
+        verify(constraintViolationBuilder, times(4)).addConstraintViolation();
         assertThat(violationCaptor.getAllValues())
-            .hasSize(3)
+            .hasSize(4)
             .containsExactly(
                 "Invalid count default value, 'default' should be greater than 'limit'",
                 "Invalid probabilistic default value, 'default' should be lower than 'limit'",
-                "Invalid temporal default value, 'default' should be greater than 'limit'"
+                "Invalid temporal default value, 'default' should be greater than 'limit'",
+                "Invalid windowed count 'default' value: count must be positive"
             );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/validator/GraviteePropertiesValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/validator/GraviteePropertiesValidator.java
@@ -83,11 +83,21 @@ public class GraviteePropertiesValidator {
         if (configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.key(), String.class) != null) {
             temporalSettingsBuilder.limit(configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.key(), String.class));
         }
+        final MessageSampling.WindowedCount.WindowedCountBuilder windowedSettingsBuilder = MessageSampling.WindowedCount.builder();
+        if (configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_DEFAULT.key(), String.class) != null) {
+            windowedSettingsBuilder.defaultValue(
+                configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_DEFAULT.key(), String.class)
+            );
+        }
+        if (configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT.key(), String.class) != null) {
+            windowedSettingsBuilder.limit(configuration.getProperty(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT.key(), String.class));
+        }
 
         final MessageSampling messageSampling = builder
             .count(countBuilder.build())
             .probabilistic(probabilisticSettingsBuilder.build())
             .temporal(temporalSettingsBuilder.build())
+            .windowedCount(windowedSettingsBuilder.build())
             .build();
 
         return validator.validate(messageSampling);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImpl.java
@@ -150,6 +150,18 @@ public class AnalyticsValidationServiceImpl extends TransactionalService impleme
                     .findFirst()
                     .orElse(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.defaultValue())
             );
+            case WINDOWED_COUNT -> new SamplingType.ValidationLimit.WindowedCountLimit(
+                parameterService
+                    .findAll(
+                        executionContext,
+                        Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT,
+                        Function.identity(),
+                        ParameterReferenceType.ORGANIZATION
+                    )
+                    .stream()
+                    .findFirst()
+                    .orElse(Key.LOGGING_MESSAGE_SAMPLING_WINDOWED_COUNT_LIMIT.defaultValue())
+            );
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -314,6 +314,9 @@ analytics:
 #    temporal:
 #      default: PT1S
 #      limit: PT1S
+#    windowed_count:
+#      default: 1/PT10S
+#      limit: 1/PT1S
 
 # Authentication and identity sources
 # Users can have following roles (authorities):


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1557

## Description

* Added a new value to SampleType, updated OpenAPI spec
  * Strategy is implemented in https://github.com/gravitee-io/gravitee-api-management/pull/14209
  * Value format is `COUNT/WINDOW` where `COUNT` is a **positive** number and `WINDOW` an [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations)
* Added validation based on a rate of message (cannot exceed the limit)
* Added configuration keys, defaults and limits
  * Default: `1/10PTS` (0.1/sec)
  * Limit (highest possible rate): `1/1PTS` (1/sec)
  * Added configuration validation

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

