### PR TITLE
feat(console): update order and parentID for a navigation item

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -33,6 +33,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
@@ -108,6 +109,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudSe
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -872,8 +874,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public PortalNavigationItemValidatorService portalNavigationItemValidatorService() {
-        return mock(PortalNavigationItemValidatorService.class);
+    public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalPageContentQueryService portalPageContentQueryService
+    ) {
+        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+    }
+
+    @Bean
+    public PortalPageContentQueryService portalPageContentQueryService() {
+        return new PortalPageContentQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -28,6 +28,7 @@ import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -93,6 +94,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudSe
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -1011,8 +1013,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public PortalNavigationItemValidatorService portalNavigationItemValidatorService() {
-        return mock(PortalNavigationItemValidatorService.class);
+    public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalPageContentQueryService portalPageContentQueryService
+    ) {
+        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+    }
+
+    @Bean
+    public PortalPageContentQueryService portalPageContentQueryService() {
+        return new PortalPageContentQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -27,6 +27,7 @@ import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -92,6 +93,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudSe
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -972,8 +974,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public PortalNavigationItemValidatorService portalNavigationItemValidatorService() {
-        return mock(PortalNavigationItemValidatorService.class);
+    public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalPageContentQueryService portalPageContentQueryService
+    ) {
+        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+    }
+
+    @Bean
+    public PortalPageContentQueryService portalPageContentQueryService() {
+        return new PortalPageContentQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public class InvalidPortalNavigationItemDataException extends ValidationDomainException {
+
+    private InvalidPortalNavigationItemDataException(String message) {
+        super(message);
+    }
+
+    public static InvalidPortalNavigationItemDataException fieldIsEmpty(String field) {
+        return new InvalidPortalNavigationItemDataException("The %s field is required and cannot be blank.".formatted(field));
+    }
+
+    public static InvalidPortalNavigationItemDataException typeMismatch(String received, String expected) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation item type cannot be changed or is mismatched (expected %s, got %s).".formatted(expected, received)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -106,5 +106,7 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
 
     public void update(UpdatePortalNavigationItem navItem) {
         this.setTitle(navItem.getTitle().trim());
+        this.setOrder(navItem.getOrder());
+        this.setParentId(navItem.getParentId());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12060

## Description

- updating order for a navigation item
- updating parent id for a nav item
- if parent id provided -> item moved under the item corresponding to the id
- if parent id is not provided or is null, item is moved to root level.
- if parent id is provided and is not in the db, parent id not found exception thrown.

`{{baseURL}}/portal-navigation-items/{{navigationId}}`

sample payload

```
{
    "title": "updated title",
    "type": "LINK",
    "order": 1,
    "url": "http://www.google.com",
    "parentId": "46949072-b6a1-4e46-b273-81eeb9a73685"
}
```

response

```
{
    "type": "LINK",
    "url": "http://www.google.com",
    "id": "98548f54-00f3-43ae-846a-880feb7bf319",
    "organizationId": "DEFAULT",
    "environmentId": "DEFAULT",
    "title": "updated title",
    "area": "TOP_NAVBAR",
    "parentId": "46949072-b6a1-4e46-b273-81eeb9a73685",
    "order": 1
}
```


https://github.com/user-attachments/assets/ce1785cf-0f26-44f5-880e-92495d572884



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

