### PR TITLE
fix(console): MAPI-v2: HTTP Status 500 when missing portalArea query …

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -67,14 +68,21 @@ public class PortalNavigationItemsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.READ) })
     public PortalNavigationItemsResponse getPortalNavigationItems(
-        @QueryParam("area") PortalArea area,
+        @QueryParam("area") @DefaultValue("TOP_NAVBAR") String area,
         @QueryParam("parentId") String parentId,
         @QueryParam("loadChildren") @DefaultValue("true") boolean loadChildren
     ) {
+        final PortalArea portalArea;
+        try {
+            portalArea = PortalArea.valueOf(area);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid value '" + area + "' for query parameter 'area'");
+        }
+
         var result = listPortalNavigationItemsUseCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 GraviteeContext.getCurrentEnvironment(),
-                area,
+                portalArea,
                 Optional.ofNullable(parentId).map(PortalNavigationItemId::of),
                 loadChildren,
                 PortalNavigationItemViewerContext.forConsole()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1792,6 +1792,7 @@ components:
       description: The portal area (used by portal navigation items)
       enum: [ HOMEPAGE, TOP_NAVBAR ]
       example: TOP_NAVBAR
+      default: TOP_NAVBAR
     PortalVisibility:
       type: string
       description: The portal visibility (used by portal navigation items)
@@ -2246,7 +2247,7 @@ components:
       name: area
       in: query
       description: The portal area (eg. "homepage", "top_navbar")
-      required: true
+      required: false
       schema:
         $ref: "#/components/schemas/PortalArea"
 


### PR DESCRIPTION
…param

## Issue

https://gravitee.atlassian.net/browse/APIM-11976

## Description

- made area (portal area) in GET call for portal-navigation-items as default - TOP_NAVBAR
- made area (portal area) in query param is required=false
- added test cases


https://github.com/user-attachments/assets/9921424e-50b6-46d9-8d39-bb7a37df2f37


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

