### PR TITLE
fix: make deploy banner reactive to API state changes

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -484,7 +484,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
         },
       ]);
       req.flush(planA);
-
+      expectGetApi(api);
       expectNewNgOnInit();
     });
 
@@ -763,6 +763,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
           method: 'PUT',
         });
         req.flush(planA);
+        expectGetApi(api);
         expectNewNgOnInit();
         expect(goSpy).toHaveBeenCalledWith('/apis/api-id/v4/policy-studio/0/1');
       });

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -290,6 +290,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
 
           return this.apiPlanV2Service.update(this.activatedRoute.snapshot.params.apiId, apiPlan.id, updatedApiPlan);
         }),
+        switchMap(() => this.apiV2Service.refreshLastApiFetch()),
         catchError((err) => {
           this.snackBarService.error(err.error?.message ?? err.message);
           return EMPTY;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11877

## Description

Make deploy banner reactive to API state change.
For example while adding/editing flow, deploy banner should appear and on deployment should go away.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

