### PR TITLE
Helm: adapt template to old version of helm

### DIFF
--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -210,12 +210,14 @@ spec:
               value: "https://{{ index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}"
             {{- end }}
             {{- end }}
-            {{- if and .Values.kafkaConsole.jwt.secret .Values.kafkaConsole.jwt.secret.value }}
+            {{- with .Values.kafkaConsole.jwt.secret }}
+              {{- if .value }}
             - name: GRAVITEE_KAFKA_CONSOLE_SERVER_SECURITY_SECRET
-              value: {{ .Values.kafkaConsole.jwt.secret.value }}
-            {{- else if and .Values.kafkaConsole.jwt.secret .Values.kafkaConsole.jwt.secret.valueFrom }}
+              value: {{ .value }}
+              {{- else if .valueFrom }}
             - name: GRAVITEE_KAFKA_CONSOLE_SERVER_SECURITY_SECRET
-              valueFrom: {{- toYaml .Values.kafkaConsole.jwt.secret.valueFrom | nindent 16 }}
+              valueFrom: {{- toYaml .valueFrom | nindent 16 }}
+              {{- end }}
             {{- end }}
 {{- if .Values.api.env | default .Values.api.deployment.extraEnvs }}
 {{ toYaml ( .Values.api.env | default .Values.api.deployment.extraEnvs ) | indent 12 }}


### PR DESCRIPTION
## Description

This PR change the api-deployment template to avoid using this syntax:
`{{- if and foo.bar foo.bar.baz}}`

With Helm 3.9.x, in case `foo.bar` is null, helm `foo.bar.baz` is anyway evaluated, leading to a NPE.
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/67919/workflows/09a6f002-b193-46c2-98ee-939b9b1b505f/jobs/1374813?invite=true#step-104-17_173

<img width="444" height="365" alt="image" src="https://github.com/user-attachments/assets/3d793319-5cca-4689-b740-2ac04b30ffc6" />
