### PR TITLE
feat(portal): implement additional client metadata in application creation form

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -147,6 +147,17 @@
                     >The client_certificate of the application. This field is required to subscribe to certain mTLS plans.
                   </mat-hint>
                 </mat-form-field>
+
+                @if (!isSimpleType()) {
+                  <div class="metadata-container">
+                    <div>
+                      <div class="m3-title-medium">
+                        <span i18n="@@createApplicationAdditionalMetadataTitle">Additional Client Metadata (optional)</span>
+                      </div>
+                    </div>
+                    <app-form-key-value-pairs formControlName="metadata" />
+                  </div>
+                }
               </form>
             } @else {
               <p i18n="@@selectApplicationTypeFirst">Please select an application type first</p>

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.scss
@@ -86,6 +86,12 @@
   gap: 12px;
 }
 
+.metadata-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .grant-type-toggle {
   display: flex;
   align-items: center;

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -30,6 +30,7 @@ import { Router } from '@angular/router';
 import { startWith } from 'rxjs';
 
 import { BreadcrumbNavigationComponent } from '../../../components/breadcrumb-navigation/breadcrumb-navigation.component';
+import { FormKeyValuePairsComponent } from '../../../components/form-key-value-pairs/form-key-value-pairs.component';
 import { LoaderComponent } from '../../../components/loader/loader.component';
 import { MobileClassDirective } from '../../../directives/mobile-class.directive';
 import { ApplicationInput, ApplicationSettings, ApplicationType } from '../../../entities/application/application';
@@ -43,6 +44,7 @@ type BaseControls = {
   clientCertificate: FormControl<string>;
   appType: FormControl<string>;
   appClientId: FormControl<string>;
+  metadata: FormControl<Record<string, string> | null>;
   dynamic: FormRecord<FormControl<unknown>>;
 };
 
@@ -57,6 +59,7 @@ interface GrantTypeVM {
   imports: [
     ApplicationTypeTranslatePipe,
     BreadcrumbNavigationComponent,
+    FormKeyValuePairsComponent,
     LoaderComponent,
     MatButtonModule,
     MatCard,
@@ -93,6 +96,7 @@ export class CreateApplicationComponent {
     clientCertificate: new FormControl('', { nonNullable: true }),
     appType: new FormControl('', { nonNullable: true }),
     appClientId: new FormControl('', { nonNullable: true }),
+    metadata: new FormControl<Record<string, string> | null>(null, { nonNullable: false }),
     dynamic: new FormRecord<FormControl<unknown>>({}),
   });
 
@@ -311,12 +315,14 @@ export class CreateApplicationComponent {
       : (() => {
           const grantTypes = (formValue.dynamic?.['grantTypes'] as string[] | undefined) ?? [];
           const redirectUris = (formValue.dynamic?.['redirectUris'] as string[] | undefined) ?? [];
+          const metadata = formValue.metadata ?? null;
 
           return {
             oauth: {
               application_type: selectedType.id || selectedType.name || undefined,
               grant_types: grantTypes.length > 0 ? grantTypes : undefined,
               redirect_uris: redirectUris.length > 0 ? redirectUris : undefined,
+              additional_client_metadata: metadata && Object.keys(metadata).length > 0 ? metadata : undefined,
             },
           };
         })();

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.html
@@ -1,0 +1,71 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div [appIsMobile]="'table-mobile'">
+  <table class="table-light table-light--fit-content form-key-value-pairs__table">
+    <thead>
+      <tr class="form-key-value-pairs__table__header-row">
+        <th class="mat-column-key m3-title-medium">KEY</th>
+        <th class="mat-column-value m3-title-medium">VALUE</th>
+        <th class="mat-column-actions"></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      @for (control of metadataFormArray.controls; track i; let i = $index) {
+        <tr [formGroup]="control">
+          <td class="mat-column-key">
+            <mat-form-field appearance="outline" class="form-key-value-pairs__table__form-field" subscriptSizing="dynamic">
+              <input
+                [id]="'key-value-key-' + i"
+                formControlName="key"
+                matInput
+                placeholder="Name..."
+                class="m3-body-medium"
+                (blur)="onTouched()" />
+            </mat-form-field>
+          </td>
+
+          <td class="mat-column-value">
+            <mat-form-field appearance="outline" class="form-key-value-pairs__table__form-field" subscriptSizing="dynamic">
+              <input
+                [id]="'key-value-value-' + i"
+                formControlName="value"
+                matInput
+                placeholder="Value..."
+                class="m3-body-medium"
+                (blur)="onTouched()" />
+            </mat-form-field>
+          </td>
+
+          <td class="mat-column-actions form-key-value-pairs__table__cell-actions">
+            @if (isDeleteVisible(i)) {
+              <button
+                class="form-key-value-pairs--delete-button"
+                mat-icon-button
+                aria-label="Delete"
+                [disabled]="metadataFormArray.disabled"
+                (click)="onDeletePair(i)">
+                <mat-icon>close_small</mat-icon>
+              </button>
+            }
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.scss
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/theme';
+@use '@angular/material' as mat;
+
+:host {
+  display: block;
+  margin-bottom: 18px;
+}
+
+.table-mobile {
+  overflow-x: auto;
+}
+
+.form-key-value-pairs {
+  &__table {
+    width: 100%;
+
+    .mat-column-actions {
+      width: 5%;
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    thead {
+      background-color: color-mix(in srgb, theme.$primary-main-color 8%, theme.$card-background-color);
+
+      th {
+        padding: 12px 24px;
+      }
+
+      .mat-column-actions {
+        width: 5%;
+      }
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    &__cell-actions {
+      padding-right: 8px;
+    }
+
+    &__form-field {
+      display: block;
+      width: 100%;
+      padding-top: 0;
+      margin: 0;
+
+      @include mat.form-field-overrides(
+        (
+          container-height: 36px,
+          container-vertical-padding: 6px,
+          subscript-text-line-height: 0,
+          subscript-text-size: 0,
+          outlined-outline-width: 0,
+          outlined-focus-outline-width: 0,
+          outlined-outline-color: transparent,
+          filled-container-color: transparent,
+          filled-disabled-container-color: transparent,
+        )
+      );
+
+      .mat-mdc-form-field-flex {
+        width: 100%;
+      }
+    }
+  }
+
+  &--delete-button {
+    color: theme.$default-text-color;
+    opacity: 0.6;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      color: theme.$error-main-color;
+      opacity: 1;
+      transform: scale(1.1);
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.spec.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { FormKeyValuePairsComponent } from './form-key-value-pairs.component';
+
+describe('FormKeyValuePairsComponent', () => {
+  let component: FormKeyValuePairsComponent;
+  let fixture: ComponentFixture<FormKeyValuePairsComponent>;
+
+  beforeEach(waitForAsync(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormKeyValuePairsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormKeyValuePairsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }));
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('initial state', () => {
+    it('starts with a single empty pair', () => {
+      expect(component.metadataFormArray.value).toEqual([{ key: '', value: '' }]);
+    });
+  });
+
+  describe('writeValue (CVA)', () => {
+    it('populates pairs from Record and keeps trailing empty row', () => {
+      component.writeValue({ 'app-name': 'MyApp', version: '1.0' });
+
+      expect(component.metadataFormArray.value).toEqual([
+        { key: 'app-name', value: 'MyApp' },
+        { key: 'version', value: '1.0' },
+        { key: '', value: '' },
+      ]);
+    });
+
+    it('trims keys and values when writing', () => {
+      component.writeValue({ '  key  ': '  value  ' });
+
+      expect(component.metadataFormArray.value).toEqual([
+        { key: 'key', value: 'value' },
+        { key: '', value: '' },
+      ]);
+    });
+
+    it('clears pairs when null is written, leaving only trailing empty row', () => {
+      component.writeValue({ k1: 'v1' });
+      expect(component.metadataFormArray.length).toBeGreaterThan(0);
+
+      component.writeValue(null);
+
+      expect(component.metadataFormArray.value).toEqual([{ key: '', value: '' }]);
+    });
+  });
+
+  describe('change propagation (registerOnChange)', () => {
+    it('calls onChange with Record when user edits a row', waitForAsync(async () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.metadataFormArray.at(0).patchValue({ key: 'test-key', value: 'test-value' });
+
+      await fixture.whenStable();
+
+      expect(onChangeSpy).toHaveBeenLastCalledWith({ 'test-key': 'test-value' });
+    }));
+
+    it('filters out empty pairs from onChange payload', waitForAsync(async () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.metadataFormArray.at(0).patchValue({ key: 'valid-key', value: 'valid-value' });
+      await fixture.whenStable();
+
+      // trailing row should exist already; keep it empty
+      const trailingIndex = component.metadataFormArray.length - 1;
+      component.metadataFormArray.at(trailingIndex).patchValue({ key: '', value: '' });
+      await fixture.whenStable();
+
+      expect(onChangeSpy).toHaveBeenLastCalledWith({ 'valid-key': 'valid-value' });
+    }));
+
+    it('overwrites duplicate keys with the last value', waitForAsync(async () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.metadataFormArray.at(0).patchValue({ key: 'dup', value: 'v1' });
+      await fixture.whenStable();
+
+      const trailingIndex = component.metadataFormArray.length - 1;
+      component.metadataFormArray.at(trailingIndex).patchValue({ key: 'dup', value: 'v2' });
+      await fixture.whenStable();
+
+      expect(onChangeSpy).toHaveBeenLastCalledWith({ dup: 'v2' });
+    }));
+
+    it('adds a new trailing empty row when the last row becomes non-empty', waitForAsync(async () => {
+      component.metadataFormArray.at(0).patchValue({ key: 'k1', value: 'v1' });
+
+      await fixture.whenStable();
+
+      expect(component.metadataFormArray.value).toEqual([
+        { key: 'k1', value: 'v1' },
+        { key: '', value: '' },
+      ]);
+    }));
+
+    it('does not add extra trailing row if last row is still empty', waitForAsync(async () => {
+      component.metadataFormArray.at(0).patchValue({ key: '', value: '' });
+
+      await fixture.whenStable();
+
+      expect(component.metadataFormArray.length).toBe(1);
+    }));
+  });
+
+  describe('touched propagation (registerOnTouched)', () => {
+    it('calls onTouched on explicit blur hook', () => {
+      const onTouchedSpy = jest.fn();
+      component.registerOnTouched(onTouchedSpy);
+
+      component.onTouched();
+
+      expect(onTouchedSpy).toHaveBeenCalled();
+    });
+
+    it('calls onTouched when deleting a row', () => {
+      component.writeValue({ key1: 'val1', key2: 'val2' });
+
+      const onTouchedSpy = jest.fn();
+      component.registerOnTouched(onTouchedSpy);
+
+      component.onDeletePair(0);
+
+      expect(onTouchedSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state (setDisabledState)', () => {
+    it('disables the form array', () => {
+      component.setDisabledState(true);
+      expect(component.metadataFormArray.disabled).toBe(true);
+    });
+
+    it('enables the form array back', () => {
+      component.setDisabledState(true);
+      component.setDisabledState(false);
+      expect(component.metadataFormArray.enabled).toBe(true);
+    });
+
+    it('removes trailing empty row when disabled', waitForAsync(async () => {
+      component.metadataFormArray.at(0).patchValue({ key: 'k1', value: 'v1' });
+      await fixture.whenStable();
+
+      expect(component.metadataFormArray.length).toBe(2);
+
+      component.setDisabledState(true);
+      await fixture.whenStable();
+
+      expect(component.metadataFormArray.value).toEqual([{ key: 'k1', value: 'v1' }]);
+    }));
+
+    it('restores trailing empty row when enabled again', waitForAsync(async () => {
+      component.metadataFormArray.at(0).patchValue({ key: 'k1', value: 'v1' });
+      await fixture.whenStable();
+
+      component.setDisabledState(true);
+      await fixture.whenStable();
+
+      component.setDisabledState(false);
+      await fixture.whenStable();
+
+      expect(component.metadataFormArray.value).toEqual([
+        { key: 'k1', value: 'v1' },
+        { key: '', value: '' },
+      ]);
+    }));
+  });
+
+  describe('deleting pairs', () => {
+    it('removes the pair at given index', () => {
+      component.writeValue({ key1: 'val1', key2: 'val2' });
+      const initialLength = component.metadataFormArray.length;
+
+      component.onDeletePair(0);
+
+      expect(component.metadataFormArray.length).toBe(initialLength - 1);
+      expect(component.metadataFormArray.at(0).value).toEqual({ key: 'key2', value: 'val2' });
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgIf } from '@angular/common';
+import { Component, DestroyRef, forwardRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor, FormArray, FormControl, FormGroup, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { map, tap } from 'rxjs/operators';
+
+import { MobileClassDirective } from '../../directives/mobile-class.directive';
+
+export interface KeyValuePair {
+  key: string;
+  value: string;
+}
+
+@Component({
+  selector: 'app-form-key-value-pairs',
+  templateUrl: './form-key-value-pairs.component.html',
+  styleUrls: ['./form-key-value-pairs.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => FormKeyValuePairsComponent),
+      multi: true,
+    },
+  ],
+  standalone: true,
+  imports: [ReactiveFormsModule, MatFormFieldModule, MatIconModule, MatInputModule, MatButtonModule, MobileClassDirective, NgIf],
+})
+export class FormKeyValuePairsComponent implements OnInit, ControlValueAccessor {
+  public metadataFormArray = new FormArray([
+    new FormGroup({
+      key: new FormControl(''),
+      value: new FormControl(''),
+    }),
+  ]);
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  public ngOnInit(): void {
+    this.metadataFormArray.valueChanges
+      .pipe(
+        map(pairs =>
+          pairs.map(pair => ({
+            key: (pair.key ?? '').trim(),
+            value: (pair.value ?? '').trim(),
+          })),
+        ),
+        tap(pairs => {
+          const validPairs = pairs.filter(p => p.key || p.value);
+          this._onChange(this.toRecord(validPairs));
+          this.ensureTrailingEmptyRow();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  public writeValue(value: Record<string, string> | null): void {
+    this.metadataFormArray.clear({ emitEvent: false });
+
+    if (value) {
+      Object.entries(value).forEach(([key, val]) => {
+        this.metadataFormArray.push(
+          new FormGroup({
+            key: new FormControl(key.trim()),
+            value: new FormControl(val.trim()),
+          }),
+          { emitEvent: false },
+        );
+      });
+    }
+
+    this.ensureTrailingEmptyRow();
+  }
+
+  public registerOnChange(fn: (value: Record<string, string> | null) => void): void {
+    this._onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    isDisabled ? this.metadataFormArray.disable({ emitEvent: false }) : this.metadataFormArray.enable({ emitEvent: false });
+    this.ensureTrailingEmptyRow();
+  }
+
+  public onDeletePair(pairIndex: number): void {
+    this._onTouched();
+    this.metadataFormArray.removeAt(pairIndex);
+  }
+
+  public onTouched(): void {
+    this._onTouched();
+  }
+
+  isDeleteVisible(i: number): boolean {
+    return !this.metadataFormArray.disabled && i < this.metadataFormArray.length - 1;
+  }
+
+  private _onChange: (_value: Record<string, string> | null) => void = () => ({});
+  private _onTouched: () => void = () => ({});
+
+  private ensureTrailingEmptyRow(): void {
+    if (this.metadataFormArray.disabled) {
+      const lastIndex = this.metadataFormArray.length - 1;
+      const lastControl = lastIndex >= 0 ? this.metadataFormArray.at(lastIndex) : null;
+      const isEmpty = lastControl && !lastControl.get('key')?.value && !lastControl.get('value')?.value;
+      if (isEmpty && lastIndex >= 0) {
+        this.metadataFormArray.removeAt(lastIndex, { emitEvent: false });
+      }
+      return;
+    }
+
+    if (this.metadataFormArray.length === 0) {
+      this.metadataFormArray.push(this.createEmptyGroup(), { emitEvent: false });
+      return;
+    }
+
+    const lastControl = this.metadataFormArray.at(-1) as FormGroup;
+    const lastIsEmpty = !lastControl.get('key')?.value && !lastControl.get('value')?.value;
+
+    if (!lastIsEmpty) {
+      this.metadataFormArray.push(this.createEmptyGroup(), { emitEvent: false });
+    }
+  }
+
+  private createEmptyGroup(): FormGroup {
+    return new FormGroup({
+      key: new FormControl(''),
+      value: new FormControl(''),
+    });
+  }
+
+  private toRecord(pairs: KeyValuePair[] | null): Record<string, string> | null {
+    if (!pairs || pairs.length === 0) {
+      return null;
+    }
+
+    const record: Record<string, string> = {};
+    pairs.forEach(pair => {
+      if (pair.key) {
+        record[pair.key] = pair.value || '';
+      }
+    });
+
+    return Object.keys(record).length > 0 ? record : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.harness.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class FormKeyValuePairsHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-form-key-value-pairs';
+
+  /**
+   * Get the number of rows in the form
+   */
+  async getRowCount(): Promise<number> {
+    const rows = await this.locatorForAll('tbody tr')();
+    return rows.length;
+  }
+
+  /**
+   * Get the key input field for a specific row
+   */
+  async getKeyField(rowIndex: number): Promise<MatInputHarness> {
+    return this.locatorFor(MatInputHarness.with({ selector: `#key-value-key-${rowIndex}` }))();
+  }
+
+  /**
+   * Get the value input field for a specific row
+   */
+  async getValueField(rowIndex: number): Promise<MatInputHarness> {
+    return this.locatorFor(MatInputHarness.with({ selector: `#key-value-value-${rowIndex}` }))();
+  }
+
+  /**
+   * Get the current key value for a specific row
+   */
+  async getKeyValue(rowIndex: number): Promise<string> {
+    const keyField = await this.getKeyField(rowIndex);
+    return keyField.getValue();
+  }
+
+  /**
+   * Get the current value for a specific row
+   */
+  async getValue(rowIndex: number): Promise<string> {
+    const valueField = await this.getValueField(rowIndex);
+    return valueField.getValue();
+  }
+
+  /**
+   * Get the key-value pair for a specific row
+   */
+  async getKeyValuePair(rowIndex: number): Promise<{ key: string; value: string }> {
+    const [key, value] = await Promise.all([this.getKeyValue(rowIndex), this.getValue(rowIndex)]);
+    return { key, value };
+  }
+
+  /**
+   * Set the key value for a specific row
+   */
+  async setKeyValue(rowIndex: number, key: string): Promise<void> {
+    const keyField = await this.getKeyField(rowIndex);
+    await keyField.setValue(key);
+    await keyField.blur();
+  }
+
+  /**
+   * Set the value for a specific row
+   */
+  async setValue(rowIndex: number, value: string): Promise<void> {
+    const valueField = await this.getValueField(rowIndex);
+    await valueField.setValue(value);
+    await valueField.blur();
+  }
+
+  /**
+   * Set both key and value for a specific row
+   */
+  async setKeyValuePair(rowIndex: number, key: string, value: string): Promise<void> {
+    // Set sequentially to match user behavior and ensure proper change detection
+    await this.setKeyValue(rowIndex, key);
+    await this.setValue(rowIndex, value);
+  }
+
+  /**
+   * Get the delete button for a specific row (if it exists)
+   */
+  async getDeleteButton(rowIndex: number): Promise<MatButtonHarness | null> {
+    const selector = `tbody tr:nth-child(${rowIndex + 1}) button[aria-label="Delete"]`;
+    return this.locatorForOptional(MatButtonHarness.with({ selector }))();
+  }
+
+  /**
+   * Check if the delete button is visible for a specific row
+   */
+  async isDeleteButtonVisible(rowIndex: number): Promise<boolean> {
+    const deleteButton = await this.getDeleteButton(rowIndex);
+    return deleteButton !== null;
+  }
+
+  /**
+   * Click the delete button for a specific row
+   */
+  async clickDelete(rowIndex: number): Promise<void> {
+    const deleteButton = await this.getDeleteButton(rowIndex);
+    if (!deleteButton) {
+      throw new Error(`Delete button not found for row ${rowIndex}`);
+    }
+    await deleteButton.click();
+  }
+
+  /**
+   * Check if the form is disabled
+   */
+  async isFormDisabled(): Promise<boolean> {
+    const keyField = await this.getKeyField(0);
+    return keyField.isDisabled();
+  }
+
+  /**
+   * Get all key-value pairs as a Record<string, string>
+   * This filters out empty pairs (where both key and value are empty)
+   */
+  async getAllKeyValuePairs(): Promise<Record<string, string>> {
+    const rowCount = await this.getRowCount();
+    const pairs: Record<string, string> = {};
+
+    for (let i = 0; i < rowCount; i++) {
+      const { key, value } = await this.getKeyValuePair(i);
+      const trimmedKey = key.trim();
+      const trimmedValue = value.trim();
+
+      if (trimmedKey) {
+        pairs[trimmedKey] = trimmedValue;
+      }
+    }
+
+    return pairs;
+  }
+
+  /**
+   * Wait for the row count to reach a specific value
+   */
+  async waitForRowCount(expectedCount: number, timeout = 5000): Promise<void> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      const currentCount = await this.getRowCount();
+      if (currentCount === expectedCount) {
+        return;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    throw new Error(`Expected row count ${expectedCount} not reached within ${timeout}ms`);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12095

## Description

To support the “Additional Metadata” field task, I built a new reusable component for adding a list of key–value pairs.
The UX is based on [the existing Particles UI component](https://particles.gravitee.io/?path=/docs/components-form-headers--readme).
The behavior is the same: it lets users enter key–value pairs that are used as metadata for the “Additional Metadata” form field.
The only difference is that this version supports only simple key–value pairs, without predefined keys or the header features available in the Particles UI component

## Additional context

https://github.com/user-attachments/assets/eb154ee7-49fa-41f0-b7c9-36c807076c05


