### PR TITLE
Helm: improve kafka console deployment template

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.9.8
+- Kafka Console:
+  - allow to define volumes & volume mounts
+  - allow to define a custom mAPI base URL instead of relying on `organization` and `environment` fields
+  - allow to use secrets from jwt.secret and apim.security.token
+
 ### 4.9.6
 - allow configuration of httpClient proxy excludes [issues/10855](https://github.com/gravitee-io/issues/issues/10855).
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,11 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: 'Kafka console: allow to define volumes & volume mounts'
+    - kind: added
+      description: 'Kafka console: allow to define a custom mAPI base URL instead of relying on "organization" and "environment" fields'
+    - kind: added
+      description: 'Kafka console: allow to use secrets from jwt.secret and apim.security.token '
+

--- a/helm/templates/kafkaConsole/kafkaConsole-deployment.yaml
+++ b/helm/templates/kafkaConsole/kafkaConsole-deployment.yaml
@@ -106,13 +106,26 @@ spec:
           imagePullPolicy: {{ .Values.kafkaConsole.image.pullPolicy }}
           securityContext: {{ toYaml .Values.kafkaConsole.deployment.securityContext | nindent 12 }}
           env:
+    {{- if and .Values.kafkaConsole.jwt.secret .Values.kafkaConsole.jwt.secret.value }}
             - name: AUTH_JWT_SECRET
-              value: {{ .Values.kafkaConsole.jwt.secret }}
+              value: {{ .Values.kafkaConsole.jwt.secret.value }}
+    {{- else if and .Values.kafkaConsole.jwt.secret .Values.kafkaConsole.jwt.secret.valueFrom }}
+            - name: AUTH_JWT_SECRET
+              valueFrom: {{- toYaml .Values.kafkaConsole.jwt.secret.valueFrom | nindent 16}}
+    {{- end}}
+    {{- if .Values.kafkaConsole.apim.apiUrl }}
+            - name: KAFKA_GRAVITEE_MANAGEMENTAPIURL
+              value: {{ .Values.kafkaConsole.apim.apiUrl }}
+    {{- else }}
             - name: KAFKA_GRAVITEE_MANAGEMENTAPIURL
               value: http://{{ template "gravitee.api.fullname" . }}:{{ .Values.api.service.externalPort }}/management/v2/organizations/{{ .Values.kafkaConsole.apim.organization }}/environments/{{ .Values.kafkaConsole.apim.environment }}
-    {{- if .Values.kafkaConsole.apim.security.token }}
+    {{- end}}
+    {{- if and .Values.kafkaConsole.apim.security.token .Values.kafkaConsole.apim.security.token.value }}
             - name: KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINTOKEN
-              value: {{ .Values.kafkaConsole.apim.security.token }}
+              value: {{ .Values.kafkaConsole.apim.security.token.value }}
+    {{- else if and .Values.kafkaConsole.apim.security.token .Values.kafkaConsole.apim.security.token.valueFrom }}
+            - name: KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINTOKEN
+              valueFrom: {{- toYaml .Values.kafkaConsole.apim.security.token.valueFrom | nindent 16}}
     {{- else }}
             - name: KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINUSERNAME
               value: {{ .Values.kafkaConsole.apim.security.username }}
@@ -156,6 +169,12 @@ spec:
           startupProbe: {{ toYaml .Values.kafkaConsole.deployment.customStartupProbe | nindent 12 }}
           {{- end }}
           resources: {{ toYaml .Values.kafkaConsole.resources | nindent 12 }}
+          {{- if .Values.kafkaConsole.extraVolumeMounts }}
+          volumeMounts:
+            {{- with .Values.kafkaConsole.extraVolumeMounts }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end}}
+          {{- end}}
         {{- if .Values.kafkaConsole.extraContainers }}
         {{- with .Values.kafkaConsole.extraContainers }}
         {{- tpl . $ | nindent 8 }}
@@ -165,7 +184,10 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.kafkaConsole.image.pullSecrets }}
       {{- end }}
-      {{- with .Values.kafkaConsole.extraVolumes }}
-        {{- tpl . $ | nindent 8 }}
+      {{- if .Values.kafkaConsole.extraVolumes }}
+      volumes:
+        {{- with .Values.kafkaConsole.extraVolumes }}
+          {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end -}}

--- a/helm/tests/kafkaConsole/deployment_test.yaml
+++ b/helm/tests/kafkaConsole/deployment_test.yaml
@@ -4,11 +4,15 @@ templates:
 set:
   kafkaConsole:
     enabled: true
-    jwt:
-      secret: 4j5ipCZn93qnLBykgex5pSvUdA8Nnqts
+
 tests:
   - it: Should generate default env variables
     template: kafkaConsole/kafkaConsole-deployment.yaml
+    set:
+      kafkaConsole:
+        jwt:
+          secret:
+            value: 4j5ipCZn93qnLBykgex5pSvUdA8Nnqts
     asserts:
       - hasDocuments:
           count: 1
@@ -42,10 +46,12 @@ tests:
     set:
       kafkaConsole:
         jwt:
-          secret: TCkyfrr8F6c75mAGKpRtKPaBHt9LyJ7P
+          secret:
+            value: TCkyfrr8F6c75mAGKpRtKPaBHt9LyJ7P
         apim:
           security:
-            token: 1111-2222-333333-44-555555
+            token:
+              value: 1111-2222-333333-44-555555
           organization: 1234-5678
           environment: 9876-5432
     asserts:
@@ -69,6 +75,74 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[2].value
           value: "1111-2222-333333-44-555555"
+
+  - it: Should generate with overridden apim URL
+    template: kafkaConsole/kafkaConsole-deployment.yaml
+    set:
+      kafkaConsole:
+        jwt:
+          secret:
+            value: TCkyfrr8F6c75mAGKpRtKPaBHt9LyJ7P
+        apim:
+          security:
+            token:
+              value: 1111-2222-333333-44-555555
+          apiUrl: https://my.company.org:8083/organizations/1234/environments/5678
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: "KAFKA_GRAVITEE_MANAGEMENTAPIURL"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "https://my.company.org:8083/organizations/1234/environments/5678"
+
+  - it: Should generate with env variables using secrets
+    template: kafkaConsole/kafkaConsole-deployment.yaml
+    set:
+      kafkaConsole:
+        jwt:
+          secret:
+            valueFrom:
+              secretKeyRef:
+                name: secretJWTName
+                key: secretJWTKey
+        apim:
+          security:
+            token:
+              valueFrom:
+                secretKeyRef:
+                  name: secretTokenName
+                  key: secretTokenKey
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "AUTH_JWT_SECRET"
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom
+          value:
+            secretKeyRef:
+              name: secretJWTName
+              key: secretJWTKey
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: "KAFKA_GRAVITEE_MANAGEMENTAPIURL"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "http://RELEASE-NAME-apim-api:83/management/v2/organizations/DEFAULT/environments/DEFAULT"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: "KAFKA_GRAVITEE_MANAGEMENTAPIORGADMINTOKEN"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom
+          value:
+            secretKeyRef:
+              name: secretTokenName
+              key: secretTokenKey
+
 
   - it: Should have default resources
     template: kafkaConsole/kafkaConsole-deployment.yaml

--- a/helm/tests/kafkaConsole/external_configuration.yaml
+++ b/helm/tests/kafkaConsole/external_configuration.yaml
@@ -1,0 +1,38 @@
+suite: Test APIM Kafka console deployment with a volumeMount named secret defined
+templates:
+  - "kafkaConsole/kafkaConsole-deployment.yaml"
+tests:
+  - it: Should generate a volume named secret in kafkaConsole-deployment.yaml
+    template: kafkaConsole/kafkaConsole-deployment.yaml
+    set:
+      kafkaConsole:
+        enabled: true
+        extraVolumes: |
+          - name: foo
+            secret:
+              secretName: mysecret
+              defaultMode: 420
+              items:
+                - key: username
+                  path: my-group/my-username
+        extraVolumeMounts: |
+          - mountPath: /etc/foo
+            name: foo
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: foo
+            mountPath: /etc/foo
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: foo
+            secret:
+              secretName: mysecret
+              defaultMode: 420
+              items:
+                - key: username
+                  path: my-group/my-username

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2187,22 +2187,44 @@ kafkaConsole:
     #  lifecycle:
     #    postStart: '[ "/bin/sh", "-c", "echo Post starting Gravitee Portal" ]'
     #    preStop: '[ "/bin/sh", "-c", "echo Pre stopping Gravitee Portal" ]'
-    ## Additional gravitee ui volume mounts
-    # Defines additional volume mounts.
-    # extraVolumeMounts: |
-    # - name: extra-volume
-    #   mountPath: /mnt/volume
-    #   readOnly: true
+
+  # Defines additional volume mounts.
+  #extraVolumeMounts: |
+  #  - name: extra-volume
+  #    mountPath: /mnt/volume
+  #    readOnly: true
+  #
+
+  # Defines additional volumes.
+  #extraVolumes: |
+  #  - name: config
+  #    configMap:
+  #      name: gravitee-config-configmap-name
+  #  - name: cert
+  #    secret:
+  #      secretName: gravitee-cert-secret-name
 
   jwt:
-    secret: # put here a 32bits string. It's used to signed JWT token for communication between management API and kafka console
+    secret:
+      value: # put here a 32bits string. It's used to signed JWT token for communication between management API and kafka console
+  #    valueFrom:
+  #      secretKeyRef:
+  #        name:
+  #        key:
+
   apim:
+  #  apiUrl: # put here the URL to your management API. This should contain the organization and the environment information. If provided, `organization` & `environment` fields will be ignored. Example: https://my.company.com:8083/organizations/6eb27b47-2560-481f-b27b-472560581fff/environments/808a51a9-48f5-4517-8a51-a948f5e517b3
+    organization: DEFAULT
+    environment: DEFAULT
     security:
       username: admin # put here an org admin username. Ignored if token is provided
       password: admin # put here an org admin password. Ignored if token is provided
-  #    token:         # put here an org admin Personal Access Token. It replaces username and password
-    organization: DEFAULT
-    environment: DEFAULT
+  #    token:
+  #      value: # put here an org admin Personal Access Token. It replaces username and password
+  #      valueFrom:
+  #        secretKeyRef:
+  #          name:
+  #          key:
 
 
 #secrets:


### PR DESCRIPTION
## Description

 - allow to define volumes & volume mounts
 - allow to define a custom mAPI base URL instead of relying on `organization` and `environment` fields
 - allow to use secrets from jwt.secret and apim.security.token