### PR TITLE
Update OpenAPI schema for analytics filters and intervals

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
@@ -27,7 +27,6 @@ import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ArrayFilter;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Bucket;
@@ -37,7 +36,6 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetMetri
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponseMetricsInner;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Interval;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Measure;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricRequest;
@@ -49,7 +47,6 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeries
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucketLeaf;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponseMetricsInner;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -159,23 +156,4 @@ public interface AnalyticsMeasuresMapper {
 
     @Mapping(target = "facets", source = "by")
     TimeSeriesRequest fromRequestEntity(io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesRequest requestEntity);
-
-    default Long parseInterval(Interval interval) {
-        return parseIntervalDuration(interval).toMillis();
-    }
-
-    default Duration parseIntervalDuration(Interval interval) {
-        return switch (interval.getActualInstance()) {
-            case Number n -> Duration.ofMillis(n.longValue());
-            case String s -> parseDurationString(s);
-            default -> throw new TechnicalDomainException("unknown value type for interval");
-        };
-    }
-
-    default Duration parseDurationString(String s) {
-        if (s.endsWith("d")) {
-            return Duration.parse("P" + s.toUpperCase());
-        }
-        return Duration.parse("PT" + s);
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1267,7 +1267,7 @@ components:
                 operator:
                     $ref: "#/components/schemas/Operator"
                 value:
-                    type: number
+                    type: integer
                     description: Filter value (number for LTE/GTE)
             example: { name: "HTTP_STATUS", operator: "GTE", value: 200 }
 
@@ -1285,7 +1285,7 @@ components:
                     items:
                         oneOf:
                             - type: string
-                            - type: number
+                            - type: integer
                     description: Filter value (array for IN operator)
             example: { name: "HTTP_STATUS_CODE_GROUP", operator: "IN", value: ["2xx", "3xx"] }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -554,7 +554,7 @@ paths:
                   timeRange:
                     from: "2025-11-22T16:40:30Z"
                     to: "2025-11-22T16:45:30Z"
-                  interval: 1m
+                  interval: 3600000
                   metrics:
                     - name: "HTTP_REQUESTS"
                       measures: [ "COUNT" ]
@@ -564,7 +564,7 @@ paths:
                   timeRange:
                     from: "2025-11-22T16:40:30Z"
                     to: "2025-11-22T16:45:30Z"
-                  interval: 1m
+                  interval: 3600000
                   metrics:
                     - name: "HTTP_REQUESTS"
                       measures: [ "COUNT" ]
@@ -576,7 +576,7 @@ paths:
                   timeRange:
                     from: "2025-11-22T16:40:30Z"
                     to: "2025-11-22T16:45:30Z"
-                  interval: 1m
+                  interval: 60000
                   by: [ "API" ]
                   ranges: [
                     { from: 100, to: 399 },
@@ -1436,7 +1436,7 @@ components:
                 timeRange:
                     from: "2025-01-01T00:00:00Z"
                     to: "2025-01-31T23:59:59Z"
-                interval: 1h
+                interval: 3600000
                 by: ["API"]
                 filters:
                     - name: "API"
@@ -1778,7 +1778,7 @@ components:
                     example:
                         name: "HTTP_REQUESTS"
                         type: "TIME_SERIES"
-                        interval: "-1d"
+                        interval: -3600000
                 details:
                     type: array
                     description: A list of details about the error

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1283,9 +1283,7 @@ components:
                 value:
                     type: array
                     items:
-                        oneOf:
-                            - type: string
-                            - type: integer
+                        type: string
                     description: Filter value (array for IN operator)
             example: { name: "HTTP_STATUS_CODE_GROUP", operator: "IN", value: ["2xx", "3xx"] }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1191,15 +1191,9 @@ components:
         Interval:
           description: |
             A fixed time interval for time series analytics queries.
-            Fixed intervals can be expressed as a duration string (e.g. "1h", "24h") or as a number of milliseconds.
-          oneOf:
-                - type: string
-                  pattern: ^\d+[smhd]$
-                  description: Shorthand for expressing interval in seconds, minutes, hours or days as a string
-                  example: "1s"
-                - type: number
-                  description: Interval in milliseconds
-                  example: 1000
+            Intervals are be expressed in milliseconds.
+          type: integer
+          example: 1000
 
         TimeRange:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
@@ -19,7 +19,6 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetMetri
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsRequest;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Filter;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Interval;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasureName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresRequest;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricName;
@@ -63,7 +62,7 @@ public class AnalyticsEngineFixtures {
 
         return new TimeSeriesRequest()
             .timeRange(timeRange())
-            .interval(new Interval("1h"))
+            .interval(3600000)
             .filters(Arrays.asList(filters))
             .ranges(List.of(new NumberRange().from(100).to(199), new NumberRange().from(200).to(299)))
             .metrics(List.of(metric));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -40,7 +40,6 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.BucketLeaf
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponseMetricsInner;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Interval;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Measure;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasureName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresResponse;
@@ -363,7 +362,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
 
         @Test
         void should_fail_with_negative_interval() {
-            var invalidRequest = aRequestCountTimeSeries().interval(new Interval("-1m"));
+            var invalidRequest = aRequestCountTimeSeries().interval(-60000);
             var response = rootTarget().path("time-series").request().post(Entity.json(invalidRequest));
 
             assertThat(response).hasStatus(400);


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/GKO-1942

## Description

This PR updates the OpenAPI schema for analytics to:
- Enforce the `number` type for interval definitions.
- Enforce the `string` type for filter values in the `IN` operator.
- Change filter values type from `number` to `integer`.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->