### PR TITLE
feat(papi): include content and type in portal page content response

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -84,7 +84,9 @@ describe('DocumentationFolderComponent', () => {
     routerSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
 
     jest.spyOn(navigationService, 'getNavigationItems').mockReturnValue(of(params.items as unknown as PortalNavigationItem[]));
-    jest.spyOn(navigationService, 'getNavigationItemContent').mockReturnValueOnce(of(params.content!));
+    jest
+      .spyOn(navigationService, 'getNavigationItemContent')
+      .mockReturnValueOnce(of({ content: params.content!, type: 'GRAVITEE_MARKDOWN' }));
 
     fixture = TestBed.createComponent(DocumentationFolderComponent);
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, DocumentationFolderComponentHarness);

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -16,7 +16,7 @@
 import { Component, input } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { map, Observable, Subject, switchMap, tap } from 'rxjs';
+import { catchError, map, Observable, Subject, switchMap, tap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { GraviteeMarkdownViewerModule } from '@gravitee/gravitee-markdown';
@@ -84,6 +84,9 @@ export class DocumentationFolderComponent {
       return of('');
     }
 
-    return this.itemsService.getNavigationItemContent(pageId).pipe(map(content => content));
+    return this.itemsService.getNavigationItemContent(pageId).pipe(
+      map(({ content }) => content),
+      catchError(() => of('')),
+    );
   }
 }

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type PortalPageContentType = 'GRAVITEE_MARKDOWN';
+
+export interface PortalPageContent {
+  type: PortalPageContentType;
+  content: string;
+}

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
 import { PortalNavigationItemsService } from './portal-navigation-items.service';
 import { PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
+import { AppTestingModule } from '../testing/app-testing.module';
 
 describe('PortalNavigationItemsService', () => {
   let service: PortalNavigationItemsService;
@@ -27,7 +28,7 @@ describe('PortalNavigationItemsService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [AppTestingModule],
       providers: [{ provide: ConfigService, useValue: { baseURL } }],
     });
 
@@ -115,16 +116,18 @@ describe('PortalNavigationItemsService', () => {
   });
 
   it('should get navigation item content', done => {
-    const mockContent = 'MOCK CONTENT';
-    const id = 'testId';
+    const mockContent = {
+      type: 'GRAVITEE_MARKDOWN',
+      content: '# Welcome to the portal\nThis is the home page content.',
+    };
 
-    service.getNavigationItemContent(id).subscribe(items => {
-      expect(items).toEqual(mockContent);
+    service.getNavigationItemContent('1').subscribe(content => {
+      expect(content).toEqual(mockContent);
       done();
     });
 
-    const req = httpMock.expectOne(r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/${id}/content`);
-
+    const req = httpMock.expectOne(`${baseURL}/portal-navigation-items/1/content`);
+    expect(req.request.method).toBe('GET');
     req.flush(mockContent);
   });
 

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
@@ -20,6 +20,7 @@ import { of } from 'rxjs/internal/observable/of';
 
 import { ConfigService } from './config.service';
 import { PortalArea, PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
+import { PortalPageContent } from '../entities/portal-navigation/portal-page-content';
 
 @Injectable({
   providedIn: 'root',
@@ -48,10 +49,8 @@ export class PortalNavigationItemsService {
     return this.http.get<PortalNavigationItem>(`${this.configService.baseURL}/portal-navigation-items/${id}`).pipe(catchError(_ => of()));
   }
 
-  getNavigationItemContent(id: string): Observable<string> {
-    return this.http
-      .get(`${this.configService.baseURL}/portal-navigation-items/${id}/content`, { responseType: 'text' })
-      .pipe(catchError(_ => of('')));
+  getNavigationItemContent(id: string): Observable<PortalPageContent> {
+    return this.http.get<PortalPageContent>(`${this.configService.baseURL}/portal-navigation-items/${id}/content`);
   }
 
   loadTopNavBarItems(): Observable<void> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -21,11 +21,14 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -52,6 +55,9 @@ public interface PortalNavigationItemMapper {
     io.gravitee.rest.api.portal.rest.model.PortalNavigationFolder map(PortalNavigationFolder folder);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationLink map(PortalNavigationLink link);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationPage map(PortalNavigationPage page);
+
+    @Mapping(source = "type", target = "type")
+    io.gravitee.rest.api.portal.rest.model.PortalPageContent map(PortalPageContent content);
 
     default String map(@Nullable PortalNavigationItemId portalNavigationItemId) {
         if (portalNavigationItemId == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -71,6 +71,6 @@ public class PortalNavigationItemResource extends AbstractResource {
             )
         );
 
-        return Response.ok(result.portalPageContent().getContent()).build();
+        return Response.ok(portalNavigationItemMapper.map(result.portalPageContent())).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6418,18 +6418,17 @@ components:
             type: object
             description: Portal page content
             properties:
-                id:
-                    type: string
-                    description: The unique ID of the portal page content
                 type:
-                    type: string
-                    description: Content type
-                    enum:
-                        - GRAVITEE_MARKDOWN
+                    $ref: "#/components/schemas/PortalPageContentType"
                 content:
                     type: string
                     description: The content of the page
-            required: [id, type, content]
+            required: [type, content]
+        PortalPageContentType:
+            type: string
+            description: Type of portal page content
+            enum:
+                - GRAVITEE_MARKDOWN
 
     responses:
         InternalServerError:
@@ -6531,8 +6530,7 @@ components:
             content:
                 application/json:
                     schema:
-                        type: string
-                        description: The content of the portal page
+                        $ref: "#/components/schemas/PortalPageContent"
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
@@ -23,6 +23,8 @@ import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
+import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
+import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -154,8 +156,9 @@ public class PortalNavigationItemResourceNotAuthenticatedTest extends AbstractRe
 
             // Then
             assertThat(response.getStatus()).isEqualTo(200);
-            var content = response.readEntity(String.class);
-            assertThat(content).isEqualTo("Page content text");
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("Page content text");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -28,6 +28,8 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
+import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
+import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -183,8 +185,9 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
 
             // Then
             assertThat(response.getStatus()).isEqualTo(200);
-            var content = response.readEntity(String.class);
-            assertThat(content).isEqualTo("Page content text");
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("Page content text");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
         }
 
         @Test
@@ -212,8 +215,9 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
 
             // Then
             assertThat(response.getStatus()).isEqualTo(200);
-            var content = response.readEntity(String.class);
-            assertThat(content).isEqualTo("Page content text");
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("Page content text");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 @Getter
 public final class GraviteeMarkdownPageContent extends PortalPageContent {
 
+    private static final PortalPageContentType TYPE = PortalPageContentType.GRAVITEE_MARKDOWN;
+
     @Setter
     @Nonnull
     private String content;
@@ -42,6 +44,10 @@ public final class GraviteeMarkdownPageContent extends PortalPageContent {
         @Nonnull String content
     ) {
         return new GraviteeMarkdownPageContent(PortalPageContentId.random(), organizationId, environmentId, content);
+    }
+
+    public PortalPageContentType getType() {
+        return TYPE;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -38,6 +38,8 @@ public abstract sealed class PortalPageContent permits GraviteeMarkdownPageConte
 
     public abstract void update(UpdatePortalPageContent updatePortalPageContent);
 
+    public abstract PortalPageContentType getType();
+
     public abstract String getContent();
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContentType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContentType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+public enum PortalPageContentType {
+    GRAVITEE_MARKDOWN,
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12147

## Description

- refactor `/portal-navigation-items/:navId/content` endpoint to return an object instead of a string
- create the corresponding services in portal-next

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

