### PR TITLE
Apim 11950 add visibility to portal nav items

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
@@ -43,6 +43,11 @@ public class PortalNavigationItem {
         TOP_NAVBAR,
     }
 
+    public enum Visibility {
+        PUBLIC,
+        PRIVATE,
+    }
+
     @EqualsAndHashCode.Include
     private String id;
 
@@ -63,4 +68,6 @@ public class PortalNavigationItem {
     private String configuration;
 
     private boolean published;
+
+    private Visibility visibility;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -54,6 +54,7 @@ public class JdbcPortalNavigationItemRepository
             .addColumn("order", Types.INTEGER, Integer.class)
             .addColumn("configuration", Types.NVARCHAR, String.class)
             .addColumn("published", Types.BOOLEAN, boolean.class)
+            .addColumn("visibility", Types.NVARCHAR, PortalNavigationItem.Visibility.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
@@ -15,6 +15,7 @@ databaseChangeLog:
               - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: order, type: integer, constraints: { nullable: true } }
               - column: {name: published, type: boolean, constraints: { nullable: false } }
+              - column: {name: visibility, type: nvarchar(16), constraints: { nullable: false } }
               - column: {name: configuration, type: nclob, constraints: { nullable: true } }
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}portal_navigation_items

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
@@ -33,4 +33,5 @@ public class PortalNavigationItemMongo {
     private Integer order;
     private String configuration;
     private boolean published;
+    private PortalNavigationItem.Visibility visibility;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -101,6 +101,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .order(4)
             .published(true)
             .configuration("{ \"url\": \"https://support.example.com\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
             .build();
 
         PortalNavigationItem created = portalNavigationItemRepository.create(item);
@@ -142,6 +143,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .order(1)
             .published(true)
             .configuration("{ \"url\": \"https://original.com\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
             .build();
 
         PortalNavigationItem created = portalNavigationItemRepository.create(item);
@@ -158,6 +160,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .order(2)
             .published(false)
             .configuration("{ \"url\": \"https://updated.com\" }")
+            .visibility(PortalNavigationItem.Visibility.PRIVATE)
             .build();
 
         PortalNavigationItem updated = portalNavigationItemRepository.update(updatedItem);
@@ -167,6 +170,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         assertThat(updated.getOrder()).isEqualTo(2);
         assertThat(updated.getConfiguration()).isEqualTo("{ \"url\": \"https://updated.com\" }");
         assertThat(updated.isPublished()).isFalse();
+        assertThat(updated.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PRIVATE);
 
         portalNavigationItemRepository.delete("update-nav-item");
     }
@@ -265,6 +269,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .order(10)
             .published(false)
             .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
             .build();
 
         portalNavigationItemRepository.create(unpublishedItem);
@@ -320,6 +325,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             .order(11)
             .published(false)
             .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
             .build();
 
         portalNavigationItemRepository.create(unpublishedItem);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
@@ -9,7 +9,8 @@
     "parentId": null,
     "order": 1,
     "published": true,
-    "configuration": "{ \"portalPageContentId\": \"550e8400-e29b-41d4-a716-446655440000\" }"
+    "configuration": "{ \"portalPageContentId\": \"550e8400-e29b-41d4-a716-446655440000\" }",
+    "visibility": "PUBLIC"
   },
   {
     "id": "3e8c0d7f-2b3c-4d5e-9f0a-1b2c3d4e5f6a",
@@ -21,7 +22,8 @@
     "parentId": null,
     "order": 2,
     "published": true,
-    "configuration": "{ \"href\": \"https://docs.example.com\" }"
+    "configuration": "{ \"href\": \"https://docs.example.com\" }",
+    "visibility": "PUBLIC"
   },
   {
     "id": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
@@ -33,7 +35,8 @@
     "parentId": null,
     "order": 3,
     "published": true,
-    "configuration": "{}"
+    "configuration": "{}",
+    "visibility": "PUBLIC"
   },
   {
     "id": "6b1c2d3e-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
@@ -45,7 +48,8 @@
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 1,
     "published": true,
-    "configuration": "{ \"portalPageContentId\": \"660e8400-e29b-41d4-a716-446655440001\" }"
+    "configuration": "{ \"portalPageContentId\": \"660e8400-e29b-41d4-a716-446655440001\" }",
+    "visibility": "PUBLIC"
   },
   {
     "id": "7c2d3e4f-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
@@ -57,7 +61,8 @@
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 2,
     "published": true,
-    "configuration": "{ \"portalPageContentId\": \"770e8400-e29b-41d4-a716-446655440002\" }"
+    "configuration": "{ \"portalPageContentId\": \"770e8400-e29b-41d4-a716-446655440002\" }",
+    "visibility": "PUBLIC"
   },
   {
     "id": "8d3e4f5a-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
@@ -69,6 +74,7 @@
     "parentId": "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
     "order": 3,
     "published": true,
-    "configuration": "{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }"
+    "configuration": "{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }",
+    "visibility": "PUBLIC"
   }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1773,6 +1773,11 @@ components:
       description: The portal area (used by portal navigation items)
       enum: [ HOMEPAGE, TOP_NAVBAR ]
       example: TOP_NAVBAR
+    PortalVisibility:
+      type: string
+      description: The portal visibility (used by portal navigation items)
+      enum: [ PUBLIC, PRIVATE ]
+      example: PUBLIC
     PortalNavigationItemType:
       type: string
       description: The type of the navigation item
@@ -1815,7 +1820,9 @@ components:
           type: boolean
           description: Whether the navigation item is published or not
           example: true
-      required: [ id, organizationId, environmentId, title, type, area, order, published ]
+        visibility:
+          $ref: "#/components/schemas/PortalVisibility"
+      required: [ id, organizationId, environmentId, title, type, area, order, published, visibility ]
       discriminator:
         propertyName: type
         mapping:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.management.v2.rest.model.BasePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
@@ -102,7 +103,8 @@ class PortalNavigationItemsMapperTest {
                 PortalArea.TOP_NAVBAR,
                 3,
                 "https://example.com",
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             var result = mapper.map(link);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
@@ -137,7 +137,8 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("parentId", page.getParentId())
             .hasFieldOrPropertyWithValue("order", page.getOrder())
             .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
-            .hasFieldOrPropertyWithValue("published", false);
+            .hasFieldOrPropertyWithValue("published", false)
+            .hasFieldOrPropertyWithValue("visibility", io.gravitee.rest.api.management.v2.rest.model.PortalVisibility.PUBLIC);
     }
 
     @Test
@@ -163,7 +164,8 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("parentId", folder.getParentId())
             .hasFieldOrPropertyWithValue("order", folder.getOrder())
             .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
-            .hasFieldOrPropertyWithValue("published", false);
+            .hasFieldOrPropertyWithValue("published", false)
+            .hasFieldOrPropertyWithValue("visibility", io.gravitee.rest.api.management.v2.rest.model.PortalVisibility.PUBLIC);
     }
 
     @Test
@@ -190,6 +192,7 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("parentId", link.getParentId())
             .hasFieldOrPropertyWithValue("order", link.getOrder())
             .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
-            .hasFieldOrPropertyWithValue("published", false);
+            .hasFieldOrPropertyWithValue("published", false)
+            .hasFieldOrPropertyWithValue("visibility", io.gravitee.rest.api.management.v2.rest.model.PortalVisibility.PUBLIC);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationPage;
+import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationPage;
@@ -159,6 +160,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getUrl()).isEqualTo("https://gravitee.io");
         assertThat(body.getPublished()).isTrue();
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -185,6 +187,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getPublished()).isTrue();
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -247,6 +250,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getOrder()).isEqualTo(3);
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -276,6 +280,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getUrl()).isEqualTo("https://gravitee.io");
         assertThat(body.getParentId()).isEqualTo(UUID.fromString(APIS_ID));
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -303,6 +308,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getParentId()).isNull();
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -330,6 +336,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
         assertThat(body.getTitle()).isEqualTo("Updated Title");
         assertThat(body.getPublished()).isTrue();
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,15 +39,15 @@ public final class PortalNavigationFixtures {
     }
 
     public static PortalNavigationFolder folder(PortalNavigationItemId id, String title, PortalArea area) {
-        return new PortalNavigationFolder(id, "org", "env", title, area, 1, true);
+        return new PortalNavigationFolder(id, "org", "env", title, area, 1, true, PortalVisibility.PUBLIC);
     }
 
     public static PortalNavigationLink link(PortalNavigationItemId id, String title, PortalArea area, String url) {
-        return new PortalNavigationLink(id, "org", "env", title, area, 1, url, true);
+        return new PortalNavigationLink(id, "org", "env", title, area, 1, url, true, PortalVisibility.PUBLIC);
     }
 
     public static PortalNavigationPage page(PortalNavigationItemId id, String title, PortalArea area, PortalPageContentId pageId) {
-        return new PortalNavigationPage(id, "org", "env", title, area, 1, pageId, true);
+        return new PortalNavigationPage(id, "org", "env", title, area, 1, pageId, true, PortalVisibility.PUBLIC);
     }
 
     public static List<PortalNavigationItem> sampleList(PortalArea area) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
@@ -28,9 +28,10 @@ public final class PortalNavigationFolder extends PortalNavigationItem {
         @Nonnull String title,
         @Nonnull PortalArea area,
         @Nonnull Integer order,
-        @Nonnull Boolean published
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
     ) {
-        super(id, organizationId, environmentId, title, area, order, published);
+        super(id, organizationId, environmentId, title, area, order, published, visibility);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -55,6 +55,10 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
     @Nonnull
     private Boolean published;
 
+    @Setter
+    @Nonnull
+    private PortalVisibility visibility;
+
     protected PortalNavigationItem(
         @Nonnull PortalNavigationItemId id,
         @Nonnull String organizationId,
@@ -62,7 +66,8 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         @Nonnull String title,
         @Nonnull PortalArea area,
         @Nonnull Integer order,
-        @Nonnull Boolean published
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
     ) {
         this.id = id;
         this.organizationId = organizationId;
@@ -71,6 +76,7 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         this.area = area;
         this.order = order;
         this.published = published;
+        this.visibility = visibility;
     }
 
     public abstract PortalNavigationItemType getType();
@@ -103,9 +109,38 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         final var order = item.getOrder();
 
         final var newItem = switch (item.getType()) {
-            case FOLDER -> new PortalNavigationFolder(id, organizationId, environmentId, title, area, order, false);
-            case PAGE -> new PortalNavigationPage(id, organizationId, environmentId, title, area, order, contentId, false);
-            case LINK -> new PortalNavigationLink(id, organizationId, environmentId, title, area, order, url, false);
+            case FOLDER -> new PortalNavigationFolder(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                false,
+                PortalVisibility.PUBLIC
+            );
+            case PAGE -> new PortalNavigationPage(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                contentId,
+                false,
+                PortalVisibility.PUBLIC
+            );
+            case LINK -> new PortalNavigationLink(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                url,
+                false,
+                PortalVisibility.PUBLIC
+            );
         };
         newItem.setParentId(parentId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationLink.java
@@ -36,9 +36,10 @@ public final class PortalNavigationLink extends PortalNavigationItem {
         @Nonnull PortalArea area,
         @Nonnull Integer order,
         @Nonnull String url,
-        @Nonnull Boolean published
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
     ) {
-        super(id, organizationId, environmentId, title, area, order, published);
+        super(id, organizationId, environmentId, title, area, order, published, visibility);
         this.url = url;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
@@ -36,9 +36,10 @@ public final class PortalNavigationPage extends PortalNavigationItem {
         @Nonnull PortalArea area,
         @Nonnull Integer order,
         @Nonnull PortalPageContentId portalPageContentId,
-        @Nonnull Boolean published
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
     ) {
-        super(id, organizationId, environmentId, title, area, order, published);
+        super(id, organizationId, environmentId, title, area, order, published, visibility);
         this.portalPageContentId = portalPageContentId;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalVisibility.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalVisibility.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+public enum PortalVisibility {
+    PUBLIC,
+    PRIVATE,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
 
 public class PortalNavigationItemFixtures {
@@ -44,7 +45,16 @@ public class PortalNavigationItemFixtures {
     }
 
     public static PortalNavigationFolder aFolder(String id, String title, PortalNavigationItemId parentId) {
-        var folder = new PortalNavigationFolder(PortalNavigationItemId.of(id), ORG_ID, ENV_ID, title, PortalArea.TOP_NAVBAR, 0, true);
+        var folder = new PortalNavigationFolder(
+            PortalNavigationItemId.of(id),
+            ORG_ID,
+            ENV_ID,
+            title,
+            PortalArea.TOP_NAVBAR,
+            0,
+            true,
+            PortalVisibility.PUBLIC
+        );
         folder.setParentId(parentId);
         return folder;
     }
@@ -58,7 +68,8 @@ public class PortalNavigationItemFixtures {
             PortalArea.TOP_NAVBAR,
             0,
             PortalPageContentId.random(),
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
         page.setParentId(parentId);
         return page;
@@ -73,7 +84,8 @@ public class PortalNavigationItemFixtures {
             PortalArea.TOP_NAVBAR,
             0,
             "http://example.com",
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
         link.setParentId(parentId);
         return link;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -71,6 +72,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(guidesFolder.getParentId()).isNull();
         assertThat(guidesFolder.getTitle()).isEqualTo("Guides");
         assertThat(guidesFolder.getOrder()).isEqualTo(0);
+        assertThat(guidesFolder.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         final var gettingStartedPage = items
             .stream()
@@ -85,6 +87,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(gettingStartedPage.getOrder()).isEqualTo(0);
         assertThat(gettingStartedPage.getOrganizationId()).isEqualTo(guidesFolder.getOrganizationId());
         assertThat(gettingStartedPage.getEnvironmentId()).isEqualTo(guidesFolder.getEnvironmentId());
+        assertThat(gettingStartedPage.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         final var coreConceptsFolder = items
             .stream()
@@ -96,6 +99,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(coreConceptsFolder.getParentId()).isEqualTo(guidesFolder.getId());
         assertThat(coreConceptsFolder.getTitle()).isEqualTo("Core concepts");
         assertThat(coreConceptsFolder.getOrder()).isEqualTo(1);
+        assertThat(coreConceptsFolder.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         final var authPage = items
             .stream()
@@ -110,6 +114,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(authPage.getOrder()).isEqualTo(0);
         assertThat(authPage.getOrganizationId()).isEqualTo(coreConceptsFolder.getOrganizationId());
         assertThat(authPage.getEnvironmentId()).isEqualTo(coreConceptsFolder.getEnvironmentId());
+        assertThat(authPage.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         final var firstCallPage = items
             .stream()
@@ -124,6 +129,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(firstCallPage.getOrder()).isEqualTo(1);
         assertThat(firstCallPage.getOrganizationId()).isEqualTo(coreConceptsFolder.getOrganizationId());
         assertThat(firstCallPage.getEnvironmentId()).isEqualTo(coreConceptsFolder.getEnvironmentId());
+        assertThat(firstCallPage.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
 
         final var docsLink = items
             .stream()
@@ -138,6 +144,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
             "https://documentation.gravitee.io/apim/developer-portal/new-developer-portal"
         );
         assertThat(docsLink.getOrder()).isEqualTo(1);
+        assertThat(docsLink.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
     }
 
     @Test
@@ -160,5 +167,6 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(((PortalNavigationPage) homePage).getPortalPageContentId()).isNotNull();
         assertThat(homePage.getOrganizationId()).isEqualTo(ORG_ID);
         assertThat(homePage.getEnvironmentId()).isEqualTo(ENV_ID);
+        assertThat(homePage.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -38,6 +38,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -93,7 +94,8 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             "APIs",
             PortalArea.TOP_NAVBAR,
             0,
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
 
         var category1Folder = new PortalNavigationFolder(
@@ -103,7 +105,8 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             "Category1",
             PortalArea.TOP_NAVBAR,
             2,
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
         category1Folder.setParentId(apisFolder.getId());
 
@@ -115,7 +118,8 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             PortalArea.TOP_NAVBAR,
             2,
             supportContentId,
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
 
         var page11 = new PortalNavigationPage(
@@ -126,7 +130,8 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             PortalArea.TOP_NAVBAR,
             0,
             page11ContentId,
-            true
+            true,
+            PortalVisibility.PUBLIC
         );
         page11.setParentId(category1Folder.getId());
 
@@ -138,7 +143,8 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             PortalArea.TOP_NAVBAR,
             3,
             PortalPageContentId.random(),
-            false
+            false,
+            PortalVisibility.PUBLIC
         );
 
         List<PortalNavigationItem> navigationItems = List.of(apisFolder, category1Folder, supportPage, page11, unpublishedPage);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -215,7 +215,8 @@ class PortalNavigationItemAdapterTest {
                 "My Folder",
                 PortalArea.TOP_NAVBAR,
                 1,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
             entity.setParentId(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440011"));
 
@@ -232,6 +233,8 @@ class PortalNavigationItemAdapterTest {
             assertThat(repositoryItem.getParentId()).isEqualTo("550e8400-e29b-41d4-a716-446655440011");
             assertThat(repositoryItem.getOrder()).isEqualTo(1);
             assertThat(repositoryItem.getConfiguration()).isEqualTo("{}");
+            assertThat(repositoryItem.isPublished()).isTrue();
+            assertThat(repositoryItem.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PUBLIC);
         }
 
         @Test
@@ -245,7 +248,8 @@ class PortalNavigationItemAdapterTest {
                 PortalArea.HOMEPAGE,
                 2,
                 PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440013"),
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             // When
@@ -260,6 +264,8 @@ class PortalNavigationItemAdapterTest {
             assertThat(repositoryItem.getArea()).isEqualTo(PortalNavigationItem.Area.HOMEPAGE);
             assertThat(repositoryItem.getOrder()).isEqualTo(2);
             assertThat(repositoryItem.getConfiguration()).isEqualTo("{\"portalPageContentId\":\"550e8400-e29b-41d4-a716-446655440013\"}");
+            assertThat(repositoryItem.isPublished()).isTrue();
+            assertThat(repositoryItem.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PUBLIC);
         }
 
         @Test
@@ -273,7 +279,8 @@ class PortalNavigationItemAdapterTest {
                 PortalArea.TOP_NAVBAR,
                 3,
                 "https://example.com",
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             // When
@@ -288,6 +295,8 @@ class PortalNavigationItemAdapterTest {
             assertThat(repositoryItem.getArea()).isEqualTo(PortalNavigationItem.Area.TOP_NAVBAR);
             assertThat(repositoryItem.getOrder()).isEqualTo(3);
             assertThat(repositoryItem.getConfiguration()).isEqualTo("{\"url\":\"https://example.com\"}");
+            assertThat(repositoryItem.isPublished()).isTrue();
+            assertThat(repositoryItem.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PUBLIC);
         }
 
         @Test
@@ -300,7 +309,8 @@ class PortalNavigationItemAdapterTest {
                 "My Folder",
                 PortalArea.TOP_NAVBAR,
                 0,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             // When

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalNavigationItemsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_page/PortalNavigationItemsCrudServiceImplTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.model.PortalNavigationItem;
@@ -71,7 +72,16 @@ class PortalNavigationItemsCrudServiceImplTest {
         @Test
         void should_create_a_folder() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
-            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, true);
+            final var item = new PortalNavigationFolder(
+                itemId,
+                "organizationId",
+                "environmentId",
+                "title",
+                PortalArea.TOP_NAVBAR,
+                0,
+                true,
+                PortalVisibility.PUBLIC
+            );
 
             service.create(item);
 
@@ -86,6 +96,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -104,7 +115,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 contentId,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             service.create(item);
@@ -120,6 +132,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{\"portalPageContentId\":\"" + contentId.toString() + "\"}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -138,7 +151,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 url,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             service.create(item);
@@ -154,6 +168,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{\"url\":\"" + url + "\"}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).create(captor.capture());
@@ -173,7 +188,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 contentId,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
             when(repository.create(any())).thenThrow(new TechnicalException("Database error"));
 
@@ -198,7 +214,16 @@ class PortalNavigationItemsCrudServiceImplTest {
         @Test
         void should_update_a_folder() throws TechnicalException {
             final var itemId = PortalNavigationItemId.random();
-            final var item = new PortalNavigationFolder(itemId, "organizationId", "environmentId", "title", PortalArea.TOP_NAVBAR, 0, true);
+            final var item = new PortalNavigationFolder(
+                itemId,
+                "organizationId",
+                "environmentId",
+                "title",
+                PortalArea.TOP_NAVBAR,
+                0,
+                true,
+                PortalVisibility.PUBLIC
+            );
 
             service.update(item);
 
@@ -213,6 +238,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -231,7 +257,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 contentId,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             service.update(item);
@@ -247,6 +274,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{\"portalPageContentId\":\"" + contentId.toString() + "\"}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -265,7 +293,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 url,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
 
             service.update(item);
@@ -281,6 +310,7 @@ class PortalNavigationItemsCrudServiceImplTest {
                 .parentId(null)
                 .configuration("{\"url\":\"" + url + "\"}")
                 .published(true)
+                .visibility(io.gravitee.repository.management.model.PortalNavigationItem.Visibility.PUBLIC)
                 .build();
 
             verify(repository).update(captor.capture());
@@ -300,7 +330,8 @@ class PortalNavigationItemsCrudServiceImplTest {
                 PortalArea.TOP_NAVBAR,
                 0,
                 contentId,
-                true
+                true,
+                PortalVisibility.PUBLIC
             );
             when(repository.update(any())).thenThrow(new TechnicalException("Database error"));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -583,7 +583,7 @@ public class DeleteEnvironmentCommandHandlerTest {
                     13,
                     "{}",
                     true,
-                        PortalNavigationItem.Visibility.PUBLIC
+                    PortalNavigationItem.Visibility.PUBLIC
                 )
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -396,7 +396,8 @@ public class DeleteEnvironmentCommandHandlerTest {
                     null,
                     13,
                     "{\"pageId\":\"" + PAGE_CONTENT_ID + "\"}",
-                    true
+                    true,
+                    PortalNavigationItem.Visibility.PUBLIC
                 )
             )
         );
@@ -581,7 +582,8 @@ public class DeleteEnvironmentCommandHandlerTest {
                     null,
                     13,
                     "{}",
-                    true
+                    true,
+                        PortalNavigationItem.Visibility.PUBLIC
                 )
             )
         );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11950

## Description

- Include the `visibility: PUBLIC | PRIVATE` attribute in the portal navigation item from the repository up to the MAPI-v2 resource responses.
- Default pages are `PUBLIC` by default

Next PRs:
- MAPI-v2 + Console: Add visibility to the Update endpoint
- PAPI: Only return public portal nav items when a user is unauthenticated

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

