### PR TITLE
chore: enforce exact version for Yarn dependencies

### DIFF
--- a/gravitee-apim-console-webui/.yarnrc.yml
+++ b/gravitee-apim-console-webui/.yarnrc.yml
@@ -1,4 +1,5 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""
 plugins:
   - path: .yarn/plugins/build-dashboard.js
   - path: .yarn/plugins/build-portal.js

--- a/gravitee-apim-e2e/.yarnrc.yml
+++ b/gravitee-apim-e2e/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""

--- a/gravitee-apim-perf/.yarnrc.yml
+++ b/gravitee-apim-perf/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""

--- a/gravitee-apim-portal-webui-next/.yarnrc.yml
+++ b/gravitee-apim-portal-webui-next/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""

--- a/gravitee-apim-portal-webui/.yarnrc.yml
+++ b/gravitee-apim-portal-webui/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""

--- a/release/.yarnrc.yml
+++ b/release/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+defaultSemverRangePrefix: ""


### PR DESCRIPTION
## Description

This should avoid having a "pin dependencies" PR from Renovate when we add a new dependency and forgot to remove the ^ manually


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

