### PR TITLE
Apim 11950 update portal nav item visibility

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -36,6 +36,7 @@ export function fakePortalNavigationPage(overrides?: Partial<PortalNavigationPag
     area: 'HOMEPAGE',
     portalPageContentId: 'page-content-1',
     published: true,
+    visibility: 'PUBLIC',
   };
 
   if (isFunction(overrides)) {
@@ -58,6 +59,7 @@ export function fakePortalNavigationFolder(overrides?: Partial<PortalNavigationF
     order: 1,
     area: 'HOMEPAGE',
     published: true,
+    visibility: 'PUBLIC',
   };
 
   if (isFunction(overrides)) {
@@ -81,6 +83,7 @@ export function fakePortalNavigationLink(overrides?: Partial<PortalNavigationLin
     area: 'HOMEPAGE',
     url: 'https://example.com',
     published: true,
+    visibility: 'PUBLIC',
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -15,6 +15,7 @@
  */
 export type PortalArea = 'HOMEPAGE' | 'TOP_NAVBAR';
 export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK';
+export type PortalVisibility = 'PUBLIC' | 'PRIVATE';
 
 interface BasePortalNavigationItem<T extends PortalNavigationItemType> {
   id: string;
@@ -25,6 +26,7 @@ interface BasePortalNavigationItem<T extends PortalNavigationItemType> {
   order: number;
   area: PortalArea;
   published: boolean;
+  visibility: PortalVisibility;
   parentId?: string;
 }
 
@@ -64,6 +66,7 @@ interface BaseUpdatePortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;
   type: T;
   published: boolean;
+  visibility: PortalVisibility;
   parentId?: string;
   order?: number;
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -310,6 +310,7 @@ describe('PortalNavigationItemsComponent', () => {
           order: linkData.order,
           url: 'https://new.com',
           published: linkData.published,
+          visibility: linkData.visibility,
         },
         fakePortalNavigationLink({ id: linkData.id, title: 'Updated Link', url: 'https://new.com', area: linkData.area, type: 'LINK' }),
       );

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -257,6 +257,7 @@ export class PortalNavigationItemsComponent {
               parentId: existingItem.parentId,
               order: existingItem.order,
               published: existingItem.published,
+              visibility: existingItem.visibility,
               ...result,
             });
           }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1964,13 +1964,15 @@ components:
           type: boolean
           description: Whether the navigation item is published or not
           example: true
+        visibility:
+          $ref: "#/components/schemas/PortalVisibility"
       discriminator:
         propertyName: type
         mapping:
           FOLDER: "#/components/schemas/UpdatePortalNavigationFolder"
           PAGE: "#/components/schemas/UpdatePortalNavigationPage"
           LINK: "#/components/schemas/UpdatePortalNavigationLink"
-      required: [ type, title, order, published ]
+      required: [ type, title, order, published, visibility ]
     UpdatePortalNavigationFolder:
       type: object
       title: "UpdatePortalNavigationFolder"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -123,7 +123,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .order(1)
             .type(PortalNavigationItemType.PAGE)
-            .published(true);
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title
@@ -150,7 +151,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .type(PortalNavigationItemType.LINK)
             .order(0)
-            .published(true);
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title
@@ -177,7 +179,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .type(PortalNavigationItemType.FOLDER)
             .order(2)
-            .published(true);
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title
@@ -204,7 +207,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .type(PortalNavigationItemType.LINK)
             .order(3)
-            .published(false);
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 400 Bad request and response payload with trimmed title
@@ -224,7 +228,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("Won't work")
             .type(PortalNavigationItemType.PAGE)
             .order(1)
-            .published(false);
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(unknownId).request().put(json(payload));
 
         assertThat(response).hasStatus(NOT_FOUND_404);
@@ -240,7 +245,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .order(3)
             .type(PortalNavigationItemType.PAGE)
-            .published(false);
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title and updated order
@@ -270,7 +276,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .type(PortalNavigationItemType.LINK)
             .order(0)
             .parentId(UUID.fromString(APIS_ID))
-            .published(false);
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title and updated parentId
@@ -298,7 +305,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .type(PortalNavigationItemType.FOLDER)
             .order(2)
-            .published(false);
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title and parentId null ==> moving to root level
@@ -326,7 +334,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
             .title("  Updated Title  ")
             .order(1)
             .type(PortalNavigationItemType.PAGE)
-            .published(true);
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC);
         Response response = target.path(navId).request().put(json(payload));
 
         // Then: 200 OK and response payload with trimmed title
@@ -342,5 +351,34 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
         assertThat(updated.getTitle()).isEqualTo("Updated Title");
         assertThat(updated.getPublished()).isTrue();
+    }
+
+    @Test
+    void should_change_a_page_visibility_to_private() {
+        // Given an existing PAGE item
+        String navId = PAGE11_ID;
+
+        // When: PUT with visibility = PRIVATE
+        BaseUpdatePortalNavigationItem payload = new UpdatePortalNavigationPage()
+            .title("  Updated Title  ")
+            .order(1)
+            .type(PortalNavigationItemType.PAGE)
+            .published(true)
+            .visibility(PortalVisibility.PRIVATE);
+        Response response = target.path(navId).request().put(json(payload));
+
+        // Then: 200 OK and response payload with trimmed title
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationPage body = response.readEntity(PortalNavigationPage.class);
+        assertThat(body).isNotNull();
+        assertThat(body.getId()).isEqualTo(UUID.fromString(navId));
+        assertThat(body.getTitle()).isEqualTo("Updated Title");
+        assertThat(body.getPublished()).isTrue();
+        assertThat(body.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+
+        // And storage reflects the change
+        var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
+        assertThat(updated.getTitle()).isEqualTo("Updated Title");
+        assertThat(updated.getVisibility()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -152,5 +152,6 @@ public abstract sealed class PortalNavigationItem permits PortalNavigationPage, 
         this.setOrder(navItem.getOrder());
         this.setParentId(navItem.getParentId());
         this.setPublished(navItem.getPublished());
+        this.setVisibility(navItem.getVisibility());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalNavigationItem.java
@@ -32,4 +32,5 @@ public final class UpdatePortalNavigationItem {
     private PortalNavigationItemId parentId;
     private String url;
     private Boolean published;
+    private PortalVisibility visibility;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
@@ -18,11 +18,11 @@ package io.gravitee.apim.core.portal_page.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import io.gravitee.rest.api.service.exceptions.ResourceNotFoundException;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
@@ -41,7 +41,7 @@ public class UpdatePortalNavigationItemUseCase {
             PortalNavigationItemId.of(input.navigationItemId)
         );
         if (existing == null) {
-            throw new ResourceNotFoundException("Portal navigation item [%s] not found.".formatted(input.navigationItemId));
+            throw new PortalNavigationItemNotFoundException(input.navigationItemId);
         }
         validatorService.validateToUpdate(toUpdate, existing);
         existing.update(toUpdate);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11950

## Description

- add visibility to update in MAPI-v2
- make sure that when updating current features in console, the visibility is not changed

Next PRs:

- PAPI: Only return public portal nav items when a user is unauthenticated

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

