### PR TITLE
fix: recompute IDP role mapping on every login when enabled

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -2139,10 +2139,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         List<Membership> overrideUserMemberships = new ArrayList<>();
         // Delete existing memberships
         userMemberships.forEach(membership -> {
-            // Consider only membership "created by" the identity provider
-            if (identityProviderId.equals(membership.getSource())) {
-                // if there is no mapping configured on the social idp, we do not remove / reset it
-                if (hasMapping) {
+            if (hasMapping) {
+                // Consider only membership "created by" the identity provider
+                if (identityProviderId.equals(membership.getSource())) {
                     membershipService.deleteReferenceMemberBySource(
                         executionContext,
                         MembershipReferenceType.valueOf(membership.getReferenceType().name()),
@@ -2151,8 +2150,17 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                         userId,
                         membership.getSource()
                     );
+                } else {
+                    membershipService.deleteReferenceMember(
+                        executionContext,
+                        MembershipReferenceType.valueOf(membership.getReferenceType().name()),
+                        membership.getReferenceId(),
+                        MembershipMemberType.USER,
+                        userId
+                    );
                 }
             } else {
+                // if there is no mapping configured on the social idp, we do not remove / reset it
                 overrideUserMemberships.add(membership);
             }
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -2337,4 +2337,37 @@ public class UserServiceTest {
         verify(roleService).findPrimaryOwnerRoleByOrganization(ORGANIZATION, RoleScope.API);
         verify(roleService).findPrimaryOwnerRoleByOrganization(ORGANIZATION, RoleScope.APPLICATION);
     }
+
+    @Test
+    public void shouldOverrideAdminRolesWithIdpMappingsWhenSyncMappingsEnabled() throws Exception {
+        reset(identityProvider, userRepository, roleService, membershipService);
+        mockDefaultEnvironment();
+
+        when(identityProvider.isSyncMappings()).thenReturn(true);
+        when(identityProvider.getId()).thenReturn("oauth2");
+
+        RoleMappingEntity roleMapping = new RoleMappingEntity();
+        roleMapping.setCondition("true");
+        roleMapping.setEnvironments(Map.of(ENVIRONMENT, List.of("USER")));
+        when(identityProvider.getRoleMappings()).thenReturn(List.of(roleMapping));
+
+        User user = mockUser();
+        when(userRepository.findBySource("oauth2", user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(user)).thenReturn(user);
+
+        RoleEntity userRole = mockRoleEntity(RoleScope.ENVIRONMENT, "USER");
+        when(roleService.findByScopeAndName(RoleScope.ENVIRONMENT, "USER", ORGANIZATION)).thenReturn(Optional.of(userRole));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo);
+
+        verify(membershipService).updateRolesToMemberOnReferenceBySource(
+            eq(EXECUTION_CONTEXT),
+            eq(new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, ENVIRONMENT)),
+            eq(new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER)),
+            argThat(roles -> roles.contains(new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "USER"))),
+            eq("oauth2")
+        );
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9362

## Description

When "**Computed during each user authentication**" was selected in the IDP configuration, admin-assigned roles continued to override the IDP role mapping. As a result, roles were not recomputed during each authentication as expected.

Now, IDP role mapping is always executed on every login when the option is enabled.

Fix:


https://github.com/user-attachments/assets/f6cd546d-3119-405f-b712-a58bd379fbc5



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

