### PR TITLE
fix: allow gateway to listen on port 8080

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -34,7 +34,6 @@ import io.vertx.core.Vertx;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -48,6 +47,7 @@ import org.springframework.core.env.Environment;
 public class VertxReactorConfiguration {
 
     protected static final String SERVERS_PREFIX = "servers";
+    protected static final int HTTP_DEFAULT_PORT = 8082;
 
     @Bean
     public ServerManager serverManager(
@@ -64,9 +64,10 @@ public class VertxReactorConfiguration {
             while (getServerType(environment, prefix) != null) {
                 String property = getServerType(environment, prefix);
                 boolean isTcpServer = Objects.equals(property, TCP_PREFIX);
-                final VertxServerOptions options = VertxServerOptions.builder(environment, prefix)
-                    .defaultPort(isTcpServer ? TCP_DEFAULT_PORT : 8082)
-                    .build();
+
+                var defaultPort = isTcpServer ? TCP_DEFAULT_PORT : HTTP_DEFAULT_PORT;
+                var options = VertxServerOptions.builder().defaultPort(defaultPort).prefix(prefix).environment(environment).build();
+
                 if (isTcpServer) {
                     assertTcpOptions(options);
                 }
@@ -76,7 +77,7 @@ public class VertxReactorConfiguration {
         } else {
             // No server list configured, fallback to single 'http' server configuration.
             final VertxHttpServerOptions httpOptions = VertxHttpServerOptions.builder()
-                .defaultPort(8082)
+                .defaultPort(HTTP_DEFAULT_PORT)
                 .prefix(HTTP_PREFIX)
                 .environment(environment)
                 .id("http")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfigurationTest.java
@@ -112,6 +112,24 @@ class VertxReactorConfigurationTest {
     }
 
     @Test
+    void should_create_server_manager_from_server_list_with_gravitee_node_default_port() {
+        final VertxServer vertxServer1 = mock(VertxServer.class);
+
+        when(serverFactory.create(any(VertxServerOptions.class))).thenReturn(vertxServer1);
+
+        var port = VertxServerOptions.DEFAULT_PORT;
+
+        environment.setProperty("servers[0].type", "http");
+        environment.setProperty("servers[0].port", "" + port);
+
+        cut.serverManager(serverFactory, environment);
+
+        verify(serverFactory).create(optionsCaptor.capture());
+
+        assertThat(optionsCaptor.getValue().getPort()).isEqualTo(port);
+    }
+
+    @Test
     void should_create_server_manager_from_single_http_server() {
         final VertxServer vertxServer = mock(VertxServer.class);
 


### PR DESCRIPTION
With this configuration

```yaml
servers:
    - host: 0.0.0.0
      port: 1104
      id: listener-1
      type: http
    - host: 0.0.0.0
      port: 8080
      id: listener-2
      type: http
http:
  host: 0.0.0.0
  port: 1104
```

The gateway was still binding port 8082 (its default port). The bug happened only if the port defined in the server list is 8080 (which is the default port defined in gravitee-node)

This is because there is an order to respect in the server options builder so that no conflict happen between setting the application default port and providing the application environment.
