### PR TITLE
fix: prevent changing group role from PO if group owns at least one API

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -237,7 +237,12 @@
             <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
               <mat-form-field>
                 <mat-label>API role</mat-label>
-                <mat-select [id]="group.id" [aria-label]="'API roles for ' + group.id" formControlName="API">
+                <mat-select
+                  [id]="group.id"
+                  [aria-label]="'API roles for ' + group.id"
+                  formControlName="API"
+                  [disabled]="isApiRolePrimaryOwner(group.id)"
+                >
                   <mat-option>-- None --</mat-option>
                   <mat-option *ngFor="let role of apiRoles$ | async" [disabled]="role.system" [value]="role.name">{{
                     role.name

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -106,6 +106,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       customFields,
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -119,9 +120,11 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     const userCard = await loader.getHarness(MatCardHarness);
 
-    [user.displayName, user.email, customFields['custom-field-1'], 'ROLE_USER'].forEach(async (value) => {
-      expect(await userCard.getText()).toContain(value);
-    });
+    const userCardText = await userCard.getText();
+    expect(userCardText).toContain(user.displayName);
+    expect(userCardText).toContain(user.email);
+    expect(userCardText).toContain(customFields['custom-field-1']);
+    expect(userCardText).toContain('ROLE_USER');
 
     const userStatus = await userCard.getText();
     expect(await userStatus).toContain('Active');
@@ -136,6 +139,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       source: 'gravitee',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -160,11 +164,12 @@ describe('OrgSettingsUserDetailComponent', () => {
   it('should not reset password if no firstname', async () => {
     const user = fakeUser({
       id: 'userId',
-      source: 'gravitee',
+      source: 'management',
       email: null,
       firstname: null,
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -184,6 +189,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'PENDING',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -215,6 +221,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'PENDING',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -246,6 +253,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'PENDING',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -267,6 +275,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -287,6 +296,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       roles: [{ id: 'roleOrgUserId', name: 'ROLE_ORG_USER', scope: 'ORGANIZATION' }],
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -319,6 +329,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       envRoles: { environmentAlphaId: [{ id: 'roleEnvApiId' }], environmentBetaId: [] },
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectUserGroupsGetRequest(user.id);
@@ -354,6 +365,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -409,6 +421,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'PENDING',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -443,6 +456,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -476,6 +490,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -506,6 +521,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -543,6 +559,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -566,14 +583,14 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     const dialog = await rootLoader.getHarness(MatDialogHarness);
 
-    const groupIdSelect = await dialog.getHarness(MatSelectHarness.with({ selector: '[formControlName=groupId' }));
+    const groupIdSelect = await dialog.getHarness(MatSelectHarness.with({ selector: '[formControlName="groupId"]' }));
     await groupIdSelect.open();
     // group A option is filtered
     expect((await groupIdSelect.getOptions()).length).toEqual(1);
 
     await groupIdSelect.clickOptions({ text: 'Group B' });
 
-    const isAdminSelect = await dialog.getHarness(MatCheckboxHarness.with({ selector: '[formControlName=isAdmin' }));
+    const isAdminSelect = await dialog.getHarness(MatCheckboxHarness.with({ selector: '[formControlName="isAdmin"]' }));
     await isAdminSelect.check();
 
     const submitButton = await dialog.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
@@ -601,6 +618,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -641,6 +659,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     });
     const tokenResponse: Token = fakeUserToken({ name: 'My token', created_at: 1630373735403, last_use_at: 1631017105654 });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user, [tokenResponse]);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -684,6 +703,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     reqDelete.flush(null);
 
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user, []);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -701,6 +721,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -729,6 +750,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       status: 'ACTIVE',
     });
     expectGroupListByOrganizationRequest();
+    expectApiSearchRequest();
     expectUserTokensGetRequest(user);
     expectUserGetRequest(user);
     expectEnvironmentListRequest();
@@ -814,5 +836,15 @@ describe('OrgSettingsUserDetailComponent', () => {
         url: `${CONSTANTS_TESTING.org.baseURL}/groups`,
       })
       .flush(groups);
+  }
+
+  function expectApiSearchRequest() {
+    const req = httpTestingController.expectOne(
+      (request) =>
+        request.method === 'POST' && request.url.includes('/management/v2/environments/') && request.url.includes('/apis/_search'),
+    );
+    expect(req.request.method).toEqual('POST');
+    req.flush({ data: [], pagination: { page: 1, perPage: 10000, totalCount: 0, pageCount: 0, pageItemsCount: 0 } });
+    fixture.detectChanges();
   }
 });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -30,10 +30,12 @@ import io.gravitee.rest.api.management.rest.model.PagedResult;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
 import io.gravitee.rest.api.model.alert.ApplicationAlertMembershipEvent;
+import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.GroupService;
@@ -44,6 +46,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.GroupInvitationForbiddenException;
 import io.gravitee.rest.api.service.exceptions.GroupMembersLimitationExceededException;
+import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -271,6 +274,19 @@ public class GroupMembersResource extends AbstractResource {
                 RoleEntity apiRoleEntity = roleEntities.get(RoleScope.API);
                 if (apiRoleEntity != null && !apiRoleEntity.equals(previousApiRole)) {
                     String roleName = getRoleName(RoleScope.API, apiRoleEntity, groupEntity, GroupEntity::isLockApiRole, hasPermission);
+
+                    // Validate: prevent changing from PRIMARY_OWNER if group owns APIs
+                    if (
+                        previousApiRole != null &&
+                        previousApiRole.getName().equals(SystemRole.PRIMARY_OWNER.name()) &&
+                        !roleName.equals(SystemRole.PRIMARY_OWNER.name())
+                    ) {
+                        List<ApiEntity> groupApis = groupService.getApis(executionContext.getEnvironmentId(), group);
+                        if (!groupApis.isEmpty()) {
+                            throw new StillPrimaryOwnerException(groupApis.size(), ApiPrimaryOwnerMode.GROUP);
+                        }
+                    }
+
                     updatedMembership = updateRole(RoleScope.API, roleName, previousApiRole, membership, executionContext);
                     if (previousApiRole != null && previousApiRole.getName().equals(SystemRole.PRIMARY_OWNER.name())) {
                         groupService.updateApiPrimaryOwner(group, null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
@@ -23,7 +23,9 @@ import static org.mockito.Mockito.*;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.rest.model.GroupMembership;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
@@ -407,6 +409,212 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.INTEGRATION, "CUSTOM_APP")
+        );
+    }
+
+    // PRIMARY_OWNER validation tests
+    @Test
+    public void shouldThrowExceptionWhenChangingFromPrimaryOwnerToOtherRoleIfGroupOwnsApis() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API);
+
+        RoleEntity otherRole = new RoleEntity();
+        otherRole.setId("API_USER");
+        otherRole.setName("USER");
+        otherRole.setScope(RoleScope.API);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(otherRole)
+        );
+
+        RoleEntity previousApiRole = new RoleEntity();
+        previousApiRole.setId("API_PRIMARY_OWNER");
+        previousApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        previousApiRole.setScope(RoleScope.API);
+
+        Set<RoleEntity> existingRoles = Set.of(previousApiRole);
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            existingRoles
+        );
+
+        ApiEntity api1 = new ApiEntity();
+        api1.setId("api-1");
+        api1.setName("Test API 1");
+        ApiEntity api2 = new ApiEntity();
+        api2.setId("api-2");
+        api2.setName("Test API 2");
+        when(groupService.getApis(GraviteeContext.getExecutionContext().getEnvironmentId(), GROUP_ID)).thenReturn(List.of(api1, api2));
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiRole = new MemberRoleEntity();
+        newApiRole.setRoleScope(RoleScope.API);
+        newApiRole.setRoleName("USER");
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldAllowChangingFromPrimaryOwnerToOtherRoleIfGroupDoesNotOwnApis() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API);
+
+        RoleEntity otherRole = new RoleEntity();
+        otherRole.setId("API_USER");
+        otherRole.setName("USER");
+        otherRole.setScope(RoleScope.API);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(otherRole)
+        );
+
+        RoleEntity previousApiRole = new RoleEntity();
+        previousApiRole.setId("API_PRIMARY_OWNER");
+        previousApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        previousApiRole.setScope(RoleScope.API);
+
+        Set<RoleEntity> existingRoles = Set.of(previousApiRole);
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            existingRoles
+        );
+
+        when(groupService.getApis(GraviteeContext.getExecutionContext().getEnvironmentId(), GROUP_ID)).thenReturn(Collections.emptyList());
+
+        MemberEntity memberEntity = new MemberEntity();
+        memberEntity.setId(USERNAME);
+        when(membershipService.addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(
+            memberEntity
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiRole = new MemberRoleEntity();
+        newApiRole.setRoleScope(RoleScope.API);
+        newApiRole.setRoleName("USER");
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(groupService).getApis(GraviteeContext.getExecutionContext().getEnvironmentId(), GROUP_ID);
+        verify(membershipService, times(1)).addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+            new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API, "USER")
+        );
+    }
+
+    @Test
+    public void shouldAllowChangingToPrimaryOwnerFromOtherRole() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API);
+
+        RoleEntity otherRole = new RoleEntity();
+        otherRole.setId("API_USER");
+        otherRole.setName("USER");
+        otherRole.setScope(RoleScope.API);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(otherRole)
+        );
+
+        RoleEntity previousApiRole = new RoleEntity();
+        previousApiRole.setId("API_USER");
+        previousApiRole.setName("USER");
+        previousApiRole.setScope(RoleScope.API);
+
+        Set<RoleEntity> existingRoles = Set.of(previousApiRole);
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            existingRoles
+        );
+
+        MemberEntity memberEntity = new MemberEntity();
+        memberEntity.setId(USERNAME);
+        when(membershipService.addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(
+            memberEntity
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiRole = new MemberRoleEntity();
+        newApiRole.setRoleScope(RoleScope.API);
+        newApiRole.setRoleName(SystemRole.PRIMARY_OWNER.name());
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        verify(groupService, never()).getApis(anyString(), eq(GROUP_ID));
+        verify(membershipService, times(1)).addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+            new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
         );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10367

## Description

Prevent users from changing a group's API role from PO if the group is the Product Owner of at least one API.
## Additional context

<img width="1728" height="942" alt="Screenshot 2025-08-07 at 3 59 56 PM" src="https://github.com/user-attachments/assets/4ce5c114-7e0c-4a7f-a4a9-f707eefdd3c2" />

