### PR TITLE
fix: make one constant public to fox reactor message build failure

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
@@ -34,7 +34,7 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
 
     private static final String HOOK_ID = "hook-tracing-policy";
 
-    private static final String ATTR_SPAN_POLICY = "gravitee.policy";
+    public static final String ATTR_SPAN_POLICY = "gravitee.policy";
     private static final String ATTR_SPAN_POLICY_TRIGGER_EXECUTED = "gravitee.policy.trigger.executed";
     private static final String ATTR_SPAN_POLICY_TRIGGER_CONDITION = "gravitee.policy.trigger.condition";
     public static final String ATTR_POLICY_TRIGGER_CONDITION_PREFIX = "gravitee.policy.trigger.condition.";


### PR DESCRIPTION
## Issue

Reactor message if failing because of a refactoring in a constant that has change name and visibility, reverted that to previous state.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

