### PR TITLE
Bump dependencies to prepare release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <gravitee-policy-message-filtering.version>1.1.4</gravitee-policy-message-filtering.version>
         <gravitee-policy-mock.version>1.15.0</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>1.0.0</gravitee-policy-mtls.version>
-        <gravitee-policy-oauth2.version>5.1.3</gravitee-policy-oauth2.version>
+        <gravitee-policy-oauth2.version>5.1.4</gravitee-policy-oauth2.version>
         <gravitee-policy-oas-validation.version>1.1.3</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
@@ -282,7 +282,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>6.0.1</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>6.0.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.0.3</gravitee-entrypoint-mcp.version>
@@ -297,8 +297,8 @@
         <gravitee-resource-storage-azure-blob.version>1.0.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>9.0.0</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>4.3.0-alpha.7</gravitee-reactor-native-kafka.version>
-        <gravitee-reactor-mcp-proxy.version>1.0.0</gravitee-reactor-mcp-proxy.version>
-         <gravitee-reactor-llm-proxy.version>1.0.0-alpha.38</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-mcp-proxy.version>1.0.1</gravitee-reactor-mcp-proxy.version>
+        <gravitee-reactor-llm-proxy.version>1.0.0-alpha.38</gravitee-reactor-llm-proxy.version>
         <gravitee-apim-repository-bridge.version>7.1.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
@@ -306,7 +306,7 @@
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.0</gravitee-policy-kafka-topic-mapping.version>
-        <gravitee-policy-kafka-acl.version>2.1.0-alpha.1</gravitee-policy-kafka-acl.version>
+        <gravitee-policy-kafka-acl.version>3.0.0</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>


### PR DESCRIPTION
## Description

Entrypoint webhook is downgraded because versions and releases for this plugin have been remade and the git history has been rewritten. Version 6.0.0 is the right one to use now.

Other upgrades are mainly to use versions without SNAPSHOT or alpha in their pom.xml.