### PR TITLE
fix(cache-policy): always set cacheresource to prevent cache not found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <gravitee-policy-circuit-breaker.version>1.1.5</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
-        <gravitee-policy-data-cache.version>1.0.5</gravitee-policy-data-cache.version>
+        <gravitee-policy-data-cache.version>1.0.6</gravitee-policy-data-cache.version>
         <gravitee-policy-data-logging-masking.version>3.1.1</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>


### PR DESCRIPTION
## Description

https://gravitee.atlassian.net/browse/APIM-10999
Base PR : https://github.com/gravitee-io/gravitee-policy-data-cache/pull/25

In Gravitee data-cache policy repo, Removed null check from `setupCacheResource()` to resolve cache resource from current execution context on each request, fixing "Cache not found" on API redeploy with Data Cache Policy in SPGs.

## Additional context
The null check cached a stale resource reference. Removing it ensures the resource is resolved from the current context's ResourceManager on each request.


Before : 

https://github.com/user-attachments/assets/0df8a109-184c-4fd3-a9dd-587eb7a32f09

After : 

https://github.com/user-attachments/assets/12e02681-2972-4bcf-b3e0-90f2980a1275




