### PR TITLE
fix: preserve method order to prevent false redeploy state for mcp api

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/McpSelector.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/McpSelector.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.definition.model.v4.flow.selector;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,6 +34,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class McpSelector extends Selector {
 
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> methods;
 
     public McpSelector() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowMcpSelector.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowMcpSelector.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.management.model.flow.selector;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,6 +34,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class FlowMcpSelector extends FlowSelector {
 
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> methods;
 
     public FlowMcpSelector() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11877

## Description

Preserve method order in case of MCP Api to prevent false redeploy state.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

