### PR TITLE
feat: include query param metadata in mAPI v2

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,6 +40,9 @@ public interface MetadataRepository extends FindAllRepository<Metadata> {
     List<Metadata> findByReferenceType(MetadataReferenceType referenceType) throws TechnicalException;
 
     List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId) throws TechnicalException;
+
+    List<Metadata> findByReferenceTypeAndReferenceIdIn(MetadataReferenceType referenceType, Collection<String> referenceIds)
+        throws TechnicalException;
 
     /**
      * Delete Metadata by reference

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMetadataRepository.java
@@ -25,7 +25,10 @@ import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataFormat;
 import io.gravitee.repository.management.model.MetadataReferenceType;
+import java.sql.PreparedStatement;
 import java.sql.Types;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -211,6 +214,30 @@ public class JdbcMetadataRepository extends JdbcAbstractFindAllRepository<Metada
         } catch (final Exception ex) {
             LOGGER.error("Failed to find metadata by reference type and reference id", ex);
             throw new TechnicalException("Failed to find metadata by reference type and reference id", ex);
+        }
+    }
+
+    @Override
+    public List<Metadata> findByReferenceTypeAndReferenceIdIn(MetadataReferenceType referenceType, Collection<String> referenceIds)
+        throws TechnicalException {
+        if (referenceIds == null || referenceIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        LOGGER.debug("JdbcMetadataRepository.findByReferenceTypeAndReferenceIdIn({}, {} ids)", referenceType, referenceIds.size());
+        try {
+            List<String> idList = referenceIds.stream().toList();
+            String sql =
+                getOrm().getSelectAllSql() + " where reference_type = ? and reference_id in (" + getOrm().buildInClause(idList) + ")";
+            return jdbcTemplate.query(
+                sql,
+                (PreparedStatement ps) -> {
+                    ps.setString(1, referenceType.name());
+                    getOrm().setArguments(ps, idList, 2);
+                },
+                getOrm().getRowMapper()
+            );
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to find metadata by reference type and reference ids", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
@@ -24,6 +24,8 @@ import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.MetadataMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MetadataMongo;
 import io.gravitee.repository.mongodb.management.internal.model.MetadataPkMongo;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -134,6 +136,18 @@ public class MongoMetadataRepository implements MetadataRepository {
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceTypeAndIdReferenceId(referenceType, referenceId);
 
         LOGGER.debug("Find metadata by ref type '{}' done", referenceType);
+        return metadata.stream().map(this::map).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Metadata> findByReferenceTypeAndReferenceIdIn(MetadataReferenceType referenceType, Collection<String> referenceIds) {
+        if (referenceIds == null || referenceIds.isEmpty()) {
+            return List.of();
+        }
+        final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceTypeAndIdReferenceIdIn(
+            referenceType,
+            new ArrayList<>(referenceIds)
+        );
         return metadata.stream().map(this::map).collect(Collectors.toList());
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/MetadataMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/MetadataMongoRepository.java
@@ -35,6 +35,8 @@ public interface MetadataMongoRepository extends MongoRepository<MetadataMongo, 
 
     List<MetadataMongo> findByIdReferenceTypeAndIdReferenceId(MetadataReferenceType referenceType, String referenceId);
 
+    List<MetadataMongo> findByIdReferenceTypeAndIdReferenceIdIn(MetadataReferenceType referenceType, List<String> referenceIds);
+
     @Query(value = "{ '_id.referenceId': ?0, '_id.referenceType': ?1 }", fields = "{ _id : 1 }", delete = true)
     List<MetadataMongo> deleteByReferenceIdAndReferenceType(String referenceId, MetadataReferenceType referenceType);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/MetadataRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/MetadataRepositoryTest.java
@@ -24,6 +24,8 @@ import io.gravitee.repository.management.model.MetadataReferenceType;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,6 +52,26 @@ public class MetadataRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull(metadataList);
         assertEquals(1, metadataList.size());
+    }
+
+    @Test
+    public void shouldFindByReferenceTypeAndReferenceIdIn() throws Exception {
+        final List<Metadata> metadataList = metadataRepository.findByReferenceTypeAndReferenceIdIn(
+            MetadataReferenceType.API,
+            Set.of("apiId", "api-delete")
+        );
+
+        assertNotNull(metadataList);
+        assertEquals(3, metadataList.size());
+        assertEquals(Set.of("apiId", "api-delete"), metadataList.stream().map(Metadata::getReferenceId).collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void shouldFindByReferenceTypeAndReferenceIdIn_returnEmptyWhenEmptyCollection() throws Exception {
+        final List<Metadata> metadataList = metadataRepository.findByReferenceTypeAndReferenceIdIn(MetadataReferenceType.API, Set.of());
+
+        assertNotNull(metadataList);
+        assertTrue(metadataList.isEmpty());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -267,6 +267,7 @@ public interface ApiMapper {
     ApiV4 mapFromNativeApiEntity(NativeApiEntity apiEntity);
 
     @Mapping(target = "listeners", qualifiedByName = "toHttpListeners")
+    @Mapping(target = "metadata", ignore = true)
     ApiEntity map(ApiV4 api);
 
     @Mapping(target = "flows", expression = "java(mapApiV4Flows(api))")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapper.java
@@ -91,10 +91,18 @@ public interface ImportExportApiMapper {
         };
     }
 
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 map(ApiDescriptor.ApiDescriptorV4 src);
 
     @Mapping(target = "type", constant = "NATIVE")
+    @Mapping(target = "metadata", ignore = true)
     ApiV4 map(ApiDescriptor.Native src);
+
+    @AfterMapping
+    default void clearMetadata(@MappingTarget ApiV4 target) {
+        // Explicitly set metadata to null to prevent empty object serialization in export
+        target.setMetadata(null);
+    }
 
     default io.gravitee.rest.api.management.v2.rest.model.Listener map(Listener src) {
         return switch (src) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3077,7 +3077,12 @@ components:
                           type: boolean
                           description: Disable membership notifications.
                           default: false
-                      # metadata ==> dedicated resource
+                      metadata:
+                          type: object
+                          description: API metadata as key-value pairs. Only included when requested via expands parameter.
+                          example:
+                              key1: value1
+                              key2: value2
                       groups:
                           type: array
                           description: API's groups. Used to add team in your API.
@@ -8319,6 +8324,7 @@ components:
                     enum:
                         - deploymentState
                         - primaryOwner
+                        - metadata
         apiManageOnlyParam:
             name: manageOnly
             in: query

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
@@ -501,6 +501,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                                 )
                                 .visibility(io.gravitee.rest.api.management.v2.rest.model.Visibility.PRIVATE)
                                 .disableMembershipNotifications(false)
+                                .metadata(Collections.emptyMap())
                                 .responseTemplates(Collections.emptyMap())
                                 .links(
                                     new ApiLinks()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiMetadataQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiMetadataQueryService.java
@@ -16,8 +16,8 @@
 package io.gravitee.apim.core.api.query_service;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Map;
+import java.util.Set;
 
 public interface ApiMetadataQueryService {
     /**
@@ -27,4 +27,12 @@ public interface ApiMetadataQueryService {
      * @return A map of metadata key and metadata.
      */
     Map<String, ApiMetadata> findApiMetadata(String environmentId, String apiId);
+
+    /**
+     * Find all metadata for multiple APIs
+     * @param environmentId The environment id.
+     * @param apiIds The set of API ids.
+     * @return A map of API id to metadata map.
+     */
+    Map<String, Map<String, ApiMetadata>> findApisMetadata(String environmentId, Set<String> apiIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.query_service.api;
 
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
@@ -23,8 +24,6 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataFormat;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
 import java.util.function.Function;
@@ -48,31 +47,16 @@ public class ApiMetadataQueryServiceImpl implements ApiMetadataQueryService {
             Map<String, ApiMetadata> apiMetadata = metadataRepository
                 .findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, environmentId)
                 .stream()
-                .map(m ->
-                    ApiMetadata.builder()
-                        .key(m.getKey())
-                        .defaultValue(m.getValue())
-                        .name(m.getName())
-                        .format(Metadata.MetadataFormat.valueOf(m.getFormat().name()))
-                        .build()
-                )
+                .map(this::toEnvironmentApiMetadata)
                 .collect(toMap(ApiMetadata::getKey, Function.identity()));
 
             metadataRepository
                 .findByReferenceTypeAndReferenceId(MetadataReferenceType.API, apiId)
-                .forEach(m ->
-                    apiMetadata.compute(m.getKey(), (key, existing) ->
+                .forEach(metadata ->
+                    apiMetadata.compute(metadata.getKey(), (key, existing) ->
                         Optional.ofNullable(existing)
-                            .map(value -> value.toBuilder().apiId(apiId).name(m.getName()).value(m.getValue()).build())
-                            .orElse(
-                                ApiMetadata.builder()
-                                    .apiId(m.getReferenceId())
-                                    .key(m.getKey())
-                                    .value(m.getValue())
-                                    .name(m.getName())
-                                    .format(Metadata.MetadataFormat.valueOf(m.getFormat().name()))
-                                    .build()
-                            )
+                            .map(envEntry -> envEntry.toBuilder().apiId(apiId).name(metadata.getName()).value(metadata.getValue()).build())
+                            .orElse(toApiSpecificApiMetadata(metadata))
                     )
                 );
 
@@ -81,5 +65,88 @@ public class ApiMetadataQueryServiceImpl implements ApiMetadataQueryService {
             log.error("An error occurs while trying to find metadata for an API [apiId={}]", apiId, e);
             throw new TechnicalManagementException(e);
         }
+    }
+
+    @Override
+    public Map<String, Map<String, ApiMetadata>> findApisMetadata(final String environmentId, final Set<String> apiIds) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            Map<String, ApiMetadata> environmentMetadata = metadataRepository
+                .findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, environmentId)
+                .stream()
+                .map(this::toEnvironmentApiMetadata)
+                .collect(toMap(ApiMetadata::getKey, Function.identity()));
+
+            Map<String, Map<String, ApiMetadata>> apiSpecificMetadataByApiId = new HashMap<>();
+            apiIds.forEach(apiId -> apiSpecificMetadataByApiId.put(apiId, new HashMap<>()));
+
+            metadataRepository
+                .findByReferenceTypeAndReferenceIdIn(MetadataReferenceType.API, apiIds)
+                .forEach(metadata -> {
+                    String apiId = metadata.getReferenceId();
+                    Map<String, ApiMetadata> apiSpecificMetadata = apiSpecificMetadataByApiId.get(apiId);
+                    if (apiSpecificMetadata != null) {
+                        apiSpecificMetadata.put(metadata.getKey(), toApiSpecificApiMetadata(metadata));
+                    }
+                });
+
+            Map<String, Map<String, ApiMetadata>> result = new HashMap<>();
+            apiIds.forEach(apiId -> result.put(apiId, mergedMetadataView(environmentMetadata, apiSpecificMetadataByApiId.get(apiId))));
+            return result;
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private ApiMetadata toEnvironmentApiMetadata(io.gravitee.repository.management.model.Metadata metadata) {
+        return ApiMetadata.builder()
+            .key(metadata.getKey())
+            .defaultValue(metadata.getValue())
+            .name(metadata.getName())
+            .format(Metadata.MetadataFormat.valueOf(metadata.getFormat().name()))
+            .build();
+    }
+
+    private ApiMetadata toApiSpecificApiMetadata(io.gravitee.repository.management.model.Metadata metadata) {
+        return ApiMetadata.builder()
+            .apiId(metadata.getReferenceId())
+            .key(metadata.getKey())
+            .value(metadata.getValue())
+            .name(metadata.getName())
+            .format(Metadata.MetadataFormat.valueOf(metadata.getFormat().name()))
+            .build();
+    }
+
+    private static Map<String, ApiMetadata> mergedMetadataView(
+        Map<String, ApiMetadata> environmentMetadata,
+        Map<String, ApiMetadata> apiSpecificMetadata
+    ) {
+        return new AbstractMap<>() {
+            @Override
+            public ApiMetadata get(Object key) {
+                ApiMetadata apiEntry = apiSpecificMetadata != null ? apiSpecificMetadata.get(key) : null;
+                ApiMetadata envEntry = environmentMetadata.get(key);
+                if (apiEntry != null) {
+                    if (envEntry != null) {
+                        return apiEntry.toBuilder().defaultValue(envEntry.getDefaultValue()).build();
+                    }
+                    return apiEntry;
+                }
+                return envEntry;
+            }
+
+            @Override
+            public Set<Entry<String, ApiMetadata>> entrySet() {
+                Set<String> metadataKeys = new HashSet<>(environmentMetadata.keySet());
+                if (apiSpecificMetadata != null) metadataKeys.addAll(apiSpecificMetadata.keySet());
+                return metadataKeys
+                    .stream()
+                    .map(metadataKey -> new SimpleEntry<>(metadataKey, get(metadataKey)))
+                    .collect(toSet());
+            }
+        };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionContext;
@@ -166,9 +167,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private final GroupService groupService;
     private final ApiCategoryService apiCategoryService;
     private final ScoringReportRepository scoringReportRepository;
+    private final ApiMetadataQueryService apiMetadataQueryService;
 
     private static final String EMAIL_METADATA_VALUE = "${(api.primaryOwner.email)!''}";
     private static final String EXPAND_PRIMARY_OWNER = "primaryOwner";
+    private static final String EXPAND_METADATA = "metadata";
 
     public ApiServiceImpl(
         @Lazy final ApiRepository apiRepository,
@@ -200,7 +203,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final TagsValidationService tagsValidationService,
         final ApiAuthorizationService apiAuthorizationService,
         final GroupService groupService,
-        ApiCategoryService apiCategoryService
+        final ApiCategoryService apiCategoryService,
+        final ApiMetadataQueryService apiMetadataQueryService
     ) {
         this.apiRepository = apiRepository;
         this.apiMapper = apiMapper;
@@ -232,6 +236,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         this.groupService = groupService;
         this.apiCategoryService = apiCategoryService;
         this.scoringReportRepository = scoringReportRepository;
+        this.apiMetadataQueryService = apiMetadataQueryService;
     }
 
     @Override
@@ -715,7 +720,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             new ApiFieldFilter.Builder().excludePicture().build()
         );
 
-        return apis
+        List<GenericApiEntity> apiEntityList = apis
             .getContent()
             .stream()
             .map(api -> {
@@ -727,11 +732,14 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
                 return genericApiMapper.toGenericApi(api, primaryOwner);
             })
-            .collect(
-                Collectors.collectingAndThen(Collectors.toList(), apiEntityList ->
-                    new Page<>(apiEntityList, apis.getPageNumber(), (int) apis.getPageElements(), apis.getTotalElements())
-                )
-            );
+            .collect(Collectors.toList());
+
+        // Fetch metadata if requested
+        if (expands != null && expands.contains(EXPAND_METADATA) && !apiEntityList.isEmpty()) {
+            fetchAndSetMetadata(executionContext, apiEntityList);
+        }
+
+        return new Page<>(apiEntityList, apis.getPageNumber(), (int) apis.getPageElements(), apis.getTotalElements());
     }
 
     @Override
@@ -803,6 +811,38 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             String errorMsg = String.format("An error occurs while auditing API logging configuration for API:  %s", apiId);
             log.error(errorMsg, apiId, ex);
             throw new TechnicalManagementException(errorMsg, ex);
+        }
+    }
+
+    private void fetchAndSetMetadata(ExecutionContext executionContext, List<GenericApiEntity> apiEntityList) {
+        try {
+            Set<String> apiIds = apiEntityList.stream().map(GenericApiEntity::getId).collect(Collectors.toSet());
+            Map<String, Map<String, io.gravitee.apim.core.api.model.ApiMetadata>> allMetadata = apiMetadataQueryService.findApisMetadata(
+                executionContext.getEnvironmentId(),
+                apiIds
+            );
+
+            apiEntityList.forEach(apiEntity -> {
+                Map<String, io.gravitee.apim.core.api.model.ApiMetadata> apiMetadataMap = allMetadata.get(apiEntity.getId());
+                if (apiMetadataMap != null && !apiMetadataMap.isEmpty()) {
+                    Map<String, Object> metadataMap = apiMetadataMap
+                        .values()
+                        .stream()
+                        .collect(
+                            Collectors.toMap(
+                                io.gravitee.apim.core.api.model.ApiMetadata::getKey,
+                                metadata -> {
+                                    String value = metadata.getValue();
+                                    return value != null ? value : Objects.requireNonNullElse(metadata.getDefaultValue(), "");
+                                },
+                                (existing, replacement) -> replacement
+                            )
+                        );
+                    apiEntity.setMetadata(metadataMap);
+                }
+            });
+        } catch (Exception e) {
+            throw new TechnicalManagementException("Failed to fetch metadata for APIs", e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
@@ -101,6 +101,36 @@ public class ApiMetadataQueryServiceImplTest {
         }
 
         @Test
+        void should_use_api_value_when_api_overrides_env_level_key() {
+            givenExistingEnvironmentMetadata(
+                ENV_ID,
+                List.of(
+                    Metadata.builder()
+                        .key("support-email")
+                        .value("env-default@gravitee.io")
+                        .name("Support")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.MAIL)
+                )
+            );
+            givenExistingApiMetadata(
+                API_ID,
+                List.of(
+                    Metadata.builder()
+                        .key("support-email")
+                        .value("api-override@gravitee.io")
+                        .name("Support")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.MAIL)
+                )
+            );
+
+            var result = service.findApiMetadata(ENV_ID, API_ID);
+            assertThat(result).hasSize(1).containsKey("support-email");
+            assertThat(result.get("support-email").getValue()).isEqualTo("api-override@gravitee.io");
+            assertThat(result.get("support-email").getDefaultValue()).isEqualTo("env-default@gravitee.io");
+            assertThat(result.get("support-email").getApiId()).isEqualTo(API_ID);
+        }
+
+        @Test
         void should_return_api_metadata_with_their_default_value() {
             // given
             givenExistingEnvironmentMetadata(
@@ -233,5 +263,94 @@ public class ApiMetadataQueryServiceImplTest {
         when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), any())).thenThrow(
             new TechnicalException(message)
         );
+    }
+
+    @Nested
+    class FindApisMetadata {
+
+        @Test
+        @SneakyThrows
+        void should_return_metadata_for_multiple_apis() {
+            when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(ENV_ID))).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .key("env-key")
+                        .value("env-value")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.STRING)
+                        .build()
+                )
+            );
+
+            when(metadataRepository.findByReferenceTypeAndReferenceIdIn(eq(MetadataReferenceType.API), any())).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .referenceId("api-1")
+                        .key("api-key")
+                        .value("api1-value")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.STRING)
+                        .build(),
+                    Metadata.builder()
+                        .referenceId("api-2")
+                        .key("api-key")
+                        .value("api2-value")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.STRING)
+                        .build()
+                )
+            );
+
+            var result = service.findApisMetadata(ENV_ID, java.util.Set.of("api-1", "api-2"));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get("api-1")).hasSize(2).containsKeys("env-key", "api-key");
+            assertThat(result.get("api-1").get("env-key").getDefaultValue()).isEqualTo("env-value");
+            assertThat(result.get("api-1").get("api-key").getValue()).isEqualTo("api1-value");
+            assertThat(result.get("api-2").get("api-key").getValue()).isEqualTo("api2-value");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_merge_api_and_env_metadata_when_same_key_at_both_levels() {
+            when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(ENV_ID))).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .key("support-email")
+                        .value("env-default@gravitee.io")
+                        .name("Support")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.MAIL)
+                        .build()
+                )
+            );
+            when(metadataRepository.findByReferenceTypeAndReferenceIdIn(eq(MetadataReferenceType.API), any())).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .referenceId("api-1")
+                        .key("support-email")
+                        .value("api-override@gravitee.io")
+                        .name("Support")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.MAIL)
+                        .build()
+                )
+            );
+
+            var result = service.findApisMetadata(ENV_ID, java.util.Set.of("api-1"));
+
+            assertThat(result).hasSize(1).containsKey("api-1");
+            assertThat(result.get("api-1")).hasSize(1).containsKey("support-email");
+            assertThat(result.get("api-1").get("support-email").getValue()).isEqualTo("api-override@gravitee.io");
+            assertThat(result.get("api-1").get("support-email").getDefaultValue()).isEqualTo("env-default@gravitee.io");
+            assertThat(result.get("api-1").get("support-email").getApiId()).isEqualTo("api-1");
+        }
+
+        @Test
+        void should_return_empty_map_when_api_ids_is_empty() {
+            var result = service.findApisMetadata(ENV_ID, java.util.Set.of());
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_map_when_api_ids_is_null() {
+            var result = service.findApisMetadata(ENV_ID, null);
+            assertThat(result).isEmpty();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.http.HttpMethod;
@@ -302,6 +303,9 @@ public class ApiServiceImplTest {
     @Mock
     private EventManager eventManager;
 
+    @Mock
+    private ApiMetadataQueryService apiMetadataQueryService;
+
     @InjectMocks
     private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
 
@@ -368,7 +372,8 @@ public class ApiServiceImplTest {
             tagsValidationService,
             apiAuthorizationService,
             groupService,
-            apiCategoryService
+            apiCategoryService,
+            apiMetadataQueryService
         );
         var apiSearchService = new ApiSearchServiceImpl(
             apiRepository,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11932

## Description

API metadata was only retrievable via the separate /metadata endpoint, requiring multiple API calls to fetch complete API details. Updated the API aggregation logic so that metadata is embedded directly in the responses of /apis endpoints.

This allows clients to fetch full API data including metadata from a single endpoint without additional requests.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

