### PR TITLE
feat(portal): implement create application form

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -78,11 +78,11 @@
             <span class="m3-body-medium" data-testId="typeDescription">{{ applicationTypeConfiguration.description }}</span>
           </div>
           <div class="settings__form__content__integration__copy-code">
-            <app-copy-code id="client-id" title="Client ID" [text]="application.settings.oauth.client_id" data-testId="clientId" />
+            <app-copy-code id="client-id" title="Client ID" [text]="application.settings.oauth?.client_id ?? ''" data-testId="clientId" />
             <app-copy-code
               id="client-secret"
               title="Client Secret"
-              [text]="application.settings.oauth.client_secret"
+              [text]="application.settings.oauth?.client_secret ?? ''"
               [mode]="'PASSWORD'"
               data-testId="clientSecret" />
           </div>

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.ts
@@ -82,8 +82,8 @@ export class ApplicationTabSettingsReadComponent implements OnInit {
           isRedirectUriRequired: this.applicationTypeConfiguration.requires_redirect_uris,
           type: this.applicationTypeConfiguration.name,
           typeDescription: this.applicationTypeConfiguration.description,
-          redirectUris: application.settings.oauth!.redirect_uris,
-          grantTypes: application.settings.oauth!.grant_types.map(
+          redirectUris: application.settings.oauth?.redirect_uris,
+          grantTypes: application.settings.oauth?.grant_types?.map(
             type => this.applicationTypeConfiguration.allowed_grant_types!.find(grantType => grantType.type === type)!.name ?? '',
           ),
           clientId: application.settings.oauth?.client_id,

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2025 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,5 +20,162 @@
   <mat-card-content>
     <h2 i18n="@@applicationsCreateTitle">Create new application</h2>
     <p i18n="@@applicationsCreateDescription">An application is used to register and agree to plans.</p>
+
+    @if (enabledApplicationTypes(); as types) {
+      <div class="cards-container" [appIsMobile]="'cards-container--mobile'">
+        <mat-card appearance="outlined">
+          <mat-card-content>
+            <h3 class="section-title" i18n="@@createApplicationSecuritySetupTitle">Set up security</h3>
+            @if (isMobile()) {
+              <mat-form-field appearance="outline" class="type-select-mobile">
+                <mat-label i18n="@@createApplicationTypeTitleMobile">Type</mat-label>
+                <mat-select [formControl]="typeIdControl">
+                  @for (type of types; track $index) {
+                    <mat-option [value]="type.id">{{ type.name }}</mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+            } @else {
+              <span class="radio-group-label m3-title-medium" id="application-type-radio-group-label" i18n="@@createApplicationTypeLabel"
+                >Type</span
+              >
+              <mat-radio-group aria-labelledby="application-type-radio-group-label" class="types-group" [formControl]="typeIdControl">
+                @for (type of types; track $index) {
+                  <mat-radio-button class="type-radio" [value]="type.id ?? type.name">
+                    <div class="application-type-label">
+                      <div class="m3-title-medium">{{ type.name }}</div>
+                      <div class="m3-body-small">{{ type.description }}</div>
+                    </div>
+                  </mat-radio-button>
+                }
+              </mat-radio-group>
+            }
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card appearance="outlined">
+          <mat-card-content>
+            <h3 class="section-title" i18n="@@createApplicationDetailsTitle">Application details</h3>
+            @if (selectedType()) {
+              <form class="form" [formGroup]="form">
+                <mat-form-field appearance="outline">
+                  <mat-label i18n="@@createApplicationName">Application name</mat-label>
+                  <input matInput formControlName="name" />
+                  @if (form.controls.name.touched && form.controls.name.hasError('required')) {
+                    <mat-error i18n="@@createApplicationNameRequired">Name is required</mat-error>
+                  }
+                </mat-form-field>
+
+                <mat-form-field appearance="outline">
+                  <mat-label i18n="@@createApplicationDescription">Description (optional)</mat-label>
+                  <textarea matInput formControlName="description" rows="3"></textarea>
+                </mat-form-field>
+
+                <mat-divider />
+                <h3 class="section-title" i18n="@@createApplicationSecurityTitle">Security</h3>
+
+                @if (isSimpleType()) {
+                  <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                    <mat-label i18n="@@createApplicationType">Type</mat-label>
+                    <input matInput formControlName="appType" />
+                    <mat-hint i18n="@@createApplicationTypeHint">Type of the application (mobile, web, ...)</mat-hint>
+                  </mat-form-field>
+
+                  <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                    <mat-label i18n="@@createApplicationClientId">Client ID</mat-label>
+                    <input matInput formControlName="appClientId" />
+                    <mat-hint i18n="@@createApplicationClientIdHint"
+                      >The client_id of the application. This field is required to subscribe to certain types of API Plan (OAuth2, JWT)
+                    </mat-hint>
+                  </mat-form-field>
+                }
+
+                @if (grantTypesList().length > 0) {
+                  <div class="grant-types-container">
+                    <div>
+                      <div class="m3-title-medium">
+                        <span i18n="@@createApplicationGrantTypes">Select the grant types your application will use</span>
+                      </div>
+                      <div class="m3-body-medium" i18n="@@createApplicationGrantTypesHint">
+                        For security, enable only the ones you need.
+                      </div>
+                    </div>
+                    @for (grantType of grantTypesList(); track grantType.type) {
+                      <div class="grant-type-toggle">
+                        <mat-slide-toggle
+                          [checked]="isGrantTypeSelected(grantType.type)"
+                          [disabled]="grantType.isDisabled"
+                          (change)="toggleGrantType(grantType.type, $event.checked)">
+                          <span class="grant-type-label">{{ grantType.name }}</span>
+                        </mat-slide-toggle>
+                      </div>
+                    }
+                  </div>
+                }
+
+                @if (requiresRedirectUris() && redirectUrisControl; as redirectUrisCtrl) {
+                  <mat-form-field appearance="outline" floatLabel="always" subscriptSizing="dynamic">
+                    <mat-label i18n="@@applicationRedirectUris">Redirect URIs</mat-label>
+                    <mat-chip-grid #redirectURIChipGrid aria-label="Redirect URIs" [formControl]="redirectUrisCtrl">
+                      @for (uri of redirectUrisCtrl.value; track uri) {
+                        <mat-chip-row (removed)="removeRedirectUri(uri)">
+                          {{ uri }}
+                          <button matChipRemove [attr.aria-label]="'remove redirect URI ' + uri">
+                            <mat-icon>cancel</mat-icon>
+                          </button>
+                        </mat-chip-row>
+                      }
+
+                      <input
+                        [matChipInputFor]="redirectURIChipGrid"
+                        [matChipInputAddOnBlur]="true"
+                        (matChipInputTokenEnd)="addRedirectUri($event)" />
+                    </mat-chip-grid>
+                    <mat-hint i18n="@@applicationRedirectUrisHint">
+                      The URI where the authorization server sends OAuth responses.
+                    </mat-hint>
+                    @if (redirectUrisCtrl.touched && (redirectUrisCtrl.hasError('required') || redirectUrisCtrl.hasError('minlength'))) {
+                      <mat-error i18n="@@redirectUrisRequired">At least one valid redirect URI is required</mat-error>
+                    }
+                  </mat-form-field>
+                }
+
+                <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                  <mat-label i18n="@@createApplicationClientCertificate">Client Certificate (PEM Only)</mat-label>
+                  <textarea matInput formControlName="clientCertificate" rows="6"></textarea>
+                  <mat-hint i18n="@@createApplicationClientCertificateHint"
+                    >The client_certificate of the application. This field is required to subscribe to certain mTLS plans.
+                  </mat-hint>
+                </mat-form-field>
+              </form>
+            } @else {
+              <p i18n="@@selectApplicationTypeFirst">Please select an application type first</p>
+            }
+          </mat-card-content>
+        </mat-card>
+      </div>
+    } @else {
+      <app-loader />
+    }
+
+    @if (hasApplicationError) {
+      <div class="m3-title-medium error-message" i18n="@@createApplicationGeneralErrorMessage">
+        There was an error creating your application and it could not be processed. Try again, and if the issue persists, contact your
+        portal administrator.
+      </div>
+    }
+
+    <div class="actions">
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        [disabled]="form.invalid || !selectedType()"
+        (click)="onCreate()"
+        i18n="@@createApplicationCreateButton">
+        Create
+      </button>
+      <button mat-flat-button type="button" (click)="onCancel()" i18n="@@createApplicationCancelButton">Cancel</button>
+    </div>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
@@ -13,9 +13,105 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../../scss/theme';
 
 :host {
   display: flex;
   flex-flow: column;
   gap: 34px;
+}
+
+.cards-container {
+  display: flex;
+  gap: 24px;
+
+  mat-card {
+    flex: 1;
+  }
+
+  &--mobile {
+    flex-direction: column;
+  }
+}
+
+.section-title {
+  margin: 16px 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.radio-group-label {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.type-select-mobile {
+  width: 100%;
+}
+
+.types-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.type-radio {
+  display: block;
+  padding: 12px;
+  border: 1px solid theme.$border-color;
+  border-radius: theme.$container-shape;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  &.mat-mdc-radio-checked {
+    border-color: theme.$primary-main-color;
+    background-color: color-mix(in srgb, theme.$primary-main-color 8%, transparent);
+  }
+}
+
+.application-type-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.grant-types-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.grant-type-toggle {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  gap: 12px;
+
+  mat-slide-toggle {
+    margin: 0;
+  }
+}
+
+.grant-type-label {
+  line-height: 1.5;
+}
+
+.grant-types-error {
+  margin-top: 4px;
+  color: theme.$error-main-color;
+}
+
+.error-message {
+  color: theme.$error-main-color;
+}
+
+.actions {
+  display: flex;
+  margin-top: 24px;
+  gap: 16px;
 }

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.spec.ts
@@ -1,0 +1,576 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatChipGridHarness } from '@angular/material/chips/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatRadioButtonHarness } from '@angular/material/radio/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { Router } from '@angular/router';
+
+import { CreateApplicationComponent } from './create-application.component';
+import {
+  fakeApplication,
+  fakeSimpleApplicationType,
+  fakeNativeApplicationType,
+  fakeBackendToBackendApplicationType,
+  fakeBrowserApplicationType,
+} from '../../../entities/application/application.fixture';
+import { ObservabilityBreakpointService } from '../../../services/observability-breakpoint.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../testing/app-testing.module';
+
+describe('CreateApplicationComponent', () => {
+  let fixture: ComponentFixture<CreateApplicationComponent>;
+  let component: CreateApplicationComponent;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let router: Router;
+  let routerNavigateSpy: jest.SpyInstance;
+  let isMobileSignal: ReturnType<typeof signal<boolean>>;
+
+  const mockApplicationTypes = [
+    fakeSimpleApplicationType(),
+    fakeNativeApplicationType(),
+    fakeBackendToBackendApplicationType(),
+    fakeBrowserApplicationType(),
+  ];
+
+  beforeEach(async () => {
+    isMobileSignal = signal(false);
+
+    const mockObservabilityBreakpointService = {
+      isMobile: isMobileSignal.asReadonly(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CreateApplicationComponent, AppTestingModule],
+      providers: [
+        {
+          provide: ObservabilityBreakpointService,
+          useValue: mockObservabilityBreakpointService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateApplicationComponent);
+    component = fixture.componentInstance;
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  describe('Component initialization', () => {
+    it('should show loader while loading application types', () => {
+      const loader = fixture.nativeElement.querySelector('app-loader');
+      expect(loader).toBeTruthy();
+
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+    });
+
+    it('should load application types from API', () => {
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ data: mockApplicationTypes });
+    });
+
+    it('should automatically select first type (simple) as default when types are loaded', async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.typeIdControl.value).toBe('simple');
+      expect(component.selectedType()?.id).toBe('simple');
+    });
+
+    it('should display form after types are loaded', async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const loader = fixture.nativeElement.querySelector('app-loader');
+      expect(loader).toBeFalsy();
+
+      const form = fixture.nativeElement.querySelector('form');
+      expect(form).toBeTruthy();
+    });
+  });
+
+  describe('Application type selection', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should display all available application types', async () => {
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      expect(radioButtons.length).toBe(mockApplicationTypes.length);
+    });
+
+    it('should change selected type when clicking on radio button', async () => {
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check();
+
+      expect(component.typeIdControl.value).toBe('native');
+      expect(component.selectedType()?.id).toBe('native');
+    });
+
+    it('should display simple type fields (Type, Client ID) when simple type is selected', async () => {
+      const typeInput = await harnessLoader.getHarnessOrNull(MatInputHarness.with({ selector: '[formControlName="appType"]' }));
+      const clientIdInput = await harnessLoader.getHarnessOrNull(MatInputHarness.with({ selector: '[formControlName="appClientId"]' }));
+
+      expect(typeInput).toBeTruthy();
+      expect(clientIdInput).toBeTruthy();
+    });
+
+    it('should display OAuth fields (grant types, redirect URIs) when OAuth type is selected', async () => {
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const redirectUrisControl = component.redirectUrisControl;
+      const grantTypesControl = component.grantTypesControl;
+
+      expect(redirectUrisControl).toBeTruthy();
+      expect(grantTypesControl).toBeTruthy();
+    });
+
+    it('should hide simple type fields when non-simple type is selected', async () => {
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const typeInput = await harnessLoader.getHarnessOrNull(MatInputHarness.with({ selector: '[formControlName="appType"]' }));
+      const clientIdInput = await harnessLoader.getHarnessOrNull(MatInputHarness.with({ selector: '[formControlName="appClientId"]' }));
+
+      expect(typeInput).toBeFalsy();
+      expect(clientIdInput).toBeFalsy();
+    });
+  });
+
+  describe('Form validation', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should mark form as invalid when name is missing', () => {
+      expect(component.form.invalid).toBe(true);
+      expect(component.form.controls.name.hasError('required')).toBe(true);
+    });
+
+    it('should mark form as valid when all required fields are filled', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test Application');
+
+      expect(component.form.valid).toBe(true);
+    });
+
+    it('should disable Create button when form is invalid', async () => {
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      expect(await createButton.isDisabled()).toBe(true);
+    });
+
+    it('should enable Create button when form is valid', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test Application');
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      expect(await createButton.isDisabled()).toBe(false);
+    });
+
+    it('should show validation error when name field is touched and empty', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.focus();
+      await nameInput.blur();
+      fixture.detectChanges();
+
+      const error = fixture.nativeElement.querySelector('mat-error');
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe('Dynamic form fields - Redirect URIs', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should display redirect URIs field for types that require it', () => {
+      const redirectUrisControl = component.redirectUrisControl;
+      expect(redirectUrisControl).toBeTruthy();
+    });
+
+    it('should require at least one redirect URI', () => {
+      const redirectUrisControl = component.redirectUrisControl;
+      expect(redirectUrisControl?.hasError('required')).toBe(true);
+    });
+
+    it('should validate redirect URIs when at least one is provided', () => {
+      const redirectUrisControl = component.redirectUrisControl;
+      redirectUrisControl?.setValue(['https://example.com/callback']);
+      expect(redirectUrisControl?.valid).toBe(true);
+    });
+
+    it('should add redirect URI when entered and blurred', async () => {
+      const chipGrid = await harnessLoader.getHarness(MatChipGridHarness);
+      const input = await chipGrid.getInput();
+      expect(input).toBeTruthy();
+      if (input) {
+        await input.setValue('https://example.com/callback');
+        await input.blur();
+        fixture.detectChanges();
+
+        const redirectUrisControl = component.redirectUrisControl;
+        expect(redirectUrisControl?.value).toContain('https://example.com/callback');
+      }
+    });
+
+    it('should remove redirect URI when remove button is clicked', async () => {
+      const redirectUrisControl = component.redirectUrisControl;
+      redirectUrisControl?.setValue(['https://example.com/callback']);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const chipGrid = await harnessLoader.getHarness(MatChipGridHarness);
+      const rows = await chipGrid.getRows();
+      expect(rows.length).toBe(1);
+
+      await rows[0].remove();
+      fixture.detectChanges();
+
+      expect(redirectUrisControl?.value).not.toContain('https://example.com/callback');
+      expect(redirectUrisControl?.value.length).toBe(0);
+    });
+
+    it('should prevent adding duplicate redirect URI', async () => {
+      const redirectUrisControl = component.redirectUrisControl;
+      redirectUrisControl?.setValue(['https://example.com/callback']);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const chipGrid = await harnessLoader.getHarness(MatChipGridHarness);
+      const input = await chipGrid.getInput();
+      expect(input).toBeTruthy();
+      if (input) {
+        await input.setValue('https://example.com/callback');
+        await input.blur();
+        fixture.detectChanges();
+
+        expect(redirectUrisControl?.value).toEqual(['https://example.com/callback']);
+        expect(redirectUrisControl?.value.length).toBe(1);
+      }
+    });
+  });
+
+  describe('Dynamic form fields - Grant Types', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should display available grant types for selected type', () => {
+      const grantTypesList = component.grantTypesList();
+      expect(grantTypesList.length).toBeGreaterThan(0);
+    });
+
+    it('should mark mandatory grant types as disabled and checked', () => {
+      const grantTypesList = component.grantTypesList();
+      const mandatoryGrantType = grantTypesList.find(gt => gt.isDisabled);
+      expect(mandatoryGrantType).toBeTruthy();
+    });
+
+    it('should add grant type when toggled on', () => {
+      const grantTypesControl = component.grantTypesControl;
+      const initialValue = grantTypesControl?.value ?? [];
+      const grantTypeToAdd = 'refresh_token';
+
+      component.toggleGrantType(grantTypeToAdd, true);
+
+      expect(grantTypesControl?.value).toContain(grantTypeToAdd);
+      expect(grantTypesControl?.value.length).toBe(initialValue.length + 1);
+    });
+
+    it('should remove grant type when toggled off (if not mandatory)', () => {
+      const grantTypesControl = component.grantTypesControl;
+      const grantTypeToRemove = 'refresh_token';
+
+      component.toggleGrantType(grantTypeToRemove, true);
+      const valueAfterAdd = grantTypesControl?.value ?? [];
+
+      component.toggleGrantType(grantTypeToRemove, false);
+
+      expect(grantTypesControl?.value).not.toContain(grantTypeToRemove);
+      expect(grantTypesControl?.value.length).toBe(valueAfterAdd.length - 1);
+    });
+
+    it('should show error when mandatory grant types are missing', () => {
+      const grantTypesControl = component.grantTypesControl;
+      grantTypesControl?.setValue([]);
+      grantTypesControl?.markAsTouched();
+      fixture.detectChanges();
+
+      expect(grantTypesControl?.hasError('mandatoryMissing')).toBe(true);
+    });
+
+    it('should toggle grant type using slide toggle', async () => {
+      const grantTypesControl = component.grantTypesControl;
+      const grantTypeToToggle = 'refresh_token';
+
+      const slideToggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      expect(slideToggles.length).toBeGreaterThan(0);
+
+      for (const toggle of slideToggles) {
+        const label = await toggle.getLabelText();
+        if (label.includes('Refresh Token')) {
+          const isChecked = await toggle.isChecked();
+          if (!isChecked) {
+            await toggle.toggle();
+            fixture.detectChanges();
+            expect(grantTypesControl?.value).toContain(grantTypeToToggle);
+            break;
+          }
+        }
+      }
+    });
+
+    it('should not allow unchecking mandatory grant types', async () => {
+      const grantTypesList = component.grantTypesList();
+      const mandatoryGrantType = grantTypesList.find(gt => gt.isDisabled);
+
+      expect(mandatoryGrantType).toBeTruthy();
+
+      if (mandatoryGrantType) {
+        const slideToggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+        for (const toggle of slideToggles) {
+          const label = await toggle.getLabelText();
+          if (label.includes(mandatoryGrantType.name)) {
+            const isDisabled = await toggle.isDisabled();
+            expect(isDisabled).toBe(true);
+            break;
+          }
+        }
+      }
+    });
+  });
+
+  describe('Create application - success', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should send correct data to API for simple type', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test Simple App');
+
+      const appTypeInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="appType"]' }));
+      await appTypeInput.setValue('mobile');
+
+      const clientIdInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="appClientId"]' }));
+      await clientIdInput.setValue('test-client-id');
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      await createButton.click();
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        name: 'Test Simple App',
+        description: undefined,
+        settings: {
+          app: {
+            type: 'mobile',
+            client_id: 'test-client-id',
+          },
+        },
+      });
+
+      const createdApplication = fakeApplication({ id: 'new-app-id', name: 'Test Simple App' });
+      req.flush(createdApplication);
+
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['/applications', 'new-app-id']);
+    });
+
+    it('should send correct data to API for OAuth type', async () => {
+      const radioButtons = await harnessLoader.getAllHarnesses(MatRadioButtonHarness);
+      await radioButtons[1].check(); // Native type
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test OAuth App');
+
+      const redirectUrisControl = component.redirectUrisControl;
+      redirectUrisControl?.setValue(['https://example.com/callback']);
+
+      const grantTypesControl = component.grantTypesControl;
+      grantTypesControl?.setValue(['authorization_code', 'refresh_token']);
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      await createButton.click();
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.settings.oauth).toBeDefined();
+      expect(req.request.body.settings.oauth.redirect_uris).toEqual(['https://example.com/callback']);
+      expect(req.request.body.settings.oauth.grant_types).toEqual(['authorization_code', 'refresh_token']);
+
+      const createdApplication = fakeApplication({ id: 'new-oauth-app-id', name: 'Test OAuth App' });
+      req.flush(createdApplication);
+
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['/applications', 'new-oauth-app-id']);
+    });
+
+    it('should include TLS settings when client certificate is provided', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test App with TLS');
+
+      const clientCertTextarea = fixture.nativeElement.querySelector('textarea[formControlName="clientCertificate"]');
+      clientCertTextarea.value = '-----BEGIN CERTIFICATE-----\nMOCK_CERT\n-----END CERTIFICATE-----';
+      clientCertTextarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      await createButton.click();
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications`);
+      expect(req.request.body.settings.tls).toBeDefined();
+      expect(req.request.body.settings.tls.client_certificate).toContain('BEGIN CERTIFICATE');
+
+      req.flush(fakeApplication({ id: 'new-app-id' }));
+    });
+  });
+
+  describe('Create application - error', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should display error message when API call fails', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test App');
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      await createButton.click();
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications`);
+      req.flush({ error: 'Server Error' }, { status: 500, statusText: 'Internal Server Error' });
+
+      fixture.detectChanges();
+
+      expect(component.hasApplicationError).toBe(true);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      const errorMessage = fixture.nativeElement.querySelector('.error-message');
+      expect(errorMessage).toBeTruthy();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not navigate when API call fails', async () => {
+      const nameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      await nameInput.setValue('Test App');
+
+      const createButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Create/ }));
+      await createButton.click();
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications`);
+      req.flush({ error: 'Server Error' }, { status: 500, statusText: 'Internal Server Error' });
+
+      expect(routerNavigateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Navigation', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should navigate to /applications when Cancel is clicked', async () => {
+      const cancelButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: /Cancel/ }));
+      await cancelButton.click();
+
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['/applications']);
+    });
+  });
+
+  describe('Responsive design', () => {
+    beforeEach(async () => {
+      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should display dropdown on mobile', () => {
+      isMobileSignal.set(true);
+      fixture.detectChanges();
+
+      const select = fixture.nativeElement.querySelector('mat-select');
+      const radioGroup = fixture.nativeElement.querySelector('mat-radio-group');
+
+      expect(select).toBeTruthy();
+      expect(radioGroup).toBeFalsy();
+    });
+
+    it('should display radio buttons on desktop', () => {
+      isMobileSignal.set(false);
+      fixture.detectChanges();
+
+      const select = fixture.nativeElement.querySelector('mat-select');
+      const radioGroup = fixture.nativeElement.querySelector('mat-radio-group');
+
+      expect(select).toBeFalsy();
+      expect(radioGroup).toBeTruthy();
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -13,15 +13,322 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { AbstractControl, FormControl, FormGroup, FormRecord, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
+import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatError, MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInput } from '@angular/material/input';
+import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { Router } from '@angular/router';
+import { startWith } from 'rxjs';
 
 import { BreadcrumbNavigationComponent } from '../../../components/breadcrumb-navigation/breadcrumb-navigation.component';
+import { LoaderComponent } from '../../../components/loader/loader.component';
+import { MobileClassDirective } from '../../../directives/mobile-class.directive';
+import { ApplicationInput, ApplicationSettings, ApplicationType } from '../../../entities/application/application';
+import { ApplicationService } from '../../../services/application.service';
+import { ObservabilityBreakpointService } from '../../../services/observability-breakpoint.service';
+
+type BaseControls = {
+  name: FormControl<string>;
+  description: FormControl<string>;
+  clientCertificate: FormControl<string>;
+  appType: FormControl<string>;
+  appClientId: FormControl<string>;
+  dynamic: FormRecord<FormControl<unknown>>;
+};
+
+interface GrantTypeVM {
+  type: string;
+  name: string;
+  isDisabled: boolean;
+}
 
 @Component({
   selector: 'app-create-application',
-  imports: [MatCard, MatCardContent, BreadcrumbNavigationComponent],
+  imports: [
+    BreadcrumbNavigationComponent,
+    LoaderComponent,
+    MatButtonModule,
+    MatCard,
+    MatCardContent,
+    MatChipsModule,
+    MatDividerModule,
+    MatError,
+    MatFormField,
+    MatHint,
+    MatIcon,
+    MatInput,
+    MatLabel,
+    MatRadioButton,
+    MatRadioGroup,
+    MatSelectModule,
+    MatSlideToggleModule,
+    MobileClassDirective,
+    ReactiveFormsModule,
+  ],
   templateUrl: './create-application.component.html',
   styleUrl: './create-application.component.scss',
 })
-export class CreateApplicationComponent {}
+export class CreateApplicationComponent {
+  readonly applicationService = inject(ApplicationService);
+  readonly router = inject(Router);
+  readonly destroyRef = inject(DestroyRef);
+  readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
+
+  readonly typeIdControl = new FormControl<string | null>(null, { nonNullable: false });
+
+  readonly form = new FormGroup<BaseControls>({
+    name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    description: new FormControl('', { nonNullable: true }),
+    clientCertificate: new FormControl('', { nonNullable: true }),
+    appType: new FormControl('', { nonNullable: true }),
+    appClientId: new FormControl('', { nonNullable: true }),
+    dynamic: new FormRecord<FormControl<unknown>>({}),
+  });
+
+  readonly enabledApplicationTypes = toSignal(this.applicationService.getEnabledApplicationTypes());
+
+  readonly selectedTypeId = toSignal(this.typeIdControl.valueChanges.pipe(startWith(this.typeIdControl.value)), {
+    initialValue: null,
+  });
+
+  readonly selectedType = computed<ApplicationType | null>(() => {
+    const typeId = this.selectedTypeId();
+    if (!typeId) return null;
+    const types = this.enabledApplicationTypes();
+    if (!types) return null;
+    return types.find(type => type.id === typeId || type.name === typeId) ?? null;
+  });
+
+  readonly isSimpleType = computed(() => this.selectedType()?.id === 'simple');
+  readonly requiresRedirectUris = computed(() => this.selectedType()?.requires_redirect_uris ?? false);
+
+  readonly grantTypesList = computed<GrantTypeVM[]>(() => {
+    const selectedType = this.selectedType();
+    if (!selectedType) return [];
+
+    const allowed = selectedType.allowed_grant_types ?? [];
+    const mandatory = selectedType.mandatory_grant_types ?? [];
+
+    return allowed.map(grantType => ({
+      type: grantType.type ?? '',
+      name: grantType.name ?? grantType.type ?? '',
+      isDisabled: mandatory.some(m => m.type === grantType.type),
+    }));
+  });
+
+  hasApplicationError: boolean = false;
+
+  constructor() {
+    this.setupDynamicFormFields();
+    this.setupDefaultApplicationType();
+  }
+
+  get redirectUrisControl(): FormControl<string[]> | null {
+    const control = this.form.controls.dynamic.get('redirectUris');
+    return control instanceof FormControl ? control : null;
+  }
+
+  get grantTypesControl(): FormControl<string[]> | null {
+    const control = this.form.controls.dynamic.get('grantTypes');
+    return control instanceof FormControl ? control : null;
+  }
+
+  onCreate(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.form.getRawValue();
+    const selectedType = this.selectedType();
+
+    if (!selectedType) {
+      return;
+    }
+
+    const applicationInput = this.buildApplicationInput(formValue, selectedType);
+
+    this.applicationService
+      .create(applicationInput)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: application => {
+          this.router.navigate(['/applications', application.id]);
+        },
+        error: err => {
+          this.hasApplicationError = true;
+          console.error('Error creating application:', err);
+        },
+      });
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/applications']);
+  }
+
+  addRedirectUri(event: MatChipInputEvent): void {
+    const newRedirectUri = (event.value || '').trim();
+    if (!newRedirectUri) return;
+
+    const redirectUrisControl = this.redirectUrisControl;
+    if (!redirectUrisControl) return;
+
+    const currentRedirectUris = redirectUrisControl.value ?? [];
+    if (currentRedirectUris.includes(newRedirectUri)) {
+      event.chipInput!.clear();
+      return;
+    }
+
+    redirectUrisControl.setValue([...currentRedirectUris, newRedirectUri]);
+    event.chipInput!.clear();
+  }
+
+  removeRedirectUri(redirectUriToRemove: string): void {
+    const redirectUrisControl = this.redirectUrisControl;
+    if (!redirectUrisControl) return;
+
+    const currentRedirectUris = redirectUrisControl.value ?? [];
+    redirectUrisControl.setValue(currentRedirectUris.filter((uri: string) => uri !== redirectUriToRemove));
+  }
+
+  toggleGrantType(grantType: string, checked: boolean): void {
+    const grantTypesControl = this.grantTypesControl;
+    if (!grantTypesControl) return;
+
+    const currentGrantTypes = grantTypesControl.value ?? [];
+    if (checked) {
+      if (!currentGrantTypes.includes(grantType)) {
+        grantTypesControl.setValue([...currentGrantTypes, grantType]);
+      }
+    } else {
+      grantTypesControl.setValue(currentGrantTypes.filter((gt: string) => gt !== grantType));
+    }
+  }
+
+  isGrantTypeSelected(grantType: string): boolean {
+    const grantTypesControl = this.grantTypesControl;
+    if (!grantTypesControl) return false;
+    return (grantTypesControl.value ?? []).includes(grantType);
+  }
+
+  private setupDynamicFormFields(): void {
+    effect(() => {
+      const type = this.selectedType();
+      const dynamic = this.form.controls.dynamic;
+
+      this.clearDynamicControls(dynamic);
+
+      if (!type) return;
+
+      if (type.requires_redirect_uris) {
+        this.addRedirectUrisControl(dynamic);
+      }
+
+      if (this.hasGrantTypes(type)) {
+        this.addGrantTypesControl(dynamic, type);
+      }
+    });
+  }
+
+  private setupDefaultApplicationType(): void {
+    effect(() => {
+      const types = this.enabledApplicationTypes();
+      if (types && types.length > 0 && this.typeIdControl.value === null) {
+        const firstType = types[0];
+        this.typeIdControl.setValue(firstType.id ?? firstType.name, { emitEvent: true });
+      }
+    });
+  }
+
+  private clearDynamicControls(dynamic: FormRecord<FormControl<unknown>>): void {
+    Object.keys(dynamic.controls).forEach(key => dynamic.removeControl(key));
+  }
+
+  private addRedirectUrisControl(dynamic: FormRecord<FormControl<unknown>>): void {
+    dynamic.addControl(
+      'redirectUris',
+      new FormControl<string[]>([], {
+        nonNullable: true,
+        validators: [Validators.required, Validators.minLength(1)],
+      }),
+    );
+  }
+
+  private addGrantTypesControl(dynamic: FormRecord<FormControl<unknown>>, type: ApplicationType): void {
+    const defaults = this.extractGrantTypeIds(type.default_grant_types ?? []);
+    const mandatory = this.extractGrantTypeIds(type.mandatory_grant_types ?? []);
+    const initialGrantTypes = Array.from(new Set<string>([...defaults, ...mandatory]));
+
+    dynamic.addControl(
+      'grantTypes',
+      new FormControl<string[]>(initialGrantTypes, {
+        nonNullable: true,
+        validators: [this.createMandatoryGrantTypesValidator(mandatory)],
+      }),
+    );
+  }
+
+  private hasGrantTypes(type: ApplicationType): boolean {
+    return (type.allowed_grant_types ?? []).length > 0;
+  }
+
+  private extractGrantTypeIds(grantTypes: Array<{ type?: string }>): string[] {
+    return grantTypes.map(g => g.type).filter((x): x is string => !!x);
+  }
+
+  private createMandatoryGrantTypesValidator(mandatory: string[]): ValidatorFn {
+    return (control: AbstractControl) => {
+      const val = (control.value as string[]) ?? [];
+      const missing = mandatory.filter(m => !val.includes(m));
+      return missing.length ? { mandatoryMissing: missing } : null;
+    };
+  }
+
+  private buildApplicationInput(
+    formValue: ReturnType<FormGroup<BaseControls>['getRawValue']>,
+    selectedType: ApplicationType,
+  ): ApplicationInput {
+    const isSimple = selectedType.id === 'simple';
+
+    const settings: ApplicationSettings = isSimple
+      ? {
+          app: {
+            type: formValue.appType?.trim() || undefined,
+            client_id: formValue.appClientId?.trim() || undefined,
+          },
+        }
+      : (() => {
+          const grantTypes = (formValue.dynamic?.['grantTypes'] as string[] | undefined) ?? [];
+          const redirectUris = (formValue.dynamic?.['redirectUris'] as string[] | undefined) ?? [];
+
+          return {
+            oauth: {
+              application_type: selectedType.id || selectedType.name || undefined,
+              grant_types: grantTypes.length > 0 ? grantTypes : undefined,
+              redirect_uris: redirectUris.length > 0 ? redirectUris : undefined,
+            },
+          };
+        })();
+
+    if (formValue.clientCertificate?.trim()) {
+      settings.tls = {
+        client_certificate: formValue.clientCertificate.trim(),
+      };
+    }
+
+    return {
+      name: formValue.name.trim(),
+      description: formValue.description?.trim() || undefined,
+      settings,
+    };
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -70,16 +70,20 @@ export interface ApplicationSettingsApp {
 }
 
 export interface ApplicationSettingsOAuth {
-  client_id: string;
-  client_secret: string;
-  redirect_uris: string[];
-  renew_client_secret_supported: boolean;
-  response_types: string[];
-  grant_types: string[];
+  client_id?: string;
+  client_secret?: string;
+  redirect_uris?: string[];
+  renew_client_secret_supported?: boolean;
+  response_types?: string[];
+  grant_types?: string[];
+  application_type?: string;
+  client_uri?: string;
+  logo_uri?: string;
+  additional_client_metadata?: Record<string, string>;
 }
 
 export interface ApplicationSettingsTls {
-  client_certificate: string;
+  client_certificate?: string;
 }
 
 export interface ApplicationLinks {
@@ -112,7 +116,7 @@ export interface ApplicationsMetadataSubscriptions {
 
 export interface ApplicationType {
   id?: string;
-  name?: string;
+  name: string;
   description?: string;
   requires_redirect_uris?: boolean;
   allowed_grant_types?: Array<ApplicationGrantType>;
@@ -124,4 +128,15 @@ export interface ApplicationGrantType {
   type?: string;
   name?: string;
   response_types?: string[];
+}
+
+export interface ApplicationInput {
+  name: string;
+  description?: string;
+  domain?: string;
+  picture?: string;
+  groups?: string[];
+  settings: ApplicationSettings;
+  background?: string;
+  api_key_mode?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/services/application.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application.service.ts
@@ -15,10 +15,10 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { Application, ApplicationsResponse, ApplicationType } from '../entities/application/application';
+import { Application, ApplicationInput, ApplicationsResponse, ApplicationType } from '../entities/application/application';
 
 @Injectable({
   providedIn: 'root',
@@ -35,6 +35,12 @@ export class ApplicationService {
 
   getType(applicationId: string): Observable<ApplicationType> {
     return this.http.get<ApplicationType>(`${this.configService.baseURL}/applications/${applicationId}/configuration`);
+  }
+
+  getEnabledApplicationTypes(): Observable<ApplicationType[]> {
+    return this.http
+      .get<{ data: ApplicationType[] }>(`${this.configService.baseURL}/configuration/applications/types`)
+      .pipe(map(response => response.data ?? []));
   }
 
   list(page?: number, size?: number, forSubscription?: boolean): Observable<ApplicationsResponse> {
@@ -56,5 +62,9 @@ export class ApplicationService {
 
   delete(applicationId: string): Observable<void> {
     return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}`);
+  }
+
+  create(applicationInput: ApplicationInput): Observable<Application> {
+    return this.http.post<Application>(`${this.configService.baseURL}/applications`, applicationInput);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12056

## Description

Implements the create application form in the portal with dynamic field generation based on selected application type. 

### What's missing

The following items are not included in this PR and will be addressed in separate subtasks:

1. Additional metadata field (requires new component for key-value pairs)
2. Application type descriptions alignment with Figma design (requires backend changes)
3. Route guards for permission checks

## Additional context 

Demo videos (both desktop and mobile res): 

https://github.com/user-attachments/assets/7a258fd0-073c-4bc9-bdf5-136956c0f793


https://github.com/user-attachments/assets/dac8660d-d862-4c8b-b570-2c16dc968566





