### PR TITLE
chore(deps): bump gravitee-service-secrets version to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <gravitee-apim-repository-bridge.version>7.1.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
-        <gravitee-service-secrets.version>2.0.1</gravitee-service-secrets.version>
+        <gravitee-service-secrets.version>2.0.2</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.0</gravitee-policy-kafka-topic-mapping.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-636
https://gravitee.atlassian.net/browse/APIM-11938

## Description

Bump service secret to 2.0.2 to fix thread safety issues.

