### PR TITLE
fix: allow llm proxy entrypoint configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -162,6 +162,49 @@
       </div>
     </mat-card-content>
   </mat-card>
+  <mat-card *ngIf="api?.type === 'LLM_PROXY'">
+    <mat-card-content>
+      <div class="entrypoints__type">
+        <span class="mat-body-strong">Entrypoint types</span>
+        <table mat-table [dataSource]="dataSource" class="entrypoints__type__table gio-table-light" aria-label="entrypoints">
+          <ng-container matColumnDef="type">
+            <th mat-header-cell *matHeaderCellDef>Entrypoint type</th>
+            <td mat-cell *matCellDef="let element">
+              <div class="entrypoints__type__table__type"><mat-icon [svgIcon]="element.icon"></mat-icon> {{ element.type }}</div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element" class="entrypoints__type__table__actions">
+              <ng-container *ngIf="!isReadOnly">
+                <button type="button" mat-icon-button aria-label="Edit" [routerLink]="[element.id]" [disabled]="isReadOnly">
+                  <mat-icon svgIcon="gio:edit-pencil" matTooltip="Edit"> </mat-icon>
+                </button>
+                <button type="button" [disabled]="dataSource.length <= 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
+                  <mat-icon
+                    svgIcon="gio:trash"
+                    [matTooltip]="dataSource.length <= 1 ? 'At least one entrypoint is required' : 'Delete'"
+                  ></mat-icon>
+                </button>
+              </ng-container>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns" class="entrypoints__type__table__header"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+
+        <div *ngIf="shouldUpgrade">
+          <gio-license-banner
+            [license]="license$ | async"
+            [isOEM]="isOEM$ | async"
+            (onRequestUpgrade)="onRequestUpgrade()"
+          ></gio-license-banner>
+        </div>
+      </div>
+    </mat-card-content>
+  </mat-card>
 
   <exposed-entrypoints [exposedEntrypoints]="exposedEntrypoints$ | async"></exposed-entrypoints>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -52,6 +52,7 @@ const ENTRYPOINTS: Partial<ConnectorPlugin>[] = [
   { id: 'webhook', supportedApiType: 'MESSAGE', supportedListenerType: 'SUBSCRIPTION', name: 'Webhook', deployed: false },
   { id: 'native-kafka', supportedApiType: 'NATIVE', supportedListenerType: 'KAFKA', name: 'Client', deployed: false },
   { id: 'agent-to-agent', supportedApiType: 'MESSAGE', supportedListenerType: 'HTTP', name: 'Agent to agent', deployed: false },
+  { id: 'llm-proxy', supportedApiType: 'LLM_PROXY', supportedListenerType: 'HTTP', name: 'LLM Proxy Entrypoint', deployed: true },
 ];
 
 describe('ApiProxyV4EntrypointsComponent', () => {
@@ -187,6 +188,37 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       expect(virtualHost.length).toEqual(0);
       const addEntrypointButton = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Add an entrypoint' }));
       expect(addEntrypointButton.length).toEqual(0);
+    });
+  });
+
+  describe('When API has LLM PROXY architecture type', () => {
+    const RESTRICTED_DOMAINS = [];
+    const API = fakeApiV4({
+      type: 'LLM_PROXY',
+      listeners: [{ type: 'HTTP', entrypoints: [{ type: 'llm-proxy' }], paths: [{ path: '/llm-proxy' }] }],
+    });
+
+    beforeEach(async () => {
+      await createComponent(RESTRICTED_DOMAINS, API);
+    });
+
+    afterEach(() => {
+      expectApiPathVerify();
+    });
+
+    it('should not show the add entrypoint button', async () => {
+      const contextPath = await loader.getAllHarnesses(GioFormListenersContextPathHarness);
+      expect(contextPath.length).toEqual(1);
+      const virtualHost = await loader.getAllHarnesses(GioFormListenersVirtualHostHarness);
+      expect(virtualHost.length).toEqual(0);
+      const addEntrypointButton = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Add an entrypoint' }));
+      expect(addEntrypointButton.length).toEqual(0);
+    });
+
+    it('should show listener', async () => {
+      const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiEntrypointsV4GeneralHarness);
+      const rows = await harness.getEntrypointsTableRows();
+      expect(rows.length).toEqual(1);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
@@ -80,7 +80,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit, OnDestroy {
   public pathsFormControl: UntypedFormControl;
   public hostsFormControl: UntypedFormControl;
   public hostFormControl: UntypedFormControl;
-  public displayedColumns = ['type', 'qos', 'actions'];
+  public displayedColumns;
   public dataSource: EntrypointVM[] = [];
   public allEntrypoints: ConnectorPlugin[];
   public enableVirtualHost = false;
@@ -140,6 +140,8 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit, OnDestroy {
   }
 
   private initForm(api: ApiV4) {
+    this.displayedColumns = api.type === 'LLM_PROXY' ? ['type', 'actions'] : ['type', 'qos', 'actions'];
+
     if (api.type === 'MESSAGE' || api.type === 'NATIVE') {
       const selectedEntrypoints = flatten(api.listeners.map((l) => l.entrypoints)).map((e) => e.type);
       this.shouldUpgrade = this.allEntrypoints.filter((e) => selectedEntrypoints.includes(e.id)).some(({ deployed }) => !deployed);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12062

## Description

When we create an LLM proxy entrypoint we are able to configure token tracking. 
This PR makes it editable after creation, in _APIs_ -> _Entrypoints_.

Here an exemple with the LLM proxy option : 

<img width="1418" height="825" alt="Capture d’écran 2025-12-05 à 11 05 42" src="https://github.com/user-attachments/assets/37f5a602-61a1-40d2-ab93-e104846af277" />


