### PR TITLE
fix: resolve intermittent duplication issues in user display

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1291,32 +1291,18 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             // UserDocumentTransformation remove domain from email address for security reasons
             // remove it during search phase to provide results
             String sanitizedQuery = query.indexOf('@') > 0 ? query.substring(0, query.indexOf('@')) : query;
-            userQuery = QueryBuilder.create(UserEntity.class).setQuery(sanitizedQuery).setPage(pageable).build();
+            userQuery = QueryBuilder.create(UserEntity.class)
+                .setQuery(sanitizedQuery)
+                .setSort(new SortableImpl(UserDocumentTransformer.FIELD_LASTNAME_FIRSTNAME, true))
+                .setPage(pageable)
+                .build();
         }
         SearchResult results = searchEngineService.search(executionContext, userQuery);
 
         if (results.hasResults()) {
-            Set<UserEntity> fetched = findByIds(executionContext, results.getDocuments());
-            Map<String, UserEntity> byId = fetched.stream().collect(Collectors.toMap(UserEntity::getId, u -> u));
-
-            List<UserEntity> users = new ArrayList<>(results.getDocuments().size());
-            Set<String> seen = new HashSet<>();
-
-            for (String id : results.getDocuments()) {
-                if (seen.add(id)) {
-                    UserEntity u = byId.get(id);
-                    if (u != null) {
-                        users.add(u);
-                    }
-                }
-            }
-
-            users.sort(
-                Comparator.comparing(UserEntity::getFirstname, Comparator.nullsLast(String::compareToIgnoreCase)).thenComparing(
-                    UserEntity::getLastname,
-                    Comparator.nullsLast(String::compareToIgnoreCase)
-                )
-            );
+            List<String> orderedIds = new ArrayList<>(results.getDocuments());
+            List<UserEntity> users = new ArrayList<>((findByIds(executionContext, orderedIds)));
+            users.sort(Comparator.comparingInt(user -> orderedIds.indexOf(user.getId())));
 
             populateUserFlags(executionContext.getOrganizationId(), users);
 
@@ -1370,12 +1356,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .getContent()
                 .stream()
                 .map(u -> convert(u, false, userMetadataService.findAllByUserId(u.getId())))
-                .sorted(
-                    Comparator.comparing(UserEntity::getFirstname, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)).thenComparing(
-                        UserEntity::getLastname,
-                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)
-                    )
-                )
                 .collect(toList());
 
             populateUserFlags(executionContext.getOrganizationId(), entities);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10754

## Description

Eliminated duplicate entries in organization search users results.
Issues like:
1. Duplicate records on different pages
2. Search results are different when searched again using same params(Intermittent results)
3. Sorting behaviour confusing

## Additional context

Also, removed the sorting after pagination: https://github.com/gravitee-io/gravitee-api-management/pull/12945




