### PR TITLE
Apim 11950 console handle visibility

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -22,6 +22,9 @@ import {
   NewPagePortalNavigationItem,
   NewFolderPortalNavigationItem,
   NewLinkPortalNavigationItem,
+  UpdatePagePortalNavigationItem,
+  UpdateLinkPortalNavigationItem,
+  UpdateFolderPortalNavigationItem,
 } from './portalNavigationItem';
 import { PortalNavigationItemsResponse } from './portalNavigationItemsResponse';
 
@@ -151,6 +154,63 @@ export function fakeNewLinkPortalNavigationItem(overrides?: Partial<NewLinkPorta
     type: 'LINK',
     area: 'HOMEPAGE',
     url: 'https://example.com',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakeUpdatePagePortalNavigationItem(overrides?: Partial<UpdatePagePortalNavigationItem>): UpdatePagePortalNavigationItem {
+  const base: UpdatePagePortalNavigationItem = {
+    published: false,
+    type: 'PAGE',
+    title: 'Updated Page',
+    visibility: 'PUBLIC',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakeUpdateLinkPortalNavigationItem(overrides?: Partial<UpdateLinkPortalNavigationItem>): UpdateLinkPortalNavigationItem {
+  const base: UpdateLinkPortalNavigationItem = {
+    published: false,
+    type: 'LINK',
+    title: 'Updated Link',
+    visibility: 'PUBLIC',
+    url: 'https://updated-example.com',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakeUpdateFolderPortalNavigationItem(
+  overrides?: Partial<UpdateFolderPortalNavigationItem>,
+): UpdateFolderPortalNavigationItem {
+  const base: UpdateFolderPortalNavigationItem = {
+    published: false,
+    type: 'FOLDER',
+    title: 'Updated Folder',
+    visibility: 'PUBLIC',
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree-node.component.html
@@ -60,6 +60,7 @@
     mat-icon-button
     class="tree__button more-actions"
     aria-label="More actions"
+    [attr.data-testid]="'more-actions-' + node().id"
     [matMenuTriggerFor]="moreMenu"
     (click)="$event.stopPropagation()"
     *gioPermission="{ anyOf: ['environment-documentation-u', 'environment-documentation-d'] }"
@@ -82,7 +83,7 @@
       </button>
     }
     <mat-divider></mat-divider>
-    <button mat-menu-item (click)="triggerEdit()">
+    <button mat-menu-item (click)="triggerEdit()" data-testid="edit-node-button">
       <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
       Edit
     </button>

--- a/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/tree-component/tree.component.harness.ts
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatMenuItemHarness } from '@angular/material/menu/testing';
 
 import { EmptyStateComponentHarness } from '../../../shared/components/empty-state/empty-state.component.harness';
 
 export class TreeComponentHarness extends ComponentHarness {
   static hostSelector = 'portal-tree-component';
 
+  private readonly _documentRootLocator = this.documentRootLocatorFactory();
+
   private getSelectedLabelButton = this.locatorForOptional('.tree__row.selected .tree__label');
   private getTreeLabelButtons = this.locatorForAll('.tree__label');
   private getEmptyState = this.locatorForOptional(EmptyStateComponentHarness);
+  private getEditButton = this._documentRootLocator.locatorFor(MatMenuItemHarness.with({ selector: '[data-testid="edit-node-button"]' }));
+  protected getMoreActionsButtonById = (id: string) =>
+    this.locatorFor(MatButtonHarness.with({ selector: `[data-testid="more-actions-${id}"]` }));
 
   async getSelectedItemTitle(): Promise<string | null> {
     const labelButton = await this.getSelectedLabelButton();
@@ -68,5 +75,13 @@ export class TreeComponentHarness extends ComponentHarness {
   async isEmptyStateDisplayed(): Promise<boolean> {
     const emptyState = await this.getEmptyState();
     return emptyState !== null;
+  }
+
+  async selectEditById(id: string): Promise<void> {
+    const moreActionsButton = await this.getMoreActionsButtonById(id)();
+    return moreActionsButton
+      .click()
+      .then((_) => this.getEditButton())
+      .then((editButton) => editButton.click());
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -69,10 +69,11 @@
             {{ selectedNavigationItem().label }}
           </div>
 
-          <div>
-            <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'" data-testid="status-badge">
+          <div class="panel-header__title__badges">
+            <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
               {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
             </span>
+            <span class="gio-badge-primary">{{ selectedNavigationItem().data.visibility | titlecase }}</span>
           </div>
         </div>
       }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -65,11 +65,15 @@
     <header class="panel-header editor-panel__header">
       @if (selectedNavigationItem()) {
         <div class="panel-header__title">
-          {{ selectedNavigationItem().label }}
+          <div>
+            {{ selectedNavigationItem().label }}
+          </div>
 
-          <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'" data-testid="status-badge">
-            {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
-          </span>
+          <div>
+            <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'" data-testid="status-badge">
+              {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
+            </span>
+          </div>
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -54,6 +54,7 @@ $typography: map.get(gio.$mat-theme, typography);
     @include mat.m2-typography-level($typography, 'subtitle-1');
     display: flex;
     gap: 4px;
+    align-items: center;
   }
 
   &__actions {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -55,6 +55,10 @@ $typography: map.get(gio.$mat-theme, typography);
     display: flex;
     gap: 4px;
     align-items: center;
+
+    &__badges {
+      display: flex;
+    }
   }
 
   &__actions {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -39,6 +39,7 @@ import {
   fakePortalNavigationItemsResponse,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
+  fakeUpdatePagePortalNavigationItem,
   NewPortalNavigationItem,
   PortalNavigationItem,
   PortalNavigationItemsResponse,
@@ -719,6 +720,33 @@ describe('PortalNavigationItemsComponent', () => {
       it('should show "Public" badge', async () => {
         expect(await harness.isPublicBadgeVisible()).toBe(true);
       });
+
+      it('should change visibility in edit dialog', async () => {
+        await harness.editNodeById('nav-item-1');
+
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const authToggle = await dialog.getAuthenticationToggle();
+        expect(await authToggle.isChecked()).toBe(false);
+
+        await authToggle.toggle();
+
+        await dialog.clickSubmitButton();
+        expectPutPortalNavigationItem(
+          publicNavItem.id,
+          fakeUpdatePagePortalNavigationItem({
+            title: publicNavItem.title,
+            parentId: publicNavItem.parentId,
+            order: publicNavItem.order,
+            published: publicNavItem.published,
+            visibility: 'PRIVATE',
+          }),
+          fakePortalNavigationPage({}),
+        );
+
+        // After update, component refreshes the list — satisfy the subsequent GET
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publicNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+      });
     });
 
     describe('private navigation item', () => {
@@ -738,6 +766,33 @@ describe('PortalNavigationItemsComponent', () => {
       });
       it('should show "Private" badge', async () => {
         expect(await harness.isPrivateBadgeVisible()).toBe(true);
+      });
+
+      it('should change visibility in edit dialog', async () => {
+        await harness.editNodeById('nav-item-1');
+
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const authToggle = await dialog.getAuthenticationToggle();
+        expect(await authToggle.isChecked()).toBe(true);
+
+        await authToggle.toggle();
+
+        await dialog.clickSubmitButton();
+        expectPutPortalNavigationItem(
+          privateNavItem.id,
+          fakeUpdatePagePortalNavigationItem({
+            title: privateNavItem.title,
+            parentId: privateNavItem.parentId,
+            order: privateNavItem.order,
+            published: privateNavItem.published,
+            visibility: 'PUBLIC',
+          }),
+          fakePortalNavigationPage({}),
+        );
+
+        // After update, component refreshes the list — satisfy the subsequent GET
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [privateNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
       });
     });
   });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -700,6 +700,48 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('changing navigation item visibility', () => {
+    describe('public navigation item', () => {
+      const publicNavItem = fakePortalNavigationPage({
+        id: 'nav-item-1',
+        title: 'Nav Item 1',
+        portalPageContentId: 'nav-item-1-content',
+        visibility: 'PUBLIC',
+      });
+      beforeEach(async () => {
+        const fakeResponse = fakePortalNavigationItemsResponse({
+          items: [publicNavItem],
+        });
+
+        await expectGetNavigationItems(fakeResponse);
+        expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+      });
+      it('should show "Public" badge', async () => {
+        expect(await harness.isPublicBadgeVisible()).toBe(true);
+      });
+    });
+
+    describe('private navigation item', () => {
+      const privateNavItem = fakePortalNavigationPage({
+        id: 'nav-item-1',
+        title: 'Nav Item 1',
+        portalPageContentId: 'nav-item-1-content',
+        visibility: 'PRIVATE',
+      });
+      beforeEach(async () => {
+        const fakeResponse = fakePortalNavigationItemsResponse({
+          items: [privateNavItem],
+        });
+
+        await expectGetNavigationItems(fakeResponse);
+        expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+      });
+      it('should show "Private" badge', async () => {
+        expect(await harness.isPrivateBadgeVisible()).toBe(true);
+      });
+    });
+  });
+
   describe('resizing the sections panel', () => {
     beforeEach(async () => {
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [] }));

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -26,7 +26,7 @@ import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/me
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 
 import {
@@ -72,6 +72,7 @@ import { GioPermissionService } from '../../shared/components/gio-permission/gio
     AsyncPipe,
     MatCardModule,
     NgTemplateOutlet,
+    TitleCasePipe,
   ],
 })
 export class PortalNavigationItemsComponent {
@@ -258,7 +259,6 @@ export class PortalNavigationItemsComponent {
               parentId: existingItem.parentId,
               order: existingItem.order,
               published: existingItem.published,
-              visibility: existingItem.visibility,
               ...result,
             });
           }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -17,7 +17,7 @@ import { GraviteeMarkdownEditorModule } from '@gravitee/gravitee-markdown';
 
 import { GIO_DIALOG_WIDTH, GioCardEmptyStateModule, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { Component, computed, DestroyRef, inject, NgZone, Signal, signal } from '@angular/core';
-import { MatButton } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -62,7 +62,7 @@ import { GioPermissionService } from '../../shared/components/gio-permission/gio
     ReactiveFormsModule,
     EmptyStateComponent,
     GioCardEmptyStateModule,
-    MatButton,
+    MatButtonModule,
     TreeComponent,
     GioPermissionModule,
     MatMenuModule,

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -165,4 +165,9 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     const titleText = await titleDiv.getText();
     return titleText.includes('Private');
   }
+
+  async editNodeById(id: string): Promise<void> {
+    const tree = await this.getTree();
+    return tree.selectEditById(id);
+  }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -153,4 +153,16 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     const titleText = await titleDiv.getText();
     return titleText.includes('Unpublished');
   }
+
+  async isPublicBadgeVisible() {
+    const titleDiv = await this.getTitle();
+    const titleText = await titleDiv.getText();
+    return titleText.includes('Public');
+  }
+
+  async isPrivateBadgeVisible(): Promise<boolean> {
+    const titleDiv = await this.getTitle();
+    const titleText = await titleDiv.getText();
+    return titleText.includes('Private');
+  }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -44,6 +44,11 @@
       </mat-form-field>
     }
 
+    <div class="form-field-title">Authentication</div>
+    <mat-slide-toggle formControlName="isPrivate" aria-label="Use system proxy"
+      >Authentication is required to view this {{ type | lowercase }}.</mat-slide-toggle
+    >
+
     <gio-banner-info type="info">
       This change will not be visible in the Developer Portal until you publish the {{ type | lowercase }}.
     </gio-banner-info>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -51,6 +51,6 @@
 
   <mat-dialog-actions align="end">
     <button mat-button type="button" (click)="onCancel()">Cancel</button>
-    <button mat-flat-button color="primary" type="submit" [disabled]="!form.valid">{{ buttonTitle }}</button>
+    <button mat-flat-button color="primary" type="submit" [disabled]="!form.valid || formIsUnchanged()">{{ buttonTitle }}</button>
   </mat-dialog-actions>
 </form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -238,6 +238,24 @@ describe('SectionEditorDialogComponent', () => {
           title: 'Updated Page',
         });
       });
+
+      it('should not allow save when title is not updated', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+
+      it('should disable save when title is the same as before after changes', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        const titleInput = await dialog.getTitleInput();
+        await titleInput.setValue('Updated Page');
+
+        expect(await dialog.isSubmitButtonDisabled()).toEqual(false);
+
+        await titleInput.setValue('Existing Page');
+        expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
     });
     describe('when editing a link', () => {
       beforeEach(() => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -106,6 +106,22 @@ describe('SectionEditorDialogComponent', () => {
 
         expect(component.dialogValue).toEqual({
           title: 'My new page',
+          visibility: 'PUBLIC',
+        });
+      });
+      it('should save authentication', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const authToggle = await dialog.getAuthenticationToggle();
+        expect(await authToggle.isChecked()).toEqual(false);
+
+        await authToggle.toggle();
+        const titleInput = await dialog.getTitleInput();
+        await titleInput.setValue('My new page');
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+        expect(component.dialogValue).toEqual({
+          title: 'My new page',
+          visibility: 'PRIVATE',
         });
       });
       it('should close the dialog when canceling', async () => {
@@ -161,6 +177,7 @@ describe('SectionEditorDialogComponent', () => {
 
         expect(component.dialogValue).toEqual({
           title: 'Gravitee Homepage',
+          visibility: 'PUBLIC',
           url: 'https://gravitee.io',
         });
       });
@@ -189,6 +206,7 @@ describe('SectionEditorDialogComponent', () => {
 
         expect(component.dialogValue).toEqual({
           title: 'My new folder',
+          visibility: 'PUBLIC',
         });
       });
       it('should close the dialog when canceling', async () => {
@@ -236,6 +254,7 @@ describe('SectionEditorDialogComponent', () => {
 
         expect(component.dialogValue).toEqual({
           title: 'Updated Page',
+          visibility: 'PUBLIC',
         });
       });
 
@@ -255,6 +274,28 @@ describe('SectionEditorDialogComponent', () => {
 
         await titleInput.setValue('Existing Page');
         expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+    });
+    describe('when editing a private page', () => {
+      beforeEach(() => {
+        const existingPage = fakePortalNavigationPage({
+          id: 'p1',
+          title: 'Existing Page',
+          portalPageContentId: 'content1',
+          visibility: 'PRIVATE',
+        });
+        fixture.componentRef.setInput('type', 'PAGE');
+        fixture.componentRef.setInput('existingItem', existingPage);
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+      });
+
+      it('should have authentication as true by default', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const toggle = await dialog.getAuthenticationToggle();
+
+        expect(await toggle.isChecked()).toEqual(true);
       });
     });
     describe('when editing a link', () => {
@@ -288,6 +329,7 @@ describe('SectionEditorDialogComponent', () => {
 
         expect(component.dialogValue).toEqual({
           title: 'Updated Link',
+          visibility: 'PUBLIC',
           url: 'https://new.com',
         });
       });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -24,7 +24,7 @@ import { LowerCasePipe, TitleCasePipe } from '@angular/common';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 import { isEqual } from 'lodash';
 
-import { PortalNavigationItem, PortalNavigationItemType } from '../../../entities/management-api-v2';
+import { PortalNavigationItem, PortalNavigationItemType, PortalVisibility } from '../../../entities/management-api-v2';
 import { urlValidator } from '../../../shared/validators/url.validator';
 
 export type SectionEditorDialogMode = 'create' | 'edit';
@@ -44,16 +44,19 @@ export type SectionEditorDialogData = SectionEditorDialogCreateData | SectionEdi
 
 export interface SectionEditorDialogResult {
   title: string;
+  visibility: PortalVisibility;
   url?: string;
 }
 
 interface SectionFormControls {
   title: FormControl<string>;
+  isPrivate: FormControl<boolean>;
   url?: FormControl<string>; // Optional for 'LINK' type
 }
 
 interface SectionFormValues {
   title: string;
+  isPrivate: boolean;
   url?: string;
 }
 
@@ -78,6 +81,7 @@ type SectionForm = FormGroup<SectionFormControls>;
 export class SectionEditorDialogComponent implements OnInit {
   form: SectionForm = new FormGroup<SectionFormControls>({
     title: new FormControl<string>('', { validators: [Validators.required], nonNullable: true }),
+    isPrivate: new FormControl(false),
   });
   public initialFormValues: SectionFormValues;
 
@@ -120,13 +124,19 @@ export class SectionEditorDialogComponent implements OnInit {
         ...(this.data.existingItem.type === 'LINK' ? { url: this.data.existingItem.url } : {}),
 
         title: this.data.existingItem.title,
+        isPrivate: this.data.existingItem.visibility === 'PRIVATE',
       });
     }
   }
 
   onSubmit(): void {
     if (this.form.valid) {
-      this.dialogRef.close({ ...this.form.getRawValue() });
+      const formValues = this.form.getRawValue();
+      this.dialogRef.close({
+        title: formValues.title,
+        visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
+        ...(this.type === 'LINK' ? { url: formValues.url! } : {}),
+      });
     }
   }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -22,6 +22,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { LowerCasePipe, TitleCasePipe } from '@angular/common';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
+import { isEqual } from 'lodash';
 
 import { PortalNavigationItem, PortalNavigationItemType } from '../../../entities/management-api-v2';
 import { urlValidator } from '../../../shared/validators/url.validator';
@@ -51,6 +52,11 @@ interface SectionFormControls {
   url?: FormControl<string>; // Optional for 'LINK' type
 }
 
+interface SectionFormValues {
+  title: string;
+  url?: string;
+}
+
 type SectionForm = FormGroup<SectionFormControls>;
 
 @Component({
@@ -73,6 +79,7 @@ export class SectionEditorDialogComponent implements OnInit {
   form: SectionForm = new FormGroup<SectionFormControls>({
     title: new FormControl<string>('', { validators: [Validators.required], nonNullable: true }),
   });
+  public initialFormValues: SectionFormValues;
 
   public type: PortalNavigationItemType;
   public mode: SectionEditorDialogMode;
@@ -97,6 +104,8 @@ export class SectionEditorDialogComponent implements OnInit {
   ngOnInit(): void {
     this.addTypeSpecificControls();
     this.prefillExistingItem();
+
+    this.initialFormValues = this.form.getRawValue();
   }
 
   private addTypeSpecificControls(): void {
@@ -123,5 +132,9 @@ export class SectionEditorDialogComponent implements OnInit {
 
   onCancel(): void {
     this.dialogRef.close();
+  }
+
+  formIsUnchanged(): boolean {
+    return isEqual(this.form.getRawValue(), this.initialFormValues);
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -17,6 +17,7 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 export class SectionEditorDialogHarness extends ComponentHarness {
   static hostSelector = 'section-editor-dialog';
@@ -25,6 +26,7 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   private locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
+  private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
 
   async getTitleInput(): Promise<MatInputHarness> {
     return this.locateTitleInput();
@@ -60,5 +62,14 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
+  }
+
+  async getAuthenticationToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateAuthenticationToggle();
+  }
+
+  async toggleAuthentication(): Promise<void> {
+    const toggle = await this.locateAuthenticationToggle();
+    return toggle.toggle();
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11950

## Description

Fix odd badge behavior with a long title:

<img width="885" height="97" alt="Screenshot 2025-12-10 at 16 57 37" src="https://github.com/user-attachments/assets/240622cb-b489-4a71-9b25-1cc69e42466d" />

Add the authentication toggle to the dialog for changing the visibility of a nav item:

https://github.com/user-attachments/assets/b7904eb9-d53a-4032-9fa9-b2afd42d137e



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

