### PR TITLE
Bump redis cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <gravitee-resource-auth-provider-http.version>1.4.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.0</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>4.0.1</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>4.0.3</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12148

## Description

Bump redis cache.
Related to that fix: https://github.com/gravitee-io/gravitee-resource-cache-redis/pull/67