### PR TITLE
fix: migration V2 → V4 EL properties

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ApiTemplateVariableProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ApiTemplateVariableProvider.java
@@ -37,6 +37,10 @@ public class ApiTemplateVariableProvider implements TemplateVariableProvider {
 
     @Override
     public void provide(TemplateContext templateContext) {
+        // Keep this variable for backward compatibility for migration purpose
+        if (apiVariables.getProperties() != null) {
+            templateContext.setVariable("properties", apiVariables.getProperties());
+        }
         templateContext.setVariable("api", apiVariables);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12088

## Description

Accept `{#properties[key]}` as equivalent of `{#api.properties[key]}`