### PR TITLE
Apim 11555 add org and env id to page content

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
@@ -39,6 +39,10 @@ public class PortalPageContent {
     @EqualsAndHashCode.Include
     private String id;
 
+    private String organizationId;
+
+    private String environmentId;
+
     private Type type;
 
     private String configuration;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContentRepository.java
@@ -42,6 +42,8 @@ public class JdbcPortalPageContentRepository
             .addColumn("type", Types.NVARCHAR, PortalPageContent.Type.class)
             .addColumn("configuration", Types.NVARCHAR, String.class)
             .addColumn("content", Types.NVARCHAR, String.class)
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/01_add_portal_page_contents_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/01_add_portal_page_contents_table.yml
@@ -7,6 +7,8 @@ databaseChangeLog:
             tableName: ${gravitee_prefix}portal_page_contents
             columns:
               - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: configuration, type: nclob, constraints: { nullable: true } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
@@ -7,8 +7,8 @@ databaseChangeLog:
             tableName: ${gravitee_prefix}portal_navigation_items
             columns:
               - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: true } }
-              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: true } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: title, type: nvarchar(255), constraints: { nullable: false } }
               - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: area, type: nvarchar(64), constraints: { nullable: false } }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalPageContentMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalPageContentMongo.java
@@ -24,6 +24,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class PortalPageContentMongo {
 
     private String id;
+    private String organizationId;
+    private String environmentId;
     private PortalPageContent.Type type;
     private String configuration;
     private String content;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContentRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalPageContentRepositoryTest.java
@@ -51,6 +51,8 @@ public class PortalPageContentRepositoryTest extends AbstractManagementRepositor
     public void should_create_and_delete_page_content() throws Exception {
         PortalPageContent content = PortalPageContent.builder()
             .id("new-page-content")
+            .organizationId("DEFAULT_ORGANIZATION")
+            .environmentId("DEFAULT_ENVIRONMENT")
             .type(PortalPageContent.Type.GRAVITEE_MARKDOWN)
             .configuration("{ \"pageId\": \"contact\" }")
             .content("# Contact us")
@@ -73,6 +75,8 @@ public class PortalPageContentRepositoryTest extends AbstractManagementRepositor
         PortalPageContent toUpdate = PortalPageContent.builder()
             .id(existing.getId())
             .type(existing.getType())
+            .organizationId(existing.getOrganizationId())
+            .environmentId(existing.getEnvironmentId())
             .configuration(existing.getConfiguration())
             .content("# Updated content")
             .build();

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalpagecontent-tests/portalPageContents.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalpagecontent-tests/portalPageContents.json
@@ -1,12 +1,16 @@
 [
   {
     "id": "page-content-1",
+    "organizationId": "DEFAULT_ORGANIZATION",
+    "environmentId": "DEFAULT_ENVIRONMENT",
     "type": "GRAVITEE_MARKDOWN",
     "configuration": "{ \"pageId\": \"home\" }",
     "content": "# Welcome to the portal"
   },
   {
     "id": "page-content-2",
+    "organizationId": "DEFAULT_ORGANIZATION",
+    "environmentId": "DEFAULT_ENVIRONMENT",
     "type": "GRAVITEE_MARKDOWN",
     "configuration": "{ \"pageId\": \"about\" }",
     "content": "# About us"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -42,7 +42,12 @@ class PortalPageContentMapperTest {
     void should_map_gravitee_markdown_page_content() {
         // Given
         var contentId = PortalPageContentId.of("12345678-1234-1234-1234-123456789abc");
-        var markdownContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(contentId, "# Welcome\n\nThis is a test page.");
+        var markdownContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+            contentId,
+            "ORG",
+            "ENV",
+            "# Welcome\n\nThis is a test page."
+        );
 
         // When
         var result = mapper.map(markdownContent);
@@ -70,7 +75,7 @@ class PortalPageContentMapperTest {
     void should_map_portal_page_content_polymorphically() {
         // Given
         var contentId = PortalPageContentId.random();
-        var markdownContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(contentId, "Test content");
+        var markdownContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(contentId, "ORG", "ENV", "Test content");
 
         // When
         var result = mapper.map((io.gravitee.apim.core.portal_page.model.PortalPageContent) markdownContent);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
@@ -81,7 +81,12 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
     @Test
     void should_return_portal_page_content() {
         // Given
-        var content = PortalPageContentFixtures.aGraviteeMarkdownPageContent();
+        var content = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+            PortalPageContentId.of(CONTENT_ID),
+            ORGANIZATION,
+            ENVIRONMENT,
+            PortalPageContentFixtures.CONTENT
+        );
 
         when(getPortalPageContentUseCase.execute(new GetPortalPageContentUseCase.Input(PortalPageContentId.of(CONTENT_ID)))).thenReturn(
             new GetPortalPageContentUseCase.Output(content)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContentCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContentCrudService.java
@@ -20,5 +20,5 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 public interface PortalPageContentCrudService {
     PortalPageContent create(PortalPageContent content);
 
-    PortalPageContent createDefault();
+    PortalPageContent createDefault(String organizationId, String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -51,7 +51,7 @@ public class PortalNavigationItemDomainService {
             createPortalNavigationItem.getType() == PortalNavigationItemType.PAGE &&
             createPortalNavigationItem.getPortalPageContentId() == null
         ) {
-            final var defaultPageContent = pageContentCrudService.createDefault();
+            final var defaultPageContent = pageContentCrudService.createDefault(organizationId, environmentId);
             createPortalNavigationItem.setPortalPageContentId(defaultPageContent.getId());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
@@ -26,13 +26,22 @@ public final class GraviteeMarkdownPageContent extends PortalPageContent {
     @Nonnull
     private String content;
 
-    public GraviteeMarkdownPageContent(@Nonnull PortalPageContentId id, @Nonnull String content) {
-        super(id);
+    public GraviteeMarkdownPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull String content
+    ) {
+        super(id, organizationId, environmentId);
         this.content = content;
     }
 
-    public static GraviteeMarkdownPageContent create(@Nonnull String content) {
-        return new GraviteeMarkdownPageContent(PortalPageContentId.random(), content);
+    public static GraviteeMarkdownPageContent create(
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull String content
+    ) {
+        return new GraviteeMarkdownPageContent(PortalPageContentId.random(), organizationId, environmentId, content);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -24,8 +24,16 @@ public abstract sealed class PortalPageContent permits GraviteeMarkdownPageConte
     @Nonnull
     private final PortalPageContentId id;
 
-    protected PortalPageContent(@Nonnull PortalPageContentId id) {
+    @Nonnull
+    private final String organizationId;
+
+    @Nonnull
+    private final String environmentId;
+
+    protected PortalPageContent(@Nonnull PortalPageContentId id, @Nonnull String organizationId, @Nonnull String environmentId) {
         this.id = id;
+        this.organizationId = organizationId;
+        this.environmentId = environmentId;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
@@ -62,15 +62,15 @@ public class CreateDefaultPortalNavigationItemsUseCase {
     public void execute(String organizationId, String environmentId) {
         final var folderGuides = createPortalFolder("Guides", organizationId, environmentId, null);
 
-        final var contentGettingStarted = createPortalPageContent(GETTING_STARTED_PATH);
+        final var contentGettingStarted = createPortalPageContent(organizationId, environmentId, GETTING_STARTED_PATH);
         createPortalPage("Getting started", organizationId, environmentId, contentGettingStarted.getId(), folderGuides.getId());
 
         final var folderCoreConcepts = createPortalFolder("Core concepts", organizationId, environmentId, folderGuides.getId());
 
-        final var contentAuthentication = createPortalPageContent(AUTHENTICATION_PATH);
+        final var contentAuthentication = createPortalPageContent(organizationId, environmentId, AUTHENTICATION_PATH);
         createPortalPage("Authentication", organizationId, environmentId, contentAuthentication.getId(), folderCoreConcepts.getId());
 
-        final var contentFirstApiCall = createPortalPageContent(FIRST_API_CALL_PATH);
+        final var contentFirstApiCall = createPortalPageContent(organizationId, environmentId, FIRST_API_CALL_PATH);
         createPortalPage(
             "Making your first API call",
             organizationId,
@@ -123,8 +123,13 @@ public class CreateDefaultPortalNavigationItemsUseCase {
         return CreatePortalNavigationItem.builder().title(title).area(PortalArea.TOP_NAVBAR).parentId(parentId).build();
     }
 
-    private PortalPageContent createPortalPageContent(String contentPath) {
-        final var content = new GraviteeMarkdownPageContent(PortalPageContentId.random(), loadContent(contentPath));
+    private PortalPageContent createPortalPageContent(String organizationId, String environmentId, String contentPath) {
+        final var content = new GraviteeMarkdownPageContent(
+            PortalPageContentId.random(),
+            organizationId,
+            environmentId,
+            loadContent(contentPath)
+        );
         return pageContentCrudService.create(content);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
@@ -34,7 +34,12 @@ public interface PortalPageContentAdapter {
     default GraviteeMarkdownPageContent graviteeMarkdownPageContentFromRepository(
         io.gravitee.repository.management.model.PortalPageContent portalPageContent
     ) {
-        return new GraviteeMarkdownPageContent(PortalPageContentId.of(portalPageContent.getId()), portalPageContent.getContent());
+        return new GraviteeMarkdownPageContent(
+            PortalPageContentId.of(portalPageContent.getId()),
+            portalPageContent.getOrganizationId(),
+            portalPageContent.getEnvironmentId(),
+            portalPageContent.getContent()
+        );
     }
 
     default io.gravitee.repository.management.model.PortalPageContent toRepository(PortalPageContent portalPageContent) {
@@ -48,6 +53,8 @@ public interface PortalPageContentAdapter {
     ) {
         return io.gravitee.repository.management.model.PortalPageContent.builder()
             .id(portalPageContent.getId().toString())
+            .organizationId(portalPageContent.getOrganizationId())
+            .environmentId(portalPageContent.getEnvironmentId())
             .type(io.gravitee.repository.management.model.PortalPageContent.Type.GRAVITEE_MARKDOWN)
             .content(portalPageContent.getContent())
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImpl.java
@@ -53,9 +53,14 @@ public class PortalPageContentCrudServiceImpl implements PortalPageContentCrudSe
     }
 
     @Override
-    public PortalPageContent createDefault() {
+    public PortalPageContent createDefault(String organizationId, String environmentId) {
         final var pageContentId = PortalPageContentId.random();
-        final var portalPageContent = new GraviteeMarkdownPageContent(pageContentId, getDefaultPortalPageContent());
+        final var portalPageContent = new GraviteeMarkdownPageContent(
+            pageContentId,
+            organizationId,
+            environmentId,
+            getDefaultPortalPageContent()
+        );
         return this.create(portalPageContent);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
@@ -22,19 +22,26 @@ import java.util.List;
 
 public class PortalPageContentFixtures {
 
+    public static final String ORGANIZATION_ID = "org-1234";
+    public static final String ENVIRONMENT_ID = "env-1234";
     public static final String CONTENT_ID = "00000000-0000-0000-0000-000000000001";
     public static final String CONTENT = "# Welcome\n\nThis is a sample page content.";
 
     public static GraviteeMarkdownPageContent aGraviteeMarkdownPageContent() {
-        return new GraviteeMarkdownPageContent(PortalPageContentId.of(CONTENT_ID), CONTENT);
+        return new GraviteeMarkdownPageContent(PortalPageContentId.of(CONTENT_ID), ORGANIZATION_ID, ENVIRONMENT_ID, CONTENT);
     }
 
     public static GraviteeMarkdownPageContent aGraviteeMarkdownPageContent(String content) {
-        return new GraviteeMarkdownPageContent(PortalPageContentId.of(CONTENT_ID), content);
+        return new GraviteeMarkdownPageContent(PortalPageContentId.of(CONTENT_ID), ORGANIZATION_ID, ENVIRONMENT_ID, content);
     }
 
-    public static GraviteeMarkdownPageContent aGraviteeMarkdownPageContent(PortalPageContentId id, String content) {
-        return new GraviteeMarkdownPageContent(id, content);
+    public static GraviteeMarkdownPageContent aGraviteeMarkdownPageContent(
+        PortalPageContentId id,
+        String organizationId,
+        String environmentId,
+        String content
+    ) {
+        return new GraviteeMarkdownPageContent(id, organizationId, environmentId, content);
     }
 
     public static List<PortalPageContent> samplePortalPageContents() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
@@ -49,9 +49,9 @@ public class PortalPageContentCrudServiceInMemory implements InMemoryAlternative
     }
 
     @Override
-    public PortalPageContent createDefault() {
+    public PortalPageContent createDefault(String organizationId, String environmentId) {
         final var pageContentId = PortalPageContentId.random();
-        final var portalPageContent = new GraviteeMarkdownPageContent(pageContentId, "default page content");
+        final var portalPageContent = new GraviteeMarkdownPageContent(pageContentId, organizationId, environmentId, "default page content");
         return this.create(portalPageContent);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -83,6 +83,8 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(gettingStartedPage.getTitle()).isEqualTo("Getting started");
         assertThat(((PortalNavigationPage) gettingStartedPage).getPortalPageContentId()).isNotNull();
         assertThat(gettingStartedPage.getOrder()).isEqualTo(0);
+        assertThat(gettingStartedPage.getOrganizationId()).isEqualTo(guidesFolder.getOrganizationId());
+        assertThat(gettingStartedPage.getEnvironmentId()).isEqualTo(guidesFolder.getEnvironmentId());
 
         final var coreConceptsFolder = items
             .stream()
@@ -106,6 +108,8 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(authPage.getTitle()).isEqualTo("Authentication");
         assertThat(((PortalNavigationPage) authPage).getPortalPageContentId()).isNotNull();
         assertThat(authPage.getOrder()).isEqualTo(0);
+        assertThat(authPage.getOrganizationId()).isEqualTo(coreConceptsFolder.getOrganizationId());
+        assertThat(authPage.getEnvironmentId()).isEqualTo(coreConceptsFolder.getEnvironmentId());
 
         final var firstCallPage = items
             .stream()
@@ -118,6 +122,8 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(firstCallPage.getTitle()).isEqualTo("Making your first API call");
         assertThat(((PortalNavigationPage) firstCallPage).getPortalPageContentId()).isNotNull();
         assertThat(firstCallPage.getOrder()).isEqualTo(1);
+        assertThat(firstCallPage.getOrganizationId()).isEqualTo(coreConceptsFolder.getOrganizationId());
+        assertThat(firstCallPage.getEnvironmentId()).isEqualTo(coreConceptsFolder.getEnvironmentId());
 
         final var docsLink = items
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -142,6 +142,8 @@ class CreatePortalNavigationItemUseCaseTest {
             .hasSize(numberOfContents + 1)
             .anySatisfy(content -> {
                 assertThat(content.getId()).isEqualTo(contentId);
+                assertThat(content.getOrganizationId()).isEqualTo(ORG_ID);
+                assertThat(content.getEnvironmentId()).isEqualTo(ENV_ID);
                 assertThat(content).isInstanceOf(GraviteeMarkdownPageContent.class);
                 assertThat(((GraviteeMarkdownPageContent) content).getContent()).isEqualTo("default page content");
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
@@ -82,6 +82,8 @@ class PortalPageContentAdapterTest {
             // Given
             final var entityContent = new GraviteeMarkdownPageContent(
                 PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440000"),
+                "DEFAULT_ORG",
+                "DEFAULT_ENV",
                 "# Welcome\n\nThis is a sample page content."
             );
 
@@ -91,6 +93,8 @@ class PortalPageContentAdapterTest {
             // Then
             assertThat(repositoryContent.getType()).isEqualTo(PortalPageContent.Type.GRAVITEE_MARKDOWN);
             assertThat(repositoryContent.getId()).isEqualTo(entityContent.getId().toString());
+            assertThat(repositoryContent.getOrganizationId()).isEqualTo("DEFAULT_ORG");
+            assertThat(repositoryContent.getEnvironmentId()).isEqualTo("DEFAULT_ENV");
             assertThat(repositoryContent.getContent()).isEqualTo(entityContent.getContent());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImplTest.java
@@ -44,6 +44,9 @@ import org.springframework.core.io.ClassPathResource;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PortalPageContentCrudServiceImplTest {
 
+    private static final String ORGANIZATION_ID = "DEFAULT_ORG";
+    private static final String ENVIRONMENT_ID = "DEFAULT_ENV";
+
     @Mock
     PortalPageContentRepository repository;
 
@@ -71,7 +74,12 @@ class PortalPageContentCrudServiceImplTest {
         void should_create_a_page_content() throws TechnicalException {
             // Given
             final var pageContentId = PortalPageContentId.random();
-            final var portalPageContent = new GraviteeMarkdownPageContent(pageContentId, "# Welcome\n\nThis is a sample page content.");
+            final var portalPageContent = new GraviteeMarkdownPageContent(
+                pageContentId,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                "# Welcome\n\nThis is a sample page content."
+            );
             final var repoContent = portalPageContentAdapter.toRepository(portalPageContent);
 
             // When
@@ -93,12 +101,14 @@ class PortalPageContentCrudServiceImplTest {
             }
 
             // When
-            service.createDefault();
+            service.createDefault(ORGANIZATION_ID, ENVIRONMENT_ID);
 
             // Then
             verify(repository).create(captor.capture());
             assertThat(captor.getValue().getType()).isEqualTo(PortalPageContent.Type.GRAVITEE_MARKDOWN);
             assertThat(captor.getValue().getContent()).isEqualTo(defaultContent);
+            assertThat(captor.getValue().getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+            assertThat(captor.getValue().getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageContentQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageContentQueryServiceImplTest.java
@@ -57,6 +57,8 @@ class PortalPageContentQueryServiceImplTest {
             var contentId = "00000000-0000-0000-0000-000000000001";
             var repoContent = io.gravitee.repository.management.model.PortalPageContent.builder()
                 .id(contentId)
+                .organizationId("DEFAULT_ORG")
+                .environmentId("DEFAULT_ENV")
                 .type(io.gravitee.repository.management.model.PortalPageContent.Type.GRAVITEE_MARKDOWN)
                 .content("# Welcome\n\nThis is a sample page content.")
                 .build();
@@ -70,6 +72,8 @@ class PortalPageContentQueryServiceImplTest {
             assertThat(result).isPresent();
             assertThat(result.get()).isInstanceOf(GraviteeMarkdownPageContent.class);
             assertThat(result.get().getId()).isEqualTo(PortalPageContentId.of(contentId));
+            assertThat(result.get().getOrganizationId()).isEqualTo("DEFAULT_ORG");
+            assertThat(result.get().getEnvironmentId()).isEqualTo("DEFAULT_ENV");
             assertThat(((GraviteeMarkdownPageContent) result.get()).getContent()).isEqualTo("# Welcome\n\nThis is a sample page content.");
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11555

## Description

- Add organization id and environment id to the portal page content object.
- Set org id and env id as required for JDBC Portal Navigation Items table

Next PR:
- Create use case for updating a portal page content

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

