### PR TITLE
fix(Console): wrap long headers in runtime logs message tabs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/components/api-runtime-logs-message-item/api-runtime-logs-message-item-content.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/components/api-runtime-logs-message-item/api-runtime-logs-message-item-content.component.scss
@@ -9,5 +9,6 @@ $typography: map.get(gio.$mat-theme, typography);
     background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'default');
     padding: 12px 16px;
     white-space: pre-wrap;
+    word-break: break-all;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12278

## Description
Add word-break CSS to prevent header values from extending horizontally.
Headers with long JWT tokens now wrap properly within the container.

## Additional context

### Before Fix
<img width="1725" height="910" alt="Screenshot 2025-12-16 at 3 41 57 PM" src="https://github.com/user-attachments/assets/7267b233-feae-41ab-adb5-671d78c02aa9" />

### After Fix

https://github.com/user-attachments/assets/590a2d47-25d4-4fa2-9e81-94a86f3cd1cd



