### PR TITLE
fix: include query param metadata in mAPI v2

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -160,24 +160,29 @@ public interface ApiMapper {
 
     @Mapping(target = "originContext", expression = "java(computeOriginContext(apiEntity))")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
+    @Mapping(target = "metadata", ignore = true)
     ApiFederated mapToFederated(FederatedApiEntity apiEntity, UriInfo uriInfo);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToV4(ApiEntity apiEntity, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "listeners", qualifiedByName = "fromHttpListeners")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToV4(ApiEntity apiEntity);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToV4(NativeApiEntity apiEntity, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "listeners", qualifiedByName = "fromNativeListeners")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToV4(NativeApiEntity apiEntity);
 
     default ApiV4 mapToV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState) {
@@ -207,6 +212,7 @@ public interface ApiMapper {
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
     @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToHttpV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "source.originContext")
@@ -218,6 +224,7 @@ public interface ApiMapper {
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
     @Mapping(target = "listeners", source = "source.apiDefinitionNativeV4.listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToNativeV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "source.originContext")
@@ -231,13 +238,16 @@ public interface ApiMapper {
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
     @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapToV4(io.gravitee.apim.core.api.model.ApiWithFlows source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
+    @Mapping(target = "metadata", ignore = true)
     ApiV2 mapToV2(io.gravitee.rest.api.model.api.ApiEntity apiEntity, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
+    @Mapping(target = "metadata", ignore = true)
     io.gravitee.rest.api.management.v2.rest.model.ApiV1 mapToV1(
         io.gravitee.rest.api.model.api.ApiEntity apiEntity,
         UriInfo uriInfo,
@@ -246,13 +256,16 @@ public interface ApiMapper {
 
     @Mapping(target = "listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(target = "links", ignore = true)
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapFromHttpApiEntity(ApiEntity apiEntity);
 
     @Mapping(target = "listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "links", ignore = true)
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 mapFromNativeApiEntity(NativeApiEntity apiEntity);
 
     @Mapping(target = "listeners", qualifiedByName = "toHttpListeners")
+    @Mapping(target = "metadata", ignore = true)
     ApiEntity map(ApiV4 api);
 
     @Mapping(target = "listeners", qualifiedByName = "toHttpListeners")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -80,7 +80,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
-                - $ref: "#/components/parameters/apisSearchExpandsParam"
+                - $ref: "#/components/parameters/apisGetExpandsParam"
             tags:
                 - APIs
             summary: List APIs
@@ -188,7 +188,7 @@ paths:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
                 - $ref: "#/components/parameters/apiSortByParam"
-                - $ref: "#/components/parameters/apisGetExpandsParam"
+                - $ref: "#/components/parameters/apisSearchExpandsParam"
                 - $ref: "#/components/parameters/apiManageOnlyParam"
             tags:
                 - APIs
@@ -2868,7 +2868,11 @@ components:
                           type: boolean
                           description: Disable membership notifications.
                           default: false
-                      # metadata ==> dedicated resource
+                      metadata:
+                          type: array
+                          description: API's metadata. Optional list that can be included with the expands=metadata query parameter.
+                          items:
+                              $ref: "#/components/schemas/Metadata"
                       groups:
                           type: array
                           description: API's groups. Used to add team in your API.
@@ -7711,20 +7715,10 @@ components:
         ###############################
         # Other Query Parameters      #
         ###############################
-        apisSearchExpandsParam:
-            name: expands
-            in: query
-            description: Expansion of data to return in APIs.
-            schema:
-                type: array
-                items:
-                    type: string
-                    enum:
-                        - deploymentState
         apisGetExpandsParam:
             name: expands
             in: query
-            description: Expansion of data to return in APIs.
+            description: Expansion of data to return in APIs for GET operation.
             schema:
                 type: array
                 items:
@@ -7732,6 +7726,17 @@ components:
                     enum:
                         - deploymentState
                         - primaryOwner
+                        - metadata
+        apisSearchExpandsParam:
+            name: expands
+            in: query
+            description: Expansion of data to return in APIs for SEARCH operation.
+            schema:
+                type: array
+                items:
+                    type: string
+                    enum:
+                        - deploymentState
         apiManageOnlyParam:
             name: manageOnly
             in: query

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -142,6 +142,12 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected ApiMetadataService apiMetadataService;
 
     @Autowired
+    protected io.gravitee.apim.core.api.query_service.ApiMetadataQueryService apiMetadataQueryService;
+
+    @Autowired
+    protected io.gravitee.apim.core.api.use_case.GetApiMetadataUseCase getApiMetadataUseCase;
+
+    @Autowired
     protected PageService pageService;
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.spy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCRDExportDomainServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
@@ -424,6 +426,14 @@ public class ResourceContextConfiguration {
     @Bean
     public GetApiDefinitionUseCase getApiDefinitionUseCase() {
         return mock(GetApiDefinitionUseCase.class);
+    }
+
+    @Bean
+    public io.gravitee.apim.core.api.use_case.GetApiMetadataUseCase getApiMetadataUseCase(
+        io.gravitee.apim.core.api.crud_service.ApiCrudService apiCrudService,
+        io.gravitee.apim.core.api.query_service.ApiMetadataQueryService apiMetadataQueryService
+    ) {
+        return new io.gravitee.apim.core.api.use_case.GetApiMetadataUseCase(apiCrudService, apiMetadataQueryService);
     }
 
     @Bean


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11932

## Description

API metadata was only retrievable via the separate /metadata endpoint, requiring multiple API calls to fetch complete API details. Updated the API aggregation logic so that metadata is embedded directly in the responses of /apis endpoints.

This allows clients to fetch full API data including metadata from a single endpoint without additional requests.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

