### PR TITLE
feat(portal): forms for registration URLs

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -59,6 +59,8 @@ import { categoriesResolver } from '../resolvers/categories.resolver';
 import { homepageContentResolver } from '../resolvers/homepage-content.resolver';
 import { pagesResolver } from '../resolvers/pages.resolver';
 import { ApiTabToolsComponent } from './api/api-details/api-tab-tools/api-tab-tools.component';
+import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
+import { RegistrationComponent } from './registration/registration.component';
 
 const apiRoutes: Routes = [
   {
@@ -151,6 +153,11 @@ export const routes: Routes = [
         resolve: {
           categories: categoriesResolver,
         },
+      },
+      {
+        path: 'all',
+        redirectTo: '',
+        pathMatch: 'full',
       },
       {
         path: 'categories',
@@ -271,6 +278,16 @@ export const routes: Routes = [
         ],
       },
     ],
+  },
+  {
+    path: 'registration',
+    component: RegistrationComponent,
+    canActivate: [anonymousGuard],
+  },
+  {
+    path: 'registration/confirm/:token',
+    component: RegistrationConfirmationComponent,
+    canActivate: [anonymousGuard],
   },
   { path: 'log-out', component: LogOutComponent, canActivate: [redirectGuard] },
   { path: '404', component: NotFoundComponent },

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -74,7 +74,8 @@
         </button>
       }
       <div class="log-in__registration m3-label-large">
-        <span i18n="@@logInSignupPrefix">Don’t have an account? </span> <a class="internal-link" routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
+        <span i18n="@@logInSignupPrefix">Don’t have an account? </span>
+        <a class="internal-link" routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
       </div>
     </mat-card-content>
   </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -73,6 +73,9 @@
           </div>
         </button>
       }
+      <div class="log-in__registration">
+        <span i18n="@@logInSignupPrefix">Don’t have an account? </span> <a routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
+      </div>
     </mat-card-content>
   </mat-card>
 </form>

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -53,7 +53,7 @@
             <button [disabled]="logInForm.invalid" type="submit" mat-flat-button i18n="@@logInAction" class="log-in__form__submit">
               Log in
             </button>
-            <a class="log-in__form__forgot-password m3-label-large" i18n="@@resetPasswordAction" routerLink="reset-password">
+            <a class="log-in__form__forgot-password m3-label-large internal-link" i18n="@@resetPasswordAction" routerLink="reset-password">
               Forgot password?
             </a>
           </div>
@@ -73,8 +73,8 @@
           </div>
         </button>
       }
-      <div class="log-in__registration">
-        <span i18n="@@logInSignupPrefix">Don’t have an account? </span> <a routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
+      <div class="log-in__registration m3-label-large">
+        <span i18n="@@logInSignupPrefix">Don’t have an account? </span> <a class="internal-link" routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
       </div>
     </mat-card-content>
   </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
@@ -16,17 +16,6 @@
 @use '../../scss/theme';
 @use '../../scss/layout' as layout;
 
-%link-style {
-  margin-top: 5px;
-  color: #{theme.$primary-main-color};
-  text-align: center;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 :host {
   @include layout.small-container-legacy();
 }
@@ -47,7 +36,6 @@
     }
 
     &__container {
-      // width: 100%;
       border-radius: 8px;
 
       &--mobile {
@@ -76,7 +64,8 @@
     }
 
     &__forgot-password {
-      @extend %link-style;
+      text-align: center;
+      margin-top: 5px;
     }
 
     &__error {
@@ -87,10 +76,6 @@
   &__registration {
     margin-top: 20px;
     text-align: center;
-
-    a {
-      @extend %link-style;
-    }
   }
 
   &__or-separator {

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
@@ -64,8 +64,8 @@
     }
 
     &__forgot-password {
-      text-align: center;
       margin-top: 5px;
+      text-align: center;
     }
 
     &__error {

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
@@ -40,7 +40,7 @@
         <div class="registration-confirmation__form">
           <div class="registration-confirmation__form__fields">
             <mat-form-field appearance="outline" class="registration-confirmation__form__input">
-              <mat-label i18n="@@registrationConfirmationUsername">Firstname</mat-label>
+              <mat-label i18n="@@registrationConfirmationFirstname">Firstname</mat-label>
               <input matInput formControlName="firstname" />
               @if (registrationConfirmationForm.controls.firstname.hasError('required')) {
                 <mat-error i18n="@@registrationConfirmationFirstnameErrorRequired">Firstname is required</mat-error>
@@ -60,7 +60,7 @@
                 <mat-error i18n="@@registrationConfirmationEmailErrorRequired">Email is required</mat-error>
               }
               @if (registrationConfirmationForm.controls.email.hasError('email')) {
-                <mat-error i18n="@@registrationConfirmationEmailErrorFormat">Email format error</mat-error>
+                <mat-error i18n="@@registrationConfirmationEmailErrorFormat">Invalid email format</mat-error>
               }
             </mat-form-field>
 
@@ -80,7 +80,7 @@
             </mat-form-field>
           </div>
           @if (error() === 400) {
-            <mat-error i18n="@@registrationConfirmationBadToken">Bad request. Invalid password</mat-error>
+            <mat-error i18n="@@registrationConfirmationBadPassword">Bad request. Invalid password</mat-error>
           }
           <div class="registration-confirmation__form__buttons">
             <button
@@ -97,19 +97,19 @@
     </mat-card-content>
   } @else if (submitted()) {
     <mat-card-header class="registration-confirmation__form__header">
-      <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTitle"
-        >Registration confirmed
+      <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationSuccessTitle"
+        >Account created
       </mat-card-title>
     </mat-card-header>
     <mat-card-content class="registration-confirmation__success__content">
       <div class="registration-confirmation__success__content__icon">
         <mat-icon>how_to_reg</mat-icon>
       </div>
-      <div i18n="@@registrationConfirmationSuccessMessage">An email has been confirmed</div>
+      <div i18n="@@registrationConfirmationSuccessMessage">Your account has been successfully created</div>
       <button
         type="submit"
         mat-flat-button
-        i18n="@@registrationConfirmationAction"
+        i18n="@@registrationConfirmationSuccessAction"
         class="registration-confirmation__form__submit"
         routerLink="/">
         Back to portal

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
@@ -1,0 +1,119 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card appearance="outlined" class="registration-confirmation registration-confirmation__form__container content">
+  @if (error() === 401) {
+    <mat-card-header class="registration-confirmation__form__header">
+      <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTokenErrorTitle">
+        Invalid token
+      </mat-card-title>
+      <mat-card-content class="registration-confirmation__form__content">
+        <mat-error i18n="@@registrationConfirmationBadToken">Bad request. Invalid token value</mat-error>
+      </mat-card-content>
+    </mat-card-header>
+  } @else if (!submitted()) {
+    <mat-card-header class="registration-confirmation__form__header">
+      <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTitle"
+        >Confirm registration
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="registration-confirmation__form__content">
+      <form
+        [formGroup]="registrationConfirmationForm"
+        (ngSubmit)="confirmRegistration()"
+        [appIsMobile]="'registrationConfirmation__form__container--mobile'">
+        <div class="registration-confirmation__form">
+          <div class="registration-confirmation__form__fields">
+            <mat-form-field appearance="outline" class="registration-confirmation__form__input">
+              <mat-label i18n="@@registrationConfirmationUsername">Firstname</mat-label>
+              <input matInput formControlName="firstname" />
+              @if (registrationConfirmationForm.controls.firstname.hasError('required')) {
+                <mat-error i18n="@@registrationConfirmationFirstnameErrorRequired">Firstname is required</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="registration-confirmation__form__input">
+              <mat-label i18n="@@registrationConfirmationLastname">Lastname</mat-label>
+              <input matInput formControlName="lastname" />
+              @if (registrationConfirmationForm.controls.lastname.hasError('required')) {
+                <mat-error i18n="@@registrationConfirmationLastnameErrorRequired">Lastname is required</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="registration-confirmation__form__input">
+              <mat-label i18n="@@registrationConfirmationEmail">Email</mat-label>
+              <input type="text" matInput formControlName="email" />
+              @if (registrationConfirmationForm.controls.email.hasError('required')) {
+                <mat-error i18n="@@registrationConfirmationEmailErrorRequired">Email is required</mat-error>
+              }
+              @if (registrationConfirmationForm.controls.email.hasError('email')) {
+                <mat-error i18n="@@registrationConfirmationEmailErrorFormat">Email format error</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="registration-confirmation__form__input">
+              <mat-label i18n="@@registrationConfirmationChoosePassword">Choose a password</mat-label>
+              <input type="password" matInput formControlName="password" />
+              @if (registrationConfirmationForm.controls.password.hasError('required')) {
+                <mat-error i18n="@@registrationConfirmationPasswordErrorRequired">Password is required</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="log-in__form__input">
+              <mat-label i18n="@@registrationConfirmationConfirmPassword">Confirm your password</mat-label>
+              <input type="password" matInput formControlName="confirmedPassword" />
+              @if (registrationConfirmationForm.controls.confirmedPassword.hasError('required')) {
+                <mat-error i18n="@@registrationConfirmationPasswordErrorRequired">Password is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          @if (error() === 400) {
+            <mat-error i18n="@@registrationConfirmationBadToken">Bad request. Invalid password</mat-error>
+          }
+          <div class="registration-confirmation__form__buttons">
+            <button
+              [disabled]="registrationConfirmationForm.invalid"
+              type="submit"
+              mat-flat-button
+              i18n="@@registrationConfirmationAction"
+              class="registration-confirmation__form__submit">
+              CONFIRM
+            </button>
+          </div>
+        </div>
+      </form>
+    </mat-card-content>
+  } @else if (submitted()) {
+    <mat-card-header class="registration-confirmation__form__header">
+      <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTitle"
+        >Registration confirmed
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="registration-confirmation__success__content">
+      <div class="registration-confirmation__success__content__icon">
+        <mat-icon>how_to_reg</mat-icon>
+      </div>
+      <div i18n="@@registrationConfirmationSuccessMessage">An email has been confirmed</div>
+      <button
+        type="submit"
+        mat-flat-button
+        i18n="@@registrationConfirmationAction"
+        class="registration-confirmation__form__submit"
+        routerLink="/">
+        Back to portal
+      </button>
+    </mat-card-content>
+  }
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
@@ -22,10 +22,10 @@
       <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTokenErrorTitle">
         Invalid token
       </mat-card-title>
-      <mat-card-content class="registration-confirmation__form__content">
-        <mat-error i18n="@@registrationConfirmationBadToken">Bad request. Invalid token value</mat-error>
-      </mat-card-content>
     </mat-card-header>
+    <mat-card-content class="registration-confirmation__form__content">
+      <mat-error i18n="@@registrationConfirmationBadToken">Bad request. Invalid token value</mat-error>
+    </mat-card-content>
   } @else if (!submitted()) {
     <mat-card-header class="registration-confirmation__form__header">
       <mat-card-title class="registration-confirmation__form__title" i18n="@@registrationConfirmationTitle"
@@ -40,17 +40,17 @@
         <div class="registration-confirmation__form">
           <div class="registration-confirmation__form__fields">
             <mat-form-field appearance="outline" class="registration-confirmation__form__input">
-              <mat-label i18n="@@registrationConfirmationFirstname">Firstname</mat-label>
+              <mat-label i18n="@@registrationConfirmationFirstname">First name</mat-label>
               <input matInput formControlName="firstname" />
               @if (registrationConfirmationForm.controls.firstname.hasError('required')) {
-                <mat-error i18n="@@registrationConfirmationFirstnameErrorRequired">Firstname is required</mat-error>
+                <mat-error i18n="@@registrationConfirmationFirstnameErrorRequired">First name is required</mat-error>
               }
             </mat-form-field>
             <mat-form-field appearance="outline" class="registration-confirmation__form__input">
-              <mat-label i18n="@@registrationConfirmationLastname">Lastname</mat-label>
+              <mat-label i18n="@@registrationConfirmationLastname">Last name</mat-label>
               <input matInput formControlName="lastname" />
               @if (registrationConfirmationForm.controls.lastname.hasError('required')) {
-                <mat-error i18n="@@registrationConfirmationLastnameErrorRequired">Lastname is required</mat-error>
+                <mat-error i18n="@@registrationConfirmationLastnameErrorRequired">Last name is required</mat-error>
               }
             </mat-form-field>
             <mat-form-field appearance="outline" class="registration-confirmation__form__input">
@@ -89,7 +89,7 @@
               mat-flat-button
               i18n="@@registrationConfirmationAction"
               class="registration-confirmation__form__submit">
-              CONFIRM
+              Confirm
             </button>
           </div>
         </div>

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.scss
@@ -59,7 +59,6 @@
     }
 
     &__container {
-      width: 400px;
       border-radius: 8px;
 
       &--mobile {

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.scss
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../scss/theme';
+@use '../../../scss/layout' as layout;
+
+:host {
+  display: flex;
+  justify-content: center;
+  @include layout.small-container-legacy();
+}
+
+.registration-confirmation {
+  display: flex;
+  flex-flow: column;
+  gap: 20px;
+
+  &__success {
+    &__content {
+      display: flex;
+      flex-flow: column;
+      align-items: center;
+      gap: 16px;
+      text-align: center;
+
+      &__icon {
+        font-size: 64px;
+
+        mat-icon {
+          width: 64px;
+          height: 64px;
+          font-size: 64px;
+          line-height: 64px;
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-flow: column;
+    gap: 16px;
+
+    &__header {
+      padding: 20px;
+    }
+
+    &__container {
+      width: 400px;
+      border-radius: 8px;
+
+      &--mobile {
+        max-width: 75vw;
+      }
+    }
+
+    &__content:last-child {
+      padding: 0 20px 20px;
+    }
+
+    &__fields {
+      display: flex;
+      flex-flow: column;
+      gap: 8px;
+    }
+
+    &__buttons {
+      display: flex;
+      flex-flow: column;
+      gap: 16px;
+    }
+
+    &__submit {
+      width: 100%;
+    }
+
+    &__error {
+      text-align: center;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs/internal/observable/of';
+
+import { RegistrationConfirmationComponent } from './registration-confirmation.component';
+import { TokenService } from '../../../services/token.service';
+import { AppTestingModule } from '../../../testing/app-testing.module';
+
+describe('RegistrationConfirmationComponent', () => {
+  let fixture: ComponentFixture<RegistrationConfirmationComponent>;
+
+  let httpTestingController: HttpTestingController;
+
+  const init = async (params?: { token?: string; parsedToken?: { firstname: string; lastname: string; email: string } | null }) => {
+    const token = params?.token ?? 'token-123';
+
+    const defaultParsed = { firstname: 'John', lastname: 'Doe', email: 'john@doe.com' };
+    const parsedToken = params && 'parsedToken' in params ? params.parsedToken : defaultParsed;
+
+    await TestBed.configureTestingModule({
+      imports: [RegistrationConfirmationComponent, AppTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ token })) },
+        },
+        {
+          provide: TokenService,
+          useValue: { parseToken: jest.fn().mockReturnValue(parsedToken) } as Partial<TokenService>,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegistrationConfirmationComponent);
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should display invalid token view when token cannot be parsed', async () => {
+    await init({ parsedToken: null });
+
+    // error() === 401 -> "Invalid token" + "Bad request. Invalid token value"
+    const titleEl: HTMLElement | null = fixture.nativeElement.querySelector('.registration-confirmation__form__title');
+    expect(titleEl).not.toBeNull();
+    expect(titleEl!.textContent).toContain('Invalid token');
+
+    const errorEl: HTMLElement | null = fixture.nativeElement.querySelector('mat-error');
+    expect(errorEl).not.toBeNull();
+    expect(errorEl!.textContent).toContain('Bad request. Invalid token value');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
@@ -70,13 +70,7 @@ interface RegistrationConfirmationFormValue {
   styleUrl: './registration-confirmation.component.scss',
 })
 export class RegistrationConfirmationComponent implements OnInit {
-  registrationConfirmationForm: RegistrationConfirmationFormType = new FormGroup<{
-    firstname: FormControl<string | null>;
-    lastname: FormControl<string | null>;
-    email: FormControl<string | null>;
-    password: FormControl<string | null>;
-    confirmedPassword: FormControl<string | null>;
-  }>({
+  registrationConfirmationForm: RegistrationConfirmationFormType = new FormGroup({
     firstname: new FormControl({ value: '', disabled: true }),
     lastname: new FormControl({ value: '', disabled: true }),
     email: new FormControl({ value: '', disabled: true }),
@@ -145,12 +139,12 @@ export class RegistrationConfirmationComponent implements OnInit {
         password: val.password,
       })
       .pipe(
+        tap(_ => this.submitted.set(true)),
         catchError(_ => {
           this.error.set(400);
           return EMPTY;
         }),
       )
-      .pipe(tap(_ => this.submitted.set(true)))
       .subscribe();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatCard, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
+import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInput } from '@angular/material/input';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { catchError, EMPTY, filter, map, tap } from 'rxjs';
+
+import { MobileClassDirective } from '../../../directives/mobile-class.directive';
+import { TokenService } from '../../../services/token.service';
+import { UsersService } from '../../../services/users.service';
+
+type RegistrationConfirmationFormType = FormGroup<{
+  firstname: FormControl<string | null>;
+  lastname: FormControl<string | null>;
+  email: FormControl<string | null>;
+  password: FormControl<string | null>;
+  confirmedPassword: FormControl<string | null>;
+}>;
+
+interface RegistrationToken {
+  firstname: string;
+  lastname: string;
+  email: string;
+}
+
+interface RegistrationConfirmationFormValue {
+  firstname: string;
+  lastname: string;
+  password: string;
+  customFields?: { [key: string]: string };
+}
+
+@Component({
+  selector: 'app-registration-confirmation',
+  imports: [
+    MatError,
+    MatButton,
+    MatCard,
+    MatCardContent,
+    MatCardHeader,
+    MatCardTitle,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    ReactiveFormsModule,
+    RouterLink,
+    MobileClassDirective,
+    MatIcon,
+  ],
+  templateUrl: './registration-confirmation.component.html',
+  styleUrl: './registration-confirmation.component.scss',
+})
+export class RegistrationConfirmationComponent implements OnInit {
+  registrationConfirmationForm: RegistrationConfirmationFormType = new FormGroup<{
+    firstname: FormControl<string | null>;
+    lastname: FormControl<string | null>;
+    email: FormControl<string | null>;
+    password: FormControl<string | null>;
+    confirmedPassword: FormControl<string | null>;
+  }>({
+    firstname: new FormControl({ value: '', disabled: true }),
+    lastname: new FormControl({ value: '', disabled: true }),
+    email: new FormControl({ value: '', disabled: true }),
+    password: new FormControl('', Validators.required),
+    confirmedPassword: new FormControl('', Validators.required),
+  });
+
+  token: string | null = null;
+  userFromToken?: RegistrationToken;
+
+  submitted = signal(false);
+
+  error = signal(200);
+
+  constructor(
+    private route: ActivatedRoute,
+    private readonly destroyRef: DestroyRef,
+    private tokenService: TokenService,
+    private usersService: UsersService,
+  ) {}
+
+  static sameValueValidator(field: AbstractControl): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const forbidden = field.valid && field.value !== control.value;
+      return forbidden ? { passwordError: { value: control.value } } : null;
+    };
+  }
+
+  ngOnInit(): void {
+    this.registrationConfirmationForm
+      .get('confirmedPassword')!
+      .setValidators([
+        Validators.required,
+        RegistrationConfirmationComponent.sameValueValidator(this.registrationConfirmationForm.get('password')!),
+      ]);
+    this.route.paramMap
+      .pipe(
+        map(params => params.get('token')),
+        tap(token => (this.token = token)),
+        map(token => this.tokenService.parseToken(token)),
+        tap(userFromToken => {
+          if (!userFromToken) {
+            this.error.set(401);
+          }
+        }),
+        filter(userFromToken => !!userFromToken),
+        tap(userFromToken => {
+          this.userFromToken = userFromToken;
+          this.registrationConfirmationForm.get('firstname')?.patchValue(this.userFromToken?.firstname || '');
+          this.registrationConfirmationForm.get('lastname')?.patchValue(this.userFromToken?.lastname || '');
+          this.registrationConfirmationForm.get('email')?.patchValue(this.userFromToken?.email || '');
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  confirmRegistration() {
+    const val = this.registrationConfirmationForm!.value as RegistrationConfirmationFormValue;
+
+    this.usersService
+      .finalizeRegistration({
+        firstname: this.userFromToken!.firstname,
+        lastname: this.userFromToken!.lastname,
+        token: this.token!,
+        password: val.password,
+      })
+      .pipe(
+        catchError(_ => {
+          this.error.set(400);
+          return EMPTY;
+        }),
+      )
+      .pipe(tap(_ => this.submitted.set(true)))
+      .subscribe();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
@@ -93,26 +93,24 @@
               class="registration__form__submit">
               Sign up
             </button>
-            <a mat-stroked-button class="m3-label-large" i18n="@@registrationBackToPortalAction" routerLink="/log-in"> Back to log in </a>
+            <a mat-stroked-button class="m3-label-large" i18n="@@registrationBackToPortalAction" routerLink="/log-in"> Back to Login </a>
           </div>
         </div>
       </form>
     </mat-card-content>
   } @else {
-    <div class="registration__success__container">
-      <mat-card-header class="registration__form__header">
-        <mat-card-title class="registration__form__title" i18n="@@registrationSuccessHeader">Registration success</mat-card-title>
-      </mat-card-header>
-      <mat-card-content class="registration__form__content">
+    <mat-card-header class="registration__form__header">
+      <mat-card-title class="registration__form__title" i18n="@@registrationSuccessHeader">Registration success </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="registration__form__content">
+      <div class="registration__success__container">
         <div class="registration__success__container__icon">
           <mat-icon>outgoing_mail</mat-icon>
         </div>
         <div i18n="@@registrationSuccessLabel">An email has been sent to:</div>
         <div>{{ sentToEmail() }}</div>
-        <button type="submit" mat-flat-button i18n="@@registrationBackAction" class="registration__form__submit" routerLink="/">
-          Back to portal
-        </button>
-      </mat-card-content>
-    </div>
+        <button mat-flat-button i18n="@@registrationBackAction" class="registration__form__submit" routerLink="/">Back to portal</button>
+      </div>
+    </mat-card-content>
   }
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
@@ -1,0 +1,118 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card appearance="outlined" class="registration registration__form__container content">
+  @if (!submitted()) {
+    <mat-card-header class="registration__form__header">
+      <mat-card-title class="registration__form__title" i18n="@@registrationTitle">Create account</mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="registration__form__content">
+      <form [formGroup]="registrationForm" (ngSubmit)="register()" [appIsMobile]="'registration__form__container--mobile'">
+        <div class="registration__form">
+          <div class="registration__form__fields">
+            <mat-form-field appearance="outline" class="registration__form__input">
+              <mat-label i18n="@@registrationFirsname">First name</mat-label>
+              <input matInput formControlName="firstname" />
+              @if (registrationForm.controls.firstname.hasError('required')) {
+                <mat-error i18n="@@registrationFirsnameErrorRequired">First name is required</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="registration__form__input">
+              <mat-label i18n="@@registrationLastname">Last name</mat-label>
+              <input matInput formControlName="lastname" />
+              @if (registrationForm.controls.lastname.hasError('required')) {
+                <mat-error i18n="@@registrationLastnameErrorRequired">Last name is required</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="registration__form__input">
+              <mat-label i18n="@@registrationEmail">Email</mat-label>
+              <input matInput formControlName="email" />
+              @if (registrationForm.controls.email.hasError('required')) {
+                <mat-error i18n="@@registrationEmailErrorRequired">Email is required</mat-error>
+              }
+              @if (registrationForm.controls.email.hasError('email')) {
+                <mat-error i18n="@@registrationEmailErrorFormat">Email format error</mat-error>
+              }
+            </mat-form-field>
+
+            @if ((customUserFields() ?? []).length > 0) {
+              <div formGroupName="customFields">
+                @for (customField of customUserFields(); track customField.key) {
+                  @if ((customField.values ?? []).length === 0) {
+                    <mat-form-field appearance="outline" class="registration__form__input">
+                      <mat-label>{{ customField.label }}</mat-label>
+                      <input matInput [formControlName]="customField.key!" />
+                      @if (registrationForm.get(['customFields', customField.key!])?.hasError('required')) {
+                        <mat-error i18n="@@registrationUserFieldValueErrorRequired">Value is required</mat-error>
+                      }
+                    </mat-form-field>
+                  }
+                  @if ((customField.values ?? []).length > 0) {
+                    <mat-form-field appearance="outline">
+                      <mat-label>{{ customField.label }}</mat-label>
+                      <mat-select [formControlName]="customField.key!" [aria-label]="customField.label!" data-testId="grantTypes">
+                        @for (customFieldValue of customField.values; track customFieldValue) {
+                          <mat-option [value]="customFieldValue">{{ customFieldValue }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                  }
+                }
+              </div>
+            }
+
+            @if (error() === 401) {
+              <mat-error class="registration__form__error m3-label-large" i18n="@@registrationError401">Unauthorized</mat-error>
+            } @else if (error() === 400) {
+              <mat-error class="registration__form__error m3-label-large" i18n="@@registrationError400">User cannot be created</mat-error>
+            } @else if (error() !== 200) {
+              <mat-error class="registration__form__error m3-label-large" i18n="@@registrationErrorUnknown">Unknown error</mat-error>
+            }
+          </div>
+          <div class="registration__form__buttons">
+            <button
+              [disabled]="registrationForm.invalid"
+              type="submit"
+              mat-flat-button
+              i18n="@@registrationAction"
+              class="registration__form__submit">
+              Sign up
+            </button>
+            <a mat-stroked-button class="m3-label-large" i18n="@@registrationBackToPortalAction" routerLink="/log-in"> Back to log in </a>
+          </div>
+        </div>
+      </form>
+    </mat-card-content>
+  } @else {
+    <div class="registration__success__container">
+      <mat-card-header class="registration__form__header">
+        <mat-card-title class="registration__form__title" i18n="@@registrationSuccessHeader">Registration success</mat-card-title>
+      </mat-card-header>
+      <mat-card-content class="registration__form__content">
+        <div class="registration__success__container__icon">
+          <mat-icon>outgoing_mail</mat-icon>
+        </div>
+        <div i18n="@@registrationSuccessLabel">An email has been sent to:</div>
+        <div>{{ sentToEmail() }}</div>
+        <button type="submit" mat-flat-button i18n="@@registrationBackAction" class="registration__form__submit" routerLink="/">
+          Back to portal
+        </button>
+      </mat-card-content>
+    </div>
+  }
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.scss
@@ -64,7 +64,6 @@
     }
 
     &__container {
-      width: 400px;
       border-radius: 8px;
 
       &--mobile {

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.scss
@@ -16,26 +16,43 @@
 @use '../../scss/theme';
 @use '../../scss/layout' as layout;
 
-%link-style {
-  margin-top: 5px;
-  color: #{theme.$primary-main-color};
-  text-align: center;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 :host {
+  display: flex;
+  justify-content: center;
   @include layout.small-container-legacy();
 }
 
-.log-in {
+.registration {
   display: flex;
   width: 100%;
   flex-flow: column;
   gap: 20px;
+
+  &__success {
+    &__container {
+      display: flex;
+      flex-flow: column;
+      align-items: center;
+      gap: 16px;
+      text-align: center;
+
+      &__icon {
+        font-size: 64px;
+
+        mat-icon {
+          width: 64px;
+          height: 64px;
+          font-size: 64px;
+          line-height: 64px;
+          text-align: center;
+        }
+      }
+
+      button {
+        margin-top: 20px;
+      }
+    }
+  }
 
   &__form {
     display: flex;
@@ -47,7 +64,7 @@
     }
 
     &__container {
-      // width: 100%;
+      width: 400px;
       border-radius: 8px;
 
       &--mobile {
@@ -75,68 +92,8 @@
       width: 100%;
     }
 
-    &__forgot-password {
-      @extend %link-style;
-    }
-
     &__error {
       text-align: center;
-    }
-  }
-
-  &__registration {
-    margin-top: 20px;
-    text-align: center;
-
-    a {
-      @extend %link-style;
-    }
-  }
-
-  &__or-separator {
-    position: relative;
-    display: flex;
-    height: 30px;
-    align-items: center;
-    margin: 20px 0;
-
-    &__line {
-      width: 100%;
-      border-top: 1px solid #{theme.$card-border-color};
-    }
-
-    &__label {
-      position: absolute;
-      display: flex;
-      width: 40px;
-      height: 100%;
-      align-items: center;
-      justify-content: center;
-      margin: auto;
-      background: #{theme.$card-background-color};
-      inset: 0;
-    }
-  }
-
-  &__sso-provider {
-    width: 100%;
-    padding: 0 18px;
-    margin-bottom: 16px;
-    color: #{theme.$button-text-text-color};
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
-
-    &__container {
-      display: flex;
-      align-items: center;
-      gap: 7px;
-    }
-
-    &__logo {
-      width: 23px;
-      height: 23px;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegistrationComponent } from './registration.component';
+import { AppTestingModule } from '../../testing/app-testing.module';
+import { DivHarness } from '../../testing/div.harness';
+
+describe('RegistrationComponent', () => {
+  let fixture: ComponentFixture<RegistrationComponent>;
+  let harnessLoader: HarnessLoader;
+
+  const init = async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegistrationComponent, AppTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegistrationComponent);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+
+    fixture.detectChanges(); // ngOnInit -> listCustomUserFields()
+
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {});
+
+  it('should display registration form by default (submitted=false)', async () => {
+    await init();
+
+    const cardEl: HTMLElement | null = fixture.nativeElement.querySelector('mat-card.registration__form__container');
+    expect(cardEl).not.toBeNull();
+
+    const formEl: HTMLFormElement | null = fixture.nativeElement.querySelector('mat-card.registration__form__container form');
+    expect(formEl).not.toBeNull();
+
+    const success = await harnessLoader.getHarnessOrNull(DivHarness.with({ selector: '.registration__success__container' }));
+    expect(success).toBeNull();
+  });
+  //
+});

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
@@ -38,8 +38,6 @@ describe('RegistrationComponent', () => {
     fixture.detectChanges();
   };
 
-  afterEach(() => {});
-
   it('should display registration form by default (submitted=false)', async () => {
     await init();
 
@@ -52,5 +50,4 @@ describe('RegistrationComponent', () => {
     const success = await harnessLoader.getHarnessOrNull(DivHarness.with({ selector: '.registration__success__container' }));
     expect(success).toBeNull();
   });
-  //
 });

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
@@ -95,8 +95,9 @@ export class RegistrationComponent implements OnInit {
             this.registrationForm.addControl('customFields', customFields);
           }
         }),
+        takeUntilDestroyed(this.destroyRef),
       )
-      .pipe(takeUntilDestroyed(this.destroyRef))
+
       .subscribe();
   }
 
@@ -107,15 +108,13 @@ export class RegistrationComponent implements OnInit {
     this.usersService
       .registerNewUser({ ...userRegistrationFormValue, confirmation_page_url: confirmationPageUrl })
       .pipe(
-        catchError(err => {
-          this.error.set(err.status);
-          return EMPTY;
-        }),
-      )
-      .pipe(
         tap(() => {
           this.sentToEmail.set(userRegistrationFormValue.email);
           this.submitted.set(true);
+        }),
+        catchError(err => {
+          this.error.set(err.status);
+          return EMPTY;
         }),
       )
       .subscribe();

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCard, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
+import { MatIcon } from '@angular/material/icon';
+import { MatError, MatFormField, MatInput, MatLabel } from '@angular/material/input';
+import { MatOption, MatSelect } from '@angular/material/select';
+import { RouterLink } from '@angular/router';
+import { catchError, EMPTY, tap } from 'rxjs';
+
+import { MobileClassDirective } from '../../directives/mobile-class.directive';
+import { CustomUserField } from '../../entities/user/custom-user-field';
+import { UsersService } from '../../services/users.service';
+
+interface UserRegistrationFormValue {
+  firstname: string;
+  lastname: string;
+  email: string;
+  customFields?: { [key: string]: string };
+}
+
+@Component({
+  selector: 'app-registration',
+  imports: [
+    MatCard,
+    MatCardContent,
+    MatCardHeader,
+    MatCardTitle,
+    MatError,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatButtonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    MobileClassDirective,
+    MatOption,
+    MatSelect,
+    MatIcon,
+  ],
+  templateUrl: './registration.component.html',
+  styleUrl: './registration.component.scss',
+})
+export class RegistrationComponent implements OnInit {
+  submitted = signal(false);
+  sentToEmail = signal('');
+
+  customUserFields = signal<CustomUserField[]>([]);
+
+  registrationForm: FormGroup<{
+    firstname: FormControl;
+    lastname: FormControl;
+    email: FormControl;
+    customFields?: FormGroup;
+  }> = new FormGroup({
+    firstname: new FormControl('', [Validators.required]),
+    lastname: new FormControl('', [Validators.required]),
+    email: new FormControl('', [Validators.required, Validators.email]),
+  });
+
+  error = signal(200);
+
+  constructor(
+    private usersService: UsersService,
+    private readonly destroyRef: DestroyRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.usersService
+      .listCustomUserFields()
+      .pipe(
+        tap(customUserFields => {
+          this.customUserFields.set(customUserFields);
+          if ((customUserFields || []).length > 0) {
+            const customFields = new FormGroup({});
+            for (const customUserField of customUserFields) {
+              customFields.addControl(customUserField.key!, new FormControl('', customUserField.required ? [Validators.required] : []));
+            }
+            this.registrationForm.addControl('customFields', customFields);
+          }
+        }),
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  register() {
+    const confirmationPageUrl = window.location.origin + window.location.pathname + '/confirm';
+    const userRegistrationFormValue = this.registrationForm.value as UserRegistrationFormValue;
+
+    this.usersService
+      .registerNewUser({ ...userRegistrationFormValue, confirmation_page_url: confirmationPageUrl })
+      .pipe(
+        catchError(err => {
+          this.error.set(err.status);
+          return EMPTY;
+        }),
+      )
+      .pipe(
+        tap(() => {
+          this.sentToEmail.set(userRegistrationFormValue.email);
+          this.submitted.set(true);
+        }),
+      )
+      .subscribe();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/user/custom-user-field.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/custom-user-field.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Definition of addition user registration fields
+ */
+export interface CustomUserField {
+  /**
+   * The field identifier.
+   */
+  key?: string;
+  /**
+   * The default field label.
+   */
+  label?: string;
+  /**
+   * The field is mandatory
+   */
+  required?: boolean;
+  /**
+   * List of authorized values for the field
+   */
+  values?: Array<string>;
+}

--- a/gravitee-apim-portal-webui-next/src/scss/helper.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/helper.scss
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 @use './m3-adapter';
+@use './theme';
 
 a.external-link {
   color: inherit;
   text-decoration: none;
+}
+
+a.internal-link {
+  color: #{theme.$primary-main-color};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 code {

--- a/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from './config.service';
+import { FinalizeRegistrationInput, RegisterUserInput, UsersService } from './users.service';
+import { CustomUserField } from '../entities/user/custom-user-field';
+import { User } from '../entities/user/user';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+      providers: [
+        UsersService,
+        {
+          provide: ConfigService,
+          useValue: { baseURL: TESTING_BASE_URL } as Partial<ConfigService>,
+        },
+      ],
+    });
+
+    service = TestBed.inject(UsersService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should list custom user fields', () => {
+    const apiResponse: CustomUserField[] = [
+      { key: 'company', label: 'Company', required: true, values: [] },
+      { key: 'country', label: 'Country', required: false, values: ['PL', 'DE'] },
+    ];
+
+    service.listCustomUserFields().subscribe(res => {
+      expect(res).toEqual(apiResponse);
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/users/custom-fields`);
+    expect(req.request.method).toBe('GET');
+
+    req.flush(apiResponse);
+  });
+
+  it('should register new user', () => {
+    const input: RegisterUserInput = {
+      email: 'john@doe.com',
+      firstname: 'John',
+      lastname: 'Doe',
+      confirmation_page_url: 'http://example.local/confirm',
+      customFields: { company: 'Acme Inc' },
+    };
+
+    const apiResponse = { id: 'user-1', email: 'john@doe.com' } as User;
+
+    service.registerNewUser(input).subscribe(res => {
+      expect(res).toEqual(apiResponse);
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/users/registration`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(input);
+
+    req.flush(apiResponse);
+  });
+
+  it('should finalize registration', () => {
+    const input: FinalizeRegistrationInput = {
+      token: 'token-123',
+      password: 'Secret123!',
+      firstname: 'John',
+      lastname: 'Doe',
+    };
+
+    const apiResponse = { id: 'user-1', email: 'john@doe.com' } as User;
+
+    service.finalizeRegistration(input).subscribe(res => {
+      expect(res).toEqual(apiResponse);
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/users/registration/_finalize`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(input);
+
+    req.flush(apiResponse);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/users.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { CustomUserField } from '../entities/user/custom-user-field';
+import { User } from '../entities/user/user';
+
+export interface RegisterUserInput {
+  /**
+   * Valid email of the new user.
+   */
+  email: string;
+  /**
+   * First name of the new user.
+   */
+  firstname?: string;
+  /**
+   * Last name of the new user.
+   */
+  lastname?: string;
+  /**
+   * URL of the confirmation page to be used in the \'User Registration\' email.
+   */
+  confirmation_page_url?: string;
+  /**
+   * Values for CustomUserFields
+   */
+  customFields?: { [key: string]: string };
+}
+
+export interface FinalizeRegistrationInput {
+  /**
+   * Token of the registered user to be validated.
+   */
+  token: string;
+  /**
+   * Password of the registered user.
+   */
+  password: string;
+  /**
+   * First name of the registered user.
+   */
+  firstname: string;
+  /**
+   * Last name of the registered user.
+   */
+  lastname: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UsersService {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configService: ConfigService,
+  ) {}
+
+  listCustomUserFields(): Observable<Array<CustomUserField>> {
+    return this.http.get<Array<CustomUserField>>(`${this.configService.baseURL}/configuration/users/custom-fields`);
+  }
+
+  registerNewUser(user: RegisterUserInput) {
+    return this.http.post<User>(`${this.configService.baseURL}/users/registration`, user);
+  }
+
+  finalizeRegistration(finalizeInput: FinalizeRegistrationInput) {
+    return this.http.post<User>(`${this.configService.baseURL}/users/registration/_finalize`, finalizeInput);
+  }
+}


### PR DESCRIPTION
Added forms in portal-webui-next related to registration process 

## Issue

https://gravitee.atlassian.net/browse/APIM-10918

## Description

In the NextGen Portal, users were not able to  sign up and confirm their password.  Implementation contains:
- additional link in login form for sign up, `/log-in`
- registration component with registration form `/registration`
- registration-confirmation component used to finalize registration by setting up user's password   `/registration/confirm/:token`

additionally missing redirect from `categories/all` to `categories` was also fixed as it was requested in the related jira issue 

## Additional context

smtp configuration is required to go through the process, after registration user gets an email message with link to finalization page containing `token` created for this registration    


