### PR TITLE
Apim 11563 add published flag to portal nav item

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -35,6 +35,7 @@ export function fakePortalNavigationPage(overrides?: Partial<PortalNavigationPag
     order: 1,
     area: 'HOMEPAGE',
     portalPageContentId: 'page-content-1',
+    published: true,
   };
 
   if (isFunction(overrides)) {
@@ -56,6 +57,7 @@ export function fakePortalNavigationFolder(overrides?: Partial<PortalNavigationF
     type: 'FOLDER',
     order: 1,
     area: 'HOMEPAGE',
+    published: true,
   };
 
   if (isFunction(overrides)) {
@@ -78,6 +80,7 @@ export function fakePortalNavigationLink(overrides?: Partial<PortalNavigationLin
     order: 1,
     area: 'HOMEPAGE',
     url: 'https://example.com',
+    published: true,
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -24,6 +24,7 @@ interface BasePortalNavigationItem<T extends PortalNavigationItemType> {
   type: T;
   order: number;
   area: PortalArea;
+  published: boolean;
   parentId?: string;
 }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
@@ -61,4 +61,6 @@ public class PortalNavigationItem {
     private Integer order;
 
     private String configuration;
+
+    private boolean published;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -47,6 +47,7 @@ public class JdbcPortalNavigationItemRepository
             .addColumn("parent_id", Types.NVARCHAR, String.class)
             .addColumn("order", Types.INTEGER, Integer.class)
             .addColumn("configuration", Types.NVARCHAR, String.class)
+            .addColumn("published", Types.BOOLEAN, boolean.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
@@ -14,6 +14,7 @@ databaseChangeLog:
               - column: {name: area, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: order, type: integer, constraints: { nullable: true } }
+              - column: {name: published, type: boolean, constraints: { nullable: false } }
               - column: {name: configuration, type: nclob, constraints: { nullable: true } }
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}portal_navigation_items

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
@@ -32,4 +32,5 @@ public class PortalNavigationItemMongo {
     private String parentId;
     private Integer order;
     private String configuration;
+    private boolean published;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -98,6 +98,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .type(PortalNavigationItem.Type.LINK)
             .area(PortalNavigationItem.Area.TOP_NAVBAR)
             .order(4)
+            .published(true)
             .configuration("{ \"url\": \"https://support.example.com\" }")
             .build();
 
@@ -138,6 +139,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .type(PortalNavigationItem.Type.LINK)
             .area(PortalNavigationItem.Area.TOP_NAVBAR)
             .order(1)
+            .published(true)
             .configuration("{ \"url\": \"https://original.com\" }")
             .build();
 
@@ -153,6 +155,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .type(PortalNavigationItem.Type.LINK)
             .area(PortalNavigationItem.Area.TOP_NAVBAR)
             .order(2)
+            .published(false)
             .configuration("{ \"url\": \"https://updated.com\" }")
             .build();
 
@@ -162,6 +165,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         assertThat(updated.getTitle()).isEqualTo("Updated Title");
         assertThat(updated.getOrder()).isEqualTo(2);
         assertThat(updated.getConfiguration()).isEqualTo("{ \"url\": \"https://updated.com\" }");
+        assertThat(updated.isPublished()).isFalse();
 
         portalNavigationItemRepository.delete("update-nav-item");
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
@@ -8,6 +8,7 @@
     "area": "HOMEPAGE",
     "parentId": null,
     "order": 1,
+    "published": true,
     "configuration": "{ \"portalPageContentId\": \"550e8400-e29b-41d4-a716-446655440000\" }"
   },
   {
@@ -19,6 +20,7 @@
     "area": "TOP_NAVBAR",
     "parentId": null,
     "order": 2,
+    "published": true,
     "configuration": "{ \"href\": \"https://docs.example.com\" }"
   },
   {
@@ -30,6 +32,7 @@
     "area": "TOP_NAVBAR",
     "parentId": null,
     "order": 3,
+    "published": true,
     "configuration": "{}"
   },
   {
@@ -41,6 +44,7 @@
     "area": "TOP_NAVBAR",
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 1,
+    "published": true,
     "configuration": "{ \"portalPageContentId\": \"660e8400-e29b-41d4-a716-446655440001\" }"
   },
   {
@@ -52,6 +56,7 @@
     "area": "TOP_NAVBAR",
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 2,
+    "published": true,
     "configuration": "{ \"portalPageContentId\": \"770e8400-e29b-41d4-a716-446655440002\" }"
   },
   {
@@ -63,6 +68,7 @@
     "area": "TOP_NAVBAR",
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 3,
+    "published": true,
     "configuration": "{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }"
   }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1786,7 +1786,11 @@ components:
           type: integer
           description: The order of the navigation item (zero-based)
           example: 2
-      required: [ id, organizationId, environmentId, title, type, area, order ]
+        published:
+          type: boolean
+          description: Whether the navigation item is published or not
+          example: true
+      required: [ id, organizationId, environmentId, title, type, area, order, published ]
       discriminator:
         propertyName: type
         mapping:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -101,7 +101,8 @@ class PortalNavigationItemsMapperTest {
                 "My Link",
                 PortalArea.TOP_NAVBAR,
                 3,
-                "https://example.com"
+                "https://example.com",
+                true
             );
 
             var result = mapper.map(link);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
@@ -136,7 +136,8 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("portalPageContentId", ((CreatePortalNavigationPage) page).getPortalPageContentId())
             .hasFieldOrPropertyWithValue("parentId", page.getParentId())
             .hasFieldOrPropertyWithValue("order", page.getOrder())
-            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR);
+            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
+            .hasFieldOrPropertyWithValue("published", false);
     }
 
     @Test
@@ -161,7 +162,8 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("type", PortalNavigationItemType.FOLDER)
             .hasFieldOrPropertyWithValue("parentId", folder.getParentId())
             .hasFieldOrPropertyWithValue("order", folder.getOrder())
-            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR);
+            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
+            .hasFieldOrPropertyWithValue("published", false);
     }
 
     @Test
@@ -187,6 +189,7 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("url", ((CreatePortalNavigationLink) link).getUrl())
             .hasFieldOrPropertyWithValue("parentId", link.getParentId())
             .hasFieldOrPropertyWithValue("order", link.getOrder())
-            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR);
+            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
+            .hasFieldOrPropertyWithValue("published", false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -130,6 +130,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body).isNotNull();
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
+        assertThat(body.getPublished()).isTrue();
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -155,6 +156,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body).isNotNull();
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getUrl()).isEqualTo("https://gravitee.io");
+        assertThat(body.getPublished()).isTrue();
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -179,6 +181,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body).isNotNull();
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
+        assertThat(body.getPublished()).isTrue();
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
@@ -38,15 +38,15 @@ public final class PortalNavigationFixtures {
     }
 
     public static PortalNavigationFolder folder(PortalNavigationItemId id, String title, PortalArea area) {
-        return new PortalNavigationFolder(id, "org", "env", title, area, 1);
+        return new PortalNavigationFolder(id, "org", "env", title, area, 1, true);
     }
 
     public static PortalNavigationLink link(PortalNavigationItemId id, String title, PortalArea area, String url) {
-        return new PortalNavigationLink(id, "org", "env", title, area, 1, url);
+        return new PortalNavigationLink(id, "org", "env", title, area, 1, url, true);
     }
 
     public static PortalNavigationPage page(PortalNavigationItemId id, String title, PortalArea area, PortalPageContentId pageId) {
-        return new PortalNavigationPage(id, "org", "env", title, area, 1, pageId);
+        return new PortalNavigationPage(id, "org", "env", title, area, 1, pageId, true);
     }
 
     public static List<PortalNavigationItem> sampleList(PortalArea area) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
@@ -25,8 +25,9 @@ public final class PortalNavigationFolder extends PortalNavigationItem {
         @Nonnull String environmentId,
         @Nonnull String title,
         @Nonnull PortalArea area,
-        @Nonnull Integer order
+        @Nonnull Integer order,
+        @Nonnull Boolean published
     ) {
-        super(id, organizationId, environmentId, title, area, order);
+        super(id, organizationId, environmentId, title, area, order, published);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -51,13 +51,18 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
     @Nullable
     private PortalNavigationItemId parentId;
 
+    @Setter
+    @Nonnull
+    private Boolean published;
+
     protected PortalNavigationItem(
         @Nonnull PortalNavigationItemId id,
         @Nonnull String organizationId,
         @Nonnull String environmentId,
         @Nonnull String title,
         @Nonnull PortalArea area,
-        @Nonnull Integer order
+        @Nonnull Integer order,
+        @Nonnull Boolean published
     ) {
         this.id = id;
         this.organizationId = organizationId;
@@ -65,6 +70,7 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         this.title = title;
         this.area = area;
         this.order = order;
+        this.published = published;
     }
 
     @Override
@@ -95,9 +101,9 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         final var order = item.getOrder();
 
         final var newItem = switch (item.getType()) {
-            case FOLDER -> new PortalNavigationFolder(id, organizationId, environmentId, title, area, order);
-            case PAGE -> new PortalNavigationPage(id, organizationId, environmentId, title, area, order, contentId);
-            case LINK -> new PortalNavigationLink(id, organizationId, environmentId, title, area, order, url);
+            case FOLDER -> new PortalNavigationFolder(id, organizationId, environmentId, title, area, order, false);
+            case PAGE -> new PortalNavigationPage(id, organizationId, environmentId, title, area, order, contentId, false);
+            case LINK -> new PortalNavigationLink(id, organizationId, environmentId, title, area, order, url, false);
         };
         newItem.setParentId(parentId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
@@ -33,9 +33,10 @@ public final class PortalNavigationLink extends PortalNavigationItem {
         @Nonnull String title,
         @Nonnull PortalArea area,
         @Nonnull Integer order,
-        @Nonnull String url
+        @Nonnull String url,
+        @Nonnull Boolean published
     ) {
-        super(id, organizationId, environmentId, title, area, order);
+        super(id, organizationId, environmentId, title, area, order, published);
         this.url = url;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
@@ -33,9 +33,10 @@ public final class PortalNavigationPage extends PortalNavigationItem {
         @Nonnull String title,
         @Nonnull PortalArea area,
         @Nonnull Integer order,
-        @Nonnull PortalPageContentId portalPageContentId
+        @Nonnull PortalPageContentId portalPageContentId,
+        @Nonnull Boolean published
     ) {
-        super(id, organizationId, environmentId, title, area, order);
+        super(id, organizationId, environmentId, title, area, order, published);
         this.portalPageContentId = portalPageContentId;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -44,7 +44,7 @@ public class PortalNavigationItemFixtures {
     }
 
     public static PortalNavigationFolder aFolder(String id, String title, PortalNavigationItemId parentId) {
-        var folder = new PortalNavigationFolder(PortalNavigationItemId.of(id), ORG_ID, ENV_ID, title, PortalArea.TOP_NAVBAR, 0);
+        var folder = new PortalNavigationFolder(PortalNavigationItemId.of(id), ORG_ID, ENV_ID, title, PortalArea.TOP_NAVBAR, 0, true);
         folder.setParentId(parentId);
         return folder;
     }
@@ -57,7 +57,8 @@ public class PortalNavigationItemFixtures {
             title,
             PortalArea.TOP_NAVBAR,
             0,
-            PortalPageContentId.random()
+            PortalPageContentId.random(),
+            true
         );
         page.setParentId(parentId);
         return page;
@@ -71,7 +72,8 @@ public class PortalNavigationItemFixtures {
             title,
             PortalArea.TOP_NAVBAR,
             0,
-            "http://example.com"
+            "http://example.com",
+            true
         );
         link.setParentId(parentId);
         return link;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -149,6 +149,24 @@ class CreatePortalNavigationItemUseCaseTest {
             });
     }
 
+    @Test
+    void should_set_portal_navigation_item_to_not_published() {
+        // Given
+        final var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .type(PortalNavigationItemType.FOLDER)
+            .title("title")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .build();
+
+        // When
+        final var output = useCase.execute(new CreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, createPortalNavigationItem));
+
+        // Then
+        assertThat(output.item().getPublished()).isFalse();
+    }
+
     @Nested
     class UpdateSiblingsOrder {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
@@ -95,6 +95,7 @@ class UpdatePortalNavigationItemUseCaseTest {
         assertThat(output.updatedItem()).isNotNull();
         assertThat(output.updatedItem().getId()).isEqualTo(originalId);
         assertThat(output.updatedItem().getTitle()).isEqualTo("New Title");
+        assertThat(output.updatedItem().getPublished()).isTrue();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -214,7 +214,8 @@ class PortalNavigationItemAdapterTest {
                 "env-id",
                 "My Folder",
                 PortalArea.TOP_NAVBAR,
-                1
+                1,
+                true
             );
             entity.setParentId(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440011"));
 
@@ -243,7 +244,8 @@ class PortalNavigationItemAdapterTest {
                 "My Page",
                 PortalArea.HOMEPAGE,
                 2,
-                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440013")
+                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440013"),
+                true
             );
 
             // When
@@ -270,7 +272,8 @@ class PortalNavigationItemAdapterTest {
                 "My Link",
                 PortalArea.TOP_NAVBAR,
                 3,
-                "https://example.com"
+                "https://example.com",
+                true
             );
 
             // When
@@ -296,7 +299,8 @@ class PortalNavigationItemAdapterTest {
                 "env-id",
                 "My Folder",
                 PortalArea.TOP_NAVBAR,
-                0
+                0,
+                true
             );
 
             // When

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalNavigationItemsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalNavigationItemsCrudServiceImplTest.java
@@ -71,7 +71,7 @@ class PortalNavigationItemsCrudServiceImplTest {
         @Test
         void should_create_a_folder() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
-            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0);
+            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, true);
 
             service.create(item);
 
@@ -85,6 +85,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{}")
+                .published(true)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -102,7 +103,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 "title",
                 PortalArea.TOP_NAVBAR,
                 0,
-                contentId
+                contentId,
+                true
             );
 
             service.create(item);
@@ -117,6 +119,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{\"portalPageContentId\":\"" + contentId.toString() + "\"}")
+                .published(true)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -127,7 +130,16 @@ class PortalNavigationItemsCrudServiceImplTest {
         void should_create_a_link() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
             final var url = "http://example.com";
-            final var item = new PortalNavigationLink(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, url);
+            final var item = new PortalNavigationLink(
+                itemId,
+                "organizationId",
+                "environmentId",
+                "title",
+                PortalArea.TOP_NAVBAR,
+                0,
+                url,
+                true
+            );
 
             service.create(item);
 
@@ -141,6 +153,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{\"url\":\"" + url + "\"}")
+                .published(true)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -159,7 +172,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 "title",
                 PortalArea.TOP_NAVBAR,
                 0,
-                contentId
+                contentId,
+                true
             );
             when(repository.create(any())).thenThrow(new TechnicalException("Database error"));
 
@@ -184,7 +198,7 @@ class PortalNavigationItemsCrudServiceImplTest {
         @Test
         void should_update_a_folder() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
-            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0);
+            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, true);
 
             service.update(item);
 
@@ -198,6 +212,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{}")
+                .published(true)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -215,7 +230,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 "title",
                 PortalArea.TOP_NAVBAR,
                 0,
-                contentId
+                contentId,
+                true
             );
 
             service.update(item);
@@ -230,6 +246,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{\"portalPageContentId\":\"" + contentId.toString() + "\"}")
+                .published(true)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -240,7 +257,16 @@ class PortalNavigationItemsCrudServiceImplTest {
         void should_update_a_link() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
             final var url = "http://example.com";
-            final var item = new PortalNavigationLink(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, url);
+            final var item = new PortalNavigationLink(
+                itemId,
+                "organizationId",
+                "environmentId",
+                "title",
+                PortalArea.TOP_NAVBAR,
+                0,
+                url,
+                true
+            );
 
             service.update(item);
 
@@ -254,6 +280,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .order(0)
                 .parentId(null)
                 .configuration("{\"url\":\"" + url + "\"}")
+                .published(true)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -272,7 +299,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 "title",
                 PortalArea.TOP_NAVBAR,
                 0,
-                contentId
+                contentId,
+                true
             );
             when(repository.update(any())).thenThrow(new TechnicalException("Database error"));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -395,7 +395,8 @@ public class DeleteEnvironmentCommandHandlerTest {
                     PortalNavigationItem.Area.HOMEPAGE,
                     null,
                     13,
-                    "{\"pageId\":\"" + PAGE_CONTENT_ID + "\"}"
+                    "{\"pageId\":\"" + PAGE_CONTENT_ID + "\"}",
+                    true
                 )
             )
         );
@@ -579,7 +580,8 @@ public class DeleteEnvironmentCommandHandlerTest {
                     PortalNavigationItem.Area.HOMEPAGE,
                     null,
                     13,
-                    "{}"
+                    "{}",
+                    true
                 )
             )
         );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11563

## Description

- Add flag to portal navigation item for if it is published in repo and services
- Return `published` attribute in MAPI-v2
- Only return published nav items in PAPI
- Add published flag to Console `PortalNavigationItem` object

Next PRs:
- Add "published" to the PUT update of a given portal nav item
- Show badge in Console if the page is published
- Handle published state for homepage

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

