### PR TITLE
fix: analytics for not found errors

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -58,7 +58,9 @@ public class ReporterProcessor implements Processor {
             Metrics metrics = ctx.metrics();
             if (metrics != null && metrics.isEnabled()) {
                 metrics.setRequestEnded(true);
-                setEntrypointId(ctx, metrics);
+                if (metrics.getEntrypointId() == null) {
+                    setEntrypointId(ctx, metrics);
+                }
                 setQuota(ctx, metrics);
 
                 executeReportActions(metrics);
@@ -94,6 +96,13 @@ public class ReporterProcessor implements Processor {
                 } else {
                     // No api found report only metrics
                     reporterService.report(metrics);
+                    Log log = metrics.getLog();
+                    if (log != null) {
+                        log.setApiId(metrics.getApiId());
+                        log.setApiName(metrics.getApiName());
+                        log.setRequestEnded(metrics.isRequestEnded());
+                        reporterService.report(log);
+                    }
                 }
             }
         })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
@@ -46,7 +46,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class ManagementFilterPreProcessor implements FilterPreProcessor {
 
     private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
-
+    protected static final String UNKNOWN_SERVICE = "1";
     private final ApiAuthorizationService apiAuthorizationService;
     private final ApiRepository apiRepository;
 
@@ -59,7 +59,7 @@ public class ManagementFilterPreProcessor implements FilterPreProcessor {
         );
 
         var userApisIds = userApis.keySet();
-
+        userApis.put(UNKNOWN_SERVICE, UNKNOWN_SERVICE);
         var permissionsFilter = new Filter(API, IN, userApisIds);
 
         return context.withFilters(List.of(permissionsFilter)).withApiNamesById(userApis);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
@@ -58,12 +58,13 @@ class ManagementFilterPreProcessorTest {
     private static final Api api1 = Api.builder().id("id1").name("api1").build();
     private static final Api api2 = Api.builder().id("id2").name("api2").build();
     private static final Api api3 = Api.builder().id("id3").name("api3").build();
+    private static final Api apiNotFound = Api.builder().id("1").name("1").build();
 
     private static final String adminUserId = UUID.randomUUID().toString();
-    private static final List<Api> adminApis = List.of(api1, api2, api3);
+    private static final List<Api> adminApis = List.of(api1, api2, api3, apiNotFound);
 
     private static final String nonAdminUserId = UUID.randomUUID().toString();
-    private static final List<Api> nonAdminApis = List.of(api2);
+    private static final List<Api> nonAdminApis = List.of(api2, apiNotFound);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12149

## Description

Fixed the Not found api issue in V4 NotFoundProcessor.

Also fixed the Log index for the same.

Since the analytics were not appearing for 404 errors on UI, needed to add a hack to add the apiId=1(the id for not found) to list of api ids while filtering



https://github.com/user-attachments/assets/0853ce44-3eca-4f95-979d-2fe886e43dae



