### PR TITLE
feat: unify app type descriptions from Figma across apps

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
@@ -34,28 +34,18 @@ import { Constants } from '../../../entities/Constants';
 
 const TYPES_INFOS = {
   SIMPLE: {
-    title: 'Simple',
-    subtitle: 'A hands-free application. Using this type, you will be able to define the client_id by your own',
     icon: 'gio:hand',
   },
   BROWSER: {
-    title: 'SPA',
-    subtitle: 'Angular, React, Ember, ...',
     icon: 'gio:laptop',
   },
   WEB: {
-    title: 'Web',
-    subtitle: 'Java, .Net, ...',
     icon: 'gio:language',
   },
   NATIVE: {
-    title: 'Native',
-    subtitle: 'iOS, Android, ...',
     icon: 'gio:tablet-device',
   },
   BACKEND_TO_BACKEND: {
-    title: 'Backend to backend',
-    subtitle: 'Machine to machine',
     icon: 'gio:share-2',
   },
 };
@@ -95,8 +85,8 @@ export class ApplicationCreationComponent implements OnInit {
         return {
           ...type,
           id: type.id.toUpperCase(),
-          title: typeInfo.title,
-          subtitle: typeInfo.subtitle,
+          title: type.name,
+          subtitle: type.description,
           icon: typeInfo.icon,
         };
       }),

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -31,7 +31,7 @@
                 <mat-label i18n="@@createApplicationTypeTitleMobile">Type</mat-label>
                 <mat-select [formControl]="typeIdControl">
                   @for (type of types; track $index) {
-                    <mat-option [value]="type.id">{{ type.name }}</mat-option>
+                    <mat-option [value]="type.id">{{ type | applicationTypeTranslate: 'name' }}</mat-option>
                   }
                 </mat-select>
               </mat-form-field>
@@ -43,8 +43,8 @@
                 @for (type of types; track $index) {
                   <mat-radio-button class="type-radio" [value]="type.id ?? type.name">
                     <div class="application-type-label">
-                      <div class="m3-title-medium">{{ type.name }}</div>
-                      <div class="m3-body-small">{{ type.description }}</div>
+                      <div class="m3-title-medium">{{ type | applicationTypeTranslate: 'name' }}</div>
+                      <div class="m3-body-small">{{ type | applicationTypeTranslate: 'description' }}</div>
                     </div>
                   </mat-radio-button>
                 }

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -33,6 +33,7 @@ import { BreadcrumbNavigationComponent } from '../../../components/breadcrumb-na
 import { LoaderComponent } from '../../../components/loader/loader.component';
 import { MobileClassDirective } from '../../../directives/mobile-class.directive';
 import { ApplicationInput, ApplicationSettings, ApplicationType } from '../../../entities/application/application';
+import { ApplicationTypeTranslatePipe } from '../../../pipe/application-type-translate.pipe';
 import { ApplicationService } from '../../../services/application.service';
 import { ObservabilityBreakpointService } from '../../../services/observability-breakpoint.service';
 
@@ -54,6 +55,7 @@ interface GrantTypeVM {
 @Component({
   selector: 'app-create-application',
   imports: [
+    ApplicationTypeTranslatePipe,
     BreadcrumbNavigationComponent,
     LoaderComponent,
     MatButtonModule,

--- a/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApplicationTypeTranslatePipe } from './application-type-translate.pipe';
+import { ApplicationType } from '../entities/application/application';
+
+type LocalizeFunction = (strings: TemplateStringsArray, ...values: string[]) => string;
+type GlobalWithLocalize = typeof globalThis & { $localize?: LocalizeFunction };
+
+describe('ApplicationTypeTranslatePipe', () => {
+  const pipe = new ApplicationTypeTranslatePipe();
+  const originalLocalize = (globalThis as GlobalWithLocalize).$localize;
+
+  afterEach(() => {
+    (globalThis as GlobalWithLocalize).$localize = originalLocalize;
+  });
+
+  it('returns empty string for null/undefined or missing id', () => {
+    expect(pipe.transform(null, 'name')).toBe('');
+    expect(pipe.transform(undefined, 'name')).toBe('');
+    expect(pipe.transform({ name: 'X' } as ApplicationType, 'name')).toBe('');
+  });
+
+  describe('unknown type', () => {
+    it('falls back to backend values', () => {
+      const type: ApplicationType = { id: 'unknown', name: 'N', description: 'D' };
+      expect(pipe.transform(type, 'name')).toBe('N');
+      expect(pipe.transform(type, 'description')).toBe('D');
+    });
+
+    it('falls back to id when name missing', () => {
+      const type: ApplicationType = { id: 'unknown', name: '' };
+      expect(pipe.transform(type, 'name')).toBe('unknown');
+      expect(pipe.transform(type, 'description')).toBe('');
+    });
+  });
+
+  describe('when $localize is not available', () => {
+    beforeEach(() => {
+      delete (globalThis as GlobalWithLocalize).$localize;
+    });
+
+    it('returns backend value for known types', () => {
+      const type: ApplicationType = {
+        id: 'simple',
+        name: 'Simple',
+        description: 'Backend desc',
+      };
+
+      expect(pipe.transform(type, 'name')).toBe('Simple');
+      expect(pipe.transform(type, 'description')).toBe('Backend desc');
+    });
+  });
+
+  describe('when $localize is available', () => {
+    beforeEach(() => {
+      (globalThis as GlobalWithLocalize).$localize = (strings: TemplateStringsArray): string => {
+        const full = strings.join('');
+        const i = full.lastIndexOf(':');
+        return i >= 0 ? full.slice(i + 1) : full;
+      };
+    });
+
+    it('returns fallback EN from $localize for known type', () => {
+      const type: ApplicationType = {
+        id: 'simple',
+        name: 'Simple',
+        description: 'Backend desc',
+      };
+
+      expect(pipe.transform(type, 'name')).toBe('Simple');
+      expect(pipe.transform(type, 'description')).toBe('A standalone client where you manage your own client_id. No DCR involved.');
+    });
+
+    it('returns translated value if $localize returns different text', () => {
+      (globalThis as GlobalWithLocalize).$localize = () => '[TRANSLATED] Simple';
+
+      const type: ApplicationType = { id: 'simple', name: 'Simple' };
+      expect(pipe.transform(type, 'name')).toBe('[TRANSLATED] Simple');
+    });
+
+    it.each([
+      ['browser', 'SPA'],
+      ['web', 'Web'],
+      ['native', 'Native'],
+      ['backend_to_backend', 'Backend to backend'],
+    ])('returns EN fallback for %s name', (id, expected) => {
+      const type: ApplicationType = { id, name: expected };
+      expect(pipe.transform(type, 'name')).toBe(expected);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.ts
+++ b/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+import type { LocalizeFn } from '@angular/localize/init';
+
+import { ApplicationType } from '../entities/application/application';
+
+type ApplicationTypeField = 'name' | 'description';
+
+declare const $localize: LocalizeFn;
+
+function localizeApplicationType(typeId: string, field: ApplicationTypeField): string | null {
+  switch (`${typeId}.${field}`) {
+    case 'simple.name':
+      return $localize`:@@applicationType.simple.name:Simple`;
+    case 'simple.description':
+      return $localize`:@@applicationType.simple.description:A standalone client where you manage your own client_id. No DCR involved.`;
+
+    case 'browser.name':
+      return $localize`:@@applicationType.browser.name:SPA`;
+    case 'browser.description':
+      return $localize`:@@applicationType.browser.description:Front-end JS apps (React, Angular, Vue) using DCR for authentication.`;
+
+    case 'web.name':
+      return $localize`:@@applicationType.web.name:Web`;
+    case 'web.description':
+      return $localize`:@@applicationType.web.description:Server-side web apps (e.g., .NET, Java) that authenticate users through DCR.`;
+
+    case 'native.name':
+      return $localize`:@@applicationType.native.name:Native`;
+    case 'native.description':
+      return $localize`:@@applicationType.native.description:Mobile and desktop apps (iOS, Android) that authenticate through DCR.`;
+
+    case 'backend_to_backend.name':
+      return $localize`:@@applicationType.backendToBackend.name:Backend to backend`;
+    case 'backend_to_backend.description':
+      return $localize`:@@applicationType.backendToBackend.description:Machine-to-machine apps (scripts, daemons, CLIs) using DCR for API access.`;
+
+    default:
+      return null;
+  }
+}
+
+@Pipe({
+  name: 'applicationTypeTranslate',
+  standalone: true,
+})
+export class ApplicationTypeTranslatePipe implements PipeTransform {
+  transform(type: ApplicationType | null | undefined, field: ApplicationTypeField): string {
+    if (!type?.id) {
+      return '';
+    }
+
+    const backendValue = field === 'name' ? type.name || type.id : type.description || '';
+
+    if (typeof $localize === 'undefined') {
+      return backendValue;
+    }
+
+    const translated = localizeApplicationType(type.id, field);
+    return translated ?? backendValue;
+  }
+}

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -598,15 +598,15 @@
   },
   "applicationType": {
     "backend_to_backend": {
-      "description": "Machine to machine",
+      "description": "Machine-to-machine apps (scripts, daemons, CLIs) using DCR for API access.",
       "title": "Backend to backend"
     },
     "browser": {
-      "description": "Angular, React, ...",
+      "description": "Front-end JS apps (React, Angular, Vue) using DCR for authentication.",
       "title": "SPA"
     },
     "native": {
-      "description": "iOS, Android, ...",
+      "description": "Mobile and desktop apps (iOS, Android) that authenticate through DCR.",
       "title": "Native"
     },
     "security": {
@@ -660,11 +660,11 @@
       }
     },
     "simple": {
-      "description": "A hands-free application.<br/>Using this type, you will be able to define the client_id by your own.",
+      "description": "A standalone client where you manage your own client_id. No DCR involved.",
       "title": "Simple"
     },
     "web": {
-      "description": "Java, .Net, ...",
+      "description": "Server-side web apps (e.g., .NET, Java) that authenticate users through DCR.",
       "title": "Web"
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/applications/types.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/applications/types.json
@@ -1,170 +1,145 @@
 {
-  "data": [
-    {
-      "id": "simple",
-      "name": "Simple",
-      "description": "A hands-free application. Using this type, you will be able to define the client_id by your own.",
-      "requires_redirect_uris": false,
-      "allowed_grant_types": [],
-      "default_grant_types": [],
-      "mandatory_grant_types": []
-    },
-    {
-      "id": "browser",
-      "name": "SPA",
-      "description": "Angular, React, Ember, ...",
-      "requires_redirect_uris": true,
-      "allowed_grant_types": [
+    "data": [
         {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
+            "id": "simple",
+            "name": "Simple",
+            "description": "A standalone client where you manage your own client_id. No DCR involved.",
+            "requires_redirect_uris": false,
+            "allowed_grant_types": [],
+            "default_grant_types": [],
+            "mandatory_grant_types": []
         },
         {
-          "type": "implicit",
-          "name": "Implicit",
-          "response_types": [
-            "token",
-            "id_token"
-          ]
-        }
-      ],
-      "default_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
-        }
-      ],
-      "mandatory_grant_types": []
-    },
-    {
-      "id": "web",
-      "name": "Web",
-      "description": "Java, .Net, ...",
-      "requires_redirect_uris": true,
-      "allowed_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
+            "id": "browser",
+            "name": "SPA",
+            "description": "Front-end JS apps (React, Angular, Vue) using DCR for authentication.",
+            "requires_redirect_uris": true,
+            "allowed_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                },
+                {
+                    "type": "implicit",
+                    "name": "Implicit",
+                    "response_types": ["token", "id_token"]
+                }
+            ],
+            "default_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                }
+            ],
+            "mandatory_grant_types": []
         },
         {
-          "type": "refresh_token",
-          "name": "Refresh Token",
-          "response_types": []
+            "id": "web",
+            "name": "Web",
+            "description": "Server-side web apps (e.g., .NET, Java) that authenticate users through DCR.",
+            "requires_redirect_uris": true,
+            "allowed_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                },
+                {
+                    "type": "refresh_token",
+                    "name": "Refresh Token",
+                    "response_types": []
+                },
+                {
+                    "type": "implicit",
+                    "name": "Implicit (Hybrid)",
+                    "response_types": ["token", "id_token"]
+                }
+            ],
+            "default_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                }
+            ],
+            "mandatory_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                }
+            ]
         },
         {
-          "type": "implicit",
-          "name": "Implicit (Hybrid)",
-          "response_types": [
-            "token",
-            "id_token"
-          ]
-        }
-      ],
-      "default_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
-        }
-      ],
-      "mandatory_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
-        }
-      ]
-    },
-    {
-      "id": "native",
-      "name": "Native",
-      "description": "iOS, Android, ...",
-      "requires_redirect_uris": true,
-      "allowed_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
+            "id": "native",
+            "name": "Native",
+            "description": "Mobile and desktop apps (iOS, Android) that authenticate through DCR.",
+            "requires_redirect_uris": true,
+            "allowed_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                },
+                {
+                    "type": "refresh_token",
+                    "name": "Refresh Token",
+                    "response_types": []
+                },
+                {
+                    "type": "password",
+                    "name": "Resource Owner Password",
+                    "response_types": []
+                },
+                {
+                    "type": "implicit",
+                    "name": "Implicit (Hybrid)",
+                    "response_types": ["token", "id_token"]
+                }
+            ],
+            "default_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                }
+            ],
+            "mandatory_grant_types": [
+                {
+                    "type": "authorization_code",
+                    "name": "Authorization Code",
+                    "response_types": ["code"]
+                }
+            ]
         },
         {
-          "type": "refresh_token",
-          "name": "Refresh Token",
-          "response_types": []
-        },
-        {
-          "type": "password",
-          "name": "Resource Owner Password",
-          "response_types": []
-        },
-        {
-          "type": "implicit",
-          "name": "Implicit (Hybrid)",
-          "response_types": [
-            "token",
-            "id_token"
-          ]
+            "id": "backend_to_backend",
+            "name": "Backend to backend",
+            "description": "Machine-to-machine apps (scripts, daemons, CLIs) using DCR for API access.",
+            "requires_redirect_uris": false,
+            "allowed_grant_types": [
+                {
+                    "type": "client_credentials",
+                    "name": "Client Credentials",
+                    "response_types": []
+                }
+            ],
+            "default_grant_types": [
+                {
+                    "type": "client_credentials",
+                    "name": "Client Credentials",
+                    "response_types": []
+                }
+            ],
+            "mandatory_grant_types": [
+                {
+                    "type": "client_credentials",
+                    "name": "Client Credentials",
+                    "response_types": []
+                }
+            ]
         }
-      ],
-      "default_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
-        }
-      ],
-      "mandatory_grant_types": [
-        {
-          "type": "authorization_code",
-          "name": "Authorization Code",
-          "response_types": [
-            "code"
-          ]
-        }
-      ]
-    },
-    {
-      "id": "backend_to_backend",
-      "name": "Backend to backend",
-      "description": "Machine to machine",
-      "requires_redirect_uris": false,
-      "allowed_grant_types": [
-        {
-          "type": "client_credentials",
-          "name": "Client Credentials",
-          "response_types": []
-        }
-      ],
-      "default_grant_types": [
-        {
-          "type": "client_credentials",
-          "name": "Client Credentials",
-          "response_types": []
-        }
-      ],
-      "mandatory_grant_types": [
-        {
-          "type": "client_credentials",
-          "name": "Client Credentials",
-          "response_types": []
-        }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12096

## Description

Implement the Figma app type description in the type selection field 

All application type texts are compile-time constants, so Angular i18n can extract and handle them properly.
We also keep a backend fallback for unknown types or missing translations.

Also, modify the Console to fetch the value from the backend, and in the Old portal, update the eng version as well

## Additional context

Next Gen Portal: 
<img width="1505" height="772" alt="Zrzut ekranu 2025-12-9 o 16 09 28" src="https://github.com/user-attachments/assets/ec245cb7-06c1-41e7-b9fa-a8805079947a" />

Old Portal: 
<img width="1474" height="761" alt="Zrzut ekranu 2025-12-9 o 16 07 10" src="https://github.com/user-attachments/assets/a1ea8438-f195-4208-8f19-32d32341c4d6" />

Console: 
<img width="1127" height="614" alt="Zrzut ekranu 2025-12-9 o 16 25 18" src="https://github.com/user-attachments/assets/ebd1ca60-353a-4dd6-a69d-6bb696cf65df" />


