### PR TITLE
Try to fix some of the flaky analytics tests

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TestConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.elasticsearch.config.Endpoint;
 import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.vertx.core.Vertx;
+import java.time.Duration;
 import java.util.Collections;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 /**
@@ -113,6 +115,9 @@ public class TestConfiguration {
         if (elasticsearchVersion.startsWith("8")) {
             elasticsearchContainer.withEnv("xpack.security.enabled", "false");
         }
+        String regex = ".*(\"message\":\\s?\"started[\\s?|\"].*|] started\n$)";
+        elasticsearchContainer.setWaitStrategy(Wait.forLogMessage(regex, 1).withStartupTimeout(Duration.ofSeconds(120)));
+
         return elasticsearchContainer;
     }
 


### PR DESCRIPTION
## Description

Elasticsearch test container can take a long time to start on CI, exceeding the 60sec default startup timeout. This commit increases this limit to reduce the probability of these flaky tests

<img width="509" height="484" alt="image" src="https://github.com/user-attachments/assets/27ce9e21-9e86-4871-9832-a7abdc5521b4" />

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/67655/workflows/7d0e332a-3c44-4aff-8044-10a9e02f68b2/jobs/1367788/tests?invite=true#step-105-139430_66