### PR TITLE
feat(portal): add create application button with permission check

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -34,6 +34,7 @@ import { ApplicationTabLogsComponent } from './applications/application/applicat
 import { ApplicationTabSettingsComponent } from './applications/application/application-tab-settings/application-tab-settings.component';
 import { ApplicationComponent } from './applications/application/application.component';
 import { ApplicationsComponent } from './applications/applications.component';
+import { CreateApplicationComponent } from './applications/create-application/create-application.component';
 import { CategoriesViewComponent } from './catalog/categories-view/categories-view.component';
 import { CategoryApisComponent } from './catalog/categories-view/category-apis/category-apis.component';
 import { TabsViewComponent } from './catalog/tabs-view/tabs-view.component';
@@ -184,6 +185,11 @@ export const routes: Routes = [
     canActivateChild: [redirectGuard, authGuard],
     children: [
       { path: '', component: ApplicationsComponent, data: { breadcrumb: 'Applications' } },
+      {
+        path: 'create',
+        component: CreateApplicationComponent,
+        data: { breadcrumb: 'Create Application' },
+      },
       {
         path: ':applicationId',
         component: ApplicationComponent,

--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.html
@@ -17,12 +17,22 @@
 -->
 <mat-card appearance="outlined">
   <mat-card-content class="tile">
-    <div>
-      <h2 i18n="@@applicationsGridTitle">Applications</h2>
-      <div class="description" i18n="@@applicationsGridDescription">
-        An application represents a developer's project that interacts with the API. It acts as a means to manage access control to APIs via
-        subscriptions.
+    <div class="app-list-header">
+      <div class="app-list-header__title">
+        <h2 i18n="@@applicationsGridTitle">Applications</h2>
+        <div class="description" i18n="@@applicationsGridDescription">
+          An application represents a developer's project that interacts with the API. It acts as a means to manage access control to APIs
+          via subscriptions.
+        </div>
       </div>
+      @if (canCreate()) {
+        <div>
+          <button mat-stroked-button class="secondary-button" [routerLink]="['create']">
+            <mat-icon>add</mat-icon>
+            <span i18n="@@applicationsCreateButton">Create</span>
+          </button>
+        </div>
+      }
     </div>
 
     @if (applicationPaginator$ | async; as applications) {

--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
@@ -15,7 +15,10 @@
  */
 import { AsyncPipe, NgClass } from '@angular/common';
 import { Component, computed, inject } from '@angular/core';
+import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
+import { MatIcon } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { BehaviorSubject, EMPTY, map, Observable, scan, switchMap, tap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
@@ -24,6 +27,7 @@ import { ApplicationCardComponent } from '../../components/application-card/appl
 import { LoaderComponent } from '../../components/loader/loader.component';
 import { Application } from '../../entities/application/application';
 import { ApplicationService } from '../../services/application.service';
+import { CurrentUserService } from '../../services/current-user.service';
 import { ObservabilityBreakpointService } from '../../services/observability-breakpoint.service';
 
 export interface ApplicationPaginatorVM {
@@ -34,13 +38,28 @@ export interface ApplicationPaginatorVM {
 
 @Component({
   selector: 'app-applications',
-  imports: [AsyncPipe, InfiniteScrollModule, LoaderComponent, MatCard, MatCardContent, ApplicationCardComponent, NgClass],
+  imports: [
+    AsyncPipe,
+    InfiniteScrollModule,
+    LoaderComponent,
+    MatCard,
+    MatCardContent,
+    ApplicationCardComponent,
+    NgClass,
+    MatButton,
+    MatIcon,
+    RouterLink,
+  ],
   templateUrl: './applications.component.html',
   styleUrl: './applications.component.scss',
 })
 export class ApplicationsComponent {
+  currentUser = inject(CurrentUserService).user;
+
   applicationPaginator$: Observable<ApplicationPaginatorVM>;
   loadingPage$ = new BehaviorSubject(true);
+
+  canCreate = computed(() => this.currentUser().permissions?.APPLICATION?.includes('C') || false);
 
   appListContainerClasses = computed(() => ({
     'app-list__container--mobile': this.isMobile(),

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<app-breadcrumb-navigation />
+<mat-card appearance="outlined">
+  <mat-card-content>
+    <h2 i18n="@@applicationsCreateTitle">Create new application</h2>
+    <p i18n="@@applicationsCreateDescription">An application is used to register and agree to plans.</p>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,40 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 :host {
   display: flex;
   flex-flow: column;
-  gap: 32px;
-}
-
-.tile {
-  display: flex;
-  flex-flow: column;
-  gap: 16px;
-}
-
-.app-list-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-
-  &__title {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-.app-list__container {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-
-  &--mobile {
-    grid-template-columns: 1fr !important;
-  }
-
-  > * {
-    height: 256px;
-  }
+  gap: 34px;
 }

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,40 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-  flex-flow: column;
-  gap: 32px;
-}
+import { Component } from '@angular/core';
+import { MatCard, MatCardContent } from '@angular/material/card';
 
-.tile {
-  display: flex;
-  flex-flow: column;
-  gap: 16px;
-}
+import { BreadcrumbNavigationComponent } from '../../../components/breadcrumb-navigation/breadcrumb-navigation.component';
 
-.app-list-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-
-  &__title {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-.app-list__container {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-
-  &--mobile {
-    grid-template-columns: 1fr !important;
-  }
-
-  > * {
-    height: 256px;
-  }
-}
+@Component({
+  selector: 'app-create-application',
+  imports: [MatCard, MatCardContent, BreadcrumbNavigationComponent],
+  templateUrl: './create-application.component.html',
+  styleUrl: './create-application.component.scss',
+})
+export class CreateApplicationComponent {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11540

## Description

Button for creating an application in the next-generation portal.
The button is displayed only if the user has sufficient permissions (ENVIRONMENT_APPLICATION#CREATE).

## Additional context
https://github.com/user-attachments/assets/c10c75c7-1736-414d-aecf-feb1fc7890d6




