### PR TITLE
fix(security): add security headers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/pom.xml
@@ -56,5 +56,34 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-security</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/src/main/java/io/gravitee/apim/rest/api/automation/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/src/main/java/io/gravitee/apim/rest/api/automation/security/config/BasicSecurityConfigurerAdapter.java
@@ -26,13 +26,13 @@ import io.gravitee.rest.api.idp.core.plugin.IdentityProviderManager;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetails;
+import io.gravitee.rest.api.security.config.SecureHeadersConfigurer;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
 import io.gravitee.rest.api.security.filter.CsrfIncludeFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextAuthorizationFilter;
 import io.gravitee.rest.api.security.filter.GraviteeContextFilter;
-import io.gravitee.rest.api.security.filter.RecaptchaFilter;
 import io.gravitee.rest.api.security.filter.TokenAuthenticationFilter;
 import io.gravitee.rest.api.security.listener.AuthenticationFailureListener;
 import io.gravitee.rest.api.security.listener.AuthenticationSuccessListener;
@@ -68,7 +68,6 @@ import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -79,7 +78,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @Profile("basic")
 @EnableWebSecurity
-public class BasicSecurityConfigurerAdapter {
+public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
 
     @Autowired
     private ConfigurableEnvironment environment;
@@ -185,6 +184,7 @@ public class BasicSecurityConfigurerAdapter {
         authorizations(http);
         hsts(http);
         csrf(http);
+        configure(http, environment);
 
         http.addFilterBefore(
             new TokenAuthenticationFilter(jwtSecret, cookieGenerator, userService, tokenService, authoritiesProvider),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/src/test/java/io/gravitee/apim/rest/api/automation/security/config/BasicSecurityConfigurerAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-security/src/test/java/io/gravitee/apim/rest/api/automation/security/config/BasicSecurityConfigurerAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.security.config;
+
+import io.gravitee.rest.api.security.config.AbstractSecurityConfigurerAdapterTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@ContextConfiguration(
+    classes = {
+        BasicSecurityConfigurerAdapter.class,
+        AbstractSecurityConfigurerAdapterTest.TestConfig.class,
+        BasicSecurityConfigurerAdapterTest.DummyController.class,
+    }
+)
+class BasicSecurityConfigurerAdapterTest extends AbstractSecurityConfigurerAdapterTest {
+
+    @Override
+    protected String getPath() {
+        return "/open-api.yaml";
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @RestController
+    static class DummyController {
+
+        @GetMapping(path = { "/open-api.yaml" })
+        public void handle() {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/pom.xml
@@ -59,5 +59,34 @@
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
 		</dependency>
+
+        <!-- Test dependencies -->
+		<dependency>
+			<groupId>io.gravitee.apim.rest.api</groupId>
+			<artifactId>gravitee-apim-rest-api-security</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.idp.core.plugin.IdentityProviderManager;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetails;
+import io.gravitee.rest.api.security.config.SecureHeadersConfigurer;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
@@ -80,7 +81,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @Profile("basic")
 @EnableWebSecurity
-public class BasicSecurityConfigurerAdapter {
+public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
 
     @Autowired
     private ConfigurableEnvironment environment;
@@ -187,6 +188,7 @@ public class BasicSecurityConfigurerAdapter {
         hsts(http);
         csrf(http);
         cors(http);
+        configure(http, environment);
 
         http.addFilterBefore(
             new TokenAuthenticationFilter(jwtSecret, cookieGenerator, userService, tokenService, authoritiesProvider),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/test/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/test/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.security.config;
+
+import io.gravitee.rest.api.security.config.AbstractSecurityConfigurerAdapterTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@ContextConfiguration(
+    classes = {
+        BasicSecurityConfigurerAdapter.class,
+        AbstractSecurityConfigurerAdapterTest.TestConfig.class,
+        BasicSecurityConfigurerAdapterTest.DummyController.class,
+    }
+)
+class BasicSecurityConfigurerAdapterTest extends AbstractSecurityConfigurerAdapterTest {
+
+    @Override
+    protected String getPath() {
+        return "/openapi-v2.yaml";
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @RestController
+    static class DummyController {
+
+        @GetMapping(path = { "/openapi-v2.yaml" })
+        public void handle() {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
@@ -59,5 +59,34 @@
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
 		</dependency>
+
+		<!-- Test dependencies -->
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-security</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.idp.core.plugin.IdentityProviderManager;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetails;
+import io.gravitee.rest.api.security.config.SecureHeadersConfigurer;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
@@ -80,7 +81,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @Profile("basic")
 @EnableWebSecurity
-public class BasicSecurityConfigurerAdapter {
+public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
 
     @Autowired
     private ConfigurableEnvironment environment;
@@ -187,6 +188,7 @@ public class BasicSecurityConfigurerAdapter {
         hsts(http);
         csrf(http);
         cors(http);
+        configure(http, environment);
 
         http.addFilterBefore(
             new TokenAuthenticationFilter(jwtSecret, cookieGenerator, userService, tokenService, authoritiesProvider),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/test/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/test/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.security.config;
+
+import io.gravitee.rest.api.security.config.AbstractSecurityConfigurerAdapterTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@ContextConfiguration(
+    classes = {
+        BasicSecurityConfigurerAdapter.class,
+        AbstractSecurityConfigurerAdapterTest.TestConfig.class,
+        BasicSecurityConfigurerAdapterTest.DummyController.class,
+    }
+)
+class BasicSecurityConfigurerAdapterTest extends AbstractSecurityConfigurerAdapterTest {
+
+    @Override
+    protected String getPath() {
+        return "/openapi.json";
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @RestController
+    static class DummyController {
+
+        @GetMapping(path = { "/openapi.json" })
+        public void handle() {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
@@ -59,5 +59,34 @@
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
 		</dependency>
+
+        <!-- Test dependencies -->
+		<dependency>
+			<groupId>io.gravitee.apim.rest.api</groupId>
+			<artifactId>gravitee-apim-rest-api-security</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.security.authentication.AuthenticationProvider;
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.GraviteeAuthenticationDetails;
+import io.gravitee.rest.api.security.config.SecureHeadersConfigurer;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.csrf.CookieCsrfSignedTokenRepository;
 import io.gravitee.rest.api.security.csrf.CsrfRequestMatcher;
@@ -79,7 +80,7 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 @Profile("basic")
 @EnableWebSecurity
-public class BasicSecurityConfigurerAdapter {
+public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
 
     @Autowired
     private ConfigurableEnvironment environment;
@@ -180,6 +181,7 @@ public class BasicSecurityConfigurerAdapter {
         hsts(http);
         csrf(http);
         cors(http);
+        configure(http, environment);
 
         http.addFilterBefore(
             new TokenAuthenticationFilter(jwtSecret, cookieGenerator, null, null, authoritiesProvider),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/test/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/test/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.security.config;
+
+import io.gravitee.rest.api.security.config.AbstractSecurityConfigurerAdapterTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@ContextConfiguration(
+    classes = {
+        BasicSecurityConfigurerAdapter.class,
+        AbstractSecurityConfigurerAdapterTest.TestConfig.class,
+        BasicSecurityConfigurerAdapterTest.DummyController.class,
+    }
+)
+class BasicSecurityConfigurerAdapterTest extends AbstractSecurityConfigurerAdapterTest {
+
+    @Override
+    protected String getPath() {
+        return "/openapi";
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @RestController
+    static class DummyController {
+
+        @GetMapping(path = { "/openapi" })
+        public void handle() {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
@@ -88,5 +88,43 @@
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-transcoder</artifactId>
 		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/config/SecureHeadersConfigurer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/config/SecureHeadersConfigurer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.config;
+
+import java.util.Arrays;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+
+public interface SecureHeadersConfigurer {
+    default void configure(HttpSecurity http, ConfigurableEnvironment environment) throws Exception {
+        xframe(http, environment);
+        csp(http, environment);
+        xContentTypeOptions(http, environment);
+        referrerPolicy(http, environment);
+        permissionsPolicy(http, environment);
+    }
+
+    private void xframe(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
+        boolean enabled = environment.getProperty("http.xframe.enabled", Boolean.class, true);
+        if (enabled) {
+            String action = environment.getProperty("http.xframe.action", "SAMEORIGIN");
+            if ("SAMEORIGIN".equalsIgnoreCase(action)) {
+                security.headers().frameOptions().sameOrigin();
+            } else {
+                security.headers().frameOptions().deny();
+            }
+        } else {
+            security.headers().frameOptions().disable();
+        }
+    }
+
+    private void csp(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
+        String cspPolicy = environment.getProperty("http.csp.policy");
+        if (cspPolicy != null && !cspPolicy.isEmpty()) {
+            security.headers().contentSecurityPolicy(policy -> policy.policyDirectives(cspPolicy));
+        }
+    }
+
+    private void xContentTypeOptions(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
+        boolean enabled = environment.getProperty("http.xContentTypeOptions.enabled", Boolean.class, true);
+        if (enabled) {
+            security.headers().contentTypeOptions();
+        }
+    }
+
+    private void referrerPolicy(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
+        String policyString = environment.getProperty("http.referrerPolicy.policy");
+
+        var policy = Arrays.stream(ReferrerPolicyHeaderWriter.ReferrerPolicy.values())
+            .filter(p -> p.getPolicy().equalsIgnoreCase(policyString))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Invalid referrer policy provided: '" + policyString + "'"));
+        security.headers().referrerPolicy(policy);
+    }
+
+    private void permissionsPolicy(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
+        String permissionsPolicy = environment.getProperty("http.permissionsPolicy.policy");
+        if (permissionsPolicy != null && !permissionsPolicy.isEmpty()) {
+            security.headers().permissionsPolicy(policy -> policy.policy(permissionsPolicy));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/config/AbstractSecurityConfigurerAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/config/AbstractSecurityConfigurerAdapterTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.config;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
+import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.rest.api.idp.core.plugin.IdentityProviderManager;
+import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
+import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.ReCaptchaService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { AbstractSecurityConfigurerAdapterTest.TestConfig.class })
+@WebAppConfiguration
+@ActiveProfiles("basic")
+@TestPropertySource(
+    properties = {
+        "jwt.secret=my-secret-for-tests",
+        "http.xframe.enabled=true",
+        "http.xframe.action=SAMEORIGIN",
+        "http.xContentTypeOptions.enabled=true",
+        "http.csp.policy=frame-ancestors 'self';",
+        "http.referrerPolicy.policy=strict-origin-when-cross-origin",
+        "http.permissionsPolicy.policy=camera=(), microphone=(), geolocation=()",
+    }
+)
+public abstract class AbstractSecurityConfigurerAdapterTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Test
+    void should_configure_secure_headers() throws Exception {
+        mockMvc
+            .perform(get(getPath()).secure(true))
+            .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+            .andExpect(header().string("X-Frame-Options", "SAMEORIGIN"))
+            .andExpect(header().string("Referrer-Policy", "strict-origin-when-cross-origin"))
+            .andExpect(header().string("Permissions-Policy", "camera=(), microphone=(), geolocation=()"))
+            .andExpect(header().string("Content-Security-Policy", "frame-ancestors 'self';"));
+    }
+
+    protected abstract String getPath();
+
+    @org.springframework.context.annotation.Configuration
+    @EnableWebMvc
+    public static class TestConfig {
+
+        @Bean
+        public MockMvc mockMvc(WebApplicationContext wac) {
+            return MockMvcBuilders.webAppContextSetup(wac).apply(springSecurity()).build();
+        }
+
+        @Bean
+        public CookieGenerator cookieGenerator() {
+            return mock(CookieGenerator.class);
+        }
+
+        @Bean
+        public IdentityProviderManager identityProviderManager() {
+            return mock(IdentityProviderManager.class);
+        }
+
+        @Bean
+        public UserService userService() {
+            return mock(UserService.class);
+        }
+
+        @Bean
+        public TokenService tokenService() {
+            return mock(TokenService.class);
+        }
+
+        @Bean
+        public AuthoritiesProvider authoritiesProvider() {
+            return mock(AuthoritiesProvider.class);
+        }
+
+        @Bean
+        public InstallationAccessQueryService installationAccessQueryService() {
+            return mock(InstallationAccessQueryService.class);
+        }
+
+        @Bean
+        public InstallationTypeDomainService installationTypeDomainService() {
+            return mock(InstallationTypeDomainService.class);
+        }
+
+        @Bean
+        public AccessPointQueryService accessPointQueryService() {
+            return mock(AccessPointQueryService.class);
+        }
+
+        @Bean
+        public Configuration graviteeConfiguration() {
+            return mock(Configuration.class);
+        }
+
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+            return mock(CorsConfigurationSource.class);
+        }
+
+        @Bean
+        public ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        public EventManager eventManager() {
+            return mock(EventManager.class);
+        }
+
+        @Bean
+        public AuthenticationProviderManager authenticationProviderManager() {
+            return mock(AuthenticationProviderManager.class);
+        }
+
+        @Bean
+        public ReCaptchaService reCaptchaService() {
+            return mock(ReCaptchaService.class);
+        }
+
+        @Bean
+        public ParameterService parameterService() {
+            return mock(ParameterService.class);
+        }
+
+        @Bean
+        public EnvironmentService environmentService() {
+            return mock(EnvironmentService.class);
+        }
+
+        @Bean
+        public MembershipService membershipService() {
+            return mock(MembershipService.class);
+        }
+
+        @Bean
+        public RoleService roleService() {
+            return mock(RoleService.class);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -103,6 +103,30 @@ http:
     include-sub-domains: true
     max-age: 31536000
 
+  # Adds the X-Frame-Options header. Possible values: DENY, SAMEORIGIN. Enabled by default on SAMEORIGIN.
+  xframe:
+    enabled: true
+    action: SAMEORIGIN
+
+  # Adds the X-Content-Type-Options: nosniff header. Enabled by default.
+  xContentTypeOptions:
+    enabled: true
+
+  # Adds the Content-Security-Policy header.
+  # Example: "default-src 'self'; frame-ancestors 'none';"
+  csp:
+    policy: "frame-ancestors 'self';"
+
+  # Adds the Referrer-Policy header.
+  # Example: "no-referrer", "strict-origin-when-cross-origin", ...
+  referrerPolicy:
+    policy: "strict-origin-when-cross-origin"
+
+  # Adds the Permissions-Policy header.
+  # Example: "geolocation=(), microphone=(), camera=()"
+  permissionsPolicy:
+    policy: "geolocation=(), microphone=(), camera=()"
+
 # Plugins repository
 #plugins:
 #  path:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11975

## Description

This PR strengthens our security posture by implementing a set of standard HTTP security headers. Through a unified SecureHeadersConfigurer across all Spring Security configurations, this change provides defense against common web vulnerabilities like XSS, clickjacking...