### PR TITLE
fix: api migration parsing

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiServicesMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiServicesMigration.java
@@ -24,7 +24,6 @@ import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.api.model.utils.MigrationWarnings;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
-import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyProvider;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration;
@@ -78,12 +77,8 @@ public final class ApiServicesMigration {
             Service.builder().enabled(v2HealthCheckService.isEnabled()).overrideConfiguration(false).type("http-health-check").build()
         );
         String endpointReferenceForMessage = String.format("%s : %s", type.equals(TYPE_ENDPOINT) ? "endpoint" : "endpointgroup", name);
-        if (v2HealthCheckService.getSchedule() != null) {
-            config.put("schedule", v2HealthCheckService.getSchedule());
-        } else {
-            config.putNull("schedule");
-        }
 
+        config.put("schedule", v2HealthCheckService.getSchedule());
         config.put("failureThreshold", 2);
         config.put("successThreshold", 2);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
@@ -68,10 +68,18 @@ public class SharedConfigurationMigration {
         ObjectNode httpClientOptions = mapHttpClientOptions(source.getHttpClientOptions());
         ObjectNode httpClientSslOptionsNode = mapHttpClientSslOptions(source.getHttpClientSslOptions());
         ObjectNode sharedConfiguration = objectMapper.createObjectNode();
-        sharedConfiguration.set("http", httpClientOptions);
-        sharedConfiguration.set("ssl", httpClientSslOptionsNode);
-        sharedConfiguration.set("headers", source.getHeaders() == null ? null : objectMapper.valueToTree(source.getHeaders()));
-        sharedConfiguration.set("proxy", source.getHttpProxy() == null ? null : objectMapper.valueToTree((source.getHttpProxy())));
+        if (httpClientOptions != null) {
+            sharedConfiguration.set("http", httpClientOptions);
+        }
+        if (httpClientSslOptionsNode != null) {
+            sharedConfiguration.set("ssl", httpClientSslOptionsNode);
+        }
+        if (source.getHeaders() != null) {
+            sharedConfiguration.set("headers", objectMapper.valueToTree(source.getHeaders()));
+        }
+        if (source.getHttpProxy() != null) {
+            sharedConfiguration.set("proxy", objectMapper.valueToTree((source.getHttpProxy())));
+        }
         return objectMapper.writeValueAsString(sharedConfiguration);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.HttpHeader;
+import io.gravitee.definition.model.EndpointGroup;
+import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.HttpClientSslOptions;
+import io.gravitee.definition.model.HttpProxy;
+import io.gravitee.definition.model.ProtocolVersion;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SharedConfigurationMigrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SharedConfigurationMigration sharedConfigurationMigration;
+
+    @BeforeEach
+    void setUp() {
+        sharedConfigurationMigration = new SharedConfigurationMigration(objectMapper);
+    }
+
+    @Test
+    void should_convert_endpoint_group() throws JsonProcessingException {
+        var group = new EndpointGroup();
+        var options = new HttpClientOptions();
+        options.setVersion(ProtocolVersion.HTTP_1_1);
+        group.setHttpClientOptions(options);
+        group.setHttpClientSslOptions(new HttpClientSslOptions());
+        var headers = List.of(new HttpHeader("X-Any-Header", "any header"));
+        group.setHeaders(headers);
+        group.setHttpProxy(new HttpProxy());
+
+        var result = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(result);
+
+        JsonNode httpNode = json.get("http");
+        assertThat(httpNode).isNotNull();
+        assertThat(httpNode.get("version").asText()).isEqualTo(ProtocolVersion.HTTP_1_1.name());
+        assertThat(json.get("ssl")).isNotNull();
+        assertThat(json.get("headers")).isNotNull();
+        assertThat(json.get("headers")).hasSize(1);
+        JsonNode firstHeader = json.get("headers").get(0);
+        assertThat(firstHeader.get("name").asText()).isEqualTo("X-Any-Header");
+        assertThat(firstHeader.get("value").asText()).isEqualTo("any header");
+        assertThat(json.get("proxy")).isNotNull();
+    }
+
+    @Test
+    void should_not_set_properties_if_null() throws JsonProcessingException {
+        var group = new EndpointGroup();
+        var options = new HttpClientOptions();
+        options.setVersion(ProtocolVersion.HTTP_1_1);
+        group.setHttpClientOptions(options);
+        group.setHttpClientSslOptions(null);
+        group.setHttpProxy(null);
+
+        var result = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(result);
+
+        assertThat(json.has("http")).isTrue();
+        assertThat(json.has("ssl")).isFalse();
+        assertThat(json.has("headers")).isFalse();
+        assertThat(json.has("proxy")).isFalse();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -455,7 +455,7 @@ class V2ToV4MigrationOperatorTest {
             // Check Endpoint Group
             var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
             String configJson =
-                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}]}";
             assertSoftly(softly -> {
                 softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
                 softly.assertThat(group.getName()).isEqualTo("default-group");
@@ -491,7 +491,7 @@ class V2ToV4MigrationOperatorTest {
             v2Endpoint2.setWeight(5);
             v2Endpoint2.setInherit(false);
             String configJsonForEndpoint =
-                "{\"http\":{\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}]}";
             v2Endpoint2.setConfiguration(configJsonForEndpoint);
             // Setup EndpointGroup
             EndpointGroup v2Group = new EndpointGroup();
@@ -554,7 +554,7 @@ class V2ToV4MigrationOperatorTest {
 
             // Check Endpoint Group
             String configJson =
-                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}],\"proxy\":null}";
+                "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}]}";
             assertThat(result.getApiDefinitionHttpV4().getEndpointGroups())
                 .singleElement()
                 .satisfies(group -> {
@@ -694,7 +694,7 @@ class V2ToV4MigrationOperatorTest {
         v2Endpoint.setWeight(5);
         v2Endpoint.setInherit(false);
         v2Endpoint.setConfiguration(
-            "{\"name\":\"default\",\"target\":\"http://test\",\"weight\":1,\"backup\":false,\"status\":\"UP\",\"tenants\":[],\"type\":\"http\",\"inherit\":true,\"headers\":[],\"proxy\":null,\"http\":null,\"ssl\":null,\"healthcheck\":{\"schedule\":\"0 */1 * * * *\",\"steps\":[{\"name\":\"default-step\",\"request\":{\"path\":\"/hc3\",\"method\":\"GET\",\"headers\":[],\"fromRoot\":false},\"response\":{\"assertions\":[\"#response.status == 202\"]}}],\"enabled\":true,\"inherit\":false}}"
+            "{\"name\":\"default\",\"target\":\"http://test\",\"weight\":1,\"backup\":false,\"status\":\"UP\",\"tenants\":[],\"type\":\"http\",\"inherit\":true,\"headers\":[],\"healthcheck\":{\"schedule\":\"0 */1 * * * *\",\"steps\":[{\"name\":\"default-step\",\"request\":{\"path\":\"/hc3\",\"method\":\"GET\",\"headers\":[],\"fromRoot\":false},\"response\":{\"assertions\":[\"#response.status == 202\"]}}],\"enabled\":true,\"inherit\":false}}"
         );
         // Setup EndpointGroup
         EndpointGroup v2Group = new EndpointGroup();
@@ -776,9 +776,6 @@ class V2ToV4MigrationOperatorTest {
               "type": "http",
               "inherit": true,
               "headers": [],
-              "proxy": null,
-              "http": null,
-              "ssl": null,
               "healthcheck": {
                 "enabled": false,
                 "inherit": false
@@ -837,10 +834,76 @@ class V2ToV4MigrationOperatorTest {
             softly.assertThat(endpoint.getType()).isEqualTo("http-proxy");
             softly.assertThat(endpoint.getName()).isEqualTo("endpoint-1");
             softly.assertThat(endpoint.getWeight()).isEqualTo(5);
-            softly
-                .assertThat(endpoint.getServices().getHealthCheck())
-                .extracting(Service::isOverrideConfiguration, Service::isEnabled, Service::getType, Service::getConfiguration)
-                .contains(true, false, "http-health-check", "{\"schedule\":null,\"failureThreshold\":2,\"successThreshold\":2}");
+            softly.assertThat(endpoint.getServices().getHealthCheck()).isNull();
+        });
+    }
+
+    @Test
+    void should_not_migrate_endpoint_hc_when_inherited() {
+        // Setup Endpoint
+        Endpoint v2Endpoint = new Endpoint();
+        v2Endpoint.setName("endpoint-1");
+        v2Endpoint.setInherit(false);
+        v2Endpoint.setConfiguration(
+            """
+            {
+              "name": "default",
+              "target": "http://test",
+              "weight": 1,
+              "backup": false,
+              "status": "UP",
+              "tenants": [],
+              "type": "http",
+              "inherit": true,
+              "headers": [],
+              "healthcheck": {
+                "schedule": "0 */1 * * * *",
+                "steps": [],
+                "enabled": true,
+                "inherit": true
+              }
+            }
+            """
+        );
+        // Setup EndpointGroup
+        EndpointGroup v2Group = new EndpointGroup();
+        v2Group.setName("default-group");
+        Set<Endpoint> endpoints = new HashSet<>();
+        endpoints.add(v2Endpoint);
+        v2Group.setEndpoints(endpoints);
+
+        // Setup Proxy
+        Proxy proxy = new Proxy();
+        Set<EndpointGroup> endpointGroups = new HashSet<>();
+        endpointGroups.add(v2Group);
+        proxy.setGroups(endpointGroups);
+
+        proxy.setVirtualHosts(List.of(new VirtualHost("localhost", "/api", false)));
+
+        // Setup Api V2
+        var apiDef = new io.gravitee.definition.model.Api();
+        apiDef.setId("test-api");
+        apiDef.setName("Test API");
+        apiDef.setVersion("1.0");
+        apiDef.setProxy(proxy);
+
+        var api = ApiFixtures.aProxyApiV2().toBuilder().apiDefinition(apiDef).build();
+
+        // Act
+        var result = get(mapper.mapApi(api));
+
+        // Check Endpoint Group
+        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(group.getName()).isEqualTo("default-group");
+            softly.assertThat(group.getType()).isEqualTo("http-proxy");
+        });
+
+        // Check Endpoint
+        var endpoint = group.getEndpoints().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(endpoint.getServices().getHealthCheck()).isNull();
         });
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11978

## Description

When trying to import an API V4 that has been migrated from V2, the generated schema is invalid.

```
"endpoints" : [ {
      "name" : "default",
      "type" : "http-proxy",
      "weight" : 1,
      "inheritConfiguration" : true,
      "configuration" : {
        "target" : "http://localhost:8080"
      },
      "services" : {
        "healthCheck" : {
          "overrideConfiguration" : false,
          "configuration" : {
            "schedule" : null,
            "failureThreshold" : 2,
            "successThreshold" : 2
          },
          "enabled" : true,
          "type" : "http-health-check"
        }
      },
```

`target` is expected in the service configuration, and `schedule` should not be null.
When inherited, we should stop serializing the health check service configuration at the endpoint level. This will prevent the schema invalidation and eliminate redundancy.
