### PR TITLE
fix: capture the endpoint body and headers effectively sent

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/BufferFlow.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/BufferFlow.java
@@ -16,21 +16,25 @@
 package io.gravitee.gateway.reactive.core;
 
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.core.context.OnBuffersInterceptor;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeTransformer;
 import io.reactivex.rxjava3.core.Single;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class BufferFlow {
+public class BufferFlow implements OnBuffersInterceptor {
 
-    private Supplier<Boolean> isStreaming;
+    private List<FlowableTransformer<Buffer, Buffer>> bufferInterceptors;
+
+    private final Supplier<Boolean> isStreaming;
     private Flowable<Buffer> chunks;
     private Maybe<Buffer> cachedBuffer;
 
@@ -46,6 +50,7 @@ public class BufferFlow {
     public Maybe<Buffer> body() {
         if (Boolean.FALSE.equals(isStreaming.get())) {
             this.chunks = chunksFromCache(() -> chunksOrEmpty().compose(chunksToCache()));
+            applyBuffersInterceptors();
             return chunks.firstElement();
         } else {
             return Maybe.empty();
@@ -66,12 +71,14 @@ public class BufferFlow {
         if (Boolean.FALSE.equals(isStreaming.get())) {
             cachedBuffer = Maybe.just(buffer);
             this.chunks = cachedBuffer.toFlowable();
+            applyBuffersInterceptors();
         }
     }
 
     public Completable onBody(MaybeTransformer<Buffer, Buffer> onBody) {
         if (Boolean.FALSE.equals(isStreaming.get())) {
             this.chunks = bodyFromCache(this::reduceBody).compose(onBody).compose(bodyToCache()).toFlowable();
+            applyBuffersInterceptors();
             return this.chunks.ignoreElements();
         } else {
             return Completable.complete();
@@ -80,22 +87,33 @@ public class BufferFlow {
 
     public Flowable<Buffer> chunks() {
         chunks = chunksFromCache(this::chunksOrEmpty);
+        applyBuffersInterceptors();
         return chunks;
     }
 
     public void chunks(final Flowable<Buffer> chunks) {
         cachedBuffer = null;
         this.chunks = chunks;
+        applyBuffersInterceptors();
     }
 
     public Completable onChunks(final FlowableTransformer<Buffer, Buffer> onChunks) {
         this.chunks = this.chunksFromCache(this::chunks).compose(onChunks).compose(chunksToCache());
+        applyBuffersInterceptors();
 
         return this.chunks.ignoreElements();
     }
 
     public boolean hasChunks() {
         return chunks != null;
+    }
+
+    @Override
+    public void registerBuffersInterceptor(FlowableTransformer<Buffer, Buffer> buffersInterceptor) {
+        if (this.bufferInterceptors == null) {
+            this.bufferInterceptors = new java.util.ArrayList<>();
+        }
+        this.bufferInterceptors.add(buffersInterceptor);
     }
 
     private Flowable<Buffer> chunksOrEmpty() {
@@ -161,5 +179,22 @@ public class BufferFlow {
 
     private FlowableTransformer<Buffer, Buffer> chunksToCache() {
         return upstream -> upstream.reduce(Buffer::appendBuffer).compose(bodyToCache()).toFlowable();
+    }
+
+    private void applyBuffersInterceptors() {
+        if (chunks == null) {
+            return;
+        }
+
+        if (bufferInterceptors != null) {
+            for (FlowableTransformer<Buffer, Buffer> bufferInterceptor : bufferInterceptors) {
+                this.chunks = this.chunks.compose(bufferInterceptor);
+            }
+
+            // Make sure to apply the interceptors once.
+            bufferInterceptors.clear();
+        } else {
+            this.chunks = this.chunks.compose(c -> c);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -245,6 +245,11 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
     }
 
     @Override
+    public void registerBuffersInterceptor(FlowableTransformer<Buffer, Buffer> buffersInterceptor) {
+        lazyBufferFlow().registerBuffersInterceptor(buffersInterceptor);
+    }
+
+    @Override
     public void registerMessagesInterceptor(final MessagesInterceptor messagesInterceptor) {
         lazyMessageFlow().registerMessagesInterceptor(messagesInterceptor);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
@@ -36,7 +36,7 @@ import io.reactivex.rxjava3.core.Single;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public abstract class AbstractResponse implements MutableResponse, HttpResponseInternal {
+public abstract class AbstractResponse implements MutableResponse, HttpResponseInternal, OnBuffersInterceptor {
 
     protected BufferFlow bufferFlow;
     protected MessageFlow<Message> messageFlow;
@@ -189,5 +189,10 @@ public abstract class AbstractResponse implements MutableResponse, HttpResponseI
         }
 
         return this.messageFlow;
+    }
+
+    @Override
+    public void registerBuffersInterceptor(FlowableTransformer<Buffer, Buffer> buffersInterceptor) {
+        lazyBufferFlow().registerBuffersInterceptor(buffersInterceptor);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.reactive.api.message.Message;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<Message> {
+public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<Message>, OnBuffersInterceptor {
     /**
      * Allow setting context path.
      *

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/OnBuffersInterceptor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/OnBuffersInterceptor.java
@@ -15,20 +15,20 @@
  */
 package io.gravitee.gateway.reactive.core.context;
 
-import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.Response;
-import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
-import io.gravitee.gateway.reactive.api.message.Message;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.reactivex.rxjava3.core.FlowableTransformer;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HttpResponseInternal extends HttpResponse, OnMessagesInterceptor<Message>, OnBuffersInterceptor {
+public interface OnBuffersInterceptor {
     /**
-     * Allows to replace the response headers.
+     * Register a <code>onBuffers</code> interceptor.
+     * This allows to apply custom operations on the stream of buffers even if the stream changes later during the chain (e.g. onChunks or onBody).
+     * Main usage is to capture the stream of buffers at the endpoint level for logging purpose.
      *
-     * @param headers the new response headers.
+     * @param buffersInterceptor the interceptor to register.
      */
-    HttpResponseInternal setHeaders(final HttpHeaders headers);
+    void registerBuffersInterceptor(final FlowableTransformer<Buffer, Buffer> buffersInterceptor);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
@@ -19,7 +19,10 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 
@@ -30,34 +33,13 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 abstract class LogRequest extends io.gravitee.reporter.api.common.Request {
 
     protected final LoggingContext loggingContext;
-    protected final HttpPlainRequest request;
+    protected final HttpRequestInternal request;
 
-    protected LogRequest(LoggingContext loggingContext, HttpPlainRequest request) {
+    protected LogRequest(LoggingContext loggingContext, HttpRequestInternal request) {
         this.loggingContext = loggingContext;
         this.request = request;
 
         this.setMethod(request.method());
-    }
-
-    public void capture(BaseExecutionContext ctx) {
-        if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
-            final Buffer buffer = Buffer.buffer();
-
-            if (loggingContext.isBodyLoggable()) {
-                request.chunks(
-                    request
-                        .chunks()
-                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
-                );
-            } else {
-                this.setBody("BODY NOT CAPTURED");
-            }
-        }
-
-        if (isLogHeaders()) {
-            this.setHeaders(HttpHeaders.create(request.headers()));
-        }
     }
 
     protected abstract boolean isLogPayload();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
@@ -15,9 +15,14 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 
-import io.gravitee.gateway.reactive.api.context.HttpResponse;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
+import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
 
 /**
  * Allows to log the response status, headers and body returned by the backend endpoint depending on what is configured on the {@link LoggingContext}.
@@ -27,8 +32,39 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
  */
 public class LogEndpointResponse extends LogResponse {
 
-    public LogEndpointResponse(LoggingContext loggingContext, HttpPlainResponse response) {
+    public LogEndpointResponse(LoggingContext loggingContext, HttpResponseInternal response) {
         super(loggingContext, response);
+    }
+
+    public void setupCapture(HttpExecutionContextInternal ctx) {
+        if (isLogHeaders()) {
+            // Set a headers captor to capture the response headers coming from the endpoint, excluding any already set response headers (set by a policy, processor, ...).
+            response.setHeaders(new LogHeadersCaptor(response.headers()));
+        }
+
+        response.registerBuffersInterceptor(chunks -> {
+            // Nothing to prepare for the endpoint response.
+            if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
+                final Buffer buffer = Buffer.buffer();
+                if (loggingContext.isBodyLoggable()) {
+                    chunks = chunks
+                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
+                        .doFinally(() -> this.setBody(buffer.toString()));
+                } else {
+                    this.setBody("BODY NOT CAPTURED");
+                }
+            }
+
+            return chunks;
+        });
+    }
+
+    public void finalizeCapture(HttpExecutionContextInternal ctx) {
+        if (isLogHeaders()) {
+            this.setHeaders(response.headers());
+            response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());
+        }
+        this.setStatus(response.status());
     }
 
     protected boolean isLogPayload() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
@@ -31,37 +32,20 @@ import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeaders
 abstract class LogResponse extends io.gravitee.reporter.api.common.Response {
 
     protected final LoggingContext loggingContext;
-    protected final HttpPlainResponse response;
+    protected final HttpResponseInternal response;
 
-    protected LogResponse(LoggingContext loggingContext, HttpPlainResponse response) {
+    protected LogResponse(LoggingContext loggingContext, HttpResponseInternal response) {
         this.loggingContext = loggingContext;
         this.response = response;
     }
 
-    public void capture(BaseExecutionContext ctx) {
-        if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
-            final Buffer buffer = Buffer.buffer();
-            if (loggingContext.isBodyLoggable()) {
-                response.chunks(
-                    response
-                        .chunks()
-                        .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
-                );
-            } else {
-                this.setBody("BODY NOT CAPTURED");
-            }
-        }
-
-        if (isLogHeaders()) {
-            this.setHeaders(response.headers());
-        }
-
-        this.setStatus(response.status());
-    }
-
     @Override
     public void setHeaders(HttpHeaders headers) {
+        if (this.getHeaders() != null) {
+            // Headers have already been captured.
+            return;
+        }
+
         if (headers instanceof LogHeadersCaptor logHeadersCaptor) {
             super.setHeaders(logHeadersCaptor.getCaptured());
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -69,8 +71,8 @@ public class LogInitProcessor implements Processor {
     }
 
     private void initLogEntity(final HttpExecutionContextInternal ctx, final LoggingContext loggingContext) {
-        HttpPlainRequest request = ctx.request();
-        HttpPlainResponse response = ctx.response();
+        HttpRequestInternal request = ctx.request();
+        HttpResponseInternal response = ctx.response();
 
         Log log = Log.builder()
             .timestamp(request.timestamp())
@@ -90,7 +92,7 @@ public class LogInitProcessor implements Processor {
             log.setEntrypointResponse(logResponse);
         }
         if (loggingContext.endpointRequest()) {
-            final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+            final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, request);
             log.setEndpointRequest(logRequest);
         }
         if (loggingContext.endpointResponse()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogRequestProcessor.java
@@ -51,7 +51,8 @@ public class LogRequestProcessor implements Processor {
             LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext.entrypointRequest()) {
-                ((LogEntrypointRequest) log.getEntrypointRequest()).capture(ctx);
+                LogEntrypointRequest entrypointRequest = (LogEntrypointRequest) log.getEntrypointRequest();
+                entrypointRequest.capture(ctx);
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
@@ -51,7 +51,8 @@ public class LogResponseProcessor implements Processor {
             LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext.entrypointResponse()) {
-                ((LogEntrypointResponse) log.getEntrypointResponse()).capture(ctx);
+                LogEntrypointResponse entrypointResponse = (LogEntrypointResponse) log.getEntrypointResponse();
+                entrypointResponse.capture(ctx);
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -29,8 +29,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpRequest;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -57,16 +57,16 @@ class LogEntrypointRequestTest {
     protected LoggingContext loggingContext;
 
     @Mock
-    protected HttpRequest request;
+    protected HttpRequestInternal request;
 
     @Mock
-    BaseExecutionContext ctx;
+    private HttpExecutionContextInternal ctx;
 
     @Captor
-    ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
+    private ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
 
     @Test
-    void shouldLogMethodAndUriOnly() {
+    void should_log_method_and_uri_only() {
         when(request.method()).thenReturn(HttpMethod.POST);
         when(request.uri()).thenReturn(URI);
 
@@ -75,6 +75,7 @@ class LogEntrypointRequestTest {
 
         final var logRequest = new LogEntrypointRequest(loggingContext, request);
         logRequest.capture(ctx);
+
         assertThat(logRequest.getMethod()).isEqualTo(HttpMethod.POST);
         assertThat(logRequest.getUri()).isEqualTo(URI);
         assertNull(logRequest.getHeaders());
@@ -82,7 +83,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogHeaders() {
+    void should_log_headers() {
         final HttpHeaders headers = new VertxHttpHeaders(new HeadersMultiMap());
 
         headers.set("X-Test1", "Value1");
@@ -102,7 +103,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogBody() {
+    void should_log_body() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
 
         when(request.chunks()).thenReturn(body);
@@ -125,7 +126,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldNotLogBodyWhenContentTypeExcluded() {
+    void should_not_log_body_when_content_type_excluded() {
         final HttpHeaders headers = HttpHeaders.create();
         headers.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
         when(request.headers()).thenReturn(headers);
@@ -142,7 +143,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogPartialBodyWhenMaxPayloadSizeIsDefined() {
+    void should_log_partial_body_when_max_payload_size_is_defined() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
         final int maxPayloadSize = 5;
 
@@ -166,7 +167,7 @@ class LogEntrypointRequestTest {
     }
 
     @Test
-    void shouldLogBodyNotCaptureWhenBodyNotLoggable() {
+    void should_log_body_not_capture_when_body_not_loggable() {
         when(request.headers()).thenReturn(HttpHeaders.create());
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
         when(loggingContext.entrypointRequestPayload()).thenReturn(true);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -15,29 +15,33 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpResponse;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
-import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -58,149 +62,245 @@ class LogEndpointResponseTest {
     protected LoggingContext loggingContext;
 
     @Mock
-    protected HttpResponse response;
+    protected HttpResponseInternal response;
 
     @Mock
-    BaseExecutionContext ctx;
+    private HttpExecutionContextInternal ctx;
 
     @Captor
-    ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
+    private ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
+
+    @Captor
+    private ArgumentCaptor<FlowableTransformer<Buffer, Buffer>> buffersInterceptorCaptor;
+
+    private LogEndpointResponse cut;
+
+    @BeforeEach
+    void init() {
+        doNothing().when(response).registerBuffersInterceptor(buffersInterceptorCaptor.capture());
+        cut = new LogEndpointResponse(loggingContext, response);
+    }
 
     @Test
-    void shouldLogMethodAndUriOnly() {
-        when(response.status()).thenReturn(HttpStatusCode.OK_200);
+    void should_log_method_and_uri_only() {
+        initializeHeaders(HttpHeaders.create());
+        when(response.status()).thenReturn(OK_200);
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
 
-        assertThat(logResponse.getStatus()).isEqualTo(HttpStatusCode.OK_200);
-        assertNull(logResponse.getHeaders());
-        assertNull(logResponse.getBody());
+        assertThat(cut.getStatus()).isEqualTo(OK_200);
+        assertNull(cut.getHeaders());
+        assertNull(cut.getBody());
     }
 
     @Test
-    void shouldLogHeaders() {
-        final HttpHeaders headers = new VertxHttpHeaders(new HeadersMultiMap());
+    void should_log_headers() {
+        final HttpHeaders backendHeaders = new VertxHttpHeaders(new HeadersMultiMap());
+        backendHeaders.set("X-Test1", "Value1");
+        backendHeaders.set("X-Test2", "Value2");
+        backendHeaders.set("X-Test3", List.of("Value3-a", "Value3-b"));
 
-        headers.set("X-Test1", "Value1");
-        headers.set("X-Test2", "Value2");
-        headers.set("X-Test3", List.of("Value3-a", "Value3-b"));
-
-        when(response.headers()).thenReturn(headers);
-        when(response.status()).thenReturn(HttpStatusCode.OK_200);
+        initializeHeaders(HttpHeaders.create());
+        when(response.status()).thenReturn(OK_200);
         when(loggingContext.endpointResponseHeaders()).thenReturn(true);
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(backendHeaders);
 
-        assertNotSame(headers, logResponse.getHeaders());
-        assertThat(logResponse.getHeaders().deeplyEquals(headers)).isTrue();
-        assertNull(logResponse.getBody());
+        assertNotSame(backendHeaders, cut.getHeaders());
+        assertThat(cut.getHeaders().deeplyEquals(backendHeaders)).isTrue();
+        assertNull(cut.getBody());
     }
 
     @Test
-    void shouldLogNoHeadersWhenUsingLogHeadersCaptorAndNoHeadersHasChanged() {
+    void should_log_no_headers_when_using_log_headers_captor_and_no_headers_has_been_return_by_the_backend() {
         final VertxHttpHeaders existingHeaders = new VertxHttpHeaders(new HeadersMultiMap());
         existingHeaders.set("X-Test1", "Value1");
         existingHeaders.set("X-Test2", "Value2");
         existingHeaders.set("X-Test3", List.of("Value3-a", "Value3-b"));
 
-        final HttpHeaders headers = new LogHeadersCaptor(existingHeaders);
-
-        when(response.headers()).thenReturn(headers);
-        when(response.status()).thenReturn(HttpStatusCode.OK_200);
+        initializeHeaders(existingHeaders);
+        when(response.status()).thenReturn(OK_200);
         when(loggingContext.endpointResponseHeaders()).thenReturn(true);
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
 
-        assertNotSame(headers, logResponse.getHeaders());
-        assertThat(logResponse.getHeaders().deeplyEquals(HttpHeaders.create())).isTrue();
-        assertNull(logResponse.getBody());
+        assertNotSame(existingHeaders, cut.getHeaders());
+        assertThat(cut.getHeaders().deeplyEquals(HttpHeaders.create())).isTrue();
+        assertNull(cut.getBody());
     }
 
     @Test
-    void shouldLogBody() {
-        final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+    void should_log_only_headers_returned_by_the_backend_and_ignore_headers_set_by_the_gateway() {
+        final HttpHeaders backendHeaders = HttpHeaders.create().set("X-From-Backend1", "Backend1").set("X-From-Backend2", "Backend2");
+        final VertxHttpHeaders existingHeaders = new VertxHttpHeaders(new HeadersMultiMap());
+        existingHeaders.set("X-Test1", "Value1");
+        existingHeaders.set("X-Test2", "Value2");
+        existingHeaders.set("X-Test3", List.of("Value3-a", "Value3-b"));
 
-        when(response.chunks()).thenReturn(body);
-        when(response.headers()).thenReturn(HttpHeaders.create());
+        initializeHeaders(existingHeaders);
+        when(response.status()).thenReturn(OK_200);
+        when(loggingContext.endpointResponseHeaders()).thenReturn(true);
+        when(loggingContext.endpointResponsePayload()).thenReturn(false);
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(backendHeaders);
+
+        assertNotSame(existingHeaders, cut.getHeaders());
+        assertThat(cut.getHeaders().deeplyEquals(backendHeaders)).isTrue();
+        assertNull(cut.getBody());
+    }
+
+    @Test
+    void should_log_body_only() {
+        initializeHeaders(HttpHeaders.create());
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
         when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
 
-        final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
-        verify(response).chunks(chunksCaptor.capture());
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(HttpHeaders.create().set("X-From-Backend1", "Backend1"));
 
-        final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
-        obs.assertComplete();
-
-        assertNull(logResponse.getHeaders());
-        assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT);
+        assertNull(cut.getHeaders());
+        assertThat(cut.getBody()).isEqualTo(BODY_CONTENT);
     }
 
     @Test
-    void shouldNotLogBodyWhenContentTypeExcluded() {
-        final HttpHeaders headers = HttpHeaders.create();
-        headers.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
+    void should_log_body_and_headers() {
+        final HttpHeaders backendHeaders = HttpHeaders.create().set("X-From-Backend1", "Backend1");
 
-        when(response.headers()).thenReturn(headers);
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(true);
+        when(loggingContext.endpointResponsePayload()).thenReturn(true);
+        when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
+        when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(backendHeaders);
+
+        assertThat(cut.getHeaders().deeplyEquals(backendHeaders)).isTrue();
+        assertThat(cut.getBody()).isEqualTo(BODY_CONTENT);
+    }
+
+    @Test
+    void should_not_log_body_when_content_type_is_excluded() {
+        final HttpHeaders backendHeaders = HttpHeaders.create();
+        backendHeaders.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
+
+        initializeHeaders(HttpHeaders.create());
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(eq("application/octet-stream"), any())).thenReturn(false);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
-        verify(response, times(0)).chunks(any(Flowable.class));
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(backendHeaders);
 
-        assertNull(logResponse.getHeaders());
-        assertNull(logResponse.getBody());
+        assertNull(cut.getHeaders());
+        assertNull(cut.getBody());
     }
 
     @Test
-    void shouldLogPartialBodyWhenMaxPayloadSizeIsDefined() {
-        final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+    void should_log_partial_body_when_max_payload_size_is_defined() {
         final int maxPayloadSize = 5;
 
-        when(response.chunks()).thenReturn(body);
-        when(response.headers()).thenReturn(HttpHeaders.create());
+        initializeHeaders(HttpHeaders.create());
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(maxPayloadSize);
         when(loggingContext.isBodyLoggable()).thenReturn(true);
         when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
-        verify(response).chunks(chunksCaptor.capture());
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(HttpHeaders.create());
 
-        final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
-        obs.assertComplete();
-
-        assertNull(logResponse.getHeaders());
-        assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+        assertNull(cut.getHeaders());
+        assertThat(cut.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
     }
 
     @Test
-    void shouldLogBodyNotCapturedWhenBodyIsNotLoggable() {
-        when(response.headers()).thenReturn(HttpHeaders.create());
+    void should_log_partial_body_when_error_occurs_during_body_transfer() {
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(true);
+        when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
+        when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackendWithError();
+
+        assertNull(cut.getHeaders());
+        // The last character is missing due to the error before completion.
+        assertThat(cut.getBody()).isEqualTo(BODY_CONTENT.substring(0, BODY_CONTENT.length() - 1));
+    }
+
+    @Test
+    void should_log_body_not_captured_when_body_is_not_loggable() {
+        initializeHeaders(HttpHeaders.create());
         when(loggingContext.endpointResponseHeaders()).thenReturn(false);
         when(loggingContext.endpointResponsePayload()).thenReturn(true);
         when(loggingContext.isBodyLoggable()).thenReturn(false);
         when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
 
-        final var logResponse = new LogEndpointResponse(loggingContext, response);
-        logResponse.capture(ctx);
-        verify(response, never()).chunks(any(Flowable.class));
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(HttpHeaders.create());
 
-        assertNull(logResponse.getHeaders());
-        assertThat(logResponse.getBody()).isEqualTo("BODY NOT CAPTURED");
+        assertNull(cut.getHeaders());
+        assertThat(cut.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    private void triggerResponseFromBackend(HttpHeaders backendHeaders) {
+        if (backendHeaders != null) {
+            backendHeaders.forEach(e -> response.headers().set(e.getKey(), e.getValue()));
+        }
+
+        Flowable.fromPublisher(
+            buffersInterceptorCaptor.getValue().apply(Flowable.just(Buffer.buffer(LogEndpointResponseTest.BODY_CONTENT)))
+        )
+            .test()
+            .assertComplete();
+
+        cut.finalizeCapture(ctx);
+    }
+
+    private void triggerResponseFromBackendWithError() {
+        List<Buffer> buffers = BODY_CONTENT.chars()
+            .mapToObj(i -> Buffer.buffer(String.valueOf((char) i)))
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        // Remove last buffer to simulate error before complete.
+        buffers.removeLast();
+
+        Flowable.fromPublisher(
+            buffersInterceptorCaptor
+                .getValue()
+                .apply(Flowable.fromIterable(buffers).concatWith(Flowable.error(new RuntimeException("error"))))
+        )
+            .test()
+            .assertError(RuntimeException.class);
+
+        cut.finalizeCapture(ctx);
+    }
+
+    private void initializeHeaders(HttpHeaders initialHeaders) {
+        AtomicReference<HttpHeaders> headersRef = new AtomicReference<>(initialHeaders);
+        lenient()
+            .when(response.headers())
+            .thenAnswer(invocation -> headersRef.get());
+        lenient()
+            .when(response.setHeaders(any(HttpHeaders.class)))
+            .thenAnswer(invocation -> {
+                headersRef.set(invocation.getArgument(0));
+                return response;
+            });
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -30,8 +30,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpResponse;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
@@ -57,16 +57,16 @@ class LogEntrypointResponseTest {
     protected LoggingContext loggingContext;
 
     @Mock
-    protected HttpResponse response;
+    protected HttpResponseInternal response;
 
     @Mock
-    protected BaseExecutionContext ctx;
+    protected HttpExecutionContextInternal ctx;
 
     @Captor
     ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
 
     @Test
-    void shouldLogStatusOnly() {
+    void should_log_status_only() {
         when(response.status()).thenReturn(HttpStatusCode.OK_200);
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(false);
@@ -80,7 +80,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogHeaders() {
+    void should_log_headers() {
         final HttpHeaders headers = new VertxHttpHeaders(new HeadersMultiMap());
 
         headers.set("X-Test1", "Value1");
@@ -100,7 +100,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogBody() {
+    void should_log_body() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
 
         when(response.chunks()).thenReturn(body);
@@ -123,7 +123,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldNotLogBodyWhenContentTypeExcluded() {
+    void should_not_log_body_when_content_type_excluded() {
         final HttpHeaders headers = HttpHeaders.create();
         headers.set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
 
@@ -141,7 +141,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogPartialBodyWhenMaxPayloadSizeIsDefined() {
+    void should_log_partial_body_when_max_payload_size_is_defined() {
         final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
         final int maxPayloadSize = 5;
 
@@ -165,7 +165,7 @@ class LogEntrypointResponseTest {
     }
 
     @Test
-    void shouldLogBodyNotCapturedWhenBodyIsNotLoggable() {
+    void should_log_body_not_captured_when_body_is_not_loggable() {
         when(response.headers()).thenReturn(HttpHeaders.create());
         when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
         when(loggingContext.entrypointResponsePayload()).thenReturn(true);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
@@ -155,7 +155,6 @@ class LogInitProcessorTest extends AbstractV4ProcessorTest {
     @Test
     void shouldInitEndpointRequestWhenEndpointRequestLogEnabled() {
         when(loggingContext.endpointRequest()).thenReturn(true);
-        when(mockRequest.chunks()).thenReturn(Flowable.empty());
 
         final TestObserver<Void> obs = cut.execute(ctx).test();
         obs.assertComplete();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/logging/LoggingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/logging/LoggingV4IntegrationTest.java
@@ -36,6 +36,7 @@ import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingContent;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingPhase;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
@@ -48,6 +49,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,26 +61,10 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class LoggingV4IntegrationTest {
 
-    private static final String CUSTOM_HEADER = "X-CustomHeader";
-    private static final String CUSTOM_HEADER_VALUE = "custom header value";
-    BehaviorSubject<Log> subject;
-
     @Nested
     @GatewayTest
     @DeployApi({ "/apis/v4/http/api.json" })
-    class ProxyApi extends AbstractGatewayTest {
-
-        @BeforeEach
-        void setUp() {
-            subject = BehaviorSubject.create();
-
-            FakeReporter fakeReporter = getBean(FakeReporter.class);
-            fakeReporter.setReportableHandler(reportable -> {
-                if (reportable instanceof Log l) {
-                    subject.onNext(l);
-                }
-            });
-        }
+    class ProxyApi extends AbstractLoggingV4IntegrationTest {
 
         @Test
         void should_log_everything(HttpClient httpClient, VertxTestContext context) throws Exception {
@@ -268,51 +254,204 @@ class LoggingV4IntegrationTest {
 
             wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
         }
+    }
 
-        @Override
-        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
-            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
-        }
-
-        @Override
-        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
-            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
-        }
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/api.json" })
+    class Error502 extends AbstractLoggingV4IntegrationTest {
 
         @Override
         public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-            final Logging logging = new Logging();
-            logging.setMode(LoggingMode.builder().entrypoint(true).endpoint(true).build());
-            logging.setContent(LoggingContent.builder().headers(true).payload(true).build());
-            logging.setPhase(LoggingPhase.builder().request(true).response(true).build());
-            logging.setCondition("{#response.status == 200}");
+            super.configureApi(api, definitionClass);
 
-            var analytics = new Analytics();
-            analytics.setEnabled(true);
-            analytics.setLogging(logging);
+            Endpoint endpoint = ((io.gravitee.gateway.reactive.handlers.api.v4.Api) api).getDefinition()
+                .getEndpointGroups()
+                .get(0)
+                .getEndpoints()
+                .get(0);
+            endpoint.setConfiguration(endpoint.getConfiguration().replace("localhost", "non.existing.host." + UUID.randomUUID()));
+        }
 
-            if (api.getDefinition() instanceof Api apiDefinition) {
-                apiDefinition.setAnalytics(analytics);
-            }
+        @Test
+        void should_log_endpoint_status_0_when_502(HttpClient httpClient, VertxTestContext context) throws Exception {
+            AtomicReference<String> requestHostAndPortRef = new AtomicReference<>();
+            JsonObject requestBody = new JsonObject().put("field", "of the pelennor");
+
+            subject
+                .doOnNext(log -> {
+                    SoftAssertions.assertSoftly(soft -> {
+                        // No body is captured since the endpoint connection failed (Gravitee streams the data without loading it in memory by default).
+                        soft.assertThat(log.getEntrypointRequest().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEntrypointRequest().getUri()).isEqualTo("/test");
+                        soft
+                            .assertThat(log.getEntrypointRequest().getHeaders().toSingleValueMap())
+                            .contains(
+                                entry("host", requestHostAndPortRef.get()),
+                                entry("content-length", String.valueOf(requestBody.toString().length()))
+                            )
+                            .containsKeys("X-Gravitee-Transaction-Id", "X-Gravitee-Request-Id");
+                    });
+
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEndpointRequest().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEndpointRequest().getUri()).matches("http://non.existing.host.*/endpoint");
+                        soft
+                            .assertThat(log.getEndpointRequest().getHeaders().toSingleValueMap())
+                            .contains(entry("content-length", String.valueOf(requestBody.toString().length())))
+                            .containsKeys("X-Gravitee-Transaction-Id", "X-Gravitee-Request-Id");
+                    });
+
+                    // Since the endpoint did not respond, we expect no body, status 0 and no headers.
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEndpointResponse().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEndpointResponse().getStatus()).isEqualTo(0);
+                        soft.assertThat(log.getEndpointResponse().getHeaders().toSingleValueMap()).isNullOrEmpty();
+                    });
+
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEntrypointResponse().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEntrypointResponse().getStatus()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+                        soft
+                            .assertThat(log.getEntrypointResponse().getHeaders().toSingleValueMap())
+                            .containsKeys("X-Gravitee-Client-Identifier", "X-Gravitee-Transaction-Id", "X-Gravitee-Request-Id");
+                    });
+                })
+                .doOnNext(m -> context.completeNow())
+                .doOnError(context::failNow)
+                .subscribe();
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(request -> {
+                    request.setHost("127.0.0.1");
+                    requestHostAndPortRef.set(request.getHost() + ":" + request.getPort());
+                    return request.rxSend(requestBody.toString());
+                })
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete();
         }
     }
 
     @Nested
     @GatewayTest
     @DeployApi({ "/apis/v4/http/api.json" })
-    class ProxyApiLogCustom extends AbstractGatewayTest {
+    class Error504 extends AbstractLoggingV4IntegrationTest {
 
-        @BeforeEach
-        void setUp() {
-            subject = BehaviorSubject.create();
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
 
-            FakeReporter fakeReporter = getBean(FakeReporter.class);
-            fakeReporter.setReportableHandler(reportable -> {
-                if (reportable instanceof Log l) {
-                    subject.onNext(l);
-                }
-            });
+            Endpoint endpoint = ((io.gravitee.gateway.reactive.handlers.api.v4.Api) api).getDefinition()
+                .getEndpointGroups()
+                .get(0)
+                .getEndpoints()
+                .get(0);
+            endpoint.setSharedConfigurationOverride(
+                endpoint.getSharedConfigurationOverride().replaceAll("\"readTimeout\"\s?:\s?60000", "\"readTimeout\": 100")
+            );
         }
+
+        @Test
+        void should_log_endpoint_status_0_when_504(HttpClient httpClient, VertxTestContext context) throws Exception {
+            JsonObject mockResponseBody = new JsonObject().put("response", "body");
+            wiremock.stubFor(
+                get("/endpoint").willReturn(
+                    okJson(mockResponseBody.toString()).withFixedDelay(10000).withHeader(CUSTOM_HEADER, CUSTOM_HEADER_VALUE)
+                )
+            );
+
+            AtomicReference<String> requestHostAndPortRef = new AtomicReference<>();
+            JsonObject requestBody = new JsonObject().put("field", "of the pelennor");
+
+            subject
+                .doOnNext(log -> {
+                    final String transactionAndRequestId = wiremock
+                        .getAllServeEvents()
+                        .getFirst()
+                        .getRequest()
+                        .getHeaders()
+                        .getHeader("X-Gravitee-Transaction-Id")
+                        .firstValue();
+
+                    SoftAssertions.assertSoftly(soft -> {
+                        // In case of endpoint timeout, the request body is logged because it is actually consumed and sent to the endpoint.
+                        soft.assertThat(log.getEntrypointRequest().getBody()).isEqualTo(requestBody.toString());
+                        soft.assertThat(log.getEntrypointRequest().getUri()).isEqualTo("/test");
+                        soft
+                            .assertThat(log.getEntrypointRequest().getHeaders().toSingleValueMap())
+                            .contains(
+                                entry("host", requestHostAndPortRef.get()),
+                                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                                entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                                entry("content-length", String.valueOf(requestBody.toString().length()))
+                            );
+                    });
+
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEndpointRequest().getBody()).isEqualTo(requestBody.toString());
+                        soft.assertThat(log.getEndpointRequest().getUri()).isEqualTo("http://localhost:" + wiremock.port() + "/endpoint");
+                        soft
+                            .assertThat(log.getEndpointRequest().getHeaders().toSingleValueMap())
+                            .contains(
+                                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                                entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                                entry("content-length", String.valueOf(requestBody.toString().length()))
+                            )
+                            .doesNotContainKeys("host", "Host");
+                    });
+
+                    // Since the endpoint did not respond, we expect no body, status 0 and no headers.
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEndpointResponse().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEndpointResponse().getStatus()).isEqualTo(0);
+                        soft.assertThat(log.getEndpointResponse().getHeaders().toSingleValueMap()).isNullOrEmpty();
+                    });
+
+                    SoftAssertions.assertSoftly(soft -> {
+                        soft.assertThat(log.getEntrypointResponse().getBody()).isNullOrEmpty();
+                        soft.assertThat(log.getEntrypointResponse().getStatus()).isEqualTo(HttpStatusCode.GATEWAY_TIMEOUT_504);
+                        soft
+                            .assertThat(log.getEntrypointResponse().getHeaders().toSingleValueMap())
+                            .contains(
+                                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                                entry("X-Gravitee-Request-Id", transactionAndRequestId)
+                            )
+                            .containsKeys("X-Gravitee-Client-Identifier");
+                    });
+                })
+                .doOnNext(m -> context.completeNow())
+                .doOnError(context::failNow)
+                .subscribe();
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(request -> {
+                    request.setHost("127.0.0.1");
+                    requestHostAndPortRef.set(request.getHost() + ":" + request.getPort());
+                    return request.rxSend(requestBody.toString());
+                })
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(HttpStatusCode.GATEWAY_TIMEOUT_504);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete();
+
+            wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/api.json" })
+    class ProxyApiLogCustom extends AbstractLoggingV4IntegrationTest {
 
         @Test
         void should_not_log_video(HttpClient httpClient, VertxTestContext context) throws Exception {
@@ -404,6 +543,25 @@ class LoggingV4IntegrationTest {
                 });
 
             wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    abstract class AbstractLoggingV4IntegrationTest extends AbstractGatewayTest {
+
+        protected static final String CUSTOM_HEADER = "X-CustomHeader";
+        protected static final String CUSTOM_HEADER_VALUE = "custom header value";
+        BehaviorSubject<Log> subject;
+
+        @BeforeEach
+        void setUp() {
+            subject = BehaviorSubject.create();
+
+            FakeReporter fakeReporter = getBean(FakeReporter.class);
+            fakeReporter.setReportableHandler(reportable -> {
+                if (reportable instanceof Log l) {
+                    subject.onNext(l);
+                }
+            });
         }
 
         @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-634
https://gravitee.atlassian.net/browse/APIM-12339

## Description

This PR refactors the body/header logging mechanism, aiming to capture the body and headers sent to the backend properly and effectively. This is particularly important for the LLM Proxy endpoint connector that performs OpenAI to the Provider-specific format.