### PR TITLE
fix: capture the endpoint body and headers effectively sent

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -245,6 +245,11 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
     }
 
     @Override
+    public void registerBuffersInterceptor(FlowableTransformer<Buffer, Buffer> buffersInterceptor) {
+        lazyBufferFlow().registerBuffersInterceptor(buffersInterceptor);
+    }
+
+    @Override
     public void registerMessagesInterceptor(final MessagesInterceptor messagesInterceptor) {
         lazyMessageFlow().registerMessagesInterceptor(messagesInterceptor);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
@@ -36,7 +36,7 @@ import io.reactivex.rxjava3.core.Single;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public abstract class AbstractResponse implements MutableResponse, HttpResponseInternal {
+public abstract class AbstractResponse implements MutableResponse, HttpResponseInternal, OnBuffersInterceptor {
 
     protected BufferFlow bufferFlow;
     protected MessageFlow<Message> messageFlow;
@@ -189,5 +189,10 @@ public abstract class AbstractResponse implements MutableResponse, HttpResponseI
         }
 
         return this.messageFlow;
+    }
+
+    @Override
+    public void registerBuffersInterceptor(FlowableTransformer<Buffer, Buffer> buffersInterceptor) {
+        lazyBufferFlow().registerBuffersInterceptor(buffersInterceptor);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.reactive.api.message.Message;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<Message> {
+public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<Message>, OnBuffersInterceptor {
     /**
      * Allow setting context path.
      *

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/OnBuffersInterceptor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/OnBuffersInterceptor.java
@@ -15,20 +15,20 @@
  */
 package io.gravitee.gateway.reactive.core.context;
 
-import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.Response;
-import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
-import io.gravitee.gateway.reactive.api.message.Message;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.reactivex.rxjava3.core.FlowableTransformer;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpResponseInternal extends HttpResponse, OnMessagesInterceptor<Message>, OnBuffersInterceptor {
+public interface OnBuffersInterceptor {
     /**
-     * Allows to replace the response headers.
+     * Register a <code>onBuffers</code> interceptor.
+     * This allows to apply custom operations on the stream of buffers even if the stream changes later during the chain (e.g. onChunks or onBody).
+     * Main usage is to capture the stream of buffers at the endpoint level for logging purpose.
      *
-     * @param headers the new response headers.
+     * @param buffersInterceptor the interceptor to register.
      */
-    HttpResponseInternal setHeaders(final HttpHeaders headers);
+    void registerBuffersInterceptor(final FlowableTransformer<Buffer, Buffer> buffersInterceptor);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
@@ -19,7 +19,10 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 
@@ -30,34 +33,13 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 abstract class LogRequest extends io.gravitee.reporter.api.common.Request {
 
     protected final LoggingContext loggingContext;
-    protected final HttpPlainRequest request;
+    protected final HttpRequestInternal request;
 
-    protected LogRequest(LoggingContext loggingContext, HttpPlainRequest request) {
+    protected LogRequest(LoggingContext loggingContext, HttpRequestInternal request) {
         this.loggingContext = loggingContext;
         this.request = request;
 
         this.setMethod(request.method());
-    }
-
-    public void capture(BaseExecutionContext ctx) {
-        if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
-            final Buffer buffer = Buffer.buffer();
-
-            if (loggingContext.isBodyLoggable()) {
-                request.chunks(
-                    request
-                        .chunks()
-                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
-                );
-            } else {
-                this.setBody("BODY NOT CAPTURED");
-            }
-        }
-
-        if (isLogHeaders()) {
-            this.setHeaders(HttpHeaders.create(request.headers()));
-        }
     }
 
     protected abstract boolean isLogPayload();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
@@ -15,9 +15,14 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 
-import io.gravitee.gateway.reactive.api.context.HttpResponse;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
+import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
 
 /**
  * Allows to log the response status, headers and body returned by the backend endpoint depending on what is configured on the {@link LoggingContext}.
@@ -27,8 +32,45 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
  */
 public class LogEndpointResponse extends LogResponse {
 
-    public LogEndpointResponse(LoggingContext loggingContext, HttpPlainResponse response) {
+    public LogEndpointResponse(LoggingContext loggingContext, HttpResponseInternal response) {
         super(loggingContext, response);
+    }
+
+    public void setupCapture(HttpExecutionContextInternal ctx) {
+        if (isLogHeaders()) {
+            // Set a headers captor to capture the response headers coming from the endpoint, excluding any already set response headers (ste by a policy, processor, ...).
+            response.setHeaders(new LogHeadersCaptor(response.headers()));
+        }
+
+        response.registerBuffersInterceptor(chunks -> {
+            // Nothing to prepare for the endpoint response.
+            if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
+                final Buffer buffer = Buffer.buffer();
+                if (loggingContext.isBodyLoggable()) {
+                    chunks = chunks
+                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
+                        .doFinally(() -> this.setBody(buffer.toString()));
+                } else {
+                    this.setBody("BODY NOT CAPTURED");
+                }
+            }
+
+            // For the endpoint response logging, we can capture the response headers and status when the body receiving starts.
+            return chunks.doOnSubscribe(subscription -> captureStatusAndHeaders());
+        });
+    }
+
+    public void finalizeCapture(HttpExecutionContextInternal ctx) {
+        if (isLogHeaders()) {
+            response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());
+        }
+    }
+
+    private void captureStatusAndHeaders() {
+        if (isLogHeaders()) {
+            this.setHeaders(response.headers());
+        }
+        this.setStatus(response.status());
     }
 
     protected boolean isLogPayload() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
@@ -31,37 +32,20 @@ import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeaders
 abstract class LogResponse extends io.gravitee.reporter.api.common.Response {
 
     protected final LoggingContext loggingContext;
-    protected final HttpPlainResponse response;
+    protected final HttpResponseInternal response;
 
-    protected LogResponse(LoggingContext loggingContext, HttpPlainResponse response) {
+    protected LogResponse(LoggingContext loggingContext, HttpResponseInternal response) {
         this.loggingContext = loggingContext;
         this.response = response;
     }
 
-    public void capture(BaseExecutionContext ctx) {
-        if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
-            final Buffer buffer = Buffer.buffer();
-            if (loggingContext.isBodyLoggable()) {
-                response.chunks(
-                    response
-                        .chunks()
-                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
-                );
-            } else {
-                this.setBody("BODY NOT CAPTURED");
-            }
-        }
-
-        if (isLogHeaders()) {
-            this.setHeaders(response.headers());
-        }
-
-        this.setStatus(response.status());
-    }
-
     @Override
     public void setHeaders(HttpHeaders headers) {
+        if (this.getHeaders() != null) {
+            // Headers have already been captured.
+            return;
+        }
+
         if (headers instanceof LogHeadersCaptor logHeadersCaptor) {
             super.setHeaders(logHeadersCaptor.getCaptured());
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -69,8 +71,8 @@ public class LogInitProcessor implements Processor {
     }
 
     private void initLogEntity(final HttpExecutionContextInternal ctx, final LoggingContext loggingContext) {
-        HttpPlainRequest request = ctx.request();
-        HttpPlainResponse response = ctx.response();
+        HttpRequestInternal request = ctx.request();
+        HttpResponseInternal response = ctx.response();
 
         Log log = Log.builder()
             .timestamp(request.timestamp())
@@ -90,7 +92,7 @@ public class LogInitProcessor implements Processor {
             log.setEntrypointResponse(logResponse);
         }
         if (loggingContext.endpointRequest()) {
-            final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+            final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, request);
             log.setEndpointRequest(logRequest);
         }
         if (loggingContext.endpointResponse()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
@@ -51,7 +51,9 @@ public class LogRequestProcessor implements Processor {
             LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext.entrypointRequest()) {
-                ((LogEntrypointRequest) log.getEntrypointRequest()).capture(ctx);
+                LogEntrypointRequest entrypointRequest = (LogEntrypointRequest) log.getEntrypointRequest();
+                entrypointRequest.capture(ctx);
+                entrypointRequest.finalizeCapture(ctx);
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
@@ -51,7 +51,9 @@ public class LogResponseProcessor implements Processor {
             LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext.entrypointResponse()) {
-                ((LogEntrypointResponse) log.getEntrypointResponse()).capture(ctx);
+                LogEntrypointResponse entrypointResponse = (LogEntrypointResponse) log.getEntrypointResponse();
+                entrypointResponse.capture(ctx);
+                entrypointResponse.finalizeCapture(ctx);
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -29,8 +29,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpRequest;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -57,16 +57,16 @@ class LogEntrypointRequestTest {
     protected LoggingContext loggingContext;
 
     @Mock
-    protected HttpRequest request;
+    protected HttpRequestInternal request;
 
     @Mock
-    BaseExecutionContext ctx;
+    private HttpExecutionContextInternal ctx;
 
     @Captor
-    ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
+    private ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
 
     @Test
-    void shouldLogMethodAndUriOnly() {
+    void should_log_method_and_uri_only() {
         when(request.method()).thenReturn(HttpMethod.POST);
         when(request.uri()).thenReturn(URI);
 
@@ -75,6 +75,7 @@ class LogEntrypointRequestTest {
 
         final var logRequest = new LogEntrypointRequest(loggingContext, request);
         logRequest.capture(ctx);
+
         assertThat(logRequest.getMethod()).isEqualTo(HttpMethod.POST);
         assertThat(logRequest.getUri()).isEqualTo(URI);
         assertNull(logRequest.getHeaders());
@@ -82,7 +83,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogHeaders() {
+    void should_log_headers() {
         final HttpHeaders headers = new VertxHttpHeaders(new HeadersMultiMap());
 
         headers.set("X-Test1", "Value1");
@@ -102,7 +103,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogBody() {
+    void should_log_body() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
 
         when(request.chunks()).thenReturn(body);
@@ -125,7 +126,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldNotLogBodyWhenContentTypeExcluded() {
+    void should_not_log_body_when_content_type_excluded() {
         final HttpHeaders headers = HttpHeaders.create();
         headers.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
         when(request.headers()).thenReturn(headers);
@@ -142,7 +143,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogPartialBodyWhenMaxPayloadSizeIsDefined() {
+    void should_log_partial_body_when_max_payload_size_is_defined() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
         final int maxPayloadSize = 5;
 
@@ -166,7 +167,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogBodyNotCaptureWhenBodyNotLoggable() {
+    void should_log_body_not_capture_when_body_not_loggable() {
         when(request.headers()).thenReturn(HttpHeaders.create());
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
         when(loggingContext.entrypointRequestPayload()).thenReturn(true);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -30,8 +30,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpResponse;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -57,16 +57,16 @@ class LogEntrypointResponseTest {
     protected LoggingContext loggingContext;
 
     @Mock
-    protected HttpResponse response;
+    protected HttpResponseInternal response;
 
     @Mock
-    protected BaseExecutionContext ctx;
+    protected HttpExecutionContextInternal ctx;
 
     @Captor
     ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
 
     @Test
-    void shouldLogStatusOnly() {
+    void should_log_status_only() {
         when(response.status()).thenReturn(HttpStatusCode.OK_200);
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(false);
@@ -80,7 +80,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogHeaders() {
+    void should_log_headers() {
         final HttpHeaders headers = new VertxHttpHeaders(new HeadersMultiMap());
 
         headers.set("X-Test1", "Value1");
@@ -100,7 +100,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogBody() {
+    void should_log_body() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
 
         when(response.chunks()).thenReturn(body);
@@ -123,7 +123,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldNotLogBodyWhenContentTypeExcluded() {
+    void should_not_log_body_when_content_type_excluded() {
         final HttpHeaders headers = HttpHeaders.create();
         headers.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
 
@@ -141,7 +141,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogPartialBodyWhenMaxPayloadSizeIsDefined() {
+    void should_log_partial_body_when_max_payload_size_is_defined() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
         final int maxPayloadSize = 5;
 
@@ -165,7 +165,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogBodyNotCapturedWhenBodyIsNotLoggable() {
+    void should_log_body_not_captured_when_body_is_not_loggable() {
         when(response.headers()).thenReturn(HttpHeaders.create());
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(true);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-634

## Description

This PR refactors the body/header logging mechanism, aiming to capture the body and headers sent to the backend properly and effectively. This is particularly important for the LLM Proxy endpoint connector that performs OpenAI to the Provider-specific format.

