### PR TITLE
fix: added missing id_token_hint in SSO logout url

### DIFF
--- a/gravitee-apim-console-webui/src/auth/auth.service.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.ts
@@ -184,7 +184,15 @@ export class AuthService {
         }
         this.providerIdSelectedStore = null;
 
-        return from([oidcManager.removeUser(), oidcManager.signoutRedirect().catch(() => null), oidcManager.clearStaleState()]);
+        return from(oidcManager.getUser()).pipe(
+          switchMap((user) =>
+            from([
+              oidcManager.removeUser(),
+              oidcManager.signoutRedirect(user ? { id_token_hint: user.id_token } : {}).catch(() => null),
+              oidcManager.clearStaleState(),
+            ]),
+          ),
+        );
       }),
       switchMap(() => {
         if (!options.disableRedirect) {


### PR DESCRIPTION
added missing id_token_hint parameter  in SSO logout url

## Issue

https://gravitee.atlassian.net/browse/APIM-8954

## Description

Logout call to SSO was missing id_token_hint parameter

## Additional context



