### PR TITLE
fix: file upload restrictions on SVG files

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
@@ -182,6 +182,10 @@ public abstract class AbstractResource<T, K> {
             if (!mediaType.startsWith("image/")) {
                 throw new UploadUnauthorized("Image file format unauthorized " + mediaType);
             }
+
+            if (mediaType.startsWith("image/svg")) {
+                throw new UploadUnauthorized("SVG files are not supported");
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -22,7 +23,10 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.InlinePictureEntity;
@@ -213,6 +217,21 @@ public class UserResourceTest extends AbstractResourceTest {
         target().request().put(Entity.json(user));
 
         verify(userService, never()).update(eq(GraviteeContext.getExecutionContext()), any(), any());
+    }
+
+    @Test
+    void shouldNotUpdateAvatarWhenSvg() {
+        final String svgAvatar =
+            "data:image/svg+xml;base64,PGJyPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjQwMCIgaGVpZ2h0PSI0MDAiIHZpZXdCb3g9IjAgMCAxMjQgMTI0IiBmaWxsPSJub25lIj4KPHJlY3Qgd2lkdGg9IjEyNCIgaGVpZ2h0PSIxMjQiIHJ4PSIyNCIgZmlsbD0iIzAwMDAwMCIvPgogICA8c2NyaXB0IHR5cGU9InRleHQvamF2YXNjcmlwdCI+ICAKICAgICAgYWxlcnQoZG9jdW1lbnQubG9jYXRpb24pOwogICA8L3NjcmlwdD4KPC9zdmc+";
+        UserInput userInput = new UserInput().id(USER_NAME).avatar(svgAvatar);
+        UserEntity existingUser = new UserEntity();
+        existingUser.setSource("gravitee");
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(existingUser);
+
+        final Response response = target().request().put(Entity.json(userInput));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(userService, never()).update(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12034

## Description

We want to prevent the upload of SVG files when the user is updating his avatar on the portal. The UI has the restriction but not the API. Now we raise an `UploadUnauthorized` when the user is updated with an SVG as avatar.

Here an exemple : 

_The request_

<img width="582" height="270" alt="Capture d’écran 2025-12-02 à 15 42 57" src="https://github.com/user-attachments/assets/57b1c695-5230-47be-b63c-c1aff4190909" />


_The response_

<img width="562" height="388" alt="Capture d’écran 2025-12-02 à 15 40 28" src="https://github.com/user-attachments/assets/de3206ce-cc9a-40c5-b190-38e3f0c6c5d9" />

