### PR TITLE
Revert ES9 support on 4.6.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -325,9 +325,8 @@ workflows:
               engineType:
                 - elasticsearch
               engineVersion:
-                - 7.17.29
-                - 8.19.7
-                - 9.2.1
+                - 7.17.15
+                - 8.16.1
       - job-elastic-test-container:
           name: Analytics repository tests - OpenSearch << matrix.engineVersion >>
           context:

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -83,7 +83,7 @@ export class RepositoriesTestsWorkflow {
         requires: [buildJobName],
         matrix: {
           engineType: ['elasticsearch'],
-          engineVersion: ['7.17.29', '8.19.7', '9.2.1'],
+          engineVersion: ['7.17.15', '8.16.1'],
         },
       }),
       new workflow.WorkflowJob(opensearchTestContainerJob, {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -31,7 +31,7 @@
     <name>Gravitee.io APIM - Repository - Elasticsearch</name>
 
     <properties>
-        <gravitee-reporter-common.version>1.3.3</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.3.0</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.1.0</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.0.1</opensearch-testcontainers.version>
     </properties>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
@@ -82,7 +82,11 @@ public class ResponseTimeRangeQueryAdapter {
         var from = query.from().minus(query.interval());
         var to = query.to().plus(query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json()
+            .put("from", from.toEpochMilli())
+            .put("to", to.toEpochMilli())
+            .put("include_lower", true)
+            .put("include_upper", true);
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var bool = json().set("filter", array().add(termFilter).add(rangeFilter));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
@@ -61,8 +61,8 @@ public class SearchAverageConnectionDurationQueryAdapter {
         query.apiId().ifPresent(apiId -> terms.add(JsonObject.of("term", JsonObject.of("api-id", apiId))));
 
         var timestamp = new JsonObject();
-        query.from().ifPresent(from -> timestamp.put("gte", from.toEpochMilli()));
-        query.to().ifPresent(to -> timestamp.put("lte", to.toEpochMilli()));
+        query.from().ifPresent(from -> timestamp.put("from", from.toEpochMilli()).put("include_lower", true));
+        query.to().ifPresent(to -> timestamp.put("to", to.toEpochMilli()).put("include_upper", true));
 
         if (!timestamp.isEmpty()) {
             terms.add(JsonObject.of("range", JsonObject.of("@timestamp", timestamp)));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapter.java
@@ -80,8 +80,8 @@ public class SearchAverageMessagesPerRequestQueryAdapter {
         query.apiId().ifPresent(apiId -> terms.add(JsonObject.of("term", JsonObject.of("api-id", apiId))));
 
         var timestamp = new JsonObject();
-        query.from().ifPresent(from -> timestamp.put("gte", from.toEpochMilli()));
-        query.to().ifPresent(to -> timestamp.put("lte", to.toEpochMilli()));
+        query.from().ifPresent(from -> timestamp.put("from", from.toEpochMilli()).put("include_lower", true));
+        query.to().ifPresent(to -> timestamp.put("to", to.toEpochMilli()).put("include_upper", true));
 
         if (!timestamp.isEmpty()) {
             terms.add(JsonObject.of("range", JsonObject.of("@timestamp", timestamp)));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
@@ -55,8 +55,8 @@ public class SearchRequestsCountQueryAdapter {
         query.apiId().ifPresent(apiId -> terms.add(JsonObject.of("term", JsonObject.of("api-id", apiId))));
 
         var timestamp = new JsonObject();
-        query.from().ifPresent(from -> timestamp.put("gte", from.toEpochMilli()));
-        query.to().ifPresent(to -> timestamp.put("lte", to.toEpochMilli()));
+        query.from().ifPresent(from -> timestamp.put("from", from.toEpochMilli()).put("include_lower", true));
+        query.to().ifPresent(to -> timestamp.put("to", to.toEpochMilli()).put("include_upper", true));
 
         if (!timestamp.isEmpty()) {
             terms.add(JsonObject.of("range", JsonObject.of("@timestamp", timestamp)));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
@@ -86,7 +86,11 @@ public class SearchResponseStatusOverTimeAdapter {
         Instant from = query.from().minus(query.interval());
         Instant to = query.to().plus(query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json()
+            .put("from", from.toEpochMilli())
+            .put("to", to.toEpochMilli())
+            .put("include_lower", true)
+            .put("include_upper", true);
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var bool = json().set("filter", array().add(termFilter).add(rangeFilter));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AvailabilityQueryMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AvailabilityQueryMapper.java
@@ -40,7 +40,11 @@ public class AvailabilityQueryMapper implements QueryResponseAdapter<ApiFieldPer
     private ObjectNode query(ApiFieldPeriod query) {
         JsonNode termFilter = json().set("term", json().put("api", query.apiId()));
 
-        ObjectNode timestamp = json().put("gte", query.from().toEpochMilli()).put("lte", query.to().toEpochMilli());
+        ObjectNode timestamp = json()
+            .put("from", query.from().toEpochMilli())
+            .put("to", query.to().toEpochMilli())
+            .put("include_lower", true)
+            .put("include_upper", true);
         JsonNode rangeFilter = json().set("range", json().set("@timestamp", timestamp));
 
         return json().set("bool", json().set("filter", array().add(termFilter).add(rangeFilter)));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapter.java
@@ -68,7 +68,11 @@ public class AverageHealthCheckResponseTimeOvertimeAdapter
         Instant from = query.from().minus(query.interval());
         Instant to = query.to().plus(query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json()
+            .put("from", from.toEpochMilli())
+            .put("to", to.toEpochMilli())
+            .put("include_lower", true)
+            .put("include_upper", true);
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var bool = json().set("filter", array().add(termFilter).add(rangeFilter));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/HealthCheckLogAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/HealthCheckLogAdapter.java
@@ -63,7 +63,14 @@ public class HealthCheckLogAdapter implements QueryResponseAdapter<HealthCheckLo
         var termFilter = json().set("term", json().put("api", query.apiId()));
         var rangeFilter = json().set(
             "range",
-            json().set(TIME_FIELD, json().put("gte", query.from().toEpochMilli()).put("lte", query.to().toEpochMilli()))
+            json().set(
+                TIME_FIELD,
+                json()
+                    .put("from", query.from().toEpochMilli())
+                    .put("to", query.to().toEpochMilli())
+                    .put("include_lower", true)
+                    .put("include_upper", true)
+            )
         );
 
         var mustTerm = json();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/count.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/count.ftl
@@ -36,8 +36,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${query.timeRange().range().from()},
-              "lte": ${query.timeRange().range().to()}
+              "from": ${query.timeRange().range().from()},
+              "to": ${query.timeRange().range().to()},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/dateHistogram.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/dateHistogram.ftl
@@ -36,8 +36,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${roundedFrom},
-              "lte": ${roundedTo}
+              "from": ${roundedFrom},
+              "to": ${roundedTo},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/groupBy.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/groupBy.ftl
@@ -36,8 +36,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${query.timeRange().range().from()},
-              "lte": ${query.timeRange().range().to()}
+              "from": ${query.timeRange().range().from()},
+              "to": ${query.timeRange().range().to()},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/stats.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/stats.ftl
@@ -37,8 +37,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${query.timeRange().range().from()},
-              "lte": ${query.timeRange().range().to()}
+              "from": ${query.timeRange().range().from()},
+              "to": ${query.timeRange().range().to()},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analyticsRequest.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analyticsRequest.ftl
@@ -12,8 +12,10 @@
             {
                "range":{
                   "@timestamp":{
-                     "gte":${from},
-                     "lte":${to}
+                     "from":${from},
+                     "to":${to},
+                     "include_lower":true,
+                     "include_upper":true
                   }
                }
             }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/healthcheck/logs.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/healthcheck/logs.ftl
@@ -22,8 +22,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${query.from()},
-              "lte": ${query.to()}
+              "from": ${query.from()},
+              "to": ${query.to()},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
@@ -38,8 +38,10 @@
         {
           "range": {
             "@timestamp": {
-              "gte": ${query.timeRange().range().from()},
-              "lte": ${query.timeRange().range().to()}
+              "from": ${query.timeRange().range().from()},
+              "to": ${query.timeRange().range().to()},
+              "include_lower": true,
+              "include_upper": true
             }
           }
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
@@ -110,7 +110,7 @@ public class TestConfiguration {
     private ElasticsearchContainer generateElasticsearchContainer() {
         final String dockerImage = "docker.elastic.co/elasticsearch/elasticsearch:" + elasticsearchVersion;
         final ElasticsearchContainer elasticsearchContainer = new ElasticsearchContainer(dockerImage);
-        if (Integer.parseInt(String.valueOf(elasticsearchVersion.charAt(0))) >= 8) {
+        if (elasticsearchVersion.startsWith("8")) {
             elasticsearchContainer.withEnv("xpack.security.enabled", "false");
         }
         return elasticsearchContainer;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapterTest.java
@@ -59,10 +59,10 @@ public class ResponseTimeRangeQueryAdapterTest {
         JsonNode jsonQuery = MAPPER.readTree(result);
         // query part
         assertThat(jsonQuery.at("/query/bool/filter/0/term/api-id").asText()).isEqualTo("MyAPI");
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong()))
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/from").asLong()))
             .isBeforeOrEqualTo(start)
             .isCloseTo(start, within(interval.toMillis(), ChronoUnit.MILLIS));
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lte").asLong()))
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/to").asLong()))
             .isAfterOrEqualTo(end)
             .isCloseTo(end, within(interval.toMillis(), ChronoUnit.MILLIS));
         // aggs
@@ -97,10 +97,10 @@ public class ResponseTimeRangeQueryAdapterTest {
         JsonNode jsonQuery = MAPPER.readTree(result);
         // query part
         assertThat(jsonQuery.at("/query/bool/filter/0/term/api-id").asText()).isEqualTo("MyAPI");
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong()))
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/from").asLong()))
             .isBeforeOrEqualTo(start)
             .isCloseTo(start, within(interval.toMillis(), ChronoUnit.MILLIS));
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lte").asLong()))
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/to").asLong()))
             .isAfterOrEqualTo(end)
             .isCloseTo(end, within(interval.toMillis(), ChronoUnit.MILLIS));
         // aggs

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
@@ -186,8 +186,10 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                     {
                       "range": {
                         "@timestamp": {
-                           "gte": 1609459200000,
-                           "lte": 1609545600000
+                           "from": 1609459200000,
+                           "include_lower": true,
+                           "to": 1609545600000,
+                           "include_upper": true
                         }
                      }
                    }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapterTest.java
@@ -175,8 +175,10 @@ class SearchAverageMessagesPerRequestQueryAdapterTest {
                     {
                       "range": {
                         "@timestamp": {
-                          "gte": 1609459200000,
-                          "lte": 1609545600000
+                          "from": 1609459200000,
+                          "include_lower": true,
+                          "to": 1609545600000,
+                          "include_upper": true
                         }
                       }
                    }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
@@ -113,8 +113,10 @@ class SearchRequestsCountQueryAdapterTest {
                             {
                                  "range": {
                                      "@timestamp": {
-                                         "gte": 1609459200000,
-                                         "lte": 1609545600000
+                                         "from": 1609459200000,
+                                         "include_lower": true,
+                                         "to": 1609545600000,
+                                         "include_upper": true
                                     }
                                 }
                             }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
@@ -70,8 +70,10 @@ class SearchResponseStatusOverTimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "from": 1697882730000,
+                               "include_lower": true,
+                               "include_upper": true,
+                               "to": 1697970330000
                              }
                            }
                          }
@@ -114,8 +116,10 @@ class SearchResponseStatusOverTimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "from": 1697882730000,
+                               "include_lower": true,
+                               "include_upper": true,
+                               "to": 1697970330000
                              }
                            }
                          }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AvailabilityQueryMapperTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AvailabilityQueryMapperTest.java
@@ -69,8 +69,10 @@ class AvailabilityQueryMapperTest {
                         {
                           "range": {
                             "@timestamp": {
-                              "gte": 1697969730000,
-                              "lte": 1697883330000
+                              "from": 1697969730000,
+                              "to": 1697883330000,
+                              "include_lower": true,
+                              "include_upper": true
                             }
                           }
                         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapterTest.java
@@ -70,8 +70,10 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "from": 1697882730000,
+                               "to": 1697970330000,
+                               "include_lower": true,
+                               "include_upper": true
                              }
                            }
                          }
@@ -114,8 +116,10 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "from": 1697882730000,
+                               "to": 1697970330000,
+                               "include_lower": true,
+                               "include_upper": true
                              }
                            }
                          }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/HealthCheckLogAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/HealthCheckLogAdapterTest.java
@@ -59,8 +59,10 @@ class HealthCheckLogAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697883330000,
-                               "lte": 1697969730000
+                               "from": 1697883330000,
+                               "to": 1697969730000,
+                               "include_lower": true,
+                               "include_upper": true
                              }
                            }
                          }
@@ -96,8 +98,10 @@ class HealthCheckLogAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697883330000,
-                               "lte": 1697969730000
+                               "from": 1697883330000,
+                               "to": 1697969730000,
+                               "include_lower": true,
+                               "include_upper": true
                              }
                            }
                          }
@@ -132,8 +136,10 @@ class HealthCheckLogAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697883330000,
-                               "lte": 1697969730000
+                               "from": 1697883330000,
+                               "to": 1697969730000,
+                               "include_lower": true,
+                               "include_upper": true
                              }
                            }
                          }

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>5.5.3</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>5.5.6</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.4</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.3</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.1.0</gravitee-reporter-cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>5.5.5</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>5.5.3</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.4</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.3</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.1.0</gravitee-reporter-cloud.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1483

## Description

Revert support of ES 9 on a maintenance version. We keep it only for master (4.10.x)