### PR TITLE
chore: build distributable es index mappings with apim

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/README.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/README.md
@@ -1,0 +1,9 @@
+# gravitee-apim-distribution-es-index-mappings
+
+## Description
+
+This Maven module is responsible for generating all the Elasticsearch index templates and pipeline configuration files for the Gravitee API Management (APIM) platform. 
+
+It automates the creation of JSON files required to configure Elasticsearch indices used by APIM components.
+
+Each time a new version of APIM is released, a ZIP file containing these templates and configurations is generated. This ZIP file can be downloaded from the Maven Central repository following the versioning pattern: `gravitee-apim-distribution-es-index-mappings-{APIM_VERSION}.zip`

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.gravitee.apim.distribution</groupId>
+        <artifactId>gravitee-apim-distribution</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-distribution-es-index-mappings</artifactId>
+
+    <name>Gravitee.io APIM - Distribution - Elasticsearch Index Mappings</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.reporter</groupId>
+            <artifactId>gravitee-reporter-elasticsearch</artifactId>
+            <version>${gravitee-reporter-elasticsearch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>compile</scope><!-- Override the scope inherited from parent -->
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>compile</scope><!-- Override the scope inherited from parent -->
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>compile</scope><!-- Override the scope inherited from parent -->
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <id>build-es-index-mappings</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>io.gravitee.apim.distribution.elasticsearch.ESIndexMappingsDistributionBuilder</mainClass>
+                    <commandlineArgs>${project.build.directory}/es-index-mappings</commandlineArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--  Disable the default execution inherited from parent pom -->
+                        <id>make-distribution</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>make-es-index-mappings-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/es-index-mappings-assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/assembly/es-index-mappings-assembly.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/assembly/es-index-mappings-assembly.xml
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>es-index-mappings</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <!-- Include all generated es mappings files -->
+        <fileSet>
+            <directory>${project.build.directory}/es-index-mappings</directory>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/java/io/gravitee/apim/distribution/elasticsearch/ESIndexMappingsDistributionBuilder.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/java/io/gravitee/apim/distribution/elasticsearch/ESIndexMappingsDistributionBuilder.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.distribution.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.reporter.elasticsearch.ElasticsearchReporter;
+import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class ESIndexMappingsDistributionBuilder {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Generates ES pipeline and index mapping for each implementation version supported by the elastic-reporter (es8x, es9x, opensearch, ...).
+     * This main method is supposed to be invoked by Maven when building a new version of APIM.
+     *
+     * @param args target directory to output the generated templates.
+     * @throws Exception any exception that occurs during the generation process.
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            args = new String[] { "es-index-templates" };
+        }
+
+        FreeMarkerComponent freeMarkerComponent = FreeMarkerComponent.builder()
+            .classLoader(ElasticsearchReporter.class.getClassLoader())
+            .classLoaderTemplateBase("/freemarker/")
+            .build();
+
+        ReporterConfiguration configuration = new ReporterConfiguration();
+        PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(freeMarkerComponent);
+
+        Reflections reflections = new Reflections("io.gravitee.reporter.elasticsearch");
+        Set<Class<? extends AbstractIndexPreparer>> classes = reflections.getSubTypesOf(AbstractIndexPreparer.class);
+
+        for (Class<? extends AbstractIndexPreparer> clazz : classes) {
+            log.info("Found index preparer class: {}", clazz.getName());
+            AbstractIndexPreparer indexPreparer = buildIndexPreparer(clazz, configuration, pipelineConfiguration, freeMarkerComponent);
+
+            // Create the target directory structure if it does not exist.
+            Path dir = ensureDirectoryStructure(args[0], indexPreparer);
+
+            // Write the pipeline file.
+            Path file = dir.resolve("pipeline.json");
+            Files.writeString(file, pipelineConfiguration.createPipeline());
+            log.info("Generated pipeline template {}", indexPreparer.getTemplatePathPrefix() + "/" + file.getFileName());
+
+            for (Type type : Type.values()) {
+                String template = jsonPrettify(indexPreparer.generateIndexTemplate(type));
+                log.debug("{}/{}.json: \n{}", indexPreparer.getTemplatePathPrefix(), type.getType(), template);
+
+                // Write the index mapping file.
+                file = dir.resolve(type.getType() + ".json");
+                Files.writeString(file, template);
+
+                log.info("Generated index template {}", indexPreparer.getTemplatePathPrefix() + "/" + file.getFileName());
+            }
+        }
+    }
+
+    private static AbstractIndexPreparer buildIndexPreparer(
+        Class<? extends AbstractIndexPreparer> clazz,
+        ReporterConfiguration configuration,
+        PipelineConfiguration pipelineConfiguration,
+        FreeMarkerComponent freeMarkerComponent
+    ) throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        Constructor<? extends AbstractIndexPreparer> constructor = clazz.getConstructor(
+            ReporterConfiguration.class,
+            PipelineConfiguration.class,
+            FreeMarkerComponent.class,
+            Client.class
+        );
+        AbstractIndexPreparer indexPreparer = constructor.newInstance(configuration, pipelineConfiguration, freeMarkerComponent, null);
+        return indexPreparer;
+    }
+
+    private static Path ensureDirectoryStructure(String target, AbstractIndexPreparer indexPreparer) throws IOException {
+        String folderPath = target + "/" + indexPreparer.getTemplatePathPrefix();
+        Path dir = java.nio.file.Paths.get(folderPath);
+        if (!dir.toFile().exists()) {
+            Files.createDirectories(dir);
+        }
+        return dir;
+    }
+
+    @SneakyThrows
+    private static String jsonPrettify(String jsonString) {
+        JsonNode json = mapper.readTree(jsonString);
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+    }
+}

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/resources/logback.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/src/main/resources/logback.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="INFO" />
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -69,6 +69,9 @@
           Only Gravitee members are able to make this distribution, as it requires access to an internal repository.
     -->
 
+    <modules>
+        <module>gravitee-apim-distribution-es-index-mappings</module>
+    </modules>
 
     <!-- Default dependencies, to allow a full OSS distribution with opensource plugins only -->
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>7.3.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>7.3.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.7.0</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>3.1.0</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.8.0</gravitee-reporter-cloud.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-629

## Description

This PR introduces a new distribution module responsible for building the ES index mappings files (for each supported version) that are aligned with the APIM version. It generates a ZIP files with the following structure:

```bash
<base-directory>
       |_ es7x
       |   |_ event-metrics.json
       |   |_ health.json
       |   |_ log.json
       |   |_ monitor.json
       |   |_ pipeline.json
       |   |_ request.json
       |   |_ v4-log.json
       |   |_ v4-message-log.json
       |   |_ v4-message-metrics.json
       |   |_ v4-metrics.json
       |   
       |_ es8x
       |   |_ event-metrics.json
       |   |_ health.json
       |   ...
       |
       |_ es9x
       |   |_ event-metrics.json
       |   |_ health.json
       |   ...
       |
       |_ opensearch
           |_ event-metrics.json
           |_ health.json
           |_  ...
```

This allows for having a centralized location to find the final ES index mappings to apply for a given APIM, and can easily be used by automation or deployment tools
