### PR TITLE
fix: disable random highlighting when user clicks into request/response body

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs-details/webhook-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs-details/webhook-logs-details.component.ts
@@ -128,6 +128,9 @@ export class WebhookLogsDetailsComponent implements OnInit {
     renderLineHighlight: 'none',
     hideCursorInOverviewRuler: true,
     overviewRulerBorder: false,
+    occurrencesHighlight: 'off',
+    selectionHighlight: false,
+    readOnly: true,
     scrollbar: {
       vertical: 'hidden',
       horizontal: 'hidden',


### PR DESCRIPTION

https://github.com/user-attachments/assets/b733070e-b133-4448-9930-a33a78e8cc6b

## Issue

https://gravitee.atlassian.net/jira/software/c/projects/GKO/boards/59?selectedIssue=GKO-1948
## Description

Added
```
occurrencesHighlight: 'off',
    selectionHighlight: false,
    readOnly: true,
```
to `monacoEditorOptions` so that no weird highlighting behavior occurs when a user focuses on the webhook details request and/or response body sections in webhook details view. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

