### PR TITLE
feat: enable API Traffic for LLM Proxy

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -51,7 +51,7 @@ export class ApiV4MenuService implements ApiMenuService {
       this.addConsumersMenuEntry(hasTcpListeners),
       this.addDocumentationMenuEntry(api),
       this.addDeploymentMenuEntry(),
-      ...(api.type !== 'LLM_PROXY' ? [this.addApiTrafficMenuEntry(hasTcpListeners, api.type)] : []),
+      this.addApiTrafficMenuEntry(hasTcpListeners, api.type),
       ...(api.type !== 'NATIVE' ? [this.addLogs(hasTcpListeners)] : []),
       ...(webhooksMenuEntry ? [webhooksMenuEntry] : []),
       ...(api.type !== 'NATIVE' ? [this.addApiRuntimeAlertsMenuEntry()] : []),
@@ -382,7 +382,7 @@ export class ApiV4MenuService implements ApiMenuService {
         icon: 'bar-chart-2',
         routerLink: hasTcpListeners ? 'DISABLED' : 'v4/analytics',
       };
-      if (apiType === 'PROXY' || apiType === 'MCP_PROXY') {
+      if (apiType === 'PROXY' || apiType === 'MCP_PROXY' || apiType === 'LLM_PROXY') {
         return baseMenuItem;
       } else {
         return {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.ts
@@ -40,6 +40,9 @@ import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
         @case ('MESSAGE') {
           <api-analytics-message />
         }
+        @case ('LLM_PROXY') {
+          <api-analytics-proxy />
+        }
         @case ('PROXY') {
           <api-analytics-proxy />
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
@@ -33,7 +33,7 @@ public class ResponseTimeRangeQueryAdapter {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private static final List<String> FILTERED_ENTRYPOINT_TYPES = List.of("http-post", "http-get", "http-proxy");
+    private static final List<String> FILTERED_ENTRYPOINT_TYPES = List.of("http-post", "http-get", "http-proxy", "llm-proxy");
     private static final String TIME_FIELD = "@timestamp";
     private static final String RESPONSE_TIME_FIELD = "gateway-response-time-ms";
     private static final String REDUCE_OPERATION = "avg";

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchHistogramQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchHistogramQueryAdapter.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class SearchHistogramQueryAdapter {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final List<String> ENTRYPOINT_IDS = List.of("http-post", "http-get", "http-proxy", "mcp-proxy");
+    private static final List<String> ENTRYPOINT_IDS = List.of("http-post", "http-get", "http-proxy", "llm-proxy", "mcp-proxy");
     private static final Map<AggregationType, String> AGGREGATION_PREFIX = Map.of(
         AggregationType.FIELD,
         "by_",

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
@@ -35,7 +35,7 @@ import java.util.TreeSet;
 
 public class SearchResponseStatusOverTimeAdapter {
 
-    private static final List<String> FILTERED_ENTRYPOINT_TYPES = List.of("http-post", "http-get", "http-proxy");
+    private static final List<String> FILTERED_ENTRYPOINT_TYPES = List.of("http-post", "http-get", "http-proxy", "llm-proxy");
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static final String AGGREGATION_BY_DATE = "by_date";

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
@@ -79,7 +79,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                    "query": {
                      "bool": {
                        "filter": [
-                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy"]}}]}},{"terms":{"api":["my-api-id"]}}]}},
+                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy","llm-proxy"]}}]}},{"terms":{"api":["my-api-id"]}}]}},
                          {
                            "range": {
                              "@timestamp": {
@@ -129,7 +129,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                    "query": {
                      "bool": {
                        "filter": [
-                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy"]}}]}}]}},
+                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy","llm-proxy"]}}]}}]}},
                          {
                            "range": {
                              "@timestamp": {
@@ -179,7 +179,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                    "query": {
                      "bool": {
                        "filter": [
-                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy"]}}]}},{"terms":{"api":["my-api-id"]}}]}},
+                         {"bool":{"minimum_should_match":1,"should":[{"bool":{"must":[{"terms":{"api-id":["my-api-id"]}},{"terms":{"entrypoint-id":["http-post","http-get","http-proxy","llm-proxy"]}}]}},{"terms":{"api":["my-api-id"]}}]}},
                          {
                            "range": {
                              "@timestamp": {


### PR DESCRIPTION
## Description

Enable API Traffic for LLM Proxy. 
Currently the dashboards is the same as HTTP Proxy

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

