### PR TITLE
Apim 11555 page content update in be

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -37,4 +38,6 @@ public interface PortalPageContentMapper {
 
     @Mapping(target = "type", constant = "GRAVITEE_MARKDOWN")
     io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(GraviteeMarkdownPageContent markdownContent);
+
+    UpdatePortalPageContent map(io.gravitee.rest.api.management.v2.rest.model.UpdatePortalPageContent portalPageContent);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -845,6 +845,31 @@ paths:
           $ref: "#/components/responses/PortalPageContentResponse"
         default:
           $ref: "#/components/responses/Error"
+    put:
+      tags:
+        - Portal Pages
+      summary: Update portal page content
+      description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+      operationId: updatePortalPageContent
+      parameters:
+        - name: portalPageContentId
+          in: path
+          description: The unique ID of the portal page content
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePortalPageContent"
+      responses:
+        "200":
+          $ref: "#/components/responses/PortalPageContentResponse"
+        default:
+          $ref: "#/components/responses/Error"
+
   /portal-navigation-items:
     get:
       tags:
@@ -1983,6 +2008,16 @@ components:
           type: string
           description: The content of the page
       required: [ id, type, content ]
+
+    UpdatePortalPageContent:
+      type: object
+      description: Update portal page content
+      properties:
+        content:
+          type: string
+          description: The updated content for the page
+      required: [ content ]
+
 
   parameters:
     pageParam:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -32,6 +32,8 @@ import inmemory.ImportApplicationCRDDomainServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.PrimaryOwnerDomainServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
@@ -225,6 +227,12 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected GroupCrudServiceInMemory groupCrudServiceInMemory;
+
+    @Autowired
+    protected PortalPageContentQueryServiceInMemory portalPageContentQueryService;
+
+    @Autowired
+    protected PortalPageContentCrudServiceInMemory portalPageContentCrudService;
 
     @BeforeEach
     public void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -35,6 +35,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
@@ -115,8 +116,10 @@ import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
@@ -124,6 +127,7 @@ import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseC
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
 import io.gravitee.apim.core.promotion.use_case.CreatePromotionUseCase;
 import io.gravitee.apim.core.promotion.use_case.ProcessPromotionUseCase;
@@ -912,11 +916,6 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public PortalPageContentQueryService portalPageContentQueryService() {
-        return new PortalPageContentQueryServiceInMemory();
-    }
-
-    @Bean
     public PortalNavigationItemDomainService portalNavigationItemDomainService() {
         return mock(PortalNavigationItemDomainService.class);
     }
@@ -924,6 +923,18 @@ public class ResourceContextConfiguration {
     @Bean
     public CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase() {
         return mock(CreateDefaultPortalNavigationItemsUseCase.class);
+    }
+
+    @Bean
+    public UpdatePortalPageContentUseCase updatePortalPageContentUseCase(
+        PortalPageContentQueryService portalPageContentQueryService,
+        PortalPageContentCrudService portalPageContentCrudService
+    ) {
+        return new UpdatePortalPageContentUseCase(
+            portalPageContentQueryService,
+            new PortalPageContentValidatorService(),
+            portalPageContentCrudService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContentCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/crud_service/PortalPageContentCrudService.java
@@ -21,4 +21,6 @@ public interface PortalPageContentCrudService {
     PortalPageContent create(PortalPageContent content);
 
     PortalPageContent createDefault(String organizationId, String environmentId);
+
+    PortalPageContent update(PortalPageContent content);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.exception.EmptyPortalPageContentException;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@DomainService
+public class PortalPageContentValidatorService {
+
+    public void validateForUpdate(UpdatePortalPageContent portalPageContent) {
+        this.validateContent(portalPageContent.getContent());
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new EmptyPortalPageContentException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/EmptyPortalPageContentException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/EmptyPortalPageContentException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public class EmptyPortalPageContentException extends ValidationDomainException {
+
+    public EmptyPortalPageContentException() {
+        super("Content must not be null or empty");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
@@ -45,6 +45,11 @@ public final class GraviteeMarkdownPageContent extends PortalPageContent {
     }
 
     @Override
+    public void update(@Nonnull UpdatePortalPageContent updateGraviteeMarkdownPageContent) {
+        this.content = updateGraviteeMarkdownPageContent.getContent();
+    }
+
+    @Override
     public String toString() {
         return "GraviteeMarkdown[id=" + getId() + ", content=" + content + "]";
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -36,6 +36,8 @@ public abstract sealed class PortalPageContent permits GraviteeMarkdownPageConte
         this.environmentId = environmentId;
     }
 
+    public abstract void update(UpdatePortalPageContent updatePortalPageContent);
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalPageContent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public final class UpdatePortalPageContent {
+
+    private String content;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class UpdatePortalPageContentUseCase {
+
+    private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalPageContentValidatorService portalPageContentValidatorService;
+    private final PortalPageContentCrudService portalPageContentCrudService;
+
+    public Output execute(Input input) {
+        // Check if portal page content is existing
+        PortalPageContent existingContent = portalPageContentQueryService
+            .findById(PortalPageContentId.of(input.portalPageContentId()))
+            .orElseThrow(() -> new PageContentNotFoundException(input.portalPageContentId()));
+
+        // Check if org id and env id are appropriate
+        if (
+            !existingContent.getOrganizationId().equals(input.organizationId()) ||
+            !existingContent.getEnvironmentId().equals(input.environmentId())
+        ) {
+            throw new PageContentNotFoundException(input.portalPageContentId());
+        }
+
+        portalPageContentValidatorService.validateForUpdate(input.updatePortalPageContent());
+
+        existingContent.update(input.updatePortalPageContent());
+
+        return new Output(portalPageContentCrudService.update(existingContent));
+    }
+
+    @Builder
+    public record Input(
+        String organizationId,
+        String environmentId,
+        String portalPageContentId,
+        UpdatePortalPageContent updatePortalPageContent
+    ) {}
+
+    public record Output(PortalPageContent portalPageContent) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImpl.java
@@ -64,6 +64,18 @@ public class PortalPageContentCrudServiceImpl implements PortalPageContentCrudSe
         return this.create(portalPageContent);
     }
 
+    @Override
+    public PortalPageContent update(PortalPageContent content) {
+        try {
+            final var repoContent = portalPageContentAdapter.toRepository(content);
+            final var updatedContent = portalPageContentRepository.update(repoContent);
+            return portalPageContentAdapter.toEntity(updatedContent);
+        } catch (TechnicalException e) {
+            final var errorMessage = String.format("An error occurred while updating portal page content with id %s", content.getId());
+            throw new TechnicalDomainException(errorMessage, e);
+        }
+    }
+
     private String getDefaultPortalPageContent() {
         if (defaultPortalPageContent == null) {
             try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
@@ -54,4 +54,18 @@ public class PortalPageContentCrudServiceInMemory implements InMemoryAlternative
         final var portalPageContent = new GraviteeMarkdownPageContent(pageContentId, organizationId, environmentId, "default page content");
         return this.create(portalPageContent);
     }
+
+    @Override
+    public PortalPageContent update(PortalPageContent content) {
+        final var existingContent = storage
+            .stream()
+            .filter(c -> c.getId().id().equals(content.getId().id()))
+            .findFirst();
+        if (existingContent.isPresent()) {
+            storage.remove(existingContent.get());
+            storage.add(content);
+            return content;
+        }
+        return null;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -19,6 +19,8 @@ import inmemory.*;
 import io.gravitee.apim.core.api.domain_service.NotificationCRDDomainService;
 import io.gravitee.apim.core.integration.service_provider.A2aAgentFetcher;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.specgen.crud_service.ApiSpecGenCrudService;
 import io.gravitee.apim.core.specgen.query_service.ApiSpecGenQueryService;
 import io.gravitee.apim.core.specgen.service_provider.OasProvider;
@@ -488,5 +490,15 @@ public class InMemoryConfiguration {
     @Bean
     public PromotionCrudServiceInMemory promotionCrudService() {
         return new PromotionCrudServiceInMemory();
+    }
+
+    @Bean
+    public PortalPageContentCrudService portalPageContentCrudService() {
+        return new PortalPageContentCrudServiceInMemory();
+    }
+
+    @Bean
+    public PortalPageContentQueryService portalPageContentQueryService() {
+        return new PortalPageContentQueryServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import io.gravitee.apim.core.portal_page.exception.EmptyPortalPageContentException;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalPageContentValidatorServiceTest {
+
+    private final PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService();
+
+    @Nested
+    class ValidateForUpdate {
+
+        @Test
+        void should_validate_successfully_when_content_is_not_empty() {
+            // Given
+            final var updatePortalPageContent = UpdatePortalPageContent.builder().content("Valid content").build();
+
+            // When
+            validatorService.validateForUpdate(updatePortalPageContent);
+
+            // Then
+            // No exception thrown
+        }
+
+        @Test
+        void should_throw_exception_when_content_is_null() {
+            // Given
+            final var updatePortalPageContent = UpdatePortalPageContent.builder().content(null).build();
+
+            // When
+            final ThrowingRunnable throwing = () -> validatorService.validateForUpdate(updatePortalPageContent);
+
+            // Then
+            Exception exception = assertThrows(EmptyPortalPageContentException.class, throwing);
+            assertThat(exception.getMessage()).isEqualTo("Content must not be null or empty");
+        }
+
+        @Test
+        void should_throw_exception_when_content_is_empty() {
+            // Given
+            final var updatePortalPageContent = UpdatePortalPageContent.builder().content("").build();
+
+            // When
+            final ThrowingRunnable throwing = () -> validatorService.validateForUpdate(updatePortalPageContent);
+
+            // Then
+            Exception exception = assertThrows(EmptyPortalPageContentException.class, throwing);
+            assertThat(exception.getMessage()).isEqualTo("Content must not be null or empty");
+        }
+
+        @Test
+        void should_throw_exception_when_content_is_only_whitespace() {
+            // Given
+            final var updatePortalPageContent = UpdatePortalPageContent.builder().content("   ").build();
+
+            // When
+            final ThrowingRunnable throwing = () -> validatorService.validateForUpdate(updatePortalPageContent);
+
+            // Then
+            Exception exception = assertThrows(EmptyPortalPageContentException.class, throwing);
+            assertThat(exception.getMessage()).isEqualTo("Content must not be null or empty");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static fixtures.core.model.PortalPageContentFixtures.CONTENT_ID;
+import static fixtures.core.model.PortalPageContentFixtures.ENVIRONMENT_ID;
+import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.exception.EmptyPortalPageContentException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdatePortalPageContentUseCaseTest {
+
+    private UpdatePortalPageContentUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+        PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+        PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService();
+        useCase = new UpdatePortalPageContentUseCase(queryService, validatorService, crudService);
+
+        queryService.initWith(PortalPageContentFixtures.samplePortalPageContents());
+        crudService.initWith(PortalPageContentFixtures.samplePortalPageContents());
+    }
+
+    @Test
+    void should_update_content_when_valid() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("Updated content").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When
+        final var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent()).isInstanceOf(GraviteeMarkdownPageContent.class);
+        final var updatedContent = (GraviteeMarkdownPageContent) output.portalPageContent();
+        assertThat(updatedContent.getContent()).isEqualTo("Updated content");
+        assertThat(updatedContent.getId()).isEqualTo(PortalPageContentId.of(CONTENT_ID));
+    }
+
+    @Test
+    void should_throw_when_content_not_found() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("Updated content").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId("00000000-0000-0000-0000-000000000002")
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_throw_when_organization_id_mismatch() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("Updated content").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId("different-org")
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_throw_when_environment_id_mismatch() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("Updated content").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId("different-env")
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_throw_when_content_is_empty() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(EmptyPortalPageContentException.class)
+            .hasMessage("Content must not be null or empty");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalPageContentCrudServiceImplTest.java
@@ -111,4 +111,30 @@ class PortalPageContentCrudServiceImplTest {
             assertThat(captor.getValue().getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
         }
     }
+
+    @Nested
+    class UpdatePageContent {
+
+        @Test
+        void should_update_a_page_content() throws TechnicalException {
+            // Given
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            final var pageContentId = PortalPageContentId.random();
+            final var portalPageContent = new GraviteeMarkdownPageContent(
+                pageContentId,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                "# Updated Content\n\nThis is the updated content."
+            );
+            final var repoContent = portalPageContentAdapter.toRepository(portalPageContent);
+
+            // When
+            service.update(portalPageContent);
+
+            // Then
+            verify(repository).update(captor.capture());
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(repoContent);
+        }
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11555

## Description

Portal Page Content Updates:

- Added a PUT endpoint to update portal page content via PortalPageContentsResource.
- Created UpdatePortalPageContentUseCase for handling update logic.
- Implemented PortalPageContentValidatorService to validate update requests.
- Extended PortalPageContentCrudService to support updates.

New Models and Exceptions:

- Introduced UpdatePortalPageContent model for update operations.
- Added EmptyPortalPageContentException for handling validation errors during updates.

Documentation and OpenAPI Specification:

- Updated OpenAPI YAML to include the new PUT method for updating portal page content.

Tests:

- Added comprehensive test cases to cover new functionality, including both success and failure scenarios.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

