### PR TITLE
chore: bump plugins after use of common schema-form

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/resource/Oauth2AMResourceIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/resource/Oauth2AMResourceIntegrationTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.resource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.oauth2.Oauth2Policy;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import io.gravitee.resource.oauth2.am.OAuth2AMResource;
+import io.gravitee.resource.oauth2.am.configuration.OAuth2ResourceConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+public class Oauth2AMResourceIntegrationTest extends AbstractGatewayTest {
+
+    private static final String CLIENT_SECRET = "adminPassword";
+
+    @Override
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        resources.putIfAbsent("oauth2", ResourceBuilder.build("oauth2", OAuth2AMResource.class, OAuth2ResourceConfiguration.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.putIfAbsent("oauth2", PolicyBuilder.build("oauth2", Oauth2Policy.class, OAuth2PolicyConfiguration.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-am-oauth2-unsecured.json")
+    void should_call_oauth2_introspect__unsecured_endpoint(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-am-oauth2-secured-no-ssl-conf.json")
+    void should_call_oauth2_introspect__secured_endpoint_no_ssl_configuration(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-am-oauth2-secured-with-ssl-conf.json")
+    void should_call_oauth2_introspect__secured_endpoint_ssl_configuration(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    private void shouldCallApiSuccessfully(HttpClient httpClient) {
+        String jwt = new PlainJWT(
+            new JWTClaimsSet.Builder()
+                .subject("test")
+                .issuer("ITTest")
+                .audience("OAuth")
+                .expirationTime(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .issueTime(new Date())
+                .claim("test", "hello")
+                .build()
+        ).serialize();
+
+        // stub for introspect endpoint (called by oauth policy via oauth2 resource)
+        wiremock.stubFor(
+            post("/domain/oauth/introspect")
+                .withBasicAuth("admin", CLIENT_SECRET)
+                .willReturn(
+                    jsonResponse(
+                        """
+                        {
+                            "client_id": "admin",
+                            "sub": "the_user",
+                            "scope": [],
+                            "active": true
+                        }
+                        """,
+                        200
+                    )
+                )
+        );
+
+        // the backend
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+        callApi(httpClient, Map.of("Authorization", "Bearer " + jwt));
+
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/domain/oauth/introspect")));
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    private static void callApi(HttpClient httpClient, Map<String, String> map) {
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .doOnSuccess(req -> map.forEach(req::putHeader))
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(Buffer.buffer("response from backend"))
+            .assertComplete();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/resource/Oauth2GenericResourceIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/resource/Oauth2GenericResourceIntegrationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.resource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.oauth2.Oauth2Policy;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import io.gravitee.policy.v3.oauth2.Oauth2PolicyV3;
+import io.gravitee.resource.oauth2.generic.OAuth2GenericResource;
+import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+public class Oauth2GenericResourceIntegrationTest extends AbstractGatewayTest {
+
+    private static final String CLIENT_SECRET = "adminPassword";
+
+    @Override
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        resources.putIfAbsent("oauth2", ResourceBuilder.build("oauth2", OAuth2GenericResource.class, OAuth2ResourceConfiguration.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.putIfAbsent("oauth2", PolicyBuilder.build("oauth2", Oauth2Policy.class, OAuth2PolicyConfiguration.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-generic-oauth2-unsecured.json")
+    void should_call_oauth2_introspect__unsecured_endpoint(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-generic-oauth2-secured-no-ssl-conf.json")
+    void should_call_oauth2_introspect__secured_endpoint_no_ssl_configuration(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    @Test
+    @DeployApi("/apis/v4/resource/api-generic-oauth2-secured-with-ssl-conf.json")
+    void should_call_oauth2_introspect__secured_endpoint_ssl_configuration(HttpClient httpClient) {
+        shouldCallApiSuccessfully(httpClient);
+    }
+
+    private void shouldCallApiSuccessfully(HttpClient httpClient) {
+        String jwt = new PlainJWT(
+            new JWTClaimsSet.Builder()
+                .subject("test")
+                .issuer("ITTest")
+                .audience("OAuth")
+                .expirationTime(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .issueTime(new Date())
+                .claim("test", "hello")
+                .build()
+        ).serialize();
+
+        // stub for introspect endpoint (called by oauth policy via oauth2 resource)
+        wiremock.stubFor(
+            get("/oauth/check_token")
+                .withBasicAuth("admin", CLIENT_SECRET)
+                .withHeader("token", equalTo(jwt))
+                .willReturn(
+                    jsonResponse(
+                        """
+                        {
+                            "client_id": "admin",
+                            "sub": "the_user",
+                            "scope": []
+                        }
+                        """,
+                        200
+                    )
+                )
+        );
+
+        // the backend
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+        callApi(httpClient, Map.of("Authorization", "Bearer " + jwt));
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/oauth/check_token")));
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    private static void callApi(HttpClient httpClient, Map<String, String> map) {
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .doOnSuccess(req -> map.forEach(req::putHeader))
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(Buffer.buffer("response from backend"))
+            .assertComplete();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-secured-no-ssl-conf.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-secured-no-ssl-conf.json
@@ -1,0 +1,92 @@
+{
+    "id": "api-am-oauth2-unsecured",
+    "name": "api-am-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "am oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "serverURL": "http://localhost:8080",
+                "securityDomain": "domain",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "version": "V3_X",
+                "userClaim": "sub"
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "am oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-secured-with-ssl-conf.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-secured-with-ssl-conf.json
@@ -1,0 +1,96 @@
+{
+    "id": "api-am-oauth2-unsecured",
+    "name": "api-am-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "am oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "serverURL": "http://localhost:8080",
+                "securityDomain": "domain",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "version": "V3_X",
+                "userClaim": "sub",
+              "ssl": {
+                "trustAll": true,
+                "hostnameVerifier": false
+              }
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "am oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-unsecured.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-am-oauth2-unsecured.json
@@ -1,0 +1,92 @@
+{
+    "id": "api-am-oauth2-unsecured",
+    "name": "api-am-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "am oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "serverURL": "http://localhost:8080",
+                "securityDomain": "domain",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "version": "V3_X",
+                "userClaim": "sub"
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "am oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-secured-no-ssl-conf.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-secured-no-ssl-conf.json
@@ -1,0 +1,99 @@
+{
+    "id": "api-generic-oauth2-unsecured",
+    "name": "api-generic-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "gen oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "authorizationServerUrl": "https://localhost:8080",
+                "introspectionEndpoint": "/oauth/check_token",
+                "introspectionEndpointMethod": "GET",
+                "useClientAuthorizationHeader": true,
+                "clientAuthorizationHeaderName": "Authorization",
+                "clientAuthorizationHeaderScheme": "Basic",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "tokenIsSuppliedByHttpHeader": true,
+                "tokenHeaderName": "token",
+                "scopeSeparator": " ",
+                "userInfoEndpoint": "/userinfo",
+                "userInfoEndpointMethod": "GET"
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "gen oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-secured-with-ssl-conf.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-secured-with-ssl-conf.json
@@ -1,0 +1,103 @@
+{
+    "id": "api-generic-oauth2-unsecured",
+    "name": "api-generic-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "gen oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "authorizationServerUrl": "https://localhost:8080",
+                "introspectionEndpoint": "/oauth/check_token",
+                "introspectionEndpointMethod": "GET",
+                "useClientAuthorizationHeader": true,
+                "clientAuthorizationHeaderName": "Authorization",
+                "clientAuthorizationHeaderScheme": "Basic",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "tokenIsSuppliedByHttpHeader": true,
+                "tokenHeaderName": "token",
+                "scopeSeparator": " ",
+                "userInfoEndpoint": "/userinfo",
+                "userInfoEndpointMethod": "GET",
+                "ssl": {
+                  "trustAll": true,
+                  "hostnameVerifier": false
+                }
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "gen oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-unsecured.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/resource/api-generic-oauth2-unsecured.json
@@ -1,0 +1,99 @@
+{
+    "id": "api-generic-oauth2-unsecured",
+    "name": "api-generic-oauth2-unsecured",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "gen oauth2",
+            "type": "oauth2",
+            "configuration": {
+                "authorizationServerUrl": "http://localhost:8080",
+                "introspectionEndpoint": "/oauth/check_token",
+                "introspectionEndpointMethod": "GET",
+                "useClientAuthorizationHeader": true,
+                "clientAuthorizationHeaderName": "Authorization",
+                "clientAuthorizationHeaderScheme": "Basic",
+                "clientId": "admin",
+                "clientSecret": "adminPassword",
+                "tokenIsSuppliedByHttpHeader": true,
+                "tokenHeaderName": "token",
+                "scopeSeparator": " ",
+                "userInfoEndpoint": "/userinfo",
+                "userInfoEndpointMethod": "GET"
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ],
+            "request": [
+                {
+                    "name": "OAuth2",
+                    "enabled": true,
+                    "policy": "oauth2",
+                    "configuration": {
+                        "propagateAuthHeader": false,
+                        "requiredScopes": [],
+                        "extractPayload": false,
+                        "checkRequiredScopes": false,
+                        "oauthResource": "gen oauth2",
+                        "modeStrict": false
+                    }
+                }
+            ],
+            "response": []
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/resources/schemas/schema-form.json
@@ -91,6 +91,7 @@
   ],
   "gioExternalDefinitions": {
     "maxConcurrentConnections": {
+      "default" : 1,
       "description": "Hide the field because in the case of Http Dynamic Properties, the number of concurrent connections is fixed to 1.",
       "x-schema-form": {
         "type": "hidden"

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <gravitee-policy-http-redirect.version>1.0.2</gravitee-policy-http-redirect.version>
 
         <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
-        <gravitee-resource-oauth2-provider-am.version>4.0.0-alpha.3</gravitee-resource-oauth2-provider-am.version>
+        <gravitee-resource-oauth2-provider-am.version>4.0.0-alpha.4</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>5.0.0-alpha.4</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <gravitee-policy-jwt.version>7.0.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-metrics-reporter.version>3.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-message-filtering.version>1.1.4</gravitee-policy-message-filtering.version>
         <gravitee-policy-mock.version>1.15.0-alpha.1</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>1.0.0</gravitee-policy-mtls.version>
@@ -283,7 +283,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>5.2.0</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>6.0.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.0.3</gravitee-entrypoint-mcp.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11898

## Description

Some plugins bump on a major version because of the use of the new https://github.com/gravitee-io/gravitee-plugin-common-configurations library, which is mandatory to use common configurations for Http Client creation

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

