### PR TITLE
feat/GKO-1939-Polish-analytics-renderer-line-chart-conf

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/converter/line-converter.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/converter/line-converter.service.spec.ts
@@ -116,9 +116,9 @@ describe('LineConverterService', () => {
 
       expect(result.labels?.length).toBe(2);
       expect(result.datasets.length).toBe(2);
-      expect(result.datasets[0].label).toBe('HTTP_REQUESTS - 100-199');
+      expect(result.datasets[0].label).toBe('100-199');
       expect(result.datasets[0].data).toEqual([50, 60]);
-      expect(result.datasets[1].label).toBe('HTTP_REQUESTS - 200-299');
+      expect(result.datasets[1].label).toBe('200-299');
       expect(result.datasets[1].data).toEqual([30, 40]);
     });
 
@@ -213,8 +213,8 @@ describe('LineConverterService', () => {
 
       expect(result.labels?.length).toBe(1);
       expect(result.datasets.length).toBe(2);
-      expect(result.datasets[0].label).toBe('HTTP_REQUESTS - 100-199');
-      expect(result.datasets[1].label).toBe('HTTP_REQUESTS - 200-299');
+      expect(result.datasets[0].label).toBe('100-199');
+      expect(result.datasets[1].label).toBe('200-299');
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/converter/line-converter.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/converter/line-converter.service.ts
@@ -17,7 +17,7 @@ import { Injectable } from '@angular/core';
 import { ChartData } from 'chart.js';
 
 import { Converter } from '../../../converter';
-import { TimeSeriesResponse, TimeSeriesBucket, TimeSeries } from '../../../widget/model/response/time-series-response';
+import { TimeSeries, TimeSeriesBucket, TimeSeriesResponse } from '../../../widget/model/response/time-series-response';
 
 @Injectable({
   providedIn: 'root',
@@ -67,7 +67,7 @@ export class LineConverterService implements Converter {
     const baseMetricLabel = this.getBaseMetricLabel(metric, metricIndex);
 
     if (hasNestedBuckets) {
-      this.buildGroupedDatasetsFromNestedBuckets(metricBuckets, baseMetricLabel, bucketCount, datasets);
+      this.buildGroupedDatasetsFromNestedBuckets(metricBuckets, bucketCount, datasets);
     } else {
       this.buildSimpleDatasetFromMetric(metricBuckets, baseMetricLabel, datasets);
     }
@@ -83,7 +83,6 @@ export class LineConverterService implements Converter {
 
   private buildGroupedDatasetsFromNestedBuckets(
     metricBuckets: TimeSeriesBucket[],
-    baseMetricLabel: string,
     bucketCount: number,
     datasets: ChartData<'line', number[], string>['datasets'],
   ): void {
@@ -91,7 +90,7 @@ export class LineConverterService implements Converter {
 
     groupMap.forEach((values, groupName) => {
       datasets.push({
-        label: `${baseMetricLabel} - ${groupName}`,
+        label: `${groupName}`,
         data: values,
       });
     });
@@ -112,8 +111,8 @@ export class LineConverterService implements Converter {
         }
 
         const values = groupMap.get(groupName)!;
-        const value = nestedBucket.measures?.[0]?.value ?? 0;
-        values[timeIndex] = value;
+
+        values[timeIndex] = nestedBucket.measures?.[0]?.value ?? 0;
       });
     });
 
@@ -148,7 +147,7 @@ export class LineConverterService implements Converter {
   private toTimeLabel(bucket: TimeSeriesBucket): string {
     if (bucket.timestamp != null) {
       const date = new Date(bucket.timestamp);
-      if (!isNaN(date.getTime())) {
+      if (!Number.isNaN(date.getTime())) {
         return date.toISOString();
       }
     }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
@@ -61,7 +61,7 @@ export class LineChartComponent {
           },
         },
         tooltip: {
-          mode: 'index',
+          mode: 'nearest',
           intersect: false,
         },
       },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1939

## Description

Simplify chart legend for nested bucket and only show tooltip for nearest record on hover.

## Additional context

<img width="891" height="269" alt="Screenshot 2025-12-11 at 12 12 50" src="https://github.com/user-attachments/assets/35e3d2cc-a63f-4481-b69d-0de8c96b67dc" />
<img width="891" height="266" alt="Screenshot 2025-12-11 at 12 18 56" src="https://github.com/user-attachments/assets/ffa09091-98a6-4ef3-97ca-76830982ebb6" />



