### PR TITLE
feat(console): Add a Link and Folder item to a folder nav item

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
@@ -64,13 +64,21 @@
   <mat-menu #moreMenu="matMenu">
     @if (node()?.type === 'FOLDER') {
       <button mat-menu-item (click)="triggerCreate('PAGE')">
-        <mat-icon>description</mat-icon>
+        <mat-icon svgIcon="gio:page"></mat-icon>
         Add Page
+      </button>
+      <button mat-menu-item (click)="triggerCreate('FOLDER')">
+        <mat-icon svgIcon="gio:folder"></mat-icon>
+        Add Folder
+      </button>
+      <button mat-menu-item (click)="triggerCreate('LINK')">
+        <mat-icon svgIcon="gio:link"></mat-icon>
+        Add Link
       </button>
     }
     <mat-divider></mat-divider>
     <button mat-menu-item (click)="triggerEdit()">
-      <mat-icon>edit</mat-icon>
+      <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
       Edit
     </button>
   </mat-menu>

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.spec.ts
@@ -16,18 +16,27 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { By } from '@angular/platform-browser';
+import { By, ɵSharedStylesHost as SharedStylesHost } from '@angular/platform-browser';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
 
 import { TreeNodeComponent } from './tree-node.component';
 import { SectionNode } from './tree.component';
 
 import { GioTestingModule } from '../../../shared/testing';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+// Angular's JSDOM environment (used by Jest) currently cannot parse some modern CSS constructs
+// like `@layer` used by Angular CDK. When Material menus/overlays load, the CDK injects styles
+// into <style> tags and jsdom tries (and fails) to parse them, producing noisy errors.
+// To avoid this in unit tests, we provide a no-op SharedStylesHost so no styles are injected.
+// This relies on Angular's internal symbol which is acceptable in tests.
 
 describe('TreeNodeComponent', () => {
   let fixture: ComponentFixture<TreeNodeComponent>;
   let component: TreeNodeComponent;
+  let rootLoader: HarnessLoader;
 
   const baseNode: SectionNode = {
     id: 'n1',
@@ -45,11 +54,27 @@ describe('TreeNodeComponent', () => {
             hasAnyMatching: jest.fn().mockReturnValue(true),
           },
         },
+        // Prevent Angular from injecting style tags (which jsdom can't parse due to `@layer`).
+        {
+          provide: SharedStylesHost,
+          useValue: {
+            // no-op implementations used by Angular internally
+            addStyles: () => {},
+            addStyle: () => {},
+            addHost: () => {},
+            removeHost: () => {},
+            ngOnDestroy: () => {},
+            onStylesAdded: () => {},
+            addUsage: () => {},
+            removeUsage: () => {},
+          },
+        },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TreeNodeComponent);
     component = fixture.componentInstance;
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.componentRef.setInput('node', baseNode);
     fixture.componentRef.setInput('level', 0);
     fixture.componentRef.setInput('selectedId', null);
@@ -153,5 +178,100 @@ describe('TreeNodeComponent', () => {
     const moreBtn = fixture.debugElement.query(By.css('.tree__button.more-actions'));
     expect(moreBtn).toBeTruthy();
     expect(moreBtn.nativeElement.getAttribute('aria-label')).toBe('More actions');
+  });
+
+  it('should display add page/folder/link menu items for folder and emit corresponding actions', async () => {
+    const folderNode: SectionNode = {
+      id: 'f3',
+      label: 'Folder 3',
+      type: 'FOLDER',
+    };
+
+    fixture.componentRef.setInput('node', folderNode);
+    fixture.detectChanges();
+
+    const actionSpy = jest.fn();
+    component.nodeMenuAction.subscribe(actionSpy);
+
+    // Open the Angular Material menu via the trigger (renders in overlay)
+    const triggerBtn = fixture.debugElement.query(By.css('.tree__button.more-actions'));
+    expect(triggerBtn).toBeTruthy();
+    triggerBtn.nativeElement.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Assert items are present in the overlay and click them using harnesses
+    const menu = await rootLoader.getHarness(MatMenuHarness);
+    expect(menu).toBeTruthy();
+
+    const addPageItem = await rootLoader.getHarness(MatMenuItemHarness.with({ text: /Add Page/i }));
+    const addFolderItem = await rootLoader.getHarness(MatMenuItemHarness.with({ text: /Add Folder/i }));
+    const addLinkItem = await rootLoader.getHarness(MatMenuItemHarness.with({ text: /Add Link/i }));
+
+    expect(addPageItem).toBeTruthy();
+    expect(addFolderItem).toBeTruthy();
+    expect(addLinkItem).toBeTruthy();
+
+    await addPageItem.click();
+    await addFolderItem.click();
+    await addLinkItem.click();
+    fixture.detectChanges();
+
+    expect(actionSpy).toHaveBeenCalledTimes(3);
+    expect(actionSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'create',
+        itemType: 'PAGE',
+        node: folderNode,
+      }),
+    );
+    expect(actionSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: 'create',
+        itemType: 'FOLDER',
+        node: folderNode,
+      }),
+    );
+    expect(actionSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        action: 'create',
+        itemType: 'LINK',
+        node: folderNode,
+      }),
+    );
+  });
+
+  it('should render correct icons for node type and toggle state', () => {
+    // For PAGE node, type icon should be gio:page
+    let typeIcon = fixture.debugElement.query(By.css('.tree__icon.tree__icon__type'));
+    expect(typeIcon.attributes['ng-reflect-svg-icon'] || typeIcon.attributes['svgicon'] || '').toContain('gio:page');
+
+    // Switch to FOLDER node
+    const folderNode: SectionNode = {
+      id: 'f4',
+      label: 'Folder 4',
+      type: 'FOLDER',
+      children: [],
+    };
+    fixture.componentRef.setInput('node', folderNode);
+    fixture.detectChanges();
+
+    typeIcon = fixture.debugElement.query(By.css('.tree__icon.tree__icon__type'));
+    expect(typeIcon.attributes['ng-reflect-svg-icon'] || typeIcon.attributes['svgicon'] || '').toContain('gio:folder');
+
+    const toggleIcon = fixture.debugElement.query(By.css('.tree__icon[data-test-icon="toggle"]'));
+    // Expanded by default -> down icon
+    expect(toggleIcon.attributes['ng-reflect-svg-icon'] || toggleIcon.attributes['svgicon'] || '').toContain('gio:nav-arrow-down');
+
+    // Collapse -> right icon
+    toggleIcon.triggerEventHandler('click', { stopPropagation: jest.fn() });
+    fixture.detectChanges();
+    const toggleIconCollapsed = fixture.debugElement.query(By.css('.tree__icon[data-test-icon="toggle"]'));
+    expect(toggleIconCollapsed.attributes['ng-reflect-svg-icon'] || toggleIconCollapsed.attributes['svgicon'] || '').toContain(
+      'gio:nav-arrow-right',
+    );
   });
 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11766

## Description

- Added the ability to create a link and folder directly from the menu, available only when the navigation item is of type folder.
- If the item is not a folder, the Add link and folder option is hidden.
- When the Add action is triggered, the existing “create” dialog is opened; cancelling closes it without changes, and confirming creates a new link and folder under the same folder where the action was initiated.
- added test cases.


https://github.com/user-attachments/assets/7d460f91-9e2d-4ff5-8e72-a59ca3d2d711



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

