### PR TITLE
feat(portal): implement permission and require-auth guard

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -53,7 +53,9 @@ import { anonymousGuard } from '../guards/anonymous.guard';
 import { authGuard } from '../guards/auth.guard';
 import { catalogCategoriesViewGuard } from '../guards/catalog-categories-view.guard';
 import { catalogTabsViewGuard } from '../guards/catalog-tabs-view.guard';
+import { permissionGuard } from '../guards/permission.guard';
 import { redirectGuard } from '../guards/redirect.guard';
+import { requireAuthGuard } from '../guards/require-auth.guard';
 import { apiResolver } from '../resolvers/api.resolver';
 import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
 import { categoriesResolver } from '../resolvers/categories.resolver';
@@ -182,13 +184,20 @@ export const routes: Routes = [
   },
   {
     path: 'applications',
-    canActivateChild: [redirectGuard, authGuard],
+    canActivateChild: [redirectGuard, requireAuthGuard],
     children: [
       { path: '', component: ApplicationsComponent, data: { breadcrumb: 'Applications' } },
       {
         path: 'create',
         component: CreateApplicationComponent,
-        data: { breadcrumb: 'Create Application' },
+        canActivate: [permissionGuard],
+        data: {
+          breadcrumb: 'Create Application',
+          permissions: {
+            anyOf: ['APPLICATION-C'],
+            unauthorizedFallbackTo: '/applications',
+          },
+        },
       },
       {
         path: ':applicationId',

--- a/gravitee-apim-portal-webui-next/src/guards/permission.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/permission.guard.spec.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, ActivatedRouteSnapshot, CanActivateFn, Router, UrlTree } from '@angular/router';
+
+import { permissionGuard } from './permission.guard';
+import { fakeUser } from '../entities/user/user.fixtures';
+import { CurrentUserService } from '../services/current-user.service';
+import { AppTestingModule } from '../testing/app-testing.module';
+
+describe('permissionGuard', () => {
+  let currentUserService: CurrentUserService;
+  let activatedRoute: ActivatedRoute;
+  let router: Router;
+  const executeGuard: CanActivateFn = (...guardParameters) => TestBed.runInInjectionContext(() => permissionGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    currentUserService = TestBed.inject(CurrentUserService);
+    activatedRoute = TestBed.inject(ActivatedRoute);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow access when no permissions required', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(fakeUser());
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, { data: {} });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when user has required permission', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['C'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+    });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when user has any of the required permissions', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['R'],
+          USER: ['C'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C', 'USER-C'],
+        },
+      },
+    });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should block access when user does not have required permission', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['R'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('should redirect to unauthorizedFallbackTo when specified', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['R'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+          unauthorizedFallbackTo: '/applications',
+        },
+      },
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('/applications');
+  });
+
+  it('should redirect to parent route when no fallback specified', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['R'],
+        },
+      }),
+    );
+
+    const parentRoute: Partial<ActivatedRouteSnapshot> = Object.assign({}, activatedRoute.snapshot, {
+      routeConfig: { path: 'applications' },
+    });
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+      parent: parentRoute as ActivatedRouteSnapshot,
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('applications');
+  });
+
+  it('should redirect to homepage when no parent route and no fallback', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['R'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+      parent: null,
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('should block access when user has no permissions', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(fakeUser({ permissions: undefined }));
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('should block access when user permissions object is empty', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(fakeUser({ permissions: {} }));
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C'],
+        },
+      },
+    });
+
+    const result = executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('should handle all CRUD actions', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['C', 'R', 'U', 'D'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C', 'APPLICATION-R', 'APPLICATION-U', 'APPLICATION-D'],
+        },
+      },
+    });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should handle different resources', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(
+      fakeUser({
+        permissions: {
+          APPLICATION: ['C'],
+          USER: ['R'],
+        },
+      }),
+    );
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: ['APPLICATION-C', 'USER-R'],
+        },
+      },
+    });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when anyOf is empty array', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    currentUserService.user.set(fakeUser());
+
+    const routeSnapshot = Object.assign({}, activatedRoute.snapshot, {
+      data: {
+        permissions: {
+          anyOf: [],
+        },
+      },
+    });
+
+    expect(executeGuard(routeSnapshot, { url: '', root: activatedRoute.snapshot })).toBe(true);
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/guards/permission.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/permission.guard.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+
+import { UserEnvironmentPermissions } from '../entities/permission/permission';
+import { CurrentUserService } from '../services/current-user.service';
+
+type PermissionAction = 'C' | 'R' | 'U' | 'D';
+
+type PermissionResource = keyof UserEnvironmentPermissions;
+
+interface PermissionConfig {
+  anyOf?: string[];
+  unauthorizedFallbackTo?: string;
+}
+
+interface ParsedPermission {
+  resource: PermissionResource;
+  action: PermissionAction;
+}
+
+/**
+ * Guard that checks if user has required environment-level permissions.
+ *
+ * Note: This guard only checks UserEnvironmentPermissions (available in current user).
+ *
+ * Expects route data with 'permissions.anyOf' array in format: ['RESOURCE-ACTION'] (e.g., ['APPLICATION-C'])
+ * - RESOURCE: key from UserEnvironmentPermissions (e.g., 'APPLICATION', 'USER')
+ * - ACTION: one of 'C' (Create), 'R' (Read), 'U' (Update), 'D' (Delete)
+ *
+ * Optionally supports 'permissions.unauthorizedFallbackTo' to specify redirect path.
+ * If user doesn't have any of the required permissions:
+ * - Redirects to 'permissions.unauthorizedFallbackTo' if specified
+ * - Otherwise redirects to parent route (if exists) or homepage ('/')
+ */
+export const permissionGuard: CanActivateFn = (route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): boolean | UrlTree => {
+  const permissionsConfig = getPermissionsConfig(route);
+  if (!permissionsConfig) {
+    return true;
+  }
+
+  const user = inject(CurrentUserService).user();
+  const hasPermission = checkUserHasAnyPermission(user.permissions, permissionsConfig.anyOf || []);
+
+  if (hasPermission) {
+    return true;
+  }
+
+  return redirectUnauthorized(route, permissionsConfig);
+};
+
+function getPermissionsConfig(route: ActivatedRouteSnapshot): PermissionConfig | null {
+  const permissions = route.data?.['permissions'] as PermissionConfig | undefined;
+
+  if (!permissions?.anyOf || permissions.anyOf.length === 0) {
+    return null;
+  }
+
+  return permissions;
+}
+
+function checkUserHasAnyPermission(userPermissions: UserEnvironmentPermissions | undefined, requiredPermissions: string[]): boolean {
+  if (!userPermissions) {
+    return false;
+  }
+
+  return requiredPermissions.some(requiredPermission => {
+    const parsed = parsePermission(requiredPermission);
+    if (!parsed) {
+      return false;
+    }
+
+    return hasUserPermission(userPermissions, parsed);
+  });
+}
+
+function parsePermission(permission: string): ParsedPermission | null {
+  const [resource, action] = permission.split('-');
+
+  if (!resource || !action) {
+    console.warn(`Invalid permission format: ${permission}. Expected format: 'RESOURCE-ACTION'`);
+    return null;
+  }
+
+  if (!isValidAction(action)) {
+    console.warn(`Invalid permission action: ${action}. Expected one of: C, R, U, D`);
+    return null;
+  }
+
+  return {
+    resource: resource as PermissionResource,
+    action: action as PermissionAction,
+  };
+}
+
+function isValidAction(action: string): action is PermissionAction {
+  return ['C', 'R', 'U', 'D'].includes(action);
+}
+
+function hasUserPermission(userPermissions: UserEnvironmentPermissions, parsed: ParsedPermission): boolean {
+  const resourcePermissions = userPermissions[parsed.resource];
+  return resourcePermissions?.includes(parsed.action) || false;
+}
+
+function redirectUnauthorized(route: ActivatedRouteSnapshot, config: PermissionConfig): UrlTree {
+  const router = inject(Router);
+
+  if (config.unauthorizedFallbackTo) {
+    return router.parseUrl(config.unauthorizedFallbackTo);
+  }
+
+  const parentRoute = route.parent?.routeConfig?.path || '/';
+  return router.parseUrl(parentRoute);
+}

--- a/gravitee-apim-portal-webui-next/src/guards/require-auth.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/require-auth.guard.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, CanActivateFn, Router, UrlTree } from '@angular/router';
+import { OAuthService } from 'angular-oauth2-oidc';
+
+import { requireAuthGuard } from './require-auth.guard';
+import { fakeUser } from '../entities/user/user.fixtures';
+import { CurrentUserService } from '../services/current-user.service';
+import { AppTestingModule } from '../testing/app-testing.module';
+
+describe('requireAuthGuard', () => {
+  let currentUserService: CurrentUserService;
+  let oauthService: OAuthService;
+  let activatedRoute: ActivatedRoute;
+  let router: Router;
+  const executeGuard: CanActivateFn = (...guardParameters) => TestBed.runInInjectionContext(() => requireAuthGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    currentUserService = TestBed.inject(CurrentUserService);
+    oauthService = TestBed.inject(OAuthService);
+    activatedRoute = TestBed.inject(ActivatedRoute);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow authenticated user', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    const navigate = jest.spyOn(router, 'navigate');
+    currentUserService.user.set(fakeUser());
+
+    expect(executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot })).toBeTruthy();
+    expect(parseUrl).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('should redirect authenticated user coming from SSO', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl').mockReturnValue(router.parseUrl('/redirectPath'));
+    const navigate = jest.spyOn(router, 'navigate');
+    currentUserService.user.set(fakeUser());
+    oauthService.state = encodeURIComponent('/redirectPath');
+
+    const result = executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(oauthService.state).toEqual('');
+    expect(parseUrl).toHaveBeenCalledWith('/redirectPath');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('should redirect unauthenticated user to login', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl');
+    const createUrlTree = jest.spyOn(router, 'createUrlTree');
+    currentUserService.user.set({});
+    const url = '/applications/create';
+
+    const result = executeGuard(activatedRoute.snapshot, { url, root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(createUrlTree).toHaveBeenCalledWith(['/log-in'], { queryParams: { redirectUrl: url } });
+    expect(parseUrl).not.toHaveBeenCalled();
+  });
+
+  it('should redirect unauthenticated user to login with current URL', () => {
+    const createUrlTree = jest.spyOn(router, 'createUrlTree');
+    currentUserService.user.set({});
+    const url = '/test-route';
+
+    const result = executeGuard(activatedRoute.snapshot, { url, root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(createUrlTree).toHaveBeenCalledWith(['/log-in'], { queryParams: { redirectUrl: url } });
+  });
+
+  it('should redirect unauthenticated user even when forceLogin is disabled', () => {
+    const createUrlTree = jest.spyOn(router, 'createUrlTree');
+    currentUserService.user.set({});
+    const url = '/applications';
+
+    const result = executeGuard(activatedRoute.snapshot, { url, root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(createUrlTree).toHaveBeenCalledWith(['/log-in'], { queryParams: { redirectUrl: url } });
+  });
+
+  it('should clear OAuth state when redirecting authenticated user from SSO', () => {
+    const parseUrl = jest.spyOn(router, 'parseUrl').mockReturnValue(router.parseUrl('/some-path'));
+    currentUserService.user.set(fakeUser());
+    oauthService.state = encodeURIComponent('/some-path');
+
+    const result = executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot });
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(oauthService.state).toEqual('');
+    expect(parseUrl).toHaveBeenCalledWith('/some-path');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/guards/require-auth.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/require-auth.guard.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, RouterStateSnapshot } from '@angular/router';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { isEmpty } from 'lodash';
+
+import { CurrentUserService } from '../services/current-user.service';
+
+/**
+ * Guard that always requires authentication.
+ * If user is not authenticated, redirects to login page.
+ */
+export const requireAuthGuard: CanActivateFn = (_route, state: RouterStateSnapshot) => {
+  const authResult = checkUserAuthenticated();
+
+  if (authResult === false) {
+    const router = inject(Router);
+    return router.createUrlTree(['/log-in'], { queryParams: { redirectUrl: state.url } });
+  }
+
+  return authResult;
+};
+
+function checkUserAuthenticated() {
+  if (inject(CurrentUserService).isAuthenticated()) {
+    const redirectPath = getOAuthRedirectPath();
+    return isEmpty(redirectPath) || inject(Router).parseUrl(redirectPath);
+  }
+  return false;
+}
+
+function getOAuthRedirectPath() {
+  const oAuthService = inject(OAuthService);
+  const redirectPath = decodeURIComponent(oAuthService.state ?? '');
+  oAuthService.state = '';
+  return redirectPath;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12172

## Description

Fixed security issue where unauthenticated users could access `/applications` and `/applications/create` routes when "Force authentication to access portal" setting was disabled.

To do so, I implemented two new guards:

### Permission guard

Based on the permission guard we have in Console, this one checks for correct permissions.

It uses `anyOf` to provide a list of permissions required to access the path as well as the `unauthorizedFallbackTo` parameter.

### Require auth

This is a twin implementation of the auth guard but with one difference. It doesn't look into Console -> Settings -> Authentication -> "Force authentication to access portal" parameter, so it always requires being logged in to enter.

This way we don't have a scenario like we have on master env when this parameter is turned off and unlogged user can access both `/applications` and `/applications/create`.

## Additional context

Demo of Permission Guard on `/applications/create` route with fallback when user has no required permissions:

https://github.com/user-attachments/assets/f89eccd9-cdfd-4734-85dd-161af01ed2c6


Demo of Require Auth Guard on `/applications` and `/applications/create` routes with unlogged user:


https://github.com/user-attachments/assets/ffb5cad9-b353-4e56-91d7-2188c66f52fe


