### PR TITLE
feat(dashboard-lib): add bar chart as an option

### DIFF
--- a/gravitee-apim-portal-webui-next/.eslintrc.json
+++ b/gravitee-apim-portal-webui-next/.eslintrc.json
@@ -3,7 +3,9 @@
   "ignorePatterns": ["projects/**/*"],
   "settings": {
     "import/resolver": {
-      "typescript": {}
+      "typescript": {
+        "project": ["tsconfig.json", "projects/*/tsconfig.json", "projects/*/tsconfig.lib.json"]
+      }
     }
   },
   "plugins": ["unused-imports"],

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<canvas baseChart [data]="dataFormatted()" type="bar" [options]="option()"></canvas>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.scss
@@ -1,23 +1,21 @@
 /*
  * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChartData } from 'chart.js';
-
-import { PieType } from './chart/pie-chart/pie-chart.component';
-import { Metric, MetricsResponse } from './widget/model/response/response';
-
-export interface Converter {
-  convert(data: MetricsResponse<Metric>): ChartData<PieType | 'line' | 'bar', number[], string> | number[] | string[];
+:host {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100%;
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BarChartComponent } from './bar-chart.component';
+import { TimeSeriesBucket, TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+
+describe('BarChartComponent', () => {
+  let component: BarChartComponent;
+  let fixture: ComponentFixture<BarChartComponent>;
+
+  const createBaseBucket = (key: string, overrides: Partial<TimeSeriesBucket> = {}): TimeSeriesBucket => ({
+    key,
+    name: key,
+    timestamp: new Date(key),
+    ...overrides,
+  });
+
+  const createMeasureBucket = (key: string, value: number): TimeSeriesBucket =>
+    createBaseBucket(key, {
+      measures: [
+        {
+          name: 'COUNT',
+          value,
+        },
+      ],
+    });
+
+  const createNestedBucket = (key: string, groups: Record<string, number>): TimeSeriesBucket =>
+    createBaseBucket(key, {
+      buckets: Object.entries(groups).map(([range, value]) => ({
+        key: range,
+        name: range,
+        measures: [
+          {
+            name: 'COUNT',
+            value,
+          },
+        ],
+      })),
+    });
+
+  const createTimeSeriesResponse = (metricBuckets: TimeSeriesBucket[]): TimeSeriesResponse => ({
+    metrics: [
+      {
+        name: 'HTTP_REQUESTS',
+        buckets: metricBuckets,
+      },
+    ],
+    buckets: metricBuckets.map(({ key, name, timestamp }) => createBaseBucket(key, { name, timestamp })),
+  });
+
+  const setChartData = (data: TimeSeriesResponse) => {
+    fixture.componentRef.setInput('data', data);
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BarChartComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BarChartComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    const data = createTimeSeriesResponse([createMeasureBucket('2025-10-07T06:00:00Z', 100)]);
+
+    setChartData(data);
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should handle multiple buckets', () => {
+    const data = createTimeSeriesResponse([
+      createMeasureBucket('2025-10-07T06:00:00Z', 100),
+      createMeasureBucket('2025-10-08T06:00:00Z', 200),
+      createMeasureBucket('2025-10-09T06:00:00Z', 150),
+    ]);
+
+    setChartData(data);
+
+    const result = component.dataFormatted();
+    expect(result.labels?.length).toBe(3);
+    expect(result.datasets[0].data).toEqual([100, 200, 150]);
+  });
+
+  it('should handle empty metrics list', () => {
+    const emptyData: TimeSeriesResponse = {
+      metrics: [],
+      buckets: [],
+    };
+
+    setChartData(emptyData);
+
+    const result = component.dataFormatted();
+    expect(result.labels).toEqual([]);
+    expect(result.datasets).toEqual([]);
+  });
+
+  it('should handle nested buckets structure', () => {
+    const data = createTimeSeriesResponse([
+      createNestedBucket('2025-10-07T06:00:00Z', {
+        '100-199': 50,
+        '200-299': 30,
+      }),
+      createNestedBucket('2025-10-08T06:00:00Z', {
+        '100-199': 60,
+        '200-299': 40,
+      }),
+    ]);
+
+    setChartData(data);
+
+    const result = component.dataFormatted();
+    expect(result.labels?.length).toBe(2);
+    expect(result.datasets.length).toBe(2);
+    expect(result.datasets[0].label).toContain('100-199');
+    expect(result.datasets[1].label).toContain('200-299');
+  });
+
+  it('should have stacked bar chart options by default', () => {
+    const data = createTimeSeriesResponse([createMeasureBucket('2025-10-07T06:00:00Z', 100)]);
+    setChartData(data);
+
+    const options = component.option();
+    const xScale = options?.scales?.['x'];
+    const yScale = options?.scales?.['y'];
+
+    expect(xScale?.stacked).toBe(true);
+    expect(yScale?.stacked).toBe(true);
+    expect((yScale as { beginAtZero?: boolean })?.beginAtZero).toBe(true);
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
@@ -141,7 +141,7 @@ export const HighVolume: StoryObj<BarChartStoryArgs> = {
     storyId: 'high-volume',
     type: 'bar',
     dataPoints: Array.from({ length: 24 }, (_, i) => ({
-      timestamp: new Date(Date.now() - (23 - i) * 60 * 60 * 1000).toISOString(),
+      timestamp: new Date(new Date('2025-01-10T23:00:00Z').getTime() - (23 - i) * 60 * 60 * 1000).toISOString(),
       value: Math.floor(Math.random() * 1000) + 500,
     })),
   },

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+
+import { BarChartComponent, BarType } from './bar-chart.component';
+import { TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+
+interface BarChartStoryArgs {
+  storyId?: string;
+  type: BarType;
+  dataPoints: {
+    timestamp: string;
+    value: number;
+  }[];
+}
+
+export default {
+  title: 'Gravitee Dashboard/Components/Chart/Bar Chart',
+  component: BarChartComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [BarChartComponent],
+    }),
+    applicationConfig({
+      providers: [
+        // Register Chart.js controllers for bar charts
+        provideCharts(withDefaultRegisterables()),
+      ],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: 'A bar chart component built with Chart.js that displays time series data in a bar chart format.',
+      },
+    },
+  },
+  argTypes: {
+    storyId: {
+      table: { disable: true },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['bar'],
+      description: 'Type of bar chart to display',
+    },
+    dataPoints: {
+      control: { type: 'object' },
+      description: 'Array of data points with timestamp and value',
+    },
+  },
+  render: args => {
+    const metricBuckets = args.dataPoints.map(point => ({
+      key: point.timestamp,
+      name: point.timestamp,
+      timestamp: new Date(point.timestamp),
+      measures: [
+        {
+          name: 'COUNT' as const,
+          value: point.value,
+        },
+      ],
+    }));
+
+    const timeSeriesData: TimeSeriesResponse = {
+      interval: '1h',
+      metrics: [
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: metricBuckets,
+        },
+      ],
+      buckets: metricBuckets.map(({ key, name, timestamp }) => ({ key, name, timestamp })),
+    };
+
+    return {
+      template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-bar-chart [type]="type" [data]="timeSeriesData" />
+        </div>
+      `,
+      props: {
+        type: args.type,
+        timeSeriesData,
+      },
+    };
+  },
+} satisfies Meta<BarChartStoryArgs>;
+
+export const Default: StoryObj<BarChartStoryArgs> = {
+  args: {
+    storyId: 'default',
+    type: 'bar',
+    dataPoints: [
+      { timestamp: '2025-01-01T00:00:00Z', value: 120 },
+      { timestamp: '2025-01-01T01:00:00Z', value: 145 },
+      { timestamp: '2025-01-01T02:00:00Z', value: 98 },
+      { timestamp: '2025-01-01T03:00:00Z', value: 167 },
+      { timestamp: '2025-01-01T04:00:00Z', value: 134 },
+      { timestamp: '2025-01-01T05:00:00Z', value: 189 },
+      { timestamp: '2025-01-01T06:00:00Z', value: 156 },
+      { timestamp: '2025-01-01T07:00:00Z', value: 201 },
+      { timestamp: '2025-01-01T08:00:00Z', value: 234 },
+      { timestamp: '2025-01-01T09:00:00Z', value: 267 },
+      { timestamp: '2025-01-01T10:00:00Z', value: 289 },
+      { timestamp: '2025-01-01T11:00:00Z', value: 312 },
+    ],
+  },
+};
+
+export const SparseData: StoryObj<BarChartStoryArgs> = {
+  args: {
+    storyId: 'sparse-data',
+    type: 'bar',
+    dataPoints: [
+      { timestamp: '2025-01-01T00:00:00Z', value: 120 },
+      { timestamp: '2025-01-01T06:00:00Z', value: 156 },
+      { timestamp: '2025-01-01T12:00:00Z', value: 298 },
+      { timestamp: '2025-01-01T18:00:00Z', value: 467 },
+      { timestamp: '2025-01-02T00:00:00Z', value: 357 },
+    ],
+  },
+};
+
+export const HighVolume: StoryObj<BarChartStoryArgs> = {
+  args: {
+    storyId: 'high-volume',
+    type: 'bar',
+    dataPoints: Array.from({ length: 24 }, (_, i) => ({
+      timestamp: new Date(Date.now() - (23 - i) * 60 * 60 * 1000).toISOString(),
+      value: Math.floor(Math.random() * 1000) + 500,
+    })),
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
@@ -146,3 +146,61 @@ export const HighVolume: StoryObj<BarChartStoryArgs> = {
     })),
   },
 };
+
+export const Stacked: StoryObj<BarChartStoryArgs> = {
+  args: {
+    storyId: 'stacked',
+    type: 'bar',
+    dataPoints: [],
+  },
+  render: args => {
+    const timestamps = Array.from({ length: 40 }, (_, i) => {
+      return new Date(new Date('2025-01-01T00:00:00Z').getTime() + i * 30 * 60 * 1000).toISOString();
+    });
+
+    const getRandomValue = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+    const successBuckets = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: getRandomValue(200, 500) }],
+    }));
+
+    const errorBuckets = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: getRandomValue(10, 50) }],
+    }));
+
+    const otherBuckets = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: getRandomValue(5, 30) }],
+    }));
+
+    const timeSeriesData: TimeSeriesResponse = {
+      interval: '30m',
+      metrics: [
+        { name: 'HTTP_REQUESTS', buckets: successBuckets },
+        { name: 'HTTP_ERRORS', buckets: errorBuckets },
+        { name: 'MESSAGES', buckets: otherBuckets },
+      ],
+      buckets: timestamps.map(ts => ({ key: ts, name: ts, timestamp: new Date(ts) })),
+    };
+
+    return {
+      template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-bar-chart [type]="type" [data]="timeSeriesData" />
+        </div>
+      `,
+      props: {
+        type: args.type,
+        timeSeriesData,
+      },
+    };
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -35,14 +35,7 @@ export class BarChartComponent {
   data = input.required<TimeSeriesResponse>();
 
   public readonly dataFormatted = computed(() => {
-    const chartData = this.converter.convert(this.data());
-
-    chartData.datasets.forEach(dataset => {
-      dataset.borderWidth = 1;
-      dataset.borderRadius = 15;
-    });
-
-    return chartData;
+    return this.converter.convert(this.data());
   });
   private readonly converter = inject(BarConverterService);
 
@@ -50,6 +43,12 @@ export class BarChartComponent {
     return {
       responsive: true,
       maintainAspectRatio: false,
+      datasets: {
+        bar: {
+          borderWidth: 1,
+          borderRadius: 15,
+        },
+      },
       plugins: {
         legend: {
           display: true,

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -39,6 +39,7 @@ export class BarChartComponent {
 
     chartData.datasets.forEach(dataset => {
       dataset.borderWidth = 1;
+      dataset.borderRadius = 15;
     });
 
     return chartData;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -16,7 +16,6 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { ChartConfiguration } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
-// eslint-disable-next-line import/no-unresolved
 import 'chartjs-adapter-date-fns';
 
 import { BarConverterService } from './converter/bar-converter.service';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input } from '@angular/core';
+import { ChartConfiguration } from 'chart.js';
+import { BaseChartDirective } from 'ng2-charts';
+// eslint-disable-next-line import/no-unresolved
+import 'chartjs-adapter-date-fns';
+
+import { BarConverterService } from './converter/bar-converter.service';
+import { TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+
+export type BarType = 'bar';
+
+@Component({
+  selector: 'gd-bar-chart',
+  imports: [BaseChartDirective],
+  templateUrl: './bar-chart.component.html',
+  styleUrl: './bar-chart.component.scss',
+})
+export class BarChartComponent {
+  type = input<BarType>('bar');
+  option = input<ChartConfiguration<BarType>['options']>(this.getDefaultOptions());
+  data = input.required<TimeSeriesResponse>();
+
+  public readonly dataFormatted = computed(() => {
+    const chartData = this.converter.convert(this.data());
+
+    chartData.datasets.forEach(dataset => {
+      dataset.borderWidth = 1;
+    });
+
+    return chartData;
+  });
+  private readonly converter = inject(BarConverterService);
+
+  private getDefaultOptions(): ChartConfiguration<BarType>['options'] {
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: true,
+          position: 'bottom',
+          labels: {
+            usePointStyle: true,
+            pointStyle: 'rectRounded',
+          },
+        },
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+        },
+      },
+      scales: {
+        x: {
+          type: 'time',
+          display: true,
+          stacked: true,
+          time: {
+            tooltipFormat: 'PPpp',
+            displayFormats: {
+              second: 'HH:mm:ss',
+              minute: 'HH:mm',
+              hour: 'HH:mm',
+              day: 'EEE d',
+              week: 'd LLL',
+              month: 'LLL yyyy',
+              year: 'yyyy',
+            },
+          },
+        },
+        y: {
+          display: true,
+          beginAtZero: true,
+          stacked: true,
+        },
+      },
+    };
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.spec.ts
@@ -216,5 +216,23 @@ describe('BarConverterService', () => {
       expect(result.datasets[0].label).toBe('100-199');
       expect(result.datasets[1].label).toBe('200-299');
     });
+    it('should prioritize data.buckets over metric buckets for labels', () => {
+      // Use keys and undefined timestamps to test logic without date parsing interference
+      const metricBuckets = [makeMeasureBucket('metric-key-1', 100)];
+      metricBuckets[0].timestamp = undefined;
+
+      const globalBuckets = [makeBaseBucket('global-key-1'), makeBaseBucket('global-key-2')];
+      globalBuckets.forEach(b => (b.timestamp = undefined));
+
+      const data: TimeSeriesResponse = {
+        metrics: [{ name: 'HTTP_REQUESTS', buckets: metricBuckets }],
+        buckets: globalBuckets,
+      };
+
+      const result = service.convert(data);
+
+      expect(result.labels).toEqual(['global-key-1', 'global-key-2']);
+      expect(result.datasets[0].data).toEqual([100]);
+    });
   });
 });

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.spec.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { BarConverterService } from './bar-converter.service';
+import { TimeSeriesBucket, TimeSeriesResponse } from '../../../widget/model/response/time-series-response';
+
+describe('BarConverterService', () => {
+  let service: BarConverterService;
+  const makeBaseBucket = (key: string, overrides: Partial<TimeSeriesBucket> = {}): TimeSeriesBucket => ({
+    key,
+    name: key,
+    timestamp: new Date(key),
+    ...overrides,
+  });
+
+  const makeMeasureBucket = (key: string, value: number): TimeSeriesBucket =>
+    makeBaseBucket(key, {
+      measures: [{ name: 'COUNT', value }],
+    });
+
+  const makeNestedBucket = (key: string, groups: Record<string, number>): TimeSeriesBucket =>
+    makeBaseBucket(key, {
+      buckets: Object.entries(groups).map(([groupKey, value]) => ({
+        key: groupKey,
+        name: groupKey,
+        measures: [{ name: 'COUNT', value }],
+      })),
+    });
+
+  const makeResponse = (metrics: TimeSeriesResponse['metrics'] = []): TimeSeriesResponse => {
+    const firstMetricBuckets = metrics[0]?.buckets ?? [];
+    const buckets = (firstMetricBuckets as TimeSeriesBucket[]).map(b => ({
+      key: b.key,
+      name: b.name,
+      timestamp: b.timestamp,
+    }));
+
+    return {
+      metrics,
+      buckets,
+    };
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BarConverterService],
+    });
+    service = TestBed.inject(BarConverterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('convert', () => {
+    it('should convert TimeSeriesResponse to ChartData with labels and data', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [makeMeasureBucket('2025-10-07T06:00:00Z', 100), makeMeasureBucket('2025-10-08T06:00:00Z', 200)],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(2);
+      expect(result.datasets.length).toBe(1);
+      expect(result.datasets[0].data).toEqual([100, 200]);
+      expect(result.datasets[0].label).toBe('HTTP_REQUESTS');
+    });
+
+    it('should return empty arrays when metrics is empty', () => {
+      const data: TimeSeriesResponse = {
+        metrics: [],
+        buckets: [],
+      };
+
+      const result = service.convert(data);
+
+      expect(result.labels).toEqual([]);
+      expect(result.datasets).toEqual([]);
+    });
+
+    it('should handle nested buckets structure', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [
+            makeNestedBucket('2025-10-07T06:00:00Z', {
+              '100-199': 50,
+              '200-299': 30,
+            }),
+            makeNestedBucket('2025-10-08T06:00:00Z', {
+              '100-199': 60,
+              '200-299': 40,
+            }),
+          ],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(2);
+      expect(result.datasets.length).toBe(2);
+      expect(result.datasets[0].label).toBe('100-199');
+      expect(result.datasets[0].data).toEqual([50, 60]);
+      expect(result.datasets[1].label).toBe('200-299');
+      expect(result.datasets[1].data).toEqual([30, 40]);
+    });
+
+    it('should handle buckets without measures', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [
+            makeMeasureBucket('2025-10-07T06:00:00Z', 100),
+            makeBaseBucket('2025-10-08T06:00:00Z', { measures: [] }),
+            makeMeasureBucket('2025-10-09T06:00:00Z', 300),
+          ],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(3);
+      expect(result.datasets[0].data).toEqual([100, 0, 300]);
+    });
+
+    it('should use timestamp when available, otherwise fallback to key', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [
+            makeBaseBucket('2025-10-07T06:00:00Z', {
+              timestamp: new Date(1728288000000),
+              measures: [{ name: 'COUNT', value: 100 }],
+            }),
+            makeBaseBucket('2025-10-08T06:00:00Z', {
+              timestamp: undefined,
+              measures: [{ name: 'COUNT', value: 200 }],
+            }),
+          ],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(2);
+      expect(result.labels?.[0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(result.labels?.[1]).toBe('2025-10-08T06:00:00Z');
+    });
+
+    it('should handle multiple metrics', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [makeMeasureBucket('2025-10-07T06:00:00Z', 100)],
+        },
+        {
+          name: 'HTTP_ERRORS',
+          buckets: [makeMeasureBucket('2025-10-07T06:00:00Z', 5)],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(1);
+      expect(result.datasets.length).toBe(2);
+      expect(result.datasets[0].label).toBe('HTTP_REQUESTS');
+      expect(result.datasets[0].data).toEqual([100]);
+      expect(result.datasets[1].label).toBe('HTTP_ERRORS');
+      expect(result.datasets[1].data).toEqual([5]);
+    });
+
+    it('should create separate datasets for nested buckets without direct measures', () => {
+      const data: TimeSeriesResponse = makeResponse([
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [
+            makeBaseBucket('2025-10-07T06:00:00Z', {
+              buckets: [
+                {
+                  key: '100-199',
+                  name: '100-199',
+                  measures: [{ name: 'COUNT', value: 50 }],
+                },
+                {
+                  key: '200-299',
+                  name: '200-299',
+                  measures: [{ name: 'COUNT', value: 30 }],
+                },
+              ],
+            }),
+          ],
+        },
+      ]);
+
+      const result = service.convert(data);
+
+      expect(result.labels?.length).toBe(1);
+      expect(result.datasets.length).toBe(2);
+      expect(result.datasets[0].label).toBe('100-199');
+      expect(result.datasets[1].label).toBe('200-299');
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { ChartData } from 'chart.js';
+
+import { Converter } from '../../../converter';
+import { TimeSeries, TimeSeriesBucket, TimeSeriesResponse } from '../../../widget/model/response/time-series-response';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BarConverterService implements Converter {
+  public convert(data: TimeSeriesResponse): ChartData<'bar', number[], string> {
+    const labels: string[] = [];
+    const datasets: ChartData<'bar', number[], string>['datasets'] = [];
+
+    if (!data?.metrics?.length) {
+      return { labels, datasets };
+    }
+
+    this.extractTimeLabelsFromFirstMetric(data, labels);
+    this.processAllMetrics(data, datasets);
+
+    return { labels, datasets };
+  }
+
+  private extractTimeLabelsFromFirstMetric(data: TimeSeriesResponse, labels: string[]): void {
+    const firstMetric = data.metrics?.[0];
+
+    if (firstMetric?.buckets?.length) {
+      firstMetric.buckets.forEach(timeBucket => {
+        labels.push(this.toTimeLabel(timeBucket));
+      });
+    }
+  }
+
+  private processAllMetrics(data: TimeSeriesResponse, datasets: ChartData<'bar', number[], string>['datasets']): void {
+    data.metrics?.forEach((metric, metricIndex) => {
+      this.processMetric(metric, metricIndex, datasets);
+    });
+  }
+
+  private processMetric(metric: TimeSeries, metricIndex: number, datasets: ChartData<'bar', number[], string>['datasets']): void {
+    const metricBuckets = metric.buckets ?? [];
+    const bucketCount = metricBuckets.length;
+
+    if (!bucketCount) {
+      return;
+    }
+
+    const hasNestedBuckets = this.hasNestedBuckets(metricBuckets);
+    const baseMetricLabel = this.getBaseMetricLabel(metric, metricIndex);
+
+    if (hasNestedBuckets) {
+      this.buildGroupedDatasetsFromNestedBuckets(metricBuckets, bucketCount, datasets);
+    } else {
+      this.buildSimpleDatasetFromMetric(metricBuckets, baseMetricLabel, datasets);
+    }
+  }
+
+  private hasNestedBuckets(metricBuckets: TimeSeriesBucket[]): boolean {
+    return (metricBuckets[0].buckets?.length ?? 0) > 0;
+  }
+
+  private getBaseMetricLabel(metric: TimeSeries, metricIndex: number): string {
+    return metric.name || `Metric ${metricIndex + 1}`;
+  }
+
+  private buildGroupedDatasetsFromNestedBuckets(
+    metricBuckets: TimeSeriesBucket[],
+    bucketCount: number,
+    datasets: ChartData<'bar', number[], string>['datasets'],
+  ): void {
+    const groupMap = this.aggregateNestedBucketValuesByGroup(metricBuckets, bucketCount);
+
+    groupMap.forEach((values, groupName) => {
+      datasets.push({
+        label: `${groupName}`,
+        data: values,
+      });
+    });
+  }
+
+  private aggregateNestedBucketValuesByGroup(metricBuckets: TimeSeriesBucket[], bucketCount: number): Map<string, number[]> {
+    const groupMap = new Map<string, number[]>();
+
+    metricBuckets.forEach((timeBucket, timeIndex) => {
+      timeBucket.buckets?.forEach(nestedBucket => {
+        const groupName = nestedBucket.name || nestedBucket.key;
+        if (!groupName) {
+          return;
+        }
+
+        if (!groupMap.has(groupName)) {
+          groupMap.set(groupName, new Array(bucketCount).fill(0));
+        }
+
+        const values = groupMap.get(groupName)!;
+
+        values[timeIndex] = nestedBucket.measures?.[0]?.value ?? 0;
+      });
+    });
+
+    return groupMap;
+  }
+
+  private buildSimpleDatasetFromMetric(
+    metricBuckets: TimeSeriesBucket[],
+    baseMetricLabel: string,
+    datasets: ChartData<'bar', number[], string>['datasets'],
+  ): void {
+    const dataValues: number[] = metricBuckets.map(bucket => this.getBucketValue(bucket));
+
+    datasets.push({
+      label: baseMetricLabel,
+      data: dataValues,
+    });
+  }
+
+  private getBucketValue(bucket: TimeSeriesBucket): number {
+    if (bucket.measures?.length) {
+      return bucket.measures[0].value;
+    }
+
+    if (bucket.buckets?.length) {
+      return bucket.buckets.reduce((acc, nested) => acc + (nested.measures?.[0]?.value ?? 0), 0);
+    }
+
+    return 0;
+  }
+
+  private toTimeLabel(bucket: TimeSeriesBucket): string {
+    if (bucket.timestamp != null) {
+      const date = new Date(bucket.timestamp);
+      if (!Number.isNaN(date.getTime())) {
+        return date.toISOString();
+      }
+    }
+
+    return bucket.key ?? '';
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/converter/bar-converter.service.ts
@@ -31,17 +31,17 @@ export class BarConverterService implements Converter {
       return { labels, datasets };
     }
 
-    this.extractTimeLabelsFromFirstMetric(data, labels);
+    this.extractTimeLabels(data, labels);
     this.processAllMetrics(data, datasets);
 
     return { labels, datasets };
   }
 
-  private extractTimeLabelsFromFirstMetric(data: TimeSeriesResponse, labels: string[]): void {
-    const firstMetric = data.metrics?.[0];
+  private extractTimeLabels(data: TimeSeriesResponse, labels: string[]): void {
+    const bucketsForLabels = data.buckets?.length ? data.buckets : data.metrics?.[0]?.buckets;
 
-    if (firstMetric?.buckets?.length) {
-      firstMetric.buckets.forEach(timeBucket => {
+    if (bucketsForLabels) {
+      bucketsForLabels.forEach(timeBucket => {
         labels.push(this.toTimeLabel(timeBucket));
       });
     }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
@@ -16,7 +16,6 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { ChartConfiguration } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
-// eslint-disable-next-line import/no-unresolved
 import 'chartjs-adapter-date-fns';
 
 import { LineConverterService } from './converter/line-converter.service';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.html
@@ -53,6 +53,11 @@
                     <gd-line-chart [data]="item.response" />
                   }
                 }
+                @case ('bar') {
+                  @if (isTimeSeriesWidget(item)) {
+                    <gd-bar-chart [data]="item.response" />
+                  }
+                }
                 @default {
                   <div>Not yet Formatted - Type: {{ item.type }}</div>
                 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/grid/grid.component.ts
@@ -18,6 +18,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { CompactType, DisplayGrid, GridsterComponent, GridsterConfig, GridsterItemComponent, GridType } from 'angular-gridster2';
 
+import { BarChartComponent } from '../chart/bar-chart/bar-chart.component';
 import { LineChartComponent } from '../chart/line-chart/line-chart.component';
 import { PieChartComponent } from '../chart/pie-chart/pie-chart.component';
 import { EmptyStateComponent } from '../empty-state/empty-state.component';
@@ -33,6 +34,7 @@ import { WidgetBodyComponent, WidgetComponent, WidgetTitleComponent } from '../w
     WidgetComponent,
     WidgetTitleComponent,
     WidgetBodyComponent,
+    BarChartComponent,
     LineChartComponent,
     PieChartComponent,
     StatsComponent,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1953
## Description
→ adds bar chart as an option for widget
<img width="900" height="385" alt="Screenshot 2026-01-06 at 8 46 40 AM" src="https://github.com/user-attachments/assets/84a20ab9-ba22-42ff-9481-88e1102e13f4" />
<img width="896" height="388" alt="Screenshot 2026-01-06 at 8 41 55 AM" src="https://github.com/user-attachments/assets/4d781919-99f8-41e1-996d-3dc8dc9e70d2" />

## Additional context
Added story for the widget since it is not implemented in the analytics dashboard
http://localhost:6006/?path=/story/gravitee-dashboard-components-chart-bar-chart--default 
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

