### PR TITLE
Fix time series metrics query to include all user arguments

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/TimeSeriesRequest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/TimeSeriesRequest.java
@@ -38,4 +38,16 @@ public record TimeSeriesRequest(
     public TimeSeriesRequest emptyMetrics() {
         return new TimeSeriesRequest(timeRange, interval, filters, new ArrayList<>(), facets, limit, ranges);
     }
+
+    public TimeSeriesRequest withFilters(List<Filter> filters) {
+        return new TimeSeriesRequest(
+            this.timeRange(),
+            this.interval(),
+            filters,
+            this.metrics(),
+            this.facets(),
+            this.limit(),
+            this.ranges()
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
@@ -85,6 +85,6 @@ public class ComputeTimeSeriesUseCase {
     ) {
         var updatedFilters = analyticsQueryFilterDecorator.applyPermissionBasedFilters(request.filters(), allowedApis.keySet());
 
-        return new TimeSeriesRequest(request.timeRange(), request.interval(), updatedFilters);
+        return request.withFilters(updatedFilters);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1610
## Description

Fixed the handling of query arguments in the time series metrics retrieval to ensure all user-passed parameters are utilized.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->