### PR TITLE
fix: sanitize plan name when exporting API as CRD

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
@@ -106,7 +106,10 @@ public interface ApiCRDAdapter {
             .filter(plan -> !plan.isClosed())
             .toList();
         for (var plan : nonClosedPlans) {
-            var key = plansMap.containsKey(plan.getName()) ? randomize(plan.getName()) : plan.getName();
+            var key = plan.getName().trim().replace(" ", "-");
+            if (plansMap.containsKey(key)) {
+                key = randomize(key);
+            }
             plansMap.put(key, toCRDPlan(plan));
         }
         return plansMap;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiCRDAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiCRDAdapterTest.java
@@ -245,7 +245,7 @@ class ApiCRDAdapterTest {
         export.setPlans(plansWithConflictingNames);
         var spec = ApiCRDAdapter.INSTANCE.toCRDSpec(export, export.getApiEntity());
         assertThat(spec.getPlans()).hasSize(3);
-        assertThat(spec.getPlans()).containsKey("api key");
+        assertThat(spec.getPlans()).containsKey("api-key");
     }
 
     private static ExportApiEntity exportEntity(boolean withHrid) {


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-924
