### PR TITLE
fix(gateway): Improve SecurityChainDiagnostic for noSubscriptionPlans

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
@@ -172,7 +172,11 @@ public abstract class AbstractSecurityPlan<T extends BaseSecurityPolicy, C exten
                 }
                 securityChainDiagnostic.markPlanHasExpiredSubscription(planContext.planName(), subscription.getApplicationName());
             } else {
-                securityChainDiagnostic.markPlanHasNoSubscription(planContext.planName());
+                securityChainDiagnostic.markPlanHasNoSubscription(
+                    planContext.planName(),
+                    securityToken.getTokenType(),
+                    securityToken.getTokenValue()
+                );
             }
             return false;
         } catch (Exception t) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12299

## Description

improve wording for noSubscriptionPlans diagnostic and add security token masking

## Additional context
before
<img width="938" height="316" alt="image" src="https://github.com/user-attachments/assets/4635f29f-7133-44e6-a764-479f6a689a20" />

after 
<img width="1140" height="294" alt="image" src="https://github.com/user-attachments/assets/bfdeefc1-864f-4451-b61a-8a5f4f0d26cd" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

