### PR TITLE
feat: windowed count message sampling 

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -116,6 +116,10 @@ export interface ConsoleSettingsLogging {
       default: string;
       limit: string;
     };
+    windowedCount?: {
+      default: string;
+      limit: string;
+    };
   };
 }
 

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/sampling.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/sampling.ts
@@ -24,4 +24,4 @@ export interface Sampling {
    */
   value?: string;
 }
-export type SamplingTypeEnum = 'PROBABILITY' | 'TEMPORAL' | 'COUNT' | 'QUERY';
+export type SamplingTypeEnum = 'PROBABILITY' | 'TEMPORAL' | 'COUNT' | 'WINDOWED_COUNT';

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -290,5 +290,9 @@ export interface PortalSettingsLogging {
       default: string;
       limit: string;
     };
+    windowedCount?: {
+      default: string;
+      limit: string;
+    };
   };
 }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.html
@@ -15,172 +15,229 @@
     limitations under the License.
 
 -->
-<form *ngIf="form" [formGroup]="form">
-  <mat-card>
-    <mat-card-header>
-      <mat-card-title>Settings</mat-card-title>
-      <mat-card-subtitle>Adjust the settings to match your needs.</mat-card-subtitle>
-      <div class="settings__headerRightBtn">
-        <gio-form-slide-toggle class="failover-card__enable-toggle">
-          <gio-form-label>{{ form.get('enabled').value ? 'Enabled' : 'Disabled' }}</gio-form-label>
-          <mat-slide-toggle
-            gioFormSlideToggle
-            aria-label="Analytics enable toggle"
-            name="enableAnalytics"
-            formControlName="enabled"
-          ></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </div>
-    </mat-card-header>
-    <mat-card-content class="settings">
-      <gio-banner-info>
-        <div>Logging smartly</div>
-        <span gioBannerBody>Opt for logging checkboxes carefully, this requires extra storage and may affect API performance.</span>
-      </gio-banner-info>
 
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">Logging mode</div>
-        <div class="settings__form-control__subtitle">Customize the mode included.</div>
-        <gio-form-slide-toggle>
-          <gio-form-label>Entrypoint</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="entrypoint"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Endpoint</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="endpoint"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </div>
+@if (form) {
+  <form [formGroup]="form">
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Settings</mat-card-title>
+        <mat-card-subtitle>Adjust the settings to match your needs.</mat-card-subtitle>
+        <div class="settings__headerRightBtn">
+          <gio-form-slide-toggle class="failover-card__enable-toggle">
+            <gio-form-label>{{ form.get('enabled').value ? 'Enabled' : 'Disabled' }}</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
+              aria-label="Analytics enable toggle"
+              name="enableAnalytics"
+              formControlName="enabled"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
+      </mat-card-header>
+      <mat-card-content class="settings">
+        <gio-banner-info>
+          <div>Logging smartly</div>
+          <span gioBannerBody>Opt for logging checkboxes carefully, this requires extra storage and may affect API performance.</span>
+        </gio-banner-info>
 
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">Logging phase</div>
-        <div class="settings__form-control__subtitle">Customize the phases included.</div>
-        <gio-form-slide-toggle>
-          <gio-form-label>Request</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="request"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Response</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="response"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </div>
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">Logging mode</div>
+          <div class="settings__form-control__subtitle">Customize the mode included.</div>
+          <gio-form-slide-toggle>
+            <gio-form-label>Entrypoint</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="entrypoint"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Endpoint</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="endpoint"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
 
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">Content data</div>
-        <div class="settings__form-control__subtitle">Customize the data included.</div>
-        <p class="settings__form-control__info" *ngIf="form.get('messageContent').disabled">
-          <mat-icon svgIcon="gio:info"></mat-icon> To select an option, ensure you’ve checked one mode or more above.
-        </p>
-        <gio-form-slide-toggle>
-          <gio-form-label>Message content</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="messageContent"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Message headers</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="messageHeaders"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Message metadata</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="messageMetadata"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Headers</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="headers"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </div>
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">Logging phase</div>
+          <div class="settings__form-control__subtitle">Customize the phases included.</div>
+          <gio-form-slide-toggle>
+            <gio-form-label>Request</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="request"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Response</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="response"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
 
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">Message sampling</div>
-        <div class="settings__form-control__subtitle">Set a personalized sampling configuration.</div>
-        <mat-button-toggle-group aria-label="Select message sampling typ" class="sampling-type" formControlName="samplingType">
-          <mat-button-toggle class="sampling-type__toggle" value="PROBABILITY"> Probabilistic </mat-button-toggle>
-          <mat-button-toggle class="sampling-type__toggle" value="COUNT"> Count </mat-button-toggle>
-          <mat-button-toggle class="sampling-type__toggle" value="TEMPORAL"> Temporal </mat-button-toggle>
-        </mat-button-toggle-group>
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">Content data</div>
+          <div class="settings__form-control__subtitle">Customize the data included.</div>
+          @if (form.get('messageContent').disabled) {
+            <p class="settings__form-control__info">
+              <mat-icon svgIcon="gio:info"></mat-icon> To select an option, ensure you’ve checked one mode or more above.
+            </p>
+          }
+          <gio-form-slide-toggle>
+            <gio-form-label>Message content</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="messageContent"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Message headers</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="messageHeaders"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Message metadata</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="messageMetadata"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Headers</gio-form-label>
+            <mat-slide-toggle gioFormSlideToggle formControlName="headers"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
 
-        <ng-container *ngIf="form.get('samplingType').value === 'PROBABILITY'">
-          <p>Samples messages based on a specified probability.</p>
-          <p>The value should be between 0.01 and {{ settings?.logging.messageSampling.probabilistic.limit ?? 0.5 }}.</p>
-          <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
-            <mat-label>Message sampling</mat-label>
-            <input matInput type="number" formControlName="samplingValue" />
-            <mat-error *ngIf="form.get('samplingValue').hasError('required')"> The sampling value is required. </mat-error>
-            <mat-error *ngIf="form.get('samplingValue').hasError('min')"> The sampling value should be greater than 0.01. </mat-error>
-            <mat-error *ngIf="form.get('samplingValue').hasError('max')">
-              The sampling value should be lower than {{ settings?.logging.messageSampling.probabilistic.limit ?? 0.5 }}.
-            </mat-error>
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">Message sampling</div>
+          <div class="settings__form-control__subtitle">Set a personalized sampling configuration.</div>
+          <mat-button-toggle-group aria-label="Select message sampling typ" class="sampling-type" formControlName="samplingType">
+            <mat-button-toggle class="sampling-type__toggle" value="PROBABILITY"> Probabilistic </mat-button-toggle>
+            <mat-button-toggle class="sampling-type__toggle" value="COUNT"> Count </mat-button-toggle>
+            <mat-button-toggle class="sampling-type__toggle" value="TEMPORAL"> Temporal </mat-button-toggle>
+            <mat-button-toggle class="sampling-type__toggle" value="WINDOWED_COUNT"> Windowed Count </mat-button-toggle>
+          </mat-button-toggle-group>
+
+          @if (form.get('samplingType').value === 'PROBABILITY') {
+            <ng-container>
+              <p>Samples messages based on a specified probability.</p>
+              <p>The value should be between 0.01 and {{ settings?.logging.messageSampling.probabilistic.limit ?? 0.5 }}.</p>
+              <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
+                <mat-label>Message sampling</mat-label>
+                <input matInput type="number" formControlName="samplingValue" />
+                @if (form.get('samplingValue').hasError('required')) {
+                  <mat-error> The sampling value is required.</mat-error>
+                }
+                @if (form.get('samplingValue').hasError('min')) {
+                  <mat-error> The sampling value should be greater than 0.01.</mat-error>
+                }
+                @if (form.get('samplingValue').hasError('max')) {
+                  <mat-error>
+                    The sampling value should be lower than {{ settings?.logging.messageSampling.probabilistic.limit ?? 0.5 }}.
+                  </mat-error>
+                }
+              </mat-form-field>
+            </ng-container>
+          }
+          @if (form.get('samplingType').value === 'COUNT') {
+            <ng-container>
+              <p>Samples one message for every number of specified messages.</p>
+              <p>The value should be greater than {{ settings?.logging?.messageSampling?.count?.limit ?? 10 }}.</p>
+              <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
+                <mat-label>Message sampling</mat-label>
+                <input matInput type="number" formControlName="samplingValue" />
+                @if (form.get('samplingValue').hasError('required')) {
+                  <mat-error> The sampling value is required. </mat-error>
+                }
+                @if (form.get('samplingValue').hasError('min')) {
+                  <mat-error
+                    >The sampling value should be greater than {{ settings?.logging?.messageSampling?.count?.limit ?? 10 }}.
+                  </mat-error>
+                }
+              </mat-form-field>
+            </ng-container>
+          }
+
+          @if (form.get('samplingType').value === 'TEMPORAL') {
+            <ng-container>
+              <p>Samples messages based on time duration.</p>
+              <p>
+                The value should conform to ISO-8601 duration format, e.g. PT1S for a duration of 1 second and be greater than
+                {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
+              </p>
+              <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
+                <mat-label>Message sampling</mat-label>
+                <input matInput formControlName="samplingValue" />
+                @if (form.get('samplingValue').hasError('required')) {
+                  <mat-error> The sampling value is required. </mat-error>
+                }
+                @if (form.get('samplingValue').hasError('invalidISO8601Duration')) {
+                  <mat-error>
+                    The sampling value should use ISO-8601 duration format, e.g.
+                    {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
+                  </mat-error>
+                }
+                @if (form.get('samplingValue').hasError('minTemporal')) {
+                  <mat-error>
+                    The sampling value should be greater than {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
+                  </mat-error>
+                }
+              </mat-form-field>
+            </ng-container>
+          }
+
+          @if (form.get('samplingType').value === 'WINDOWED_COUNT') {
+            <ng-container>
+              <p>Samples a count of messages during a sliding duration window.</p>
+              <p>
+                Format is COUNT/DURATION (duration should conform to ISO-8601 duration format). The resulting rate must be lower than
+                {{ settings?.logging?.messageSampling?.windowedCount?.limit ?? '1/PT1S' }}.<br />
+                Example: <strong>2/PT15S</strong> will sample, at most, two messages during a 15-second sliding window.
+              </p>
+              <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
+                <mat-label>Message sampling</mat-label>
+                <input matInput formControlName="samplingValue" />
+                @if (form.get('samplingValue').hasError('required')) {
+                  <mat-error> The sampling value is required. </mat-error>
+                }
+                @if (form.get('samplingValue').hasError('invalidFormat')) {
+                  <mat-error>
+                    The sampling value must follow this format: COUNT/DURATION, COUNT>0, DURATION is ISO-8601 duration format e.g.
+                    {{ settings?.logging?.messageSampling?.windowedCount?.limit ?? '1/PT1S' }}.
+                  </mat-error>
+                }
+                @if (form.get('samplingValue').hasError('maxRate')) {
+                  <mat-error>
+                    The sampling rate cannot exceed
+                    {{ settings?.logging?.messageSampling?.windowedCount?.limit ?? '1/PT1S' }}, lower the count or increase the duration.
+                  </mat-error>
+                }
+              </mat-form-field>
+            </ng-container>
+          }
+        </div>
+
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">Display conditions</div>
+          <div class="settings__form-control__subtitle">Filter the data that matter to you.</div>
+
+          <mat-form-field>
+            <mat-label>Request phase condition</mat-label>
+            <input matInput formControlName="requestCondition" />
+            <mat-hint> Support EL (e.g: &#123; #request.headers['Content-Type'][0] == 'application/json' &#125;)</mat-hint>
           </mat-form-field>
-        </ng-container>
 
-        <ng-container *ngIf="form.get('samplingType').value === 'COUNT'">
-          <p>Samples one message for every number of specified messages.</p>
-          <p>The value should be greater than {{ settings?.logging?.messageSampling?.count?.limit ?? 10 }}.</p>
-          <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
-            <mat-label>Message sampling</mat-label>
-            <input matInput type="number" formControlName="samplingValue" />
-            <mat-error *ngIf="form.get('samplingValue').hasError('required')"> The sampling value is required. </mat-error>
-            <mat-error *ngIf="form.get('samplingValue').hasError('min')">
-              The sampling value should be greater than {{ settings?.logging?.messageSampling?.count?.limit ?? 10 }}.
-            </mat-error>
+          <mat-form-field class="settings__form-control__form-field">
+            <mat-label>Message condition</mat-label>
+            <input matInput formControlName="messageCondition" />
+            <mat-hint> Support EL (e.g: &#123; #message.headers['Content-Type'][0] == 'application/json' &#125;)</mat-hint>
           </mat-form-field>
-        </ng-container>
+        </div>
 
-        <ng-container *ngIf="form.get('samplingType').value === 'TEMPORAL'">
-          <p>Samples messages based on time duration.</p>
-          <p>
-            The value should conform to ISO-8601 duration format, e.g. PT1S for a duration of 1 second and be greater than
-            {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
-          </p>
-          <mat-form-field data-testid="sampling_value" class="settings__form-control__form-field">
-            <mat-label>Message sampling</mat-label>
-            <input matInput formControlName="samplingValue" />
-            <mat-error *ngIf="form.get('samplingValue').hasError('required')"> The sampling value is required. </mat-error>
-            <mat-error *ngIf="form.get('samplingValue').hasError('invalidISO8601Duration')">
-              The sampling value should use ISO-8601 duration format, e.g.
-              {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
-            </mat-error>
-            <mat-error *ngIf="form.get('samplingValue').hasError('minTemporal')">
-              The sampling value should be greater than {{ settings?.logging?.messageSampling?.temporal?.limit ?? 'PT1S' }}.
-            </mat-error>
-          </mat-form-field>
-        </ng-container>
-      </div>
-
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">Display conditions</div>
-        <div class="settings__form-control__subtitle">Filter the data that matter to you.</div>
-
-        <mat-form-field>
-          <mat-label>Request phase condition</mat-label>
-          <input matInput formControlName="requestCondition" />
-          <mat-hint> Support EL (e.g: &#123; #request.headers['Content-Type'][0] == 'application/json' &#125;)</mat-hint>
-        </mat-form-field>
-
-        <mat-form-field class="settings__form-control__form-field">
-          <mat-label>Message condition</mat-label>
-          <input matInput formControlName="messageCondition" />
-          <mat-hint> Support EL (e.g: &#123; #message.headers['Content-Type'][0] == 'application/json' &#125;)</mat-hint>
-        </mat-form-field>
-      </div>
-
-      <div class="settings__form-control">
-        <div class="settings__form-control__title">OpenTelemetry</div>
-        <div class="settings__form-control__subtitle">OpenTelemetry settings.</div>
-        <gio-form-slide-toggle>
-          <gio-form-label>Enabled</gio-form-label>
-          Enable OpenTelemetry tracing.
-          <mat-slide-toggle gioFormSlideToggle formControlName="tracingEnabled"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-        <gio-form-slide-toggle>
-          <gio-form-label>Verbose</gio-form-label>
-          Adds detailed span events with headers, context attributes, and change detection like in case of policy execution. Standard mode
-          already captures execution spans and conditions.
-          <br />
-          <mat-icon svgIcon="gio:alert-circle" class="verbose-warning-icon"></mat-icon>
-          Enable only for deep debugging - increases trace size significantly.
-          <mat-slide-toggle gioFormSlideToggle formControlName="tracingVerbose"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </div>
-    </mat-card-content>
-  </mat-card>
-  <gio-save-bar [form]="form" [formInitialValues]="initialFormValue" (submitted)="save()"></gio-save-bar>
-</form>
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">OpenTelemetry</div>
+          <div class="settings__form-control__subtitle">OpenTelemetry settings.</div>
+          <gio-form-slide-toggle>
+            <gio-form-label>Enabled</gio-form-label>
+            Enable OpenTelemetry tracing.
+            <mat-slide-toggle gioFormSlideToggle formControlName="tracingEnabled"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Verbose</gio-form-label>
+            Adds detailed span events with headers, context attributes, and change detection like in case of policy execution. Standard mode
+            already captures execution spans and conditions.
+            <br />
+            <mat-icon svgIcon="gio:alert-circle" class="verbose-warning-icon"></mat-icon>
+            Enable only for deep debugging - increases trace size significantly.
+            <mat-slide-toggle gioFormSlideToggle formControlName="tracingVerbose"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
+      </mat-card-content>
+    </mat-card>
+    <gio-save-bar [form]="form" [formInitialValues]="initialFormValue" (submitted)="save()"></gio-save-bar>
+  </form>
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.spec.ts
@@ -75,6 +75,10 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           limit: 'PT10S',
           default: 'PT10S',
         },
+        windowedCount: {
+          limit: '1/PT1S',
+          default: '1/PT10S',
+        },
       },
     },
   };
@@ -425,6 +429,44 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
       expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
 
       await componentHarness.addSamplingValue('PT11S');
+      expect(await componentHarness.samplingValueHasErrors()).toEqual(false);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeFalsy();
+    });
+
+    it('should validate sampling value with WINDOWED_COUNT type', async () => {
+      await initComponent();
+      await componentHarness.choseSamplingType('Windowed Count');
+      expect(await componentHarness.getSamplingType()).toStrictEqual('Windowed Count');
+
+      await componentHarness.addSamplingValue(null);
+      expect(await componentHarness.getSamplingValueErrors()).toEqual(['The sampling value is required.']);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
+
+      await componentHarness.addSamplingValue('2/PT1S');
+      expect(await componentHarness.getSamplingValueErrors()).toEqual([
+        'The sampling rate cannot exceed 1/PT1S, lower the count or increase the duration.',
+      ]);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
+
+      await componentHarness.addSamplingValue('-1/PT1S');
+      expect(await componentHarness.getSamplingValueErrors()).toEqual([
+        'The sampling value must follow this format: COUNT/DURATION, COUNT>0, DURATION is ISO-8601 duration format e.g. 1/PT1S.',
+      ]);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
+
+      await componentHarness.addSamplingValue('1/PT');
+      expect(await componentHarness.getSamplingValueErrors()).toEqual([
+        'The sampling value must follow this format: COUNT/DURATION, COUNT>0, DURATION is ISO-8601 duration format e.g. 1/PT1S.',
+      ]);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
+
+      await componentHarness.addSamplingValue('1:PT1S');
+      expect(await componentHarness.getSamplingValueErrors()).toEqual([
+        'The sampling value must follow this format: COUNT/DURATION, COUNT>0, DURATION is ISO-8601 duration format e.g. 1/PT1S.',
+      ]);
+      expect(await componentHarness.isSaveButtonInvalid()).toBeTruthy();
+
+      await componentHarness.addSamplingValue('1/PT11S');
       expect(await componentHarness.samplingValueHasErrors()).toEqual(false);
       expect(await componentHarness.isSaveButtonInvalid()).toBeFalsy();
     });

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count-format.validator.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count-format.validator.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *
+ *  * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+import { AbstractControl } from '@angular/forms';
+
+import { isWindowedCountValidFormat } from './windowed-count-format.validator';
+
+describe('isWindowedCountValidFormat', () => {
+  it('should return null if the control value is empty', () => {
+    const control = { value: '' } as AbstractControl;
+    expect(isWindowedCountValidFormat()(control)).toBeUndefined();
+  });
+
+  it('should return null if the control value is valid', () => {
+    const control = { value: '1/PT1S' } as AbstractControl;
+    expect(isWindowedCountValidFormat()(control)).toBeUndefined();
+  });
+
+  it('should return null if windowed count is valid', () => {
+    const control = { value: '5/PT10S' } as AbstractControl;
+    expect(isWindowedCountValidFormat()(control)).toBeUndefined();
+  });
+
+  it('should return { invalidFormat: true } if windowed count is invalid', () => {
+    const control = { value: '0/PT10S' } as AbstractControl;
+    expect(isWindowedCountValidFormat()(control)).toEqual({ invalidFormat: true });
+  });
+
+  it('should return { invalidFormat: true } if windowed count cannot be parsed', () => {
+    const control = { value: 'invalid_format' } as AbstractControl;
+    expect(isWindowedCountValidFormat()(control)).toEqual({ invalidFormat: true });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count-format.validator.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count-format.validator.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { WindowedCount } from './windowed-count';
+
+/**
+ * Creates a validator function that checks if a form control value matches the windowed count format.
+ * The validator evaluates if the input string follows the correct format for windowed count expression
+ * (e.g., "5/PT10S", "10/PT1M", etc.).
+ *
+ * @returns A validator function that returns:
+ *   - null if the value is empty or valid
+ *   - { invalidFormat: true } if the value doesn't match the expected format
+ *   - { invalidFormat: boolean } based on WindowedCount.isValid() result
+ */
+export const isWindowedCountValidFormat = (): ValidatorFn | undefined => {
+  return (control: AbstractControl): ValidationErrors | undefined => {
+    const formControlValue = control.value;
+
+    if (!formControlValue) {
+      return undefined;
+    }
+
+    try {
+      const windowedCount = WindowedCount.parse(formControlValue);
+      if (!windowedCount.isValid()) {
+        return { invalidFormat: true };
+      }
+    } catch (error) {
+      return { invalidFormat: true };
+    }
+    return undefined;
+  };
+};

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { duration } from 'moment';
+
+import { WindowedCount } from './windowed-count';
+
+describe('WindowedCount', () => {
+  const durationSec = (seconds: number) => {
+    return duration(seconds, 'seconds');
+  };
+
+  describe('constructor', () => {
+    it('should correctly set count and window', () => {
+      const window = durationSec(10);
+      const windowedCount = new WindowedCount(5, window);
+      expect(windowedCount.count).toBe(5);
+      expect(windowedCount.window).toBe(window);
+    });
+  });
+
+  describe('rate', () => {
+    it('should calculate the correct rate of events per second', () => {
+      const window = durationSec(10);
+      const windowedCount = new WindowedCount(20, window);
+      expect(windowedCount.rate()).toBe(2); // 20 events / 10 seconds = 2
+    });
+
+    it('should return 0 when count is 0', () => {
+      const window = durationSec(10);
+      const windowedCount = new WindowedCount(0, window);
+      expect(windowedCount.rate()).toBe(0);
+    });
+
+    it('should correctly handle an extremely small duration', () => {
+      const window = durationSec(0.1);
+      const windowedCount = new WindowedCount(5, window);
+      expect(windowedCount.rate()).toBeCloseTo(50); // 5 / 0.1 = 50
+    });
+    it('should correctly handle an extremely large counbt', () => {
+      const window = durationSec(50);
+      const windowedCount = new WindowedCount(1, window);
+      expect(windowedCount.rate()).toBeCloseTo(0.02); // 1/50 = 0.02
+    });
+  });
+
+  describe('parse', () => {
+    it('should correctly parse a valid format string', () => {
+      const windowedCount = WindowedCount.parse('10/PT1M');
+      expect(windowedCount.count).toBe(10);
+      expect(windowedCount.window.asSeconds()).toBe(60);
+      const reparsed = WindowedCount.parse(windowedCount.encode());
+      expect(reparsed.count).toBe(10);
+      expect(reparsed.window.asSeconds()).toBe(60);
+    });
+
+    it('should throw an error for an invalid format', () => {
+      expect(() => WindowedCount.parse('10')).toThrow('Invalid format');
+      expect(() => WindowedCount.parse('10-20')).toThrow('Invalid format');
+    });
+
+    it('should throw an error if count is not a number', () => {
+      expect(() => WindowedCount.parse('foo/PT1S')).toThrow('Invalid format');
+    });
+    it('should throw an error if window is not a duration', () => {
+      expect(() => WindowedCount.parse('1/bar')).toThrow('Invalid format');
+    });
+  });
+
+  describe('isValid', () => {
+    it('should return true if count is positive and duration is greater than zero', () => {
+      const window = durationSec(60);
+      const windowedCount = new WindowedCount(5, window);
+      expect(windowedCount.isValid()).toBe(true);
+    });
+
+    it('should return false if count is zero or negative', () => {
+      const window = durationSec(60);
+      const windowedCount = new WindowedCount(0, window);
+      expect(windowedCount.isValid()).toBe(false);
+    });
+
+    it('should return false if duration is zero or negative', () => {
+      const window = durationSec(0);
+      const windowedCount = new WindowedCount(5, window);
+      expect(windowedCount.isValid()).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/windowed-count.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ *
+ *  * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+import { duration, Duration } from 'moment';
+
+export class WindowedCountFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WindowedCountFormatError';
+  }
+}
+
+/**
+ * Represents a count of events within a time window.
+ * Used for calculating rates and validating time-based thresholds.
+ */
+export class WindowedCount {
+  count: number;
+  window: Duration;
+
+  /**
+   * Creates a new WindowedCount instance.
+   * @param count - The number of events in the window.
+   * @param window - The duration of the time window.
+   */
+  constructor(count: number, window: Duration) {
+    this.window = window;
+    this.count = count;
+  }
+
+  /**
+   * Calculates the rate of events per second.
+   * @returns The number of events per second.
+   */
+  public rate(): number {
+    return this.count / this.window.asSeconds();
+  }
+
+  /**
+   * Encodes the Windowed Count into a parsable string
+   */
+  public encode(): string {
+    return this.count + '/' + this.window.toISOString();
+  }
+
+  /**
+   * Parses a string representation of windowed count in format "count/duration".
+   * @param format - The string to parse in format "count/duration".
+   * @returns A new WindowedCount instance.
+   * @throws Error if the format is invalid.
+   */
+  public static parse(format: string): WindowedCount {
+    const parts = format.split('/');
+    if (parts.length !== 2) {
+      throw new WindowedCountFormatError('Invalid format: must be in count/duration format');
+    }
+    const count = Number.parseInt(parts[0], 10);
+    const window = duration(parts[1]);
+    if (Number.isNaN(count) || !window.isValid() || window.asMilliseconds() < 1) {
+      throw new WindowedCountFormatError('Invalid format: count must be a number and duration must be valid');
+    }
+    return new WindowedCount(count, window);
+  }
+
+  /**
+   * Checks if the windowed count is valid.
+   * @returns true if count is positive and window duration is greater than zero, false otherwise.
+   */
+  isValid(): boolean {
+    return this.count > 0 && this.window.asSeconds() > 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.component.html
@@ -16,292 +16,356 @@
 
 -->
 <div class="api-logging">
-  <form
-    *ngIf="!isLoading"
-    class="api-logging__form"
-    [formGroup]="apiLoggingForm"
-    (ngSubmit)="onSubmit()"
-    autocomplete="off"
-    gioFormFocusInvalid
-  >
-    <h1>API Logging</h1>
-    <gio-banner-info>
-      Depending on your architecture, this configuration may be overridden by a local configuration file. See documentation for more
-      information.
-    </gio-banner-info>
+  @if (!isLoading) {
+    <form class="api-logging__form" [formGroup]="apiLoggingForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+      <h1>API Logging</h1>
+      <gio-banner-info>
+        Depending on your architecture, this configuration may be overridden by a local configuration file. See documentation for more
+        information.
+      </gio-banner-info>
 
-    <mat-card class="api-logging__form__card" formGroupName="duration">
-      <mat-card-content>
-        <h2 gioTableOfContents>Duration</h2>
-        <p>
-          Limit the duration of API full logging (0 means no max duration). This avoids API publishers to log headers and / or body payload
-          during too much time and avoid to consume too much CPU/memory. By default, the calls are logged with the minimal information.
-        </p>
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonly('logging.default.max.duration')"
-          class="api-logging__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonly('logging.default.max.duration')" class="api-logging__form__card__form-field__icon" matPrefix
-            >lock
-          </mat-icon>
-          <mat-label>Max Duration (in ms)</mat-label>
-          <input matInput type="number" formControlName="maxDurationMillis" />
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card class="api-logging__form__card" formGroupName="audit">
-      <mat-card-content>
-        <h2 gioTableOfContents>Audit</h2>
-        <p>Enable to audit the consultation of log details to track who accessed to a specific data from the audit view.</p>
-        <gio-form-slide-toggle
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonly('logging.audit.enabled')"
-          class="api-logging__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonly('logging.audit.enabled')" gioFormPrefix>lock</mat-icon>
-          <gio-form-label>Enable audit on API Logging consultation</gio-form-label>
-          <mat-slide-toggle
-            gioFormSlideToggle
-            formControlName="enabled"
-            aria-label="Enable audit on API Logging consultation"
-            name="enabled"
-          ></mat-slide-toggle>
-        </gio-form-slide-toggle>
-
-        <mat-divider></mat-divider>
-
-        <gio-form-slide-toggle
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonly('logging.audit.trail.enabled')"
-          class="api-logging__form__card__form-field"
-          formGroupName="trail"
-        >
-          <mat-icon *ngIf="isReadonly('logging.audit.trail.enabled')" gioFormPrefix>lock</mat-icon>
-          <gio-form-label
-            >Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)
-          </gio-form-label>
-          <mat-slide-toggle
-            gioFormSlideToggle
-            formControlName="enabled"
-            aria-label="Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)"
-            name="trail.enabled"
-          ></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card class="api-logging__form__card" formGroupName="user">
-      <mat-card-content>
-        <h2 gioTableOfContents>User</h2>
-        <p>Display or not the end user in case of a OAuth2 / JWT plan (extracted from the sub claim).</p>
-        <gio-form-slide-toggle
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonly('logging.user.displayed')"
-          class="api-logging__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonly('logging.user.displayed')" gioFormPrefix>lock</mat-icon>
-          <gio-form-label>Display end user on API Logging (in case of OAuth2/JWT plan)</gio-form-label>
-          <mat-slide-toggle
-            gioFormSlideToggle
-            formControlName="displayed"
-            aria-label="Display end user on API Logging (in case of OAuth2/JWT plan)"
-            name="displayed"
-          ></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card class="api-logging__form__card" formGroupName="messageSampling">
-      <mat-card-content>
-        <h2 gioTableOfContents>Message Sampling</h2>
-        <p>A sampling strategy is applied to prevent issues while logging messages.</p>
-        <ng-container formGroupName="probabilistic">
-          <h3>Probabilistic</h3>
-          <p>Samples messages based on a specified probability.</p>
+      <mat-card class="api-logging__form__card" formGroupName="duration">
+        <mat-card-content>
+          <h2 gioTableOfContents>Duration</h2>
+          <p>
+            Limit the duration of API full logging (0 means no max duration). This avoids API publishers to log headers and / or body
+            payload during too much time and avoid to consume too much CPU/memory. By default, the calls are logged with the minimal
+            information.
+          </p>
           <mat-form-field
             [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.probabilistic.default')"
+            [matTooltipDisabled]="!isReadonly('logging.default.max.duration')"
             class="api-logging__form__card__form-field"
-            data-testid="probabilistic_default"
           >
-            <mat-icon
-              *ngIf="isReadonly('logging.messageSampling.probabilistic.default')"
-              class="api-logging__form__card__form-field__icon"
-              matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Default</mat-label>
-            <input matInput formControlName="default" type="number" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.default').hasError('required')"
-              >Default value is required
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.default').hasError('min')"
-              >Default value should be at least
-              {{ apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.min.min }}</mat-error
-            >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.default').hasError('max')"
-              >Default value should not be greater than
-              {{ apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.max.max }}</mat-error
-            >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.defaultGreaterThanLimit">{{
-              apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.defaultGreaterThanLimit
-            }}</mat-error>
+            @if (isReadonly('logging.default.max.duration')) {
+              <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+            }
+            <mat-label>Max Duration (in ms)</mat-label>
+            <input matInput type="number" formControlName="maxDurationMillis" />
           </mat-form-field>
+        </mat-card-content>
+      </mat-card>
 
-          <mat-hint>The limit is the maximum allowed probability</mat-hint>
-          <mat-form-field
+      <mat-card class="api-logging__form__card" formGroupName="audit">
+        <mat-card-content>
+          <h2 gioTableOfContents>Audit</h2>
+          <p>Enable to audit the consultation of log details to track who accessed to a specific data from the audit view.</p>
+          <gio-form-slide-toggle
             [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.probabilistic.limit')"
+            [matTooltipDisabled]="!isReadonly('logging.audit.enabled')"
             class="api-logging__form__card__form-field"
-            data-testid="probabilistic_limit"
           >
-            <mat-icon
-              *ngIf="isReadonly('logging.messageSampling.probabilistic.limit')"
-              class="api-logging__form__card__form-field__icon"
-              matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Limit</mat-label>
-            <input matInput formControlName="limit" type="number" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('required')"
-              >Limit value is required
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('min')"
-              >Limit value should be at least {{ apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.min.min }}</mat-error
-            >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('max')"
-              >Limit value should not be greater than
-              {{ apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.max.max }}</mat-error
-            >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.defaultGreaterThanLimit">{{
-              apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.defaultGreaterThanLimit
-            }}</mat-error>
-          </mat-form-field>
-        </ng-container>
+            @if (isReadonly('logging.audit.enabled')) {
+              <mat-icon gioFormPrefix>lock</mat-icon>
+            }
+            <gio-form-label>Enable audit on API Logging consultation</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
+              formControlName="enabled"
+              aria-label="Enable audit on API Logging consultation"
+              name="enabled"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
 
-        <ng-container formGroupName="count">
-          <h3>Count</h3>
-          <p>Samples one message for every number of specified messages.</p>
-          <mat-form-field
+          <mat-divider></mat-divider>
+
+          <gio-form-slide-toggle
             [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.count.default')"
+            [matTooltipDisabled]="!isReadonly('logging.audit.trail.enabled')"
             class="api-logging__form__card__form-field"
-            data-testid="count_default"
+            formGroupName="trail"
           >
-            <mat-icon
-              *ngIf="isReadonly('logging.messageSampling.count.default')"
-              class="api-logging__form__card__form-field__icon"
-              matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Default</mat-label>
-            <input matInput formControlName="default" type="number" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.default').hasError('required')"
-              >Default value is required
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.default').hasError('min')"
-              >Default value should be at least {{ apiLoggingForm.get('messageSampling.count.default')?.errors?.min.min }}</mat-error
+            @if (isReadonly('logging.audit.trail.enabled')) {
+              <mat-icon gioFormPrefix>lock</mat-icon>
+            }
+            <gio-form-label
+              >Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)
+            </gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
+              formControlName="enabled"
+              aria-label="Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)"
+              name="trail.enabled"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class="api-logging__form__card" formGroupName="user">
+        <mat-card-content>
+          <h2 gioTableOfContents>User</h2>
+          <p>Display or not the end user in case of a OAuth2 / JWT plan (extracted from the sub claim).</p>
+          <gio-form-slide-toggle
+            [matTooltip]="providedConfigurationMessage"
+            [matTooltipDisabled]="!isReadonly('logging.user.displayed')"
+            class="api-logging__form__card__form-field"
+          >
+            @if (isReadonly('logging.user.displayed')) {
+              <mat-icon gioFormPrefix>lock</mat-icon>
+            }
+            <gio-form-label>Display end user on API Logging (in case of OAuth2/JWT plan)</gio-form-label>
+            <mat-slide-toggle
+              gioFormSlideToggle
+              formControlName="displayed"
+              aria-label="Display end user on API Logging (in case of OAuth2/JWT plan)"
+              name="displayed"
+            ></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class="api-logging__form__card" formGroupName="messageSampling">
+        <mat-card-content>
+          <h2 gioTableOfContents>Message Sampling</h2>
+          <p>A sampling strategy is applied to prevent issues while logging messages.</p>
+          <ng-container formGroupName="probabilistic">
+            <h3>Probabilistic</h3>
+            <p>Samples messages based on a specified probability.</p>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.probabilistic.default')"
+              class="api-logging__form__card__form-field"
+              data-testid="probabilistic_default"
             >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.default').hasError('pattern')"
-              >Default value should be an integer
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.default')?.errors?.defaultLowerThanLimit">{{
-              apiLoggingForm.get('messageSampling.count.default')?.errors?.defaultLowerThanLimit
-            }}</mat-error>
-          </mat-form-field>
+              @if (isReadonly('logging.messageSampling.probabilistic.default')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Default</mat-label>
+              <input matInput formControlName="default" type="number" />
+              @if (apiLoggingForm.get('messageSampling.probabilistic.default').hasError('required')) {
+                <mat-error>Default value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.default').hasError('min')) {
+                <mat-error
+                  >Default value should be at least
+                  {{ apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.min.min }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.default').hasError('max')) {
+                <mat-error
+                  >Default value should not be greater than
+                  {{ apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.max.max }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.defaultGreaterThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.probabilistic.default')?.errors?.defaultGreaterThanLimit }} </mat-error>
+              }
+            </mat-form-field>
 
-          <mat-hint>The limit is the minimum messages number to sample</mat-hint>
-          <mat-form-field
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.count.limit')"
-            class="api-logging__form__card__form-field"
-            data-testid="count_limit"
-          >
-            <mat-icon *ngIf="isReadonly('logging.messageSampling.count.limit')" class="api-logging__form__card__form-field__icon" matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Limit</mat-label>
-            <input matInput formControlName="limit" type="number" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.limit').hasError('required')">Limit value is required </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.limit').hasError('min')"
-              >Limit value should be at least {{ apiLoggingForm.get('messageSampling.count.limit')?.errors?.min.min }}</mat-error
+            <mat-hint>The limit is the maximum allowed probability</mat-hint>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.probabilistic.limit')"
+              class="api-logging__form__card__form-field"
+              data-testid="probabilistic_limit"
             >
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.limit').hasError('pattern')"
-              >Limit value should be an integer
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.count.limit')?.errors?.defaultLowerThanLimit">{{
-              apiLoggingForm.get('messageSampling.count.limit')?.errors?.defaultLowerThanLimit
-            }}</mat-error>
-          </mat-form-field>
-        </ng-container>
+              @if (isReadonly('logging.messageSampling.probabilistic.limit')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Limit</mat-label>
+              <input matInput formControlName="limit" type="number" />
+              @if (apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('required')) {
+                <mat-error>Limit value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('min')) {
+                <mat-error
+                  >Limit value should be at least {{ apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.min.min }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.limit').hasError('max')) {
+                <mat-error
+                  >Limit value should not be greater than
+                  {{ apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.max.max }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.defaultGreaterThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.probabilistic.limit')?.errors?.defaultGreaterThanLimit }} </mat-error>
+              }
+            </mat-form-field>
+          </ng-container>
 
-        <ng-container formGroupName="temporal">
-          <h3>Temporal</h3>
-          <p>Samples messages based on time duration.</p>
-          <p>The value should conform to ISO-8601 duration format, e.g. PT1S for a duration of 1 second.</p>
+          <ng-container formGroupName="count">
+            <h3>Count</h3>
+            <p>Samples one message for every number of specified messages.</p>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.count.default')"
+              class="api-logging__form__card__form-field"
+              data-testid="count_default"
+            >
+              @if (isReadonly('logging.messageSampling.count.default')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Default</mat-label>
+              <input matInput formControlName="default" type="number" />
+              @if (apiLoggingForm.get('messageSampling.count.default').hasError('required')) {
+                <mat-error>Default value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.default').hasError('min')) {
+                <mat-error
+                  >Default value should be at least {{ apiLoggingForm.get('messageSampling.count.default')?.errors?.min.min }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.default').hasError('pattern')) {
+                <mat-error>Default value should be an integer</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.default')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.count.default')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
 
-          <mat-form-field
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.temporal.default')"
-            class="api-logging__form__card__form-field"
-            data-testid="temporal_default"
-          >
-            <mat-icon
-              *ngIf="isReadonly('logging.messageSampling.temporal.default')"
-              class="api-logging__form__card__form-field__icon"
-              matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Default</mat-label>
-            <input matInput formControlName="default" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.default').hasError('required')"
-              >Default value is required
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.default').hasError('invalidISO8601Duration')"
-              >Default value should conform to ISO-8601 duration format
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.default')?.errors?.defaultLowerThanLimit">{{
-              apiLoggingForm.get('messageSampling.temporal.default')?.errors?.defaultLowerThanLimit
-            }}</mat-error>
-          </mat-form-field>
+            <mat-hint>The limit is the minimum messages number to sample</mat-hint>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.count.limit')"
+              class="api-logging__form__card__form-field"
+              data-testid="count_limit"
+            >
+              @if (isReadonly('logging.messageSampling.count.limit')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock</mat-icon>
+              }
+              <mat-label>Limit</mat-label>
+              <input matInput formControlName="limit" type="number" />
+              @if (apiLoggingForm.get('messageSampling.count.limit').hasError('required')) {
+                <mat-error>Limit value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.limit').hasError('min')) {
+                <mat-error
+                  >Limit value should be at least {{ apiLoggingForm.get('messageSampling.count.limit')?.errors?.min.min }}
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.limit').hasError('pattern')) {
+                <mat-error>Limit value should be an integer</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.count.limit')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.count.limit')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
+          </ng-container>
 
-          <mat-hint>The limit is the minimum allowed period to sample</mat-hint>
-          <mat-form-field
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonly('logging.messageSampling.temporal.limit')"
-            class="api-logging__form__card__form-field"
-            data-testid="temporal_limit"
-          >
-            <mat-icon
-              *ngIf="isReadonly('logging.messageSampling.temporal.limit')"
-              class="api-logging__form__card__form-field__icon"
-              matPrefix
-              >lock
-            </mat-icon>
-            <mat-label>Limit</mat-label>
-            <input matInput formControlName="limit" />
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.limit').hasError('required')"
-              >Limit value is required
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.limit').hasError('invalidISO8601Duration')">
-              Limit value should conform to ISO-8601 duration format
-            </mat-error>
-            <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal.limit')?.errors?.defaultLowerThanLimit">{{
-              apiLoggingForm.get('messageSampling.temporal.limit')?.errors?.defaultLowerThanLimit
-            }}</mat-error>
-          </mat-form-field>
+          <ng-container formGroupName="temporal">
+            <h3>Temporal</h3>
+            <p>Samples messages based on time duration.</p>
+            <p>The value should conform to ISO-8601 duration format, e.g. PT1S for a duration of 1 second.</p>
 
-          <mat-error *ngIf="apiLoggingForm.get('messageSampling.temporal')?.errors?.defaultLowerThanLimit">{{
-            apiLoggingForm.get('messageSampling.temporal')?.errors?.defaultLowerThanLimit
-          }}</mat-error>
-        </ng-container>
-      </mat-card-content>
-    </mat-card>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.temporal.default')"
+              class="api-logging__form__card__form-field"
+              data-testid="temporal_default"
+            >
+              @if (isReadonly('logging.messageSampling.temporal.default')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Default</mat-label>
+              <input matInput formControlName="default" />
+              @if (apiLoggingForm.get('messageSampling.temporal.default').hasError('required')) {
+                <mat-error>Default value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.temporal.default').hasError('invalidISO8601Duration')) {
+                <mat-error>Default value should conform to ISO-8601 duration format</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.temporal.default')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.temporal.default')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
 
-    <gio-save-bar [form]="apiLoggingForm" [formInitialValues]="formInitialValues"></gio-save-bar>
-  </form>
+            <mat-hint>The limit is the minimum allowed period to sample</mat-hint>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.temporal.limit')"
+              class="api-logging__form__card__form-field"
+              data-testid="temporal_limit"
+            >
+              @if (isReadonly('logging.messageSampling.temporal.limit')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Limit</mat-label>
+              <input matInput formControlName="limit" />
+              @if (apiLoggingForm.get('messageSampling.temporal.limit').hasError('required')) {
+                <mat-error>Limit value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.temporal.limit').hasError('invalidISO8601Duration')) {
+                <mat-error>Limit value should conform to ISO-8601 duration format</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.temporal.limit')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.temporal.limit')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
+
+            @if (apiLoggingForm.get('messageSampling.temporal')?.errors?.defaultLowerThanLimit) {
+              <mat-error>{{ apiLoggingForm.get('messageSampling.temporal')?.errors?.defaultLowerThanLimit }}</mat-error>
+            }
+          </ng-container>
+          <ng-container formGroupName="windowedCount">
+            <h3>Windowed count</h3>
+            <p>Samples a count of messages during a sliding duration window.</p>
+            <p>
+              Format is COUNT/DURATION (duration should conform to ISO-8601 duration format). Example: <strong>2/PT15S</strong> will sample,
+              at most, two messages during a 15-second sliding window.
+            </p>
+
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.windowedCount.default')"
+              class="api-logging__form__card__form-field"
+              data-testid="windowedCount_default"
+            >
+              @if (isReadonly('logging.messageSampling.windowedCount.default')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Default</mat-label>
+              <input matInput formControlName="default" />
+              @if (apiLoggingForm.get('messageSampling.windowedCount.default').hasError('required')) {
+                <mat-error>Default value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.windowedCount.default').hasError('invalidFormat')) {
+                <mat-error
+                  >The sampling value must follow this format: COUNT/DURATION, where COUNT > 0 and DURATION is in ISO-8601 format (e.g.,
+                  1/PT1S)
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.windowedCount.default')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.windowedCount.default')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
+
+            <mat-hint>The limit is the minimum allowed period to sample</mat-hint>
+            <mat-form-field
+              [matTooltip]="providedConfigurationMessage"
+              [matTooltipDisabled]="!isReadonly('logging.messageSampling.windowedCount.limit')"
+              class="api-logging__form__card__form-field"
+              data-testid="windowedCount_limit"
+            >
+              @if (isReadonly('logging.messageSampling.windowedCount.limit')) {
+                <mat-icon class="api-logging__form__card__form-field__icon" matPrefix>lock </mat-icon>
+              }
+              <mat-label>Limit</mat-label>
+              <input matInput formControlName="limit" />
+              @if (apiLoggingForm.get('messageSampling.windowedCount.limit').hasError('required')) {
+                <mat-error>Limit value is required</mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.windowedCount.limit').hasError('invalidFormat')) {
+                <mat-error
+                  >The sampling value must follow this format: COUNT/DURATION, where COUNT > 0 and DURATION is in ISO-8601 format (e.g.,
+                  1/PT1S)
+                </mat-error>
+              }
+              @if (apiLoggingForm.get('messageSampling.windowedCount.limit')?.errors?.defaultLowerThanLimit) {
+                <mat-error>{{ apiLoggingForm.get('messageSampling.windowedCount.limit')?.errors?.defaultLowerThanLimit }} </mat-error>
+              }
+            </mat-form-field>
+
+            @if (apiLoggingForm.get('messageSampling.windowedCount')?.errors?.defaultLowerThanLimit) {
+              <mat-error>{{ apiLoggingForm.get('messageSampling.windowedCount')?.errors?.defaultLowerThanLimit }}</mat-error>
+            }
+          </ng-container>
+        </mat-card-content>
+      </mat-card>
+
+      <gio-save-bar [form]="apiLoggingForm" [formInitialValues]="formInitialValues"></gio-save-bar>
+    </form>
+  }
 
   <gio-table-of-contents
     class="api-logging__toc"

--- a/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.harness.ts
+++ b/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.harness.ts
@@ -21,25 +21,35 @@ import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 export class ApiLoggingHarness extends ComponentHarness {
   static hostSelector = 'api-logging';
 
-  private getSaveButton = this.locatorFor(GioSaveBarHarness);
+  private readonly getSaveButton = this.locatorFor(GioSaveBarHarness);
 
-  private getMaxDurationFormField = this.locatorFor(MatFormFieldHarness.with({ floatingLabelText: 'Max Duration (in ms)' }));
+  private readonly getMaxDurationFormField = this.locatorFor(MatFormFieldHarness.with({ floatingLabelText: 'Max Duration (in ms)' }));
 
-  private getAuditEnabledSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'enabled' }));
-  private getAuditTrailEnabledSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'trail.enabled' }));
+  private readonly getAuditEnabledSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'enabled' }));
+  private readonly getAuditTrailEnabledSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'trail.enabled' }));
 
-  private getUserDisplayedSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'displayed' }));
+  private readonly getUserDisplayedSlideToggle = this.locatorFor(MatSlideToggleHarness.with({ name: 'displayed' }));
 
-  private getSamplingCountDefaultField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=count_default]' }));
-  private getSamplingCountLimitField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=count_limit]' }));
+  private readonly getSamplingCountDefaultField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=count_default]' }));
+  private readonly getSamplingCountLimitField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=count_limit]' }));
 
-  private getSamplingProbabilisticDefaultField = this.locatorFor(
+  private readonly getSamplingProbabilisticDefaultField = this.locatorFor(
     MatFormFieldHarness.with({ selector: '[data-testid=probabilistic_default]' }),
   );
-  private getSamplingProbabilisticLimitField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=probabilistic_limit]' }));
+  private readonly getSamplingProbabilisticLimitField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '[data-testid=probabilistic_limit]' }),
+  );
 
-  private getSamplingTemporalDefaultField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=temporal_default]' }));
-  private getSamplingTemporalLimitField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=temporal_limit]' }));
+  private readonly getSamplingTemporalDefaultField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '[data-testid=temporal_default]' }),
+  );
+  private readonly getSamplingTemporalLimitField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=temporal_limit]' }));
+  private readonly getSamplingWindowedCountDefaultField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '[data-testid=windowedCount_default]' }),
+  );
+  private readonly getSamplingWindowedCountLimitField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '[data-testid=windowedCount_limit]' }),
+  );
 
   public saveSettings = async (): Promise<void> => {
     return this.getSaveButton().then((saveButton) => saveButton.clickSubmit());
@@ -175,6 +185,37 @@ export class ApiLoggingHarness extends ComponentHarness {
 
   public temporalLimitTextErrors = async (): Promise<string[]> => {
     return this.getTextErrorsFor(this.getSamplingTemporalLimitField());
+  };
+  public setWindowedCountDefault = async (value: string): Promise<void> => {
+    return this.setValueFor(this.getSamplingWindowedCountDefaultField(), value);
+  };
+
+  public windowedCountDefaultHasErrors = async (): Promise<boolean> => {
+    return this.fieldHasErrors(this.getSamplingWindowedCountDefaultField());
+  };
+
+  public windowedCountDefaultIsDisabled = async (): Promise<boolean> => {
+    return this.isFormFieldDisabled(this.getSamplingWindowedCountDefaultField());
+  };
+
+  public windowedCountDefaultTextErrors = async (): Promise<string[]> => {
+    return this.getTextErrorsFor(this.getSamplingWindowedCountDefaultField());
+  };
+
+  public setWindowedCountLimit = async (value: string): Promise<void> => {
+    return this.setValueFor(this.getSamplingWindowedCountLimitField(), value);
+  };
+
+  public windowedCountLimitHasErrors = async (): Promise<boolean> => {
+    return this.fieldHasErrors(this.getSamplingWindowedCountLimitField());
+  };
+
+  public windowedCountLimitIsDisabled = async (): Promise<boolean> => {
+    return this.isFormFieldDisabled(this.getSamplingWindowedCountLimitField());
+  };
+
+  public windowedCountLimitTextErrors = async (): Promise<string[]> => {
+    return this.getTextErrorsFor(this.getSamplingWindowedCountLimitField());
   };
 
   private setValueFor = async (formFieldPromise: Promise<MatFormFieldHarness>, value: string): Promise<void> => {

--- a/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.stories.ts
+++ b/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.stories.ts
@@ -61,6 +61,10 @@ export default {
                       limit: 'PT10S',
                       default: 'PT10S',
                     },
+                    windowedCount: {
+                      limit: '1/PT1S',
+                      default: '1/PT10S',
+                    },
                   },
                 },
               }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -481,6 +481,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             portalConfigEntity.getLogging().getMessageSampling().getCount(),
             portalConfigEntity.getLogging().getMessageSampling().getProbabilistic(),
             portalConfigEntity.getLogging().getMessageSampling().getTemporal(),
+            portalConfigEntity.getLogging().getMessageSampling().getWindowedCount(),
         };
     }
 
@@ -508,6 +509,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getLogging().getMessageSampling().getCount(),
             consoleConfigEntity.getLogging().getMessageSampling().getProbabilistic(),
             consoleConfigEntity.getLogging().getMessageSampling().getTemporal(),
+            consoleConfigEntity.getLogging().getMessageSampling().getWindowedCount(),
             consoleConfigEntity.getMaintenance(),
             consoleConfigEntity.getManagement(),
             consoleConfigEntity.getNewsletter(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1557

## Description

One field with the specific format expected by the API.

For reminder default defaults
Default rate: 1/PT10S 
Limit rate: 1/PT1S

Example above are with modified defaults in the API Logging settings page.

### Form
<img width="1038" height="286" alt="2025-12-01_11-40" src="https://github.com/user-attachments/assets/a3b58a99-a0e4-484c-b8cf-2599e0056c62" />

### Errors

#### Wrong format
<img width="1048" height="308" alt="2025-12-01_11-41" src="https://github.com/user-attachments/assets/8038ec24-78bd-432e-ba76-002ec33ccde6" />

#### Rate higher than limit
<img width="1040" height="328" alt="2025-12-01_11-42" src="https://github.com/user-attachments/assets/5e44ccb0-d4ec-4f8a-aaf4-3f5be0ea721b" />

### Settings

#### Form
<img width="926" height="302" alt="2025-12-01_11-46" src="https://github.com/user-attachments/assets/75b0465d-c6de-42f3-a567-945db3924fa0" />

#### Errors
Format
<img width="925" height="314" alt="2025-12-01_11-47" src="https://github.com/user-attachments/assets/96c87eb1-b914-4993-9486-be69e9eb3b9e" />

Default > Limit
<img width="949" height="342" alt="2025-12-01_11-47_1" src="https://github.com/user-attachments/assets/5a1e1b8a-a075-4b96-adab-0a04a6064af1" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

