### PR TITLE
fix: remove explicit error messages leaking user existence

### DIFF
--- a/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
@@ -64,10 +64,14 @@ class UserController {
   }
 
   save() {
-    this.UserService.save(this.user).then(() => {
-      this.NotificationService.show('User has been updated successfully');
-      this.onSaved();
-    });
+    this.UserService.save(this.user)
+      .then(() => {
+        this.NotificationService.show('User has been updated successfully');
+        this.onSaved();
+      })
+      .catch((error) => {
+        this.NotificationService.showError(error?.data ? error : { data: 'Failed to update user' });
+      });
   }
 
   displayDangerZone(): boolean {
@@ -99,10 +103,14 @@ class UserController {
       })
       .then((response) => {
         if (response) {
-          return this.UserService.removeCurrentUser().then(() => {
-            this.NotificationService.show('You have been successfully deleted');
-            this.onDeleteMyAccount();
-          });
+          return this.UserService.removeCurrentUser()
+            .then(() => {
+              this.NotificationService.show('You have been successfully deleted');
+              this.onDeleteMyAccount();
+            })
+            .catch((error) => {
+              this.NotificationService.showError(error?.data ? error : { data: 'Failed to delete account' });
+            });
         }
       });
   }
@@ -156,10 +164,14 @@ class UserController {
       })
       .then((response) => {
         if (response) {
-          this.TokenService.revoke(token).then(() => {
-            this.NotificationService.show('Token "' + token.name + '" has been revoked.');
-            this.$onInit();
-          });
+          this.TokenService.revoke(token)
+            .then(() => {
+              this.NotificationService.show('Token "' + token.name + '" has been revoked.');
+              this.$onInit();
+            })
+            .catch((error) => {
+              this.NotificationService.showError(error?.data ? error : { data: 'Failed to revoke token' });
+            });
         }
       });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidUserException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidUserException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class InvalidUserException extends AbstractManagementException {
+
+    private final String message;
+    private final String source;
+    private final String userId;
+    private final String organizationId;
+
+    public InvalidUserException(String message, String source, String userId, String organizationId) {
+        this.message = message;
+        this.source = source;
+        this.userId = userId;
+        this.organizationId = organizationId;
+    }
+
+    public static InvalidUserException cannotBeCreated(String source, String userId, String organizationId) {
+        return new InvalidUserException("User cannot be created.", source, userId, organizationId);
+    }
+
+    public static InvalidUserException cannotBeUpdated(String source, String userId, String organizationId) {
+        return new InvalidUserException("User cannot be updated.", source, userId, organizationId);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "user.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("user", userId);
+        parameters.put("organizationId", organizationId);
+        parameters.put("source", source);
+        return parameters;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -127,6 +127,7 @@ import io.gravitee.rest.api.service.exceptions.DefaultRoleNotFoundException;
 import io.gravitee.rest.api.service.exceptions.EmailFormatInvalidException;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InvalidUserException;
 import io.gravitee.rest.api.service.exceptions.PasswordAlreadyResetException;
 import io.gravitee.rest.api.service.exceptions.PasswordFormatInvalidException;
 import io.gravitee.rest.api.service.exceptions.ServiceAccountNotManageableException;
@@ -775,7 +776,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             );
 
             if (checkUser.isPresent()) {
-                throw new UserAlreadyExistsException(
+                throw InvalidUserException.cannotBeCreated(
                     newExternalUserEntity.getSource(),
                     newExternalUserEntity.getSourceId(),
                     organizationId
@@ -973,7 +974,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 organizationId
             );
             if (optionalUser.isPresent()) {
-                throw new UserAlreadyExistsException(
+                throw InvalidUserException.cannotBeCreated(
                     newExternalUserEntity.getSource(),
                     newExternalUserEntity.getSourceId(),
                     organizationId
@@ -1210,7 +1211,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                         user.getOrganizationId()
                     );
                     if (optionalUser.isPresent()) {
-                        throw new UserAlreadyExistsException(user.getSource(), updateUserEntity.getEmail(), user.getOrganizationId());
+                        throw InvalidUserException.cannotBeUpdated(user.getSource(), updateUserEntity.getEmail(), user.getOrganizationId());
                     }
                     user.setSourceId(updateUserEntity.getEmail());
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -432,7 +432,7 @@ public class UserServiceTest {
         userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
     }
 
-    @Test(expected = UserAlreadyExistsException.class)
+    @Test(expected = InvalidUserException.class)
     public void shouldNotCreateNormalUserBecauseAlreadyExists() throws TechnicalException {
         final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
         when(newPreRegisterUserEntity.isService()).thenReturn(false);
@@ -794,7 +794,7 @@ public class UserServiceTest {
         );
     }
 
-    @Test(expected = UserAlreadyExistsException.class)
+    @Test(expected = InvalidUserException.class)
     public void shouldNotUpdateUser_EmailAlreadyInUse() throws TechnicalException {
         final String USER_ID = "myuserid";
         final String USER_EMAIL = "my.user@acme.fr";
@@ -831,7 +831,7 @@ public class UserServiceTest {
         verify(userRepository, never()).create(any());
     }
 
-    @Test(expected = UserAlreadyExistsException.class)
+    @Test(expected = InvalidUserException.class)
     public void shouldNotCreateBecauseExists() throws TechnicalException {
         when(userRepository.findBySource(nullable(String.class), nullable(String.class), nullable(String.class))).thenReturn(
             of(new User())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11945
https://gravitee.atlassian.net/browse/APIM-12183

## Description

Replaced explicit user-identifying error messages with generic responses to prevent revealing whether an account or email exists. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

