### PR TITLE
fix(console): align folder and non-folder icons at top of nav item list

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.scss
@@ -3,7 +3,7 @@
 @use 'sass:map';
 
 $typography: map.get(gio.$mat-theme, typography);
-$indent-base: 12px;
+$indent-base: 4px;
 $folder-indent-step: 26px;
 $indent-step: 26px;
 
@@ -14,14 +14,12 @@ $indent-step: 26px;
     position: relative;
     cursor: pointer;
     transition: background-color 0.2s ease;
-    padding: 6px 4px 6px calc(#{$indent-base} + (var(--level) * #{$indent-step}));
+    padding: 6px 4px 6px calc(#{$indent-base} + #{$folder-indent-step} + (var(--level) * #{$indent-step}));
     height: 36px;
 
-    &.child {
-      padding: 6px 4px 6px calc(#{$indent-base} + #{$folder-indent-step} + (var(--level) * #{$indent-step}));
-    }
-
     &.folder {
+      padding: 6px 4px 6px calc(#{$indent-base} + (var(--level) * #{$indent-step}));
+
       &.child {
         padding: 6px 4px 6px calc(#{$indent-base} + (var(--level) * #{$folder-indent-step}));
       }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11513

## Description

Align folder and non folder icons at the root level of the nav item list.

Bug:

<img width="385" height="636" alt="image" src="https://github.com/user-attachments/assets/5e66cc9d-0140-4612-880b-4496a45b7ca3" />

Fixed: 

<img width="976" height="661" alt="Screenshot 2025-11-27 at 16 34 54" src="https://github.com/user-attachments/assets/43859867-88e2-4599-a4cb-e532dc536599" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

