### PR TITLE
fix(console): display group roles immediately after adding to user

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -436,7 +436,6 @@ describe('OrgSettingsUserDetailComponent', () => {
     const groupsCard = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__groups-card' }));
     const groupsTable = await groupsCard.getHarness(MatTableHarness);
 
-    // First row and delete column
     const deleteUserGroupButton = await (await (await groupsTable.getRows())[0].getCells())[5].getHarness(MatButtonHarness);
 
     await deleteUserGroupButton.click();
@@ -446,7 +445,6 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/groupA/members/${user.id}`);
     expect(req.request.method).toEqual('DELETE');
-    // No flush to stop test here
   });
 
   it('should display APIs user membership', async () => {
@@ -575,13 +573,13 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     const addGroupButton = await groupsCard.getHarness(MatButtonHarness.with({ text: /Add a group/ }));
     await addGroupButton.click();
-    expectGroupListByOrganizationRequest([fakeGroup({ id: 'groupA', name: 'Group A' }), fakeGroup({ id: 'groupB', name: 'Group B' })]);
     fixture.detectChanges();
+    expectGroupListByOrganizationRequest([fakeGroup({ id: 'groupA', name: 'Group A' }), fakeGroup({ id: 'groupB', name: 'Group B' })]);
+
+    const dialog = await rootLoader.getHarness(MatDialogHarness);
     expectRolesListRequest('API');
     expectRolesListRequest('APPLICATION');
     expectRolesListRequest('INTEGRATION');
-
-    const dialog = await rootLoader.getHarness(MatDialogHarness);
 
     const groupIdSelect = await dialog.getHarness(MatSelectHarness.with({ selector: '[formControlName="groupId"]' }));
     await groupIdSelect.open();
@@ -609,6 +607,16 @@ describe('OrgSettingsUserDetailComponent', () => {
         ],
       },
     ]);
+    req.flush([fakeGroupMembership({ id: 'userId', roles: [{ scope: 'GROUP', name: 'ADMIN' }] })]);
+
+    expectGroupListByOrganizationRequest([fakeGroup({ id: 'groupA', name: 'Group A' }), fakeGroup({ id: 'groupB', name: 'Group B' })]);
+
+    fixture.detectChanges();
+
+    const groupsCardAfterAdd = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__groups-card' }));
+    const groupsTableAfterAdd = await groupsCardAfterAdd.getHarness(MatTableHarness);
+    const rows = await groupsTableAfterAdd.getRows();
+    expect(rows.length).toBe(2);
   });
 
   it('should open dialog to create a token', async () => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12276

## Description

Roles were not visible in the groups table until page refresh. Now roles are immediately displayed after adding a group

## Additional context
### Before Fix
https://github.com/user-attachments/assets/03761f72-b557-47ba-93cd-cb9ef68cd8a2

### After Fix
https://github.com/user-attachments/assets/82fb8e0a-a264-4298-8c14-baf587abf47a
