### PR TITLE
Update `Interval` handling and schema in analytics

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -220,12 +220,14 @@
 					<generateSupportingFiles>true</generateSupportingFiles>
 					<supportingFilesToGenerate>JSON.java,RFC3339DateFormat.java,AbstractOpenApiSchema.java,ApiException.java</supportingFilesToGenerate>
 					<reservedWordsMappings>configuration=configuration</reservedWordsMappings>
+                    <importMappings>Interval=io.gravitee.rest.api.management.v2.rest.model.analytics.engine.CustomInterval</importMappings>
 					<configOptions>
 						<dateLibrary>java8</dateLibrary>
 						<useBeanValidation>true</useBeanValidation>
 					</configOptions>
 					<typeMappings>
 						<typeMapping>BigDecimal=Number</typeMapping>
+                        <typeMapping>Interval=CustomInterval</typeMapping>
 					</typeMappings>
 					<additionalProperties>removeEnumValuePrefix=false</additionalProperties>
 				</configuration>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
@@ -28,25 +28,8 @@ import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ArrayFilter;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Bucket;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.BucketGroup;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.BucketLeaf;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetMetricRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponseMetricsInner;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Measure;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.NumberFilter;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Operator;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.StringFilter;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucket;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucketGroup;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucketLeaf;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponseMetricsInner;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.*;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.CustomInterval;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -156,4 +139,8 @@ public interface AnalyticsMeasuresMapper {
 
     @Mapping(target = "facets", source = "by")
     TimeSeriesRequest fromRequestEntity(io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesRequest requestEntity);
+
+    default Long map(CustomInterval interval) {
+        return interval.toMillis();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomInterval.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomInterval.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.model.analytics.engine;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Duration;
+
+/**
+ * @author GraviteeSource Team
+ *
+ * Custom interval class to handle both Long (milliseconds) and String (duration format) interval representations.
+ */
+@JsonDeserialize(using = CustomIntervalDeserializer.class)
+@JsonSerialize(using = CustomIntervalSerializer.class)
+public class CustomInterval {
+
+    private final Object instanceValue;
+
+    public CustomInterval(String interval) {
+        if (interval == null) {
+            throw new IllegalArgumentException("Interval cannot be null");
+        }
+        if (interval.isEmpty()) {
+            throw new IllegalArgumentException("Interval cannot be empty");
+        }
+        instanceValue = interval;
+    }
+
+    public CustomInterval(Long interval) {
+        if (interval == null) {
+            throw new IllegalArgumentException("Interval cannot be null");
+        }
+        instanceValue = interval;
+    }
+
+    public Long toMillis() {
+        return switch (instanceValue) {
+            case Long value -> value;
+            case String value -> parseDurationString(value).toMillis();
+            default -> throw new IllegalArgumentException("Interval value is of unknown type");
+        };
+    }
+
+    private Duration parseDurationString(String duration) {
+        if (duration == null || duration.isEmpty()) {
+            return Duration.ZERO;
+        }
+
+        duration = duration.toUpperCase();
+        if (duration.endsWith("D")) {
+            return Duration.parse("P" + duration);
+        }
+        return Duration.parse("PT" + duration);
+    }
+
+    public Object getActualInstance() {
+        return instanceValue;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalDeserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.model.analytics.engine;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CustomIntervalDeserializer extends StdDeserializer<CustomInterval> {
+
+    protected CustomIntervalDeserializer() {
+        super(CustomInterval.class);
+    }
+
+    @Override
+    public CustomInterval deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonToken token = jp.currentToken();
+
+        if (token == JsonToken.VALUE_NUMBER_INT) {
+            return new CustomInterval(jp.getLongValue());
+        }
+
+        if (token == JsonToken.VALUE_STRING) {
+            String str = jp.getText();
+            if (str.isEmpty()) {
+                throw new JsonMappingException(ctxt.getParser(), "Interval cannot be empty");
+            }
+
+            try {
+                return new CustomInterval(Long.parseLong(str));
+            } catch (NumberFormatException e) {
+                // Not a number, must be a duration string.
+                return new CustomInterval(str);
+            }
+        }
+
+        throw new JsonMappingException(ctxt.getParser(), String.format("Failed deserialization for Interval: %s", token));
+    }
+
+    /**
+     * Handle deserialization of the 'null' value.
+     */
+    @Override
+    public CustomInterval getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        throw new JsonMappingException(ctxt.getParser(), "Interval cannot be null");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.model.analytics.engine;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CustomIntervalSerializer extends StdSerializer<CustomInterval> {
+
+    public CustomIntervalSerializer(Class<CustomInterval> t) {
+        super(t);
+    }
+
+    public CustomIntervalSerializer() {
+        this(null);
+    }
+
+    @Override
+    public void serialize(CustomInterval value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeObject(value.getActualInstance());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1191,10 +1191,15 @@ components:
         Interval:
           description: |
             A fixed time interval for time series analytics queries.
-            Intervals are be expressed in milliseconds.
-          type: integer
-          format: int64
-          example: 1000
+            Intervals are be expressed in milliseconds or duration strings (e.g., 10s, 1m, 5h).
+          oneOf:
+            - type: string
+              pattern: ^\d+[smhd]$
+              description: Shorthand for expressing interval in seconds, minutes, hours or days as a string
+              example: "1s"
+            - type: number
+              description: Interval in milliseconds
+              example: 1000
 
         TimeRange:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsEngineFixtures.java
@@ -15,17 +15,7 @@
  */
 package fixtures;
 
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetMetricRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Filter;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasureName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricRequest;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.NumberRange;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeRange;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesRequest;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.*;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -62,7 +52,7 @@ public class AnalyticsEngineFixtures {
 
         return new TimeSeriesRequest()
             .timeRange(timeRange())
-            .interval(3600000L)
+            .interval(new CustomInterval(3600000L))
             .filters(Arrays.asList(filters))
             .ranges(List.of(new NumberRange().from(100).to(199), new NumberRange().from(200).to(299)))
             .metrics(List.of(metric));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/model/analytics/engine/CustomIntervalTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.model.analytics.engine;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.format.DateTimeParseException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CustomIntervalTest {
+
+    ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+    }
+
+    @ParameterizedTest
+    @MethodSource("validIntervals")
+    void should_parse_valid_interval_values(Object interval, Long expectedMillis) {
+        var intervaL = mapper.convertValue(interval, CustomInterval.class);
+
+        assertThat(intervaL.toMillis()).isEqualTo(expectedMillis);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidIntervals")
+    void should_not_parse_invalid_interval_values(Object interval, Class<? extends Exception> expectedException) {
+        assertThrows(expectedException, () -> {
+            var i = mapper.convertValue(interval, CustomInterval.class);
+            i.toMillis();
+        });
+    }
+
+    static Stream<Arguments> validIntervals() {
+        return Stream.of(
+            arguments(-1, -1L),
+            arguments(0, 0L),
+            arguments(10, 10L),
+            arguments(123456789L, 123456789L),
+            arguments("1", 1L),
+            arguments("10s", 10000L),
+            arguments("1m", 60000L),
+            arguments("1h", 3600000L),
+            arguments("1d", 86400000L)
+        );
+    }
+
+    static Stream<Arguments> invalidIntervals() {
+        return Stream.of(
+            arguments(null, IllegalArgumentException.class),
+            arguments("", IllegalArgumentException.class),
+            arguments("invalid string", DateTimeParseException.class),
+            arguments(true, IllegalArgumentException.class)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -25,41 +25,17 @@ import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.Facet;
-import io.gravitee.repository.analytics.engine.api.result.FacetBucketResult;
-import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
-import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
-import io.gravitee.repository.analytics.engine.api.result.MetricFacetsResult;
-import io.gravitee.repository.analytics.engine.api.result.MetricMeasuresResult;
-import io.gravitee.repository.analytics.engine.api.result.MetricTimeSeriesResult;
-import io.gravitee.repository.analytics.engine.api.result.TimeSeriesBucketResult;
-import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
+import io.gravitee.repository.analytics.engine.api.result.*;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Bucket;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.BucketLeaf;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetsResponseMetricsInner;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Measure;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasureName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MeasuresResponseMetricsInner;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricName;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucket;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesBucketLeaf;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponse;
-import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.TimeSeriesResponseMetricsInner;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.*;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApiResourceTest;
 import jakarta.ws.rs.client.Entity;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -362,7 +338,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
 
         @Test
         void should_fail_with_negative_interval() {
-            var invalidRequest = aRequestCountTimeSeries().interval(-60000L);
+            var invalidRequest = aRequestCountTimeSeries().interval(new CustomInterval(-60000L));
             var response = rootTarget().path("time-series").request().post(Entity.json(invalidRequest));
 
             assertThat(response).hasStatus(400);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1955

## Description

- Updated OpenAPI analytics schema to support `Interval` representation as either a string or an integer.
- Implemented custom serializer and deserializer for the `Interval` class to ensure proper parsing and handling.

Supported string interval suffixes are:
- `s`: seconds
- `m`: minutes
- `h`: hours

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->