### PR TITLE
fix: update ownership of nginx files in console web ui Dockerfile for IPv4 only

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -26,7 +26,9 @@ ADD docker/config/constants.json /usr/share/nginx/html/constants.json
 ADD docker/config/default.conf /etc/nginx/conf.d/default.conf
 COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
 
-RUN chmod -R g=u /usr/share/nginx/ /etc/nginx/
+RUN chown -R nginx:root /usr/share/nginx \
+    && chown -R nginx:root /etc/nginx \
+    && chmod -R g=u /usr/share/nginx/ /etc/nginx/
 
 COPY docker/config/check_ip_config.sh /check_ip_config.sh
 


### PR DESCRIPTION
## Issue

This issue concerns the Console Web UI image.

Currently, enabling IPv4-only mode via the `IPV4_ONLY=true` environment variable does not work.  
The problem comes from incorrect permissions on the Nginx configuration files: they are owned by root, preventing the nginx user from executing the command
`mv /etc/nginx/conf.d/default.no-ipv6.conf /etc/nginx/conf.d/default.conf`
inside the `check_ip_config.sh` script.  
As a result, the IPv6 configuration cannot be replaced.

This regression seems to have appeared in version 4.9, following this commit:
https://github.com/gravitee-io/gravitee-api-management/commit/4a2a84ea75c7c2c43fc84079ffd3deca4e2c6dc8

## Description

This fix aligns the file ownership and permissions with those applied in the Portal Web UI image, ensuring the script can modify the Nginx configuration as expected.