### PR TITLE
fix: populate endpoint-request-uri for GET calls and sort V4 log headers

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-log-headers/api-proxy-request-log-headers.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-log-headers/api-proxy-request-log-headers.component.ts
@@ -25,9 +25,11 @@ export class ApiProxyRequestLogHeadersComponent {
   formattedHeaders = computed(() => {
     const headersValue = this.headers();
     if (!headersValue) return [];
-    return Object.entries(headersValue).map(([key, values]) => ({
-      key,
-      value: (values ?? []).join(','),
-    }));
+    return Object.entries(headersValue)
+      .map(([key, values]) => ({
+        key,
+        value: (values ?? []).join(','),
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key));
   });
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -69,6 +69,11 @@ public class LoggingHook implements InvokerHook {
 
             if (log != null && loggingContext != null) {
                 if (loggingContext.endpointRequest()) {
+                    // Pre-set URI: required for GET, fallback for POST/PUT.
+                    String endpoint = ctx.metrics().getEndpoint();
+                    if (endpoint != null && !endpoint.isBlank()) {
+                        log.getEndpointRequest().setUri(endpoint);
+                    }
                     log.getEndpointRequest().setMethod(ctx.request().method());
                 }
                 if (loggingContext.endpointRequestHeaders()) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12022
https://gravitee.atlassian.net/browse/APIM-12069

## Description

- Ensure endpoint-request-uri is always set, including GET requests
- Fix headers ordering for V4 APIs in alphabetical sorting way

Issues:


https://github.com/user-attachments/assets/2d2343c4-f95e-4fdc-bfc8-451d14ddf04b



https://github.com/user-attachments/assets/7d93336f-6a8a-4241-89ce-d101dd8fda52



Fixes:

https://github.com/user-attachments/assets/5987ef25-ab52-4c9d-84c8-135e9a72b685


https://github.com/user-attachments/assets/54df5e04-76d1-4e1f-a3f0-436c0ea2bb9c



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

