### PR TITLE
Apim 12282 portal filtering problem

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -84,16 +84,16 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
     // Pre-compiled pattern for removing response-time ranges from query filters
     private static final Pattern RESPONSE_TIME_RANGE_REMOVAL_PATTERN = Pattern.compile(
         "\\(\\s*response-time:\"\\[\\d+\\s+TO\\s+\\d+\\]\"(?:\\s+OR\\s+\"\\[\\d+\\s+TO\\s+\\d+\\]\")*\\s*\\)" +
-        "|" +
-        "\\(\\s*response-time:\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\"(?:\\s+OR\\s+\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\")*\\s*\\)" +
-        "|" +
-        "response-time:\"\\[\\d+\\s+TO\\s+\\d+\\]\"" +
-        "|" +
-        "response-time:\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\"" +
-        "|" +
-        "\\s+OR\\s+\"\\[\\d+\\s+TO\\s+\\d+\\]\"" +
-        "|" +
-        "\\s+OR\\s+\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\""
+            "|" +
+            "\\(\\s*response-time:\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\"(?:\\s+OR\\s+\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\")*\\s*\\)" +
+            "|" +
+            "response-time:\"\\[\\d+\\s+TO\\s+\\d+\\]\"" +
+            "|" +
+            "response-time:\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\"" +
+            "|" +
+            "\\s+OR\\s+\"\\[\\d+\\s+TO\\s+\\d+\\]\"" +
+            "|" +
+            "\\s+OR\\s+\\\\\"\\[\\d+\\s+TO\\s+\\d+\\]\\\\\""
     );
 
     @Override
@@ -221,7 +221,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
      * Extract response-time range queries from the filter string.
      * Supports both regular quotes (") and escaped quotes (\") formats.
      * Patterns: response-time:"[X TO Y]" or OR "[X TO Y]"
-     * 
+     *
      * Validates that from <= to for each range. Invalid ranges are skipped with a warning.
      * Duplicate ranges are automatically deduplicated.
      *
@@ -271,13 +271,13 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
             try {
                 final int from = Integer.parseInt(matcher.group(1));
                 final int to = Integer.parseInt(matcher.group(2));
-                
+
                 // Validate range: from must be <= to
                 if (from > to) {
                     logger.warn("Invalid response-time range: from {} > to {}, skipping", from, to);
                     continue;
                 }
-                
+
                 final String rangeKey = from + "-" + to;
                 if (seenRanges.add(rangeKey)) {
                     final Map<String, Object> range = new HashMap<>();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
@@ -24,7 +24,7 @@
         <#if query.query()?has_content>
         {
           "query_string": {
-            "query": "${query.query().filter()}"
+            "query": "${query.query().filter()?json_string}"
           }
         },
         </#if>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
@@ -21,12 +21,51 @@
           }
         },
         </#if>
-        <#if query.query()?has_content>
+        <#if responseTimeRanges?? && responseTimeRanges?has_content>
         {
-          "query_string": {
-            "query": "${query.query().filter()?json_string}"
+          "bool": {
+            "should": [
+            <#list responseTimeRanges as range>
+              {
+                "range": {
+                  "response-time": {
+                    "gte": ${range.gte},
+                    "lte": ${range.lte}
+                  }
+                }
+              }
+              <#sep>,</#sep>
+            </#list>
+            ],
+            "minimum_should_match": 1
           }
         },
+        </#if>
+        <#if query.query()?has_content>
+        <#-- Use cleaned query filter if ranges were extracted, otherwise use original -->
+        <#if responseTimeRanges?? && responseTimeRanges?has_content>
+          <#-- Ranges were extracted, use cleaned filter -->
+          <#assign queryFilter = (cleanedQueryFilter?? && cleanedQueryFilter?has_content)?then(cleanedQueryFilter, "")>
+        <#else>
+          <#-- No ranges extracted, use original filter -->
+          <#assign queryFilter = query.query().filter()>
+        </#if>
+        <#-- Only process if there's still content after removing ranges -->
+        <#if queryFilter?has_content && queryFilter?trim?length gt 0>
+        <#-- Remove leading spaces in quoted values: _id:" value" -> _id:"value" -->
+        <#assign processedQuery = queryFilter?replace('_id:" ', '_id:"', 'r')>
+        <#assign processedQuery = processedQuery?replace('transaction:" ', 'transaction:"', 'r')>
+        {
+          "query_string": {
+            "query": "${processedQuery}",
+            "default_operator": "AND",
+            "lenient": true,
+            "analyze_wildcard": true,
+            "allow_leading_wildcard": true,
+            "auto_generate_synonyms_phrase_query": false
+          }
+        },
+        </#if>
         </#if>
         <#if query.root()?has_content>
         {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
@@ -43,14 +43,15 @@
         </#if>
         <#if query.query()?has_content>
         <#-- Use cleaned query filter if ranges were extracted, otherwise use original -->
+        <#-- If ranges were extracted, cleanedQueryFilter may be empty (all filters were ranges) -->
         <#if responseTimeRanges?? && responseTimeRanges?has_content>
-          <#-- Ranges were extracted, use cleaned filter -->
+          <#-- Ranges were extracted, use cleaned filter (may be empty if query only contained ranges) -->
           <#assign queryFilter = (cleanedQueryFilter?? && cleanedQueryFilter?has_content)?then(cleanedQueryFilter, "")>
         <#else>
           <#-- No ranges extracted, use original filter -->
           <#assign queryFilter = query.query().filter()>
         </#if>
-        <#-- Only process if there's still content after removing ranges -->
+        <#-- Only generate query_string if there's remaining content after removing ranges -->
         <#if queryFilter?has_content && queryFilter?trim?length gt 0>
         <#-- Remove leading spaces in quoted values: _id:" value" -> _id:"value" -->
         <#assign processedQuery = queryFilter?replace('_id:" ', '_id:"', 'r')>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12282

## Description
Extract response-time range patterns from query strings and convert them to explicit Elasticsearch range queries instead of using query_string, which doesn't handle numeric ranges correctly.

## Additional context

### After fix
https://github.com/user-attachments/assets/e241b995-9826-4dee-8f86-0449e046d6ef


