### PR TITLE
feat: implement CSP for console and portal

### DIFF
--- a/gravitee-apim-console-webui/docker/config/default.conf
+++ b/gravitee-apim-console-webui/docker/config/default.conf
@@ -4,7 +4,7 @@ server {
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-console-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-apim-console-webui/docker/config/default.no-ipv6.conf
@@ -4,7 +4,7 @@ server {
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/default-next.conf
+++ b/gravitee-apim-portal-webui/docker/config/default-next.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
-    add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/default-next.no-ipv6.conf
+++ b/gravitee-apim-portal-webui/docker/config/default-next.no-ipv6.conf
@@ -3,7 +3,7 @@ server {
     listen $HTTPS_PORT;
     server_name $SERVER_NAME;
 
-    add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
-    add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.no-ipv6.conf
@@ -4,7 +4,7 @@ server {
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Content-Security-Policy "frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12035

## Description

As part of this task, a `Content-Security-Policy` header was updated for the **Console UI, Portal UI, and Next-Gen Portal**.

While the target state is a very strict CSP (e.g. without `unsafe-inline` / `unsafe-eval` and without allowing resources from other origins), applying such a policy in the current UI applications and typical on-premise deployment scenarios would very likely break the applications for end users.

In real-world deployments, the UIs can be:
- hosted with or without TLS,
- exposed on different hosts and/or ports than the Management API,
- rendering user-generated content (e.g. Markdown documentation) that may reference external resources such as images.

Because of this, enforcing the exact “strict CSP” proposed in the task would cause immediate functional regressions (broken API calls, missing images/avatars, broken routing, or non-functional UI).

Instead, a **balanced CSP** was introduced as an **easy win**:
- it significantly improves security by denying everything by default and blocking high-risk vectors (`default-src 'none'`, `object-src 'none'`, `frame-ancestors 'self'`, `form-action 'self'`),
- it avoids hard-breaking the Console UI, Portal UI, and Next-Gen Portal in common on-premise setups, regardless of:
  - host/port layout,
  - presence or absence of TLS,
  - user-generated content referencing external HTTP/HTTPS resources,
- it provides a solid baseline that can be further tightened in the future.

Stronger CSP rules (e.g. removing `unsafe-inline` / `unsafe-eval`, enforcing `base-uri 'none'`, or strictly limiting `connect-src` / `img-src`) are desirable from a security perspective, but would require:
- refactoring the UI applications to eliminate inline scripts/styles and runtime `eval` usage,
- clear product decisions around how user-generated content (Markdown) should be handled (e.g. proxying images or enforcing allowlists),
- careful analysis of compatibility with typical customer deployment topologies.

The current policy is therefore a deliberate compromise: it improves security without introducing a high risk of breaking existing or future on-premise installations.

## CSP comparison

| Directive | Required in task | Implemented | Rationale |
|---|---|---|---|
| `default-src` | `'none'` | `'none'` | Compliant. Strong “deny by default” foundation. |
| `script-src` | `'self'` | `'self' 'unsafe-eval' 'unsafe-inline'` | The UI applications rely on inline scripts and runtime evaluation. Removing these currently breaks the applications. Eliminating them would require non-trivial refactoring. |
| `object-src` | `'none'` | `'none'` | Compliant. Prevents legacy plugin/object execution. |
| `frame-ancestors` | `'self'` | `'self'` | Compliant. Protects against clickjacking. |
| `style-src` | `'self'` | `'self' 'unsafe-inline'` | Inline styles are used by the UI applications for dynamic rendering. Disallowing them causes layout and rendering issues. |
| `img-src` | `'self' data:` | `'self' data: https: http:` | Images can originate from the Management API (often on a different port/origin) and from user-generated Markdown content. Restricting this to `self` breaks avatars and documentation previews. |
| `connect-src` | `'self'` | `http: https:` | In on-premise deployments, the Management API is frequently hosted on a different host or port than the UI applications. Enforcing `'self'` would block API calls. |
| `base-uri` | `'none'` | `'self'` | The UI applications rely on `<base href>` for routing. Setting `base-uri 'none'` results in CSP violations and routing issues. |
| `form-action` | `'self'` | `'self'` | Compliant. |
| `font-src` | — | `'self'` | Added to avoid font loading being blocked due to `default-src 'none'`. |

## Applied CSP

```nginx
add_header Content-Security-Policy "
  default-src 'none';
  script-src 'self' 'unsafe-eval' 'unsafe-inline';
  object-src 'none';
  frame-ancestors 'self';
  style-src 'self' 'unsafe-inline';
  img-src 'self' data: https: http:;
  connect-src http: https:;
  base-uri 'self';
  form-action 'self';
  font-src 'self';
" always;
```


