### PR TITLE
Set primary owner to importing user if user doesnt exist

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -297,6 +297,42 @@ class ImportApiDefinitionUseCaseTest {
         }
 
         @Test
+        void should_create_a_new_api_with_primary_owner_as_importing_user_if_user_doesnt_exist() {
+            var importDefinition = anImportDefinition();
+            final String customId = "a-custom-id";
+            importDefinition.getApiExport().setId(customId);
+
+            io.gravitee.apim.core.membership.model.PrimaryOwnerEntity primaryOwner = PrimaryOwnerEntity.builder()
+                .id("NEW-USER-ID2")
+                .type(PrimaryOwnerEntity.Type.USER)
+                .email(USER_EMAIL)
+                .displayName("Jane2 Doe2")
+                .build();
+            importDefinition.getApiExport().setPrimaryOwner(primaryOwner);
+            useCase.execute(new ImportApiDefinitionUseCase.Input(importDefinition, AUDIT_INFO));
+
+            var expected = expectedApi();
+            expected.setId(customId);
+            SoftAssertions.assertSoftly(soft -> {
+                var createdApi = apiCrudService.get(customId);
+                soft.assertThat(createdApi).isEqualTo(expected);
+                soft.assertThat(createdApi.getCreatedAt()).isNotNull();
+                soft.assertThat(createdApi.getUpdatedAt()).isNotNull();
+
+                soft
+                    .assertThat(importDefinitionCreateDomainServiceTestInitializer.indexer.storage())
+                    .containsExactly(
+                        new IndexableApi(
+                            expected,
+                            new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
+                            Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
+                            Collections.emptySet()
+                        )
+                    );
+            });
+        }
+
+        @Test
         void should_create_a_new_api_without_sub_entities() {
             // Given
             var importDefinition = anImportDefinition();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12220


https://github.com/user-attachments/assets/e9fdb70b-cf8f-4102-a78f-7f9aac6dd01b






## Description
If Primary Owner doesnt exist in the system, set the primary owner to importing user.It should not throw an error