### PR TITLE
fix: handle internal server errors on api doc page creation.

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
@@ -312,6 +312,26 @@ describe('DocumentationNewPageComponent', () => {
           expect(await snackBar.getMessage()).toEqual('Cannot save unsafe content');
         });
 
+        it('should show error if internal server error raised on save', async () => {
+          const editor = await harnessLoader.getHarness(GioMonacoEditorHarness);
+          await editor.setValue('unsafe content');
+
+          const saveBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+          expect(await saveBtn.isDisabled()).toEqual(false);
+          await saveBtn.click();
+
+          const req = httpTestingController.expectOne({
+            method: 'POST',
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages`,
+          });
+
+          req.flush({}, { status: 500, statusText: 'Unexpected error' });
+          fixture.detectChanges();
+
+          const snackBar = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(MatSnackBarHarness);
+          expect(await snackBar.getMessage()).toEqual('Error during page creation.');
+        });
+
         it('should show error if raised on publish', async () => {
           const editor = await harnessLoader.getHarness(GioMonacoEditorHarness);
           await editor.setValue('unsafe content');

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -286,7 +286,7 @@ export class DocumentationNewPageComponent implements OnInit {
     };
     return this.apiDocumentationService.createDocumentationPage(this.api.id, createPage).pipe(
       catchError((err: HttpErrorResponse) => {
-        if (err.status === 500 && err.error.message.includes('fetch') && formValue.sourceType === 'EXTERNAL') {
+        if (err.status === 500 && err.error?.message?.includes('fetch') && formValue.sourceType === 'EXTERNAL') {
           this.snackBarService.error('External source configuration invalid.');
         } else {
           this.snackBarService.error(err.error?.message ?? 'Error during page creation.');


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12289

## Description

Handle a case in API documentation pages when an internal server error doesn't have the expected structure.