### PR TITLE
fix(console): Edit GMD page Save button should be primary

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -81,7 +81,7 @@
         <button [disabled]="contentLoadError()" mat-stroked-button (click)="onPublishToggle()">
           {{ selectedNavigationItemIsPublished() ? 'Unpublish' : 'Publish' }}
         </button>
-        <button mat-stroked-button [disabled]="contentControl.pristine" (click)="onSave()">Save</button>
+        <button mat-flat-button color="primary" [disabled]="contentControl.pristine" (click)="onSave()">Save</button>
       </div>
     </header>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11761

## Description

- changed mat-stroked to mat-flat and color = primary for save button while gmd page edit


https://github.com/user-attachments/assets/9b16040f-7ac3-4e88-8cb7-cf11dcfce72e


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

