### PR TITLE
fix: make sure to send request body when using http2

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/post/HttpPostProxyIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/post/HttpPostProxyIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.post;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+abstract class HttpPostProxyIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    void makePostCall(HttpClient httpClient) {
+        wiremock.stubFor(post("/endpoint").willReturn(ok("OK")));
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend(Flowable.just(Buffer.buffer("foobar"))))
+            .doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .flatMap(HttpClientResponse::rxBody)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(buffer -> buffer.toString().equals("OK"));
+
+        wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint")).withRequestBody(equalTo("foobar")));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/post/HttpPostProxyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/post/HttpPostProxyV4IntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.post;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class HttpPostProxyV4IntegrationTest {
+
+    @Nested
+    @GatewayTest
+    class Http2WithClearTextUpgradeTest extends HttpPostProxyIntegrationTest {
+
+        @Override
+        protected void configureHttpClient(
+            HttpClientOptions options,
+            GatewayDynamicConfig.Config gatewayConfig,
+            ParameterContext parameterContext
+        ) {
+            super.configureHttpClient(options, gatewayConfig, parameterContext);
+            options.setProtocolVersion(HttpVersion.HTTP_2);
+            options.setHttp2ClearTextUpgrade(false);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http2.json" })
+        void should_proxy_request_body_to_http2_backend_when_using_http2_client(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http11.json" })
+        void should_proxy_request_body_to_http11_backend_when_using_http2_client(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    class Http2PriorKnowledgeTest extends HttpPostProxyIntegrationTest {
+
+        @Override
+        protected void configureHttpClient(
+            HttpClientOptions options,
+            GatewayDynamicConfig.Config gatewayConfig,
+            ParameterContext parameterContext
+        ) {
+            super.configureHttpClient(options, gatewayConfig, parameterContext);
+            options.setProtocolVersion(HttpVersion.HTTP_2);
+            options.setHttp2ClearTextUpgrade(true);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http2.json" })
+        void should_proxy_request_body_to_http2_backend(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http11.json" })
+        void should_proxy_request_body_to_http11_backend(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    class Http11Test extends HttpPostProxyIntegrationTest {
+
+        @Override
+        protected void configureHttpClient(
+            HttpClientOptions options,
+            GatewayDynamicConfig.Config gatewayConfig,
+            ParameterContext parameterContext
+        ) {
+            super.configureHttpClient(options, gatewayConfig, parameterContext);
+            options.setProtocolVersion(HttpVersion.HTTP_1_1);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http2.json" })
+        void should_proxy_request_body_to_http2_backend(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+
+        @Test
+        @DeployApi({ "/apis/v4/http/post/api-endpoint-http11.json" })
+        void should_proxy_request_body_to_http11_backend(HttpClient httpClient) {
+            makePostCall(httpClient);
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/post/api-endpoint-http11.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/post/api-endpoint-http11.json
@@ -1,0 +1,49 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000,
+              "version": "HTTP_1_1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [ ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/post/api-endpoint-http2.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/post/api-endpoint-http2.json
@@ -1,0 +1,50 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000,
+              "version": "HTTP_2",
+              "clearTextUpgrade": false
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [ ],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12059

## Description

This PR ensures that the request body is properly sent, including when HTTP2 data frames are used.