### PR TITLE
feat(console): Add a GMD page tree item to a folder nav item

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
@@ -62,7 +62,17 @@
     <mat-icon svgIcon="gio:more-vertical" />
   </button>
   <mat-menu #moreMenu="matMenu">
-    <button mat-menu-item (click)="edit.emit(node())"><mat-icon>edit</mat-icon> Edit</button>
+    @if (node()?.type === 'FOLDER') {
+      <button mat-menu-item (click)="triggerCreate('PAGE')">
+        <mat-icon>description</mat-icon>
+        Add Page
+      </button>
+    }
+    <mat-divider></mat-divider>
+    <button mat-menu-item (click)="triggerEdit()">
+      <mat-icon>edit</mat-icon>
+      Edit
+    </button>
   </mat-menu>
 </div>
 
@@ -74,7 +84,7 @@
         [level]="level() + 1"
         [selectedId]="selectedId()"
         (nodeSelected)="nodeSelected.emit($event)"
-        (edit)="edit.emit($event)"
+        (nodeMenuAction)="nodeMenuAction.emit($event)"
       />
     }
   </div>

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.ts
@@ -18,15 +18,17 @@ import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatDivider } from '@angular/material/divider';
 
-import { SectionNode } from './tree.component';
+import { NodeMenuActionEvent, SectionNode } from './tree.component';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { PortalNavigationItemType } from '../../../entities/management-api-v2';
 
 @Component({
   selector: 'app-tree-node',
   standalone: true,
-  imports: [CommonModule, MatIconModule, MatButtonModule, MatMenuModule, GioPermissionModule],
+  imports: [CommonModule, MatIconModule, MatButtonModule, MatMenuModule, GioPermissionModule, MatDivider],
   templateUrl: './tree-node.component.html',
   styleUrls: ['./tree-node.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,7 +39,29 @@ export class TreeNodeComponent {
   selectedId = input<string | null>(null);
 
   nodeSelected = output<SectionNode>();
-  edit = output<SectionNode>();
+  nodeMenuAction = output<NodeMenuActionEvent>();
+
+  triggerEdit() {
+    const current = this.node();
+    if (!current) return;
+
+    this.nodeMenuAction.emit({
+      action: 'edit',
+      itemType: current.type,
+      node: current,
+    });
+  }
+
+  triggerCreate(itemType: PortalNavigationItemType) {
+    const current = this.node();
+    if (!current) return;
+
+    this.nodeMenuAction.emit({
+      action: 'create',
+      itemType,
+      node: current,
+    });
+  }
 
   isSelected = computed(() => this.selectedId() === this.node().id);
   isExpanded = signal<boolean>(true);

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.html
@@ -23,7 +23,7 @@
         [level]="0"
         [selectedId]="selectedId()"
         (nodeSelected)="select.emit($event)"
-        (edit)="edit.emit($event)"
+        (nodeMenuAction)="nodeMenuAction.emit($event)"
       ></app-tree-node>
     }
   </div>

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.ts
@@ -28,6 +28,14 @@ export interface SectionNode {
   children?: SectionNode[];
 }
 
+type NodeMenuActionType = 'create' | 'edit';
+
+export interface NodeMenuActionEvent {
+  node: SectionNode;
+  action: NodeMenuActionType;
+  itemType: PortalNavigationItemType;
+}
+
 type ProcessingNode = SectionNode & {
   __order: number;
   __parentId: string | null;
@@ -49,7 +57,7 @@ export class TreeComponent {
 
   selectedId = input<string | null>(null);
   select = output<SectionNode>();
-  edit = output<SectionNode>();
+  nodeMenuAction = output<NodeMenuActionEvent>();
 
   private mapLinksToNodes(links: PortalNavigationItem[]): SectionNode[] {
     const nodesById = this.createNodesMap(links);

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -46,7 +46,12 @@
 
     @if (menuLinks$ | async; as menuLinks) {
       <mat-card appearance="outlined" class="sections-panel__tree__container">
-        <portal-tree-component [links]="menuLinks" [selectedId]="navId()" (select)="onSelect($event)" (edit)="onEditSection($event)" />
+        <portal-tree-component
+          [links]="menuLinks"
+          [selectedId]="navId()"
+          (select)="onSelect($event)"
+          (nodeMenuAction)="onNodeMenuAction($event)"
+        />
       </mat-card>
     }
   </section>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -19,7 +19,7 @@ import { GIO_DIALOG_WIDTH, GioCardEmptyStateModule, GioConfirmDialogComponent, G
 import { Component, computed, DestroyRef, inject, NgZone, Signal, signal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { toSignal, takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
@@ -37,7 +37,7 @@ import {
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
-import { SectionNode, TreeComponent } from '../components/tree-component/tree.component';
+import { NodeMenuActionEvent, SectionNode, TreeComponent } from '../components/tree-component/tree.component';
 import {
   NewPortalNavigationItem,
   PortalArea,
@@ -146,8 +146,8 @@ export class PortalNavigationItemsComponent {
     this.manageSection(sectionType, 'create', 'TOP_NAVBAR');
   }
 
-  onEditSection(node: SectionNode) {
-    this.manageSection(node.type, 'edit', 'TOP_NAVBAR', node.data);
+  onNodeMenuAction(event: NodeMenuActionEvent) {
+    this.manageSection(event.itemType, event.action, 'TOP_NAVBAR', event.node.data);
   }
 
   onResizeStart(event: MouseEvent): void {
@@ -246,6 +246,7 @@ export class PortalNavigationItemsComponent {
               type,
               area,
               url: result.url,
+              parentId: existingItem?.id,
             });
           } else {
             if (!existingItem) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11760

## Description

- Added the ability to create a GMD page directly from the menu, available only when the navigation item is of type folder.
- If the item is not a folder, the Add GMD Page option is hidden.
- When the Add action is triggered, the existing “create” dialog is opened; cancelling closes it without changes, and confirming creates a new page under the same folder where the action was initiated.
- added test cases.


https://github.com/user-attachments/assets/8fc3897d-2e60-4967-b6fc-55f1b7b67252

<img width="490" height="524" alt="image" src="https://github.com/user-attachments/assets/dbbae797-2ad3-4087-8ce7-aabd6ca839c6" />




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

