### PR TITLE
chore: bump webhook version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>5.2.0</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>6.0.1</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.0.3</gravitee-entrypoint-mcp.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1947

## Description

* Webhook entrypoint bump
* Use latest version of the plugin (6.0.1)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

