### PR TITLE
fix(console): can edit blank page content on error

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -78,7 +78,7 @@
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">
-        <button mat-stroked-button (click)="onPublishToggle()">
+        <button [disabled]="contentLoadError()" mat-stroked-button (click)="onPublishToggle()">
           {{ selectedNavigationItemIsPublished() ? 'Unpublish' : 'Publish' }}
         </button>
         <button mat-stroked-button [disabled]="contentControl.pristine" (click)="onSave()">Save</button>
@@ -88,7 +88,11 @@
     @if (selectedNavigationItem()) {
       @switch (selectedNavigationItem().type) {
         @case ('PAGE') {
-          <gmd-editor [formControl]="contentControl" />
+          @if (!contentLoadError()) {
+            <gmd-editor [formControl]="contentControl" />
+          } @else {
+            <ng-container *ngTemplateOutlet="pageNotFound"></ng-container>
+          }
         }
         @default {
           <ng-container *ngTemplateOutlet="emptyEditorState"></ng-container>
@@ -127,6 +131,16 @@
           title="Preview"
           message="Use the page preview to see exactly how your content will look before you publish it."
         />
+      </mat-card-content>
+    </mat-card>
+  </div>
+</ng-template>
+
+<ng-template #pageNotFound>
+  <div class="empty-editor">
+    <mat-card appearance="outlined" class="empty-state">
+      <mat-card-content>
+        <empty-state iconName="gio:alert-circle" title="Page Not Found" message="Failed to load page content." />
       </mat-card-content>
     </mat-card>
   </div>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -37,6 +37,12 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     EmptyStateComponentHarness.with({ title: 'Editor', message: 'Use GMD code to customize and edit your page content.' }),
   );
   private getTitle = this.locatorFor(DivHarness.with({ selector: '.panel-header__title' }));
+  private getPageNotFoundEmptyState = this.locatorForOptional(
+    EmptyStateComponentHarness.with({
+      title: 'Page Not Found',
+      message: 'Failed to load page content.',
+    }),
+  );
 
   async getAddButtonHarness(): Promise<MatButtonHarness> {
     return this.getAddButton();
@@ -169,5 +175,15 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async editNodeById(id: string): Promise<void> {
     const tree = await this.getTree();
     return tree.selectEditById(id);
+  }
+
+  async isPageNotFoundDisplayed(): Promise<boolean> {
+    const emptyState = await this.getPageNotFoundEmptyState();
+    return emptyState !== null;
+  }
+
+  async getPageNotFoundMessage(): Promise<string | null> {
+    const emptyState = await this.getPageNotFoundEmptyState();
+    return emptyState ? emptyState.getMessage() : null;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11997

## Description

- added a flag to track content not found error
- use it to display the not found template so user is not able to edit the page if a content is not loaded for a nav page
- disabled publish button when content not found
- changed return type of loadpagecontent to an object {success:boolean, content:string} and use it to check success/failure
- added test case

<img width="1474" height="774" alt="image" src="https://github.com/user-attachments/assets/e6231f72-550c-43ef-843b-7a6b7a76c9bf" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

