### PR TITLE
fix(analytics): update Time-series interval parameter type to `int64` in OpenAPI schema

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1193,6 +1193,7 @@ components:
             A fixed time interval for time series analytics queries.
             Intervals are be expressed in milliseconds.
           type: integer
+          format: int64
           example: 1000
 
         TimeRange:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
@@ -62,7 +62,7 @@ public class AnalyticsEngineFixtures {
 
         return new TimeSeriesRequest()
             .timeRange(timeRange())
-            .interval(3600000)
+            .interval(3600000L)
             .filters(Arrays.asList(filters))
             .ranges(List.of(new NumberRange().from(100).to(199), new NumberRange().from(200).to(299)))
             .metrics(List.of(metric));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -362,7 +362,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
 
         @Test
         void should_fail_with_negative_interval() {
-            var invalidRequest = aRequestCountTimeSeries().interval(-60000);
+            var invalidRequest = aRequestCountTimeSeries().interval(-60000L);
             var response = rootTarget().path("time-series").request().post(Entity.json(invalidRequest));
 
             assertThat(response).hasStatus(400);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1952

## Description

Updated interval parameter to be a Long (64 bits) which increases the max value from ~24 days to 208 years.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

