### PR TITLE
Apim 11563 papi get portal nav item

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -38,7 +38,7 @@ public interface PortalNavigationItemMapper {
         return items.stream().map(this::getBasePortalNavigationItem).toList();
     }
 
-    private io.gravitee.rest.api.portal.rest.model.PortalNavigationItem getBasePortalNavigationItem(PortalNavigationItem item) {
+    default io.gravitee.rest.api.portal.rest.model.PortalNavigationItem getBasePortalNavigationItem(PortalNavigationItem item) {
         var baseItem = switch (item) {
             case PortalNavigationFolder folder -> map(folder);
             case PortalNavigationLink link -> map(link);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/AbstractDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/AbstractDomainExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import java.util.Map;
+
+public abstract class AbstractDomainExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
+
+    protected ErrorResponse convert(final Throwable t, final int status) {
+        return convert(t, status, null, null);
+    }
+
+    protected ErrorResponse convert(final Throwable t, final int status, final String technicalCode, final Map<String, String> parameters) {
+        final Error error = new Error();
+        error.setStatus(String.valueOf(status));
+        error.message(t.getMessage());
+        error.code(technicalCode != null ? "errors." + technicalCode : "errors.unexpected");
+        error.parameters(parameters);
+
+        ErrorResponse response = new ErrorResponse();
+        response.addErrorsItem(error);
+        return response;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/ConflictDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/ConflictDomainExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.apim.core.exception.ConflictDomainException;
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import java.util.Map;
+import java.util.Optional;
+
+@Provider
+public class ConflictDomainExceptionMapper extends AbstractDomainExceptionMapper<ConflictDomainException> {
+
+    @Override
+    public Response toResponse(ConflictDomainException exception) {
+        final Map<String, String> parameters = Optional.ofNullable(exception.getId())
+            .map(id -> Map.of("id", id))
+            .orElse(null);
+        return Response.status(Response.Status.CONFLICT)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(exception, Response.Status.CONFLICT.getStatusCode(), "conflict", parameters))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/NotAllowedDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/NotAllowedDomainExceptionMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.apim.core.exception.NotAllowedDomainException;
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class NotAllowedDomainExceptionMapper extends AbstractDomainExceptionMapper<NotAllowedDomainException> {
+
+    @Override
+    public Response toResponse(NotAllowedDomainException notAllowedException) {
+        return Response.status(Response.Status.FORBIDDEN)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(notAllowedException, Response.Status.FORBIDDEN.getStatusCode(), "notAllowed", null))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/NotFoundDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/NotFoundDomainExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import java.util.Map;
+import java.util.Optional;
+
+@Provider
+public class NotFoundDomainExceptionMapper extends AbstractDomainExceptionMapper<NotFoundDomainException> {
+
+    @Override
+    public Response toResponse(NotFoundDomainException nfe) {
+        final Map<String, String> parameters = Optional.ofNullable(nfe.getId())
+            .map(id -> Map.of("id", id))
+            .orElse(null);
+        return Response.status(Response.Status.NOT_FOUND)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(nfe, Response.Status.NOT_FOUND.getStatusCode(), "notFound", parameters))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/TechnicalDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/TechnicalDomainExceptionMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class TechnicalDomainExceptionMapper extends AbstractDomainExceptionMapper<TechnicalDomainException> {
+
+    @Override
+    public Response toResponse(TechnicalDomainException ve) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(ve, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "technical", null))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/ValidationDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/domain/ValidationDomainExceptionMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.provider.domain;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class ValidationDomainExceptionMapper extends AbstractDomainExceptionMapper<ValidationDomainException> {
+
+    @Override
+    public Response toResponse(ValidationDomainException ve) {
+        return Response.status(Response.Status.BAD_REQUEST)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(ve, Response.Status.BAD_REQUEST.getStatusCode(), "validation", ve.getParameters()))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/GraviteePortalApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/GraviteePortalApplication.java
@@ -27,6 +27,11 @@ import io.gravitee.rest.api.portal.rest.provider.PayloadInputBodyReader;
 import io.gravitee.rest.api.portal.rest.provider.QueryParamExceptionMapper;
 import io.gravitee.rest.api.portal.rest.provider.ThrowableMapper;
 import io.gravitee.rest.api.portal.rest.provider.UnrecognizedPropertyExceptionMapper;
+import io.gravitee.rest.api.portal.rest.provider.domain.ConflictDomainExceptionMapper;
+import io.gravitee.rest.api.portal.rest.provider.domain.NotAllowedDomainExceptionMapper;
+import io.gravitee.rest.api.portal.rest.provider.domain.NotFoundDomainExceptionMapper;
+import io.gravitee.rest.api.portal.rest.provider.domain.TechnicalDomainExceptionMapper;
+import io.gravitee.rest.api.portal.rest.provider.domain.ValidationDomainExceptionMapper;
 import io.gravitee.rest.api.portal.rest.resource.bootstrap.PortalUIBootstrapResource;
 import io.gravitee.rest.api.rest.filter.GraviteeContextResponseFilter;
 import io.gravitee.rest.api.rest.filter.MaintenanceFilter;
@@ -69,6 +74,12 @@ public class GraviteePortalApplication extends ResourceConfig {
         register(BadRequestExceptionMapper.class);
         register(QueryParamExceptionMapper.class);
         register(JsonMappingExceptionMapper.class);
+
+        register(ConflictDomainExceptionMapper.class);
+        register(NotAllowedDomainExceptionMapper.class);
+        register(NotFoundDomainExceptionMapper.class);
+        register(TechnicalDomainExceptionMapper.class);
+        register(ValidationDomainExceptionMapper.class);
 
         register(SecurityContextFilter.class);
         register(GraviteeContextResponseFilter.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalNavigationItemUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.PortalNavigationItemMapper;
+import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class PortalNavigationItemResource extends AbstractResource {
+
+    @Inject
+    private GetPortalNavigationItemUseCase getPortalNavigationItemUseCase;
+
+    private static final PortalNavigationItemMapper portalNavigationItemMapper = PortalNavigationItemMapper.INSTANCE;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public Response getPortalNavigationItemById(@PathParam("portalNavigationItemId") String portalNavigationItemId) {
+        var executionContext = getExecutionContext();
+        var result = getPortalNavigationItemUseCase.execute(
+            new GetPortalNavigationItemUseCase.Input(
+                PortalNavigationItemId.of(portalNavigationItemId),
+                executionContext.getEnvironmentId(),
+                true
+            )
+        );
+
+        return Response.ok(portalNavigationItemMapper.getBasePortalNavigationItem(result.portalNavigationItem())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -19,11 +19,13 @@ import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionCo
 
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentByNavigationIdUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.portal.rest.mapper.PortalNavigationItemMapper;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
@@ -32,6 +34,9 @@ public class PortalNavigationItemResource extends AbstractResource {
 
     @Inject
     private GetPortalNavigationItemUseCase getPortalNavigationItemUseCase;
+
+    @Inject
+    private GetPortalPageContentByNavigationIdUseCase getPortalPageContentByNavigationIdUseCase;
 
     private static final PortalNavigationItemMapper portalNavigationItemMapper = PortalNavigationItemMapper.INSTANCE;
 
@@ -49,5 +54,18 @@ public class PortalNavigationItemResource extends AbstractResource {
         );
 
         return Response.ok(portalNavigationItemMapper.getBasePortalNavigationItem(result.portalNavigationItem())).build();
+    }
+
+    @GET
+    @Path("/content")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public Response getPortalNavigationItemContentById(@PathParam("portalNavigationItemId") String portalNavigationItemId) {
+        var executionContext = getExecutionContext();
+        var result = getPortalPageContentByNavigationIdUseCase.execute(
+            new GetPortalPageContentByNavigationIdUseCase.Input(portalNavigationItemId, executionContext.getEnvironmentId(), true)
+        );
+
+        return Response.ok(result.portalPageContent().getContent()).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -28,8 +28,11 @@ import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +41,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class PortalNavigationItemsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
 
     @Inject
     private ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase;
@@ -60,6 +66,11 @@ public class PortalNavigationItemsResource extends AbstractResource {
         );
         var output = listPortalNavigationItemsUseCase.execute(input);
         return Response.ok(portalNavigationItemMapper.map(filterPublishedItems(output.items()))).build();
+    }
+
+    @Path("{portalNavigationItemId}")
+    public PortalNavigationItemResource getPortalNavigationItemResource() {
+        return resourceContext.getResource(PortalNavigationItemResource.class);
     }
 
     public List<PortalNavigationItem> filterPublishedItems(List<PortalNavigationItem> items) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3174,6 +3174,37 @@ paths:
                 500:
                     $ref: "#/components/responses/InternalServerError"
 
+    /portal-navigation-items/{portalNavigationItemId}:
+        parameters:
+            - name: portalNavigationItemId
+              in: path
+              required: true
+              description: Id of a portal navigation item.
+              schema:
+                  type: string
+        get:
+            tags:
+                - Portal
+            summary: Get a specific portal navigation item by its ID.
+            operationId: getPortalNavigationItemById
+            description: |
+                Get a specific portal navigation item by its ID.
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    $ref: "#/components/responses/PortalNavigationItemSuccess"
+                404:
+                    $ref: "#/components/responses/PortalNavigationItemNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+                404:
+                    $ref: "#/components/responses/PortalNavigationItemNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
 components:
     requestBodies:
         pictureUpdateInputBody:
@@ -6407,6 +6438,12 @@ components:
                 application/json:
                     schema:
                         $ref: "#/components/schemas/ErrorResponse"
+        PortalNavigationItemNotFoundError:
+            description: Portal navigation item not found
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ErrorResponse"
         AuthSuccess:
             description: Auth token in payload and bearer in cookie
             headers:
@@ -6453,6 +6490,12 @@ components:
                         type: array
                         items:
                             $ref: "#/components/schemas/PortalNavigationItem"
+        PortalNavigationItemSuccess:
+            description: A portal navigation item
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/PortalNavigationItem"
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3200,6 +3200,36 @@ paths:
                     $ref: "#/components/responses/PortalNavigationItemNotFoundError"
                 500:
                     $ref: "#/components/responses/InternalServerError"
+
+    /portal-navigation-items/{portalNavigationItemId}/content:
+        parameters:
+            - name: portalNavigationItemId
+              in: path
+              required: true
+              description: Id of a portal navigation item.
+              schema:
+                  type: string
+        get:
+            tags:
+                - Portal
+            summary: Get portal navigation item content by ID.
+            operationId: getPortalNavigationItemContentById
+            description: |
+                Get a specific portal navigation item's content by its ID.
+                Only portal navigation items of type 'PAGE' have content.
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    $ref: "#/components/responses/PortalNavigationItemContentSuccess"
+                400:
+                    description: The portal navigation item is not of type 'PAGE'.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ErrorResponse"
                 404:
                     $ref: "#/components/responses/PortalNavigationItemNotFoundError"
                 500:
@@ -6496,6 +6526,13 @@ components:
                 application/json:
                     schema:
                         $ref: "#/components/schemas/PortalNavigationItem"
+        PortalNavigationItemContentSuccess:
+            description: Portal page content
+            content:
+                application/json:
+                    schema:
+                        type: string
+                        description: The content of the portal page
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PortalNavigationItemResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "DEFAULT";
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "portal-navigation-items/";
+    }
+
+    @BeforeEach
+    public void init() {
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+        portalNavigationItemsQueryService.reset();
+    }
+
+    @Nested
+    class GetPortalNavigationItemById {
+
+        @Test
+        void should_return_portal_navigation_item_when_found_and_published() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var publishedItem = PortalNavigationFixtures.page(
+                itemId,
+                "Published Page",
+                PortalArea.TOP_NAVBAR,
+                PortalNavigationFixtures.randomPageId()
+            );
+            publishedItem.setPublished(true);
+            publishedItem.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedItem));
+
+            // When
+            Response response = target(itemId.toString()).request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(200);
+            var result = response.readEntity(io.gravitee.rest.api.portal.rest.model.PortalNavigationItem.class);
+            assertThat(result).isNotNull();
+            assertThat(result.getActualInstance()).isNotNull();
+        }
+
+        @Test
+        void should_return_404_when_item_not_found() {
+            // Given
+            var unknownId = PortalNavigationFixtures.randomNavigationId();
+            portalNavigationItemsQueryService.initWith(List.of());
+
+            // When
+            Response response = target(unknownId.toString()).request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+
+        @Test
+        void should_return_404_when_item_is_unpublished() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var unpublishedItem = PortalNavigationFixtures.page(
+                itemId,
+                "Unpublished Page",
+                PortalArea.TOP_NAVBAR,
+                PortalNavigationFixtures.randomPageId()
+            );
+            unpublishedItem.setPublished(false);
+            unpublishedItem.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(unpublishedItem));
+
+            // When
+            Response response = target(itemId.toString()).request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -15,10 +15,16 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
@@ -39,6 +45,9 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
 
+    @Autowired
+    private PortalPageContentQueryServiceInMemory portalPageContentQueryService;
+
     @Override
     protected String contextPath() {
         return "portal-navigation-items/";
@@ -53,6 +62,7 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
     public void tearDown() {
         GraviteeContext.cleanContext();
         portalNavigationItemsQueryService.reset();
+        portalPageContentQueryService.reset();
     }
 
     @Nested
@@ -113,6 +123,114 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
 
             // When
             Response response = target(itemId.toString()).request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+    }
+
+    @Nested
+    class GetPortalNavigationItemContentById {
+
+        @Test
+        void should_return_content_when_page_found_and_published() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var pageContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "Page content text"
+            );
+
+            var publishedPage = PortalNavigationFixtures.page(itemId, "Published Page", PortalArea.TOP_NAVBAR, contentId);
+            publishedPage.setPublished(true);
+            publishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedPage));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(200);
+            var content = response.readEntity(String.class);
+            assertThat(content).isEqualTo("Page content text");
+        }
+
+        @Test
+        void should_return_404_when_item_not_found() {
+            // Given
+            var unknownId = PortalNavigationFixtures.randomNavigationId();
+            portalNavigationItemsQueryService.initWith(List.of());
+
+            // When
+            Response response = target(unknownId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+
+        @Test
+        void should_return_404_when_item_is_unpublished() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var pageContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "Page content text"
+            );
+
+            var unpublishedPage = PortalNavigationFixtures.page(itemId, "Unpublished Page", PortalArea.TOP_NAVBAR, contentId);
+            unpublishedPage.setPublished(false);
+            unpublishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(unpublishedPage));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+
+        @Test
+        void should_return_400_when_item_is_not_a_page() {
+            // Given
+            var folderId = PortalNavigationFixtures.randomNavigationId();
+            var folder = PortalNavigationFixtures.folder(folderId, "Folder", PortalArea.TOP_NAVBAR);
+            folder.setPublished(true);
+            folder.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(folder));
+
+            // When
+            Response response = target(folderId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(400);
+        }
+
+        @Test
+        void should_return_404_when_page_content_not_found() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+
+            var publishedPage = PortalNavigationFixtures.page(itemId, "Published Page", PortalArea.TOP_NAVBAR, contentId);
+            publishedPage.setPublished(true);
+            publishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedPage));
+            portalPageContentQueryService.initWith(List.of()); // No content
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
 
             // Then
             assertThat(response.getStatus()).isEqualTo(404);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -26,7 +26,6 @@ import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
-import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
@@ -998,11 +997,6 @@ public class ResourceContextConfiguration {
     @Bean
     public PortalNavigationItemCrudService portalNavigationItemCrudService() {
         return new PortalNavigationItemsCrudServiceInMemory();
-    }
-
-    @Bean
-    public PortalNavigationItemsQueryService portalNavigationItemsQueryService() {
-        return new PortalNavigationItemsQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityDomainService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+
+@DomainService
+public class PortalNavigationItemVisibilityDomainService {
+
+    public boolean isNotVisibleInPortal(PortalNavigationItem portalNavigationItem) {
+        return !Boolean.TRUE.equals(portalNavigationItem.getPublished());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalNavigationItemNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalNavigationItemNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+public class PortalNavigationItemNotFoundException extends NotFoundDomainException {
+
+    public PortalNavigationItemNotFoundException(String portalNavigationItemId) {
+        super("Portal navigation item not found", portalNavigationItemId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
@@ -19,6 +19,8 @@ import jakarta.annotation.Nonnull;
 
 public final class PortalNavigationFolder extends PortalNavigationItem {
 
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.FOLDER;
+
     public PortalNavigationFolder(
         @Nonnull PortalNavigationItemId id,
         @Nonnull String organizationId,
@@ -29,5 +31,10 @@ public final class PortalNavigationFolder extends PortalNavigationItem {
         @Nonnull Boolean published
     ) {
         super(id, organizationId, environmentId, title, area, order, published);
+    }
+
+    @Override
+    public PortalNavigationItemType getType() {
+        return TYPE;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -73,6 +73,8 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         this.published = published;
     }
 
+    public abstract PortalNavigationItemType getType();
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 @Getter
 public final class PortalNavigationLink extends PortalNavigationItem {
 
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.LINK;
+
     @Setter
     @Nonnull
     private String url;
@@ -38,6 +40,11 @@ public final class PortalNavigationLink extends PortalNavigationItem {
     ) {
         super(id, organizationId, environmentId, title, area, order, published);
         this.url = url;
+    }
+
+    @Override
+    public PortalNavigationItemType getType() {
+        return TYPE;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 @Getter
 public final class PortalNavigationPage extends PortalNavigationItem {
 
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
+
     @Setter
     @Nonnull
     private PortalPageContentId portalPageContentId;
@@ -38,5 +40,10 @@ public final class PortalNavigationPage extends PortalNavigationItem {
     ) {
         super(id, organizationId, environmentId, title, area, order, published);
         this.portalPageContentId = portalPageContentId;
+    }
+
+    @Override
+    public PortalNavigationItemType getType() {
+        return TYPE;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -38,6 +38,8 @@ public abstract sealed class PortalPageContent permits GraviteeMarkdownPageConte
 
     public abstract void update(UpdatePortalPageContent updatePortalPageContent);
 
+    public abstract String getContent();
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalNavigationItemUseCase {
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationItemVisibilityDomainService portalNavigationItemVisibilityDomainService;
+
+    public Output execute(Input input) {
+        final PortalNavigationItem foundItem = Optional.ofNullable(
+            portalNavigationItemsQueryService.findByIdAndEnvironmentId(input.environmentId(), input.portalNavigationItemId())
+        ).orElseThrow(() -> new PortalNavigationItemNotFoundException(input.portalNavigationItemId().id().toString()));
+
+        if (
+            Boolean.TRUE.equals(input.onlyVisibleInPortal()) && portalNavigationItemVisibilityDomainService.isNotVisibleInPortal(foundItem)
+        ) {
+            throw new PortalNavigationItemNotFoundException(input.portalNavigationItemId().id().toString());
+        }
+
+        return new Output(foundItem);
+    }
+
+    public record Input(PortalNavigationItemId portalNavigationItemId, String environmentId, Boolean onlyVisibleInPortal) {}
+
+    public record Output(PortalNavigationItem portalNavigationItem) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalPageContentByNavigationIdUseCase {
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalNavigationItemVisibilityDomainService portalNavigationItemVisibilityDomainService;
+
+    public Output execute(Input input) {
+        // Get the portal navigation item by id and env id
+        final var portalNavigationItem = Optional.ofNullable(
+            portalNavigationItemsQueryService.findByIdAndEnvironmentId(
+                input.environmentId(),
+                PortalNavigationItemId.of(input.portalNavigationItemId())
+            )
+        ).orElseThrow(() -> new PortalNavigationItemNotFoundException(input.portalNavigationItemId()));
+
+        if (input.onlyVisibleInPortal() && portalNavigationItemVisibilityDomainService.isNotVisibleInPortal(portalNavigationItem)) {
+            throw new PortalNavigationItemNotFoundException(input.portalNavigationItemId());
+        }
+
+        // If the nav item is not a page, throw exception
+        if (!(portalNavigationItem instanceof PortalNavigationPage page)) {
+            throw InvalidPortalNavigationItemDataException.typeMismatch(
+                PortalNavigationItemType.PAGE.name(),
+                portalNavigationItem.getType().name()
+            );
+        }
+
+        // Then get the portal page content by the content id from the navigation item
+        final var portalPageContent = portalPageContentQueryService
+            .findById(page.getPortalPageContentId())
+            .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
+
+        return new Output(portalPageContent, portalNavigationItem);
+    }
+
+    public record Input(String portalNavigationItemId, String environmentId, Boolean onlyVisibleInPortal) {}
+
+    public record Output(PortalPageContent portalPageContent, PortalNavigationItem portalNavigationItem) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -31,7 +31,7 @@ public class PortalNavigationItemFixtures {
 
     public static final String APIS_ID = "00000000-0000-0000-0000-000000000001";
     private static final String GUIDES_ID = "00000000-0000-0000-0000-000000000002";
-    private static final String SUPPORT_ID = "00000000-0000-0000-0000-000000000003";
+    public static final String SUPPORT_ID = "00000000-0000-0000-0000-000000000003";
     private static final String OVERVIEW_ID = "00000000-0000-0000-0000-000000000004";
     private static final String GETTING_STARTED_ID = "00000000-0000-0000-0000-000000000005";
     private static final String CATEGORY1_ID = "00000000-0000-0000-0000-000000000006";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.api.domain_service.NotificationCRDDomainService;
 import io.gravitee.apim.core.integration.service_provider.A2aAgentFetcher;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.specgen.crud_service.ApiSpecGenCrudService;
 import io.gravitee.apim.core.specgen.query_service.ApiSpecGenQueryService;
@@ -500,5 +501,10 @@ public class InMemoryConfiguration {
     @Bean
     public PortalPageContentQueryService portalPageContentQueryService() {
         return new PortalPageContentQueryServiceInMemory();
+    }
+
+    @Bean
+    public PortalNavigationItemsQueryService portalNavigationItemsQueryService() {
+        return new PortalNavigationItemsQueryServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalNavigationItemUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = ENV_ID;
+
+    private GetPortalNavigationItemUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        PortalNavigationItemsQueryServiceInMemory queryService = new PortalNavigationItemsQueryServiceInMemory();
+        PortalNavigationItemVisibilityDomainService domainService = new PortalNavigationItemVisibilityDomainService();
+        useCase = new GetPortalNavigationItemUseCase(queryService, domainService);
+
+        queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
+    }
+
+    @Test
+    void should_return_portal_navigation_item_when_found() {
+        // Given
+        final var input = new GetPortalNavigationItemUseCase.Input(PortalNavigationItemId.of(APIS_ID), ENVIRONMENT_ID, false);
+
+        // When
+        final var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalNavigationItem()).isNotNull();
+        assertThat(output.portalNavigationItem().getId()).isEqualTo(PortalNavigationItemId.of(APIS_ID));
+        assertThat(output.portalNavigationItem().getTitle()).isEqualTo("APIs");
+    }
+
+    @Test
+    void should_throw_when_item_not_found() {
+        // Given
+        final var unknownId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000099");
+        final var input = new GetPortalNavigationItemUseCase.Input(unknownId, ENVIRONMENT_ID, false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_item_exists_in_different_environment() {
+        // Given
+        final var input = new GetPortalNavigationItemUseCase.Input(PortalNavigationItemId.of(APIS_ID), "different-env", false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_item_not_visible_in_portal() {
+        // Given
+        final var input = new GetPortalNavigationItemUseCase.Input(PortalNavigationItemId.of(PAGE11_ID), ENVIRONMENT_ID, true);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.SUPPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalPageContentByNavigationIdUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = ENV_ID;
+    private static final String UNPUBLISHED_ID = "00000000-0000-0000-0000-000000000012";
+
+    private GetPortalPageContentByNavigationIdUseCase useCase;
+    private PortalPageContentQueryServiceInMemory pageContentQueryService;
+
+    @BeforeEach
+    void setUp() {
+        PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        pageContentQueryService = new PortalPageContentQueryServiceInMemory();
+        PortalNavigationItemVisibilityDomainService portalNavigationItemVisibilityDomainService =
+            new PortalNavigationItemVisibilityDomainService();
+        useCase = new GetPortalPageContentByNavigationIdUseCase(
+            navigationItemsQueryService,
+            pageContentQueryService,
+            portalNavigationItemVisibilityDomainService
+        );
+
+        // Create page contents first with known IDs
+        var supportContentId = PortalPageContentId.of("00000000-0000-0000-0000-000000000010");
+        var page11ContentId = PortalPageContentId.of("00000000-0000-0000-0000-000000000011");
+
+        var supportContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+            supportContentId,
+            PortalPageContentFixtures.ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "Support page content"
+        );
+
+        var page11Content = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+            page11ContentId,
+            PortalPageContentFixtures.ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "Page 11 content"
+        );
+
+        pageContentQueryService.initWith(List.of(supportContent, page11Content));
+
+        // Create navigation items directly with known content IDs
+        var apisFolder = new PortalNavigationFolder(
+            PortalNavigationItemId.of(APIS_ID),
+            ORG_ID,
+            ENVIRONMENT_ID,
+            "APIs",
+            PortalArea.TOP_NAVBAR,
+            0,
+            true
+        );
+
+        var category1Folder = new PortalNavigationFolder(
+            PortalNavigationItemId.of("00000000-0000-0000-0000-000000000006"),
+            ORG_ID,
+            ENVIRONMENT_ID,
+            "Category1",
+            PortalArea.TOP_NAVBAR,
+            2,
+            true
+        );
+        category1Folder.setParentId(apisFolder.getId());
+
+        var supportPage = new PortalNavigationPage(
+            PortalNavigationItemId.of(SUPPORT_ID),
+            ORG_ID,
+            ENVIRONMENT_ID,
+            "Support",
+            PortalArea.TOP_NAVBAR,
+            2,
+            supportContentId,
+            true
+        );
+
+        var page11 = new PortalNavigationPage(
+            PortalNavigationItemId.of(PAGE11_ID),
+            ORG_ID,
+            ENVIRONMENT_ID,
+            "page11",
+            PortalArea.TOP_NAVBAR,
+            0,
+            page11ContentId,
+            true
+        );
+        page11.setParentId(category1Folder.getId());
+
+        var unpublishedPage = new PortalNavigationPage(
+            PortalNavigationItemId.of(UNPUBLISHED_ID),
+            ORG_ID,
+            ENVIRONMENT_ID,
+            "Unpublished Page",
+            PortalArea.TOP_NAVBAR,
+            3,
+            PortalPageContentId.random(),
+            false
+        );
+
+        List<PortalNavigationItem> navigationItems = List.of(apisFolder, category1Folder, supportPage, page11, unpublishedPage);
+        navigationItemsQueryService.initWith(navigationItems);
+    }
+
+    @Test
+    void should_return_portal_page_content_when_navigation_page_found() {
+        // Given
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(PAGE11_ID, ENVIRONMENT_ID, false);
+
+        // When
+        var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent()).isNotNull();
+        assertThat(output.portalPageContent()).isInstanceOf(GraviteeMarkdownPageContent.class);
+        assertThat(output.portalNavigationItem()).isNotNull();
+        assertThat(output.portalNavigationItem()).isInstanceOf(PortalNavigationPage.class);
+        assertThat(output.portalNavigationItem().getId().toString()).isEqualTo(PAGE11_ID);
+        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent()).isEqualTo("Page 11 content");
+    }
+
+    @Test
+    void should_throw_when_navigation_item_not_found() {
+        // Given
+        var unknownId = "00000000-0000-0000-0000-000000000099";
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(unknownId, ENVIRONMENT_ID, false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_navigation_item_is_not_a_page() {
+        // Given
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(PortalNavigationItemFixtures.APIS_ID, ENVIRONMENT_ID, false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("Navigation item type cannot be changed or is mismatched");
+    }
+
+    @Test
+    void should_throw_when_page_content_not_found() {
+        // Given
+        pageContentQueryService.initWith(List.of());
+
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(PAGE11_ID, ENVIRONMENT_ID, false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_throw_when_navigation_item_exists_in_different_environment() {
+        // Given
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(PAGE11_ID, "different-env", false);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_navigation_item_not_visible_in_portal() {
+        // Given
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(UNPUBLISHED_ID, ENVIRONMENT_ID, true);
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11563

## Description

The Pull Request introduces navigation item handling functionality to the Gravitee API Management Portal. It includes domain exception mappers, new API endpoints, supporting models, and test cases.

- Added multiple exception mappers to handle domain-specific errors (Conflict, NotAllowed, NotFound, Technical, Validation).
- Introduced new endpoints in the REST API to fetch navigation items and their content.
- Created mappers and resources for Portal Navigation Items with error handling and publishing validation.
- Extended and refactored domain models for navigation items (e.g., added item types, content retrieval methods).
- Added comprehensive tests for new functionality, including unit and integration tests.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

