### PR TITLE
fix(v4+v2): handle server null message with actual endpoint in 504 timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>5.0.7</gravitee-connector-http.version>
+        <gravitee-connector-http.version>5.0.8</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>5.2.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>3.0.2</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>3.0.0</gravitee-policy-assign-content.version>


### PR DESCRIPTION
## Issue

[APIM-8455](https://gravitee.atlassian.net/browse/APIM-8455)

base PR (v2) : https://github.com/gravitee-io/gravitee-connector-http/pull/109

## Description

for api, In log section for error (like in 504) it was showing server null,
it appears to be issue with vertx, so added fix in gravitee to overwrite error log with host information


## Additional context
before  :
<img width="3418" height="1928" alt="image" src="https://github.com/user-attachments/assets/2152599d-9d80-44e3-a129-9f2ef0e11ba9" />

after : 
<img width="1666" height="945" alt="image" src="https://github.com/user-attachments/assets/6e409c6f-ac68-4971-8b37-af4839016335" />







[APIM-8455]: https://gravitee.atlassian.net/browse/APIM-8455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ