### PR TITLE
feat(dashboard-lib): change color default order

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BarChartComponent } from './bar-chart.component';
 import { TimeSeriesBucket, TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+import { CHART_COLORS } from '../shared/chart-colors';
 
 describe('BarChartComponent', () => {
   let component: BarChartComponent;
@@ -145,5 +146,27 @@ describe('BarChartComponent', () => {
     expect(xScale?.stacked).toBe(true);
     expect(yScale?.stacked).toBe(true);
     expect((yScale as { beginAtZero?: boolean })?.beginAtZero).toBe(true);
+  });
+
+  it('should assign shared colors to datasets', () => {
+    const data: TimeSeriesResponse = {
+      metrics: [
+        {
+          name: 'HTTP_REQUESTS',
+          buckets: [createMeasureBucket('2025-10-07T06:00:00Z', 100)],
+        },
+        {
+          name: 'HTTP_ERRORS',
+          buckets: [createMeasureBucket('2025-10-07T06:00:00Z', 200)],
+        },
+      ],
+      buckets: [createBaseBucket('2025-10-07T06:00:00Z')],
+    };
+
+    setChartData(data);
+
+    const result = component.dataFormatted();
+    expect(result.datasets[0].backgroundColor).toBe(CHART_COLORS[0]);
+    expect(result.datasets[1].backgroundColor).toBe(CHART_COLORS[1]);
   });
 });

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.stories.ts
@@ -204,3 +204,77 @@ export const Stacked: StoryObj<BarChartStoryArgs> = {
     };
   },
 };
+
+export const StatusDistribution: StoryObj<BarChartStoryArgs> = {
+  args: {
+    storyId: 'status-distribution',
+    type: 'bar',
+    dataPoints: [],
+  },
+  render: args => {
+    const timestamps = Array.from({ length: 10 }, (_, i) => {
+      return new Date(new Date('2025-01-01T00:00:00Z').getTime() + i * 1 * 60 * 60 * 1000).toISOString();
+    });
+
+    const getRandomValue = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+    const maybeZero = (value: number, chance = 0.2) => (Math.random() < chance ? 0 : value);
+
+    const buckets1xx = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: maybeZero(getRandomValue(5, 20)) }],
+    }));
+    const buckets2xx = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: getRandomValue(100, 300) }],
+    }));
+
+    const buckets3xx = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: maybeZero(getRandomValue(10, 50)) }],
+    }));
+    const buckets4xx = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: maybeZero(getRandomValue(20, 100)) }],
+    }));
+
+    const buckets5xx = timestamps.map(ts => ({
+      key: ts,
+      name: ts,
+      timestamp: new Date(ts),
+      measures: [{ name: 'COUNT' as const, value: maybeZero(getRandomValue(0, 30)) }],
+    }));
+
+    const timeSeriesData: TimeSeriesResponse = {
+      interval: '1h',
+      metrics: [
+        { name: 'APIS', buckets: buckets1xx },
+        { name: 'HTTP_REQUESTS', buckets: buckets2xx },
+        { name: 'MESSAGES', buckets: buckets3xx },
+        { name: 'HTTP_ERRORS', buckets: buckets4xx },
+        { name: 'MESSAGE_ERRORS', buckets: buckets5xx },
+      ],
+      buckets: timestamps.map(ts => ({ key: ts, name: ts, timestamp: new Date(ts) })),
+    };
+
+    return {
+      template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-bar-chart [type]="type" [data]="timeSeriesData" />
+        </div>
+      `,
+      props: {
+        type: args.type,
+        timeSeriesData,
+      },
+    };
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -20,6 +20,7 @@ import 'chartjs-adapter-date-fns';
 
 import { BarConverterService } from './converter/bar-converter.service';
 import { TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+import { assignChartColors } from '../shared/chart-colors';
 
 export type BarType = 'bar';
 
@@ -35,7 +36,9 @@ export class BarChartComponent {
   data = input.required<TimeSeriesResponse>();
 
   public readonly dataFormatted = computed(() => {
-    return this.converter.convert(this.data());
+    const chartData = this.converter.convert(this.data());
+    assignChartColors(chartData.datasets);
+    return chartData;
   });
   private readonly converter = inject(BarConverterService);
 

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/color-palette-demo.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/color-palette-demo.stories.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
+
+import { LineChartComponent, LineType } from './line-chart.component';
+import { TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+
+interface ColorPaletteStoryArgs {
+  type: LineType;
+}
+
+export default {
+  title: 'Gravitee Dashboard/Components/Chart/Color Palette Demo',
+  component: LineChartComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [LineChartComponent],
+    }),
+    applicationConfig({
+      providers: [provideCharts(withDefaultRegisterables())],
+    }),
+  ],
+} satisfies Meta<ColorPaletteStoryArgs>;
+
+export const TwelveDatasets: StoryObj<ColorPaletteStoryArgs> = {
+  args: {
+    type: 'line' as LineType,
+  },
+  render: args => {
+    const timestamps = Array.from({ length: 10 }, (_, i) => {
+      return new Date(new Date('2025-01-01T00:00:00Z').getTime() + i * 1 * 60 * 60 * 1000).toISOString();
+    });
+
+    const createMetric = (name: string, baseValue: number) => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      name: name as any,
+      buckets: timestamps.map(ts => ({
+        key: ts,
+        name: ts,
+        timestamp: new Date(ts),
+        measures: [{ name: 'COUNT' as const, value: baseValue + Math.random() * 50 }],
+      })),
+    });
+
+    const timeSeriesData: TimeSeriesResponse = {
+      interval: '1h',
+      metrics: [
+        createMetric('01_BLUE', 100),
+        createMetric('02_GREEN', 150),
+        createMetric('03_YELLOW', 200),
+        createMetric('04_ORANGE', 250),
+        createMetric('05_RED', 300),
+        createMetric('06_PURPLE', 350),
+        createMetric('07_GREY', 400),
+        createMetric('08_PINK', 450),
+        createMetric('09_BROWN', 500),
+        createMetric('10_GREEN_LEMON', 550),
+        createMetric('11_CYCLES_TO_BLUE', 600),
+        createMetric('12_CYCLES_TO_GREEN', 650),
+      ],
+      buckets: timestamps.map(ts => ({ key: ts, name: ts, timestamp: new Date(ts) })),
+    };
+
+    return {
+      template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-line-chart [type]="type" [data]="timeSeriesData" />
+        </div>
+      `,
+      props: {
+        type: args.type,
+        timeSeriesData,
+      },
+    };
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.stories.ts
@@ -168,3 +168,249 @@ export const HighVolume: StoryObj<LineChartStoryArgs> = {
     })),
   },
 };
+
+export const ProductionResponseTime: StoryObj<LineChartStoryArgs> = {
+  args: {
+    storyId: 'production-response-time',
+    type: 'line' as LineType,
+    dataPoints: [],
+  },
+  render: args => {
+    const timeSeriesData: TimeSeriesResponse = {
+      interval: '5h36m',
+      metrics: [
+        {
+          name: 'HTTP_ENDPOINT_RESPONSE_TIME',
+          buckets: [
+            {
+              key: '2026-01-13T14:24:00Z',
+              name: '2026-01-13T14:24:00Z',
+              timestamp: new Date('2026-01-13T14:24:00Z'),
+              measures: [{ name: 'AVG', value: 0 }],
+            },
+            {
+              key: '2026-01-13T20:00:00Z',
+              name: '2026-01-13T20:00:00Z',
+              timestamp: new Date('2026-01-13T20:00:00Z'),
+              measures: [{ name: 'AVG', value: 2.6 }],
+            },
+            {
+              key: '2026-01-14T01:36:00Z',
+              name: '2026-01-14T01:36:00Z',
+              timestamp: new Date('2026-01-14T01:36:00Z'),
+              measures: [{ name: 'AVG', value: 0 }],
+            },
+            {
+              key: '2026-01-15T05:36:00Z',
+              name: '2026-01-15T05:36:00Z',
+              timestamp: new Date('2026-01-15T05:36:00Z'),
+              measures: [{ name: 'AVG', value: 38.555557 }],
+            },
+            {
+              key: '2026-01-15T11:12:00Z',
+              name: '2026-01-15T11:12:00Z',
+              timestamp: new Date('2026-01-15T11:12:00Z'),
+              measures: [{ name: 'AVG', value: 156.875 }],
+            },
+            {
+              key: '2026-01-16T04:00:00Z',
+              name: '2026-01-16T04:00:00Z',
+              timestamp: new Date('2026-01-16T04:00:00Z'),
+              measures: [{ name: 'AVG', value: 15.933333 }],
+            },
+            {
+              key: '2026-01-16T09:36:00Z',
+              name: '2026-01-16T09:36:00Z',
+              timestamp: new Date('2026-01-16T09:36:00Z'),
+              measures: [{ name: 'AVG', value: 236.8 }],
+            },
+            {
+              key: '2026-01-16T15:12:00Z',
+              name: '2026-01-16T15:12:00Z',
+              timestamp: new Date('2026-01-16T15:12:00Z'),
+              measures: [{ name: 'AVG', value: 208.3125 }],
+            },
+            {
+              key: '2026-01-17T08:00:00Z',
+              name: '2026-01-17T08:00:00Z',
+              timestamp: new Date('2026-01-17T08:00:00Z'),
+              measures: [{ name: 'AVG', value: 158.0 }],
+            },
+            {
+              key: '2026-01-19T04:48:00Z',
+              name: '2026-01-19T04:48:00Z',
+              timestamp: new Date('2026-01-19T04:48:00Z'),
+              measures: [{ name: 'AVG', value: 250.76923 }],
+            },
+            {
+              key: '2026-01-19T10:24:00Z',
+              name: '2026-01-19T10:24:00Z',
+              timestamp: new Date('2026-01-19T10:24:00Z'),
+              measures: [{ name: 'AVG', value: 28.54 }],
+            },
+            {
+              key: '2026-01-19T16:00:00Z',
+              name: '2026-01-19T16:00:00Z',
+              timestamp: new Date('2026-01-19T16:00:00Z'),
+              measures: [{ name: 'AVG', value: 268.66666 }],
+            },
+            {
+              key: '2026-01-19T21:36:00Z',
+              name: '2026-01-19T21:36:00Z',
+              timestamp: new Date('2026-01-19T21:36:00Z'),
+              measures: [{ name: 'AVG', value: 26.5 }],
+            },
+            {
+              key: '2026-01-20T08:48:00Z',
+              name: '2026-01-20T08:48:00Z',
+              timestamp: new Date('2026-01-20T08:48:00Z'),
+              measures: [{ name: 'AVG', value: 47.24616 }],
+            },
+            {
+              key: '2026-01-20T14:24:00Z',
+              name: '2026-01-20T14:24:00Z',
+              timestamp: new Date('2026-01-20T14:24:00Z'),
+              measures: [{ name: 'AVG', value: 19.258064 }],
+            },
+          ],
+        },
+        {
+          name: 'HTTP_GATEWAY_RESPONSE_TIME',
+          buckets: [
+            {
+              key: '2026-01-13T14:24:00Z',
+              name: '2026-01-13T14:24:00Z',
+              timestamp: new Date('2026-01-13T14:24:00Z'),
+              measures: [{ name: 'AVG', value: 0 }],
+            },
+            {
+              key: '2026-01-13T20:00:00Z',
+              name: '2026-01-13T20:00:00Z',
+              timestamp: new Date('2026-01-13T20:00:00Z'),
+              measures: [{ name: 'AVG', value: 3.0 }],
+            },
+            {
+              key: '2026-01-14T01:36:00Z',
+              name: '2026-01-14T01:36:00Z',
+              timestamp: new Date('2026-01-14T01:36:00Z'),
+              measures: [{ name: 'AVG', value: 0 }],
+            },
+            {
+              key: '2026-01-14T12:48:00Z',
+              name: '2026-01-14T12:48:00Z',
+              timestamp: new Date('2026-01-14T12:48:00Z'),
+              measures: [{ name: 'AVG', value: 8.0 }],
+            },
+            {
+              key: '2026-01-15T05:36:00Z',
+              name: '2026-01-15T05:36:00Z',
+              timestamp: new Date('2026-01-15T05:36:00Z'),
+              measures: [{ name: 'AVG', value: 39.88889 }],
+            },
+            {
+              key: '2026-01-15T11:12:00Z',
+              name: '2026-01-15T11:12:00Z',
+              timestamp: new Date('2026-01-15T11:12:00Z'),
+              measures: [{ name: 'AVG', value: 170.0 }],
+            },
+            {
+              key: '2026-01-16T04:00:00Z',
+              name: '2026-01-16T04:00:00Z',
+              timestamp: new Date('2026-01-16T04:00:00Z'),
+              measures: [{ name: 'AVG', value: 1103.4 }],
+            },
+            {
+              key: '2026-01-16T09:36:00Z',
+              name: '2026-01-16T09:36:00Z',
+              timestamp: new Date('2026-01-16T09:36:00Z'),
+              measures: [{ name: 'AVG', value: 237.55 }],
+            },
+            {
+              key: '2026-01-16T15:12:00Z',
+              name: '2026-01-16T15:12:00Z',
+              timestamp: new Date('2026-01-16T15:12:00Z'),
+              measures: [{ name: 'AVG', value: 413.0 }],
+            },
+            {
+              key: '2026-01-17T08:00:00Z',
+              name: '2026-01-17T08:00:00Z',
+              timestamp: new Date('2026-01-17T08:00:00Z'),
+              measures: [{ name: 'AVG', value: 160.28572 }],
+            },
+            {
+              key: '2026-01-17T13:36:00Z',
+              name: '2026-01-17T13:36:00Z',
+              timestamp: new Date('2026-01-17T13:36:00Z'),
+              measures: [{ name: 'AVG', value: 955.0 }],
+            },
+            {
+              key: '2026-01-19T04:48:00Z',
+              name: '2026-01-19T04:48:00Z',
+              timestamp: new Date('2026-01-19T04:48:00Z'),
+              measures: [{ name: 'AVG', value: 253.46153 }],
+            },
+            {
+              key: '2026-01-19T10:24:00Z',
+              name: '2026-01-19T10:24:00Z',
+              timestamp: new Date('2026-01-19T10:24:00Z'),
+              measures: [{ name: 'AVG', value: 117.26 }],
+            },
+            {
+              key: '2026-01-19T16:00:00Z',
+              name: '2026-01-19T16:00:00Z',
+              timestamp: new Date('2026-01-19T16:00:00Z'),
+              measures: [{ name: 'AVG', value: 269.66666 }],
+            },
+            {
+              key: '2026-01-19T21:36:00Z',
+              name: '2026-01-19T21:36:00Z',
+              timestamp: new Date('2026-01-19T21:36:00Z'),
+              measures: [{ name: 'AVG', value: 27.375 }],
+            },
+            {
+              key: '2026-01-20T08:48:00Z',
+              name: '2026-01-20T08:48:00Z',
+              timestamp: new Date('2026-01-20T08:48:00Z'),
+              measures: [{ name: 'AVG', value: 47.861164 }],
+            },
+            {
+              key: '2026-01-20T14:24:00Z',
+              name: '2026-01-20T14:24:00Z',
+              timestamp: new Date('2026-01-20T14:24:00Z'),
+              measures: [{ name: 'AVG', value: 19.774193 }],
+            },
+          ],
+        },
+      ],
+      buckets: [
+        { key: '2026-01-13T14:24:00Z', name: '2026-01-13T14:24:00Z', timestamp: new Date('2026-01-13T14:24:00Z') },
+        { key: '2026-01-13T20:00:00Z', name: '2026-01-13T20:00:00Z', timestamp: new Date('2026-01-13T20:00:00Z') },
+        { key: '2026-01-14T01:36:00Z', name: '2026-01-14T01:36:00Z', timestamp: new Date('2026-01-14T01:36:00Z') },
+        { key: '2026-01-15T05:36:00Z', name: '2026-01-15T05:36:00Z', timestamp: new Date('2026-01-15T05:36:00Z') },
+        { key: '2026-01-15T11:12:00Z', name: '2026-01-15T11:12:00Z', timestamp: new Date('2026-01-15T11:12:00Z') },
+        { key: '2026-01-16T04:00:00Z', name: '2026-01-16T04:00:00Z', timestamp: new Date('2026-01-16T04:00:00Z') },
+        { key: '2026-01-16T09:36:00Z', name: '2026-01-16T09:36:00Z', timestamp: new Date('2026-01-16T09:36:00Z') },
+        { key: '2026-01-16T15:12:00Z', name: '2026-01-16T15:12:00Z', timestamp: new Date('2026-01-16T15:12:00Z') },
+        { key: '2026-01-17T08:00:00Z', name: '2026-01-17T08:00:00Z', timestamp: new Date('2026-01-17T08:00:00Z') },
+        { key: '2026-01-19T04:48:00Z', name: '2026-01-19T04:48:00Z', timestamp: new Date('2026-01-19T04:48:00Z') },
+        { key: '2026-01-19T10:24:00Z', name: '2026-01-19T10:24:00Z', timestamp: new Date('2026-01-19T10:24:00Z') },
+        { key: '2026-01-19T16:00:00Z', name: '2026-01-19T16:00:00Z', timestamp: new Date('2026-01-19T16:00:00Z') },
+        { key: '2026-01-19T21:36:00Z', name: '2026-01-19T21:36:00Z', timestamp: new Date('2026-01-19T21:36:00Z') },
+        { key: '2026-01-20T08:48:00Z', name: '2026-01-20T08:48:00Z', timestamp: new Date('2026-01-20T08:48:00Z') },
+        { key: '2026-01-20T14:24:00Z', name: '2026-01-20T14:24:00Z', timestamp: new Date('2026-01-20T14:24:00Z') },
+      ],
+    };
+
+    return {
+      template: `
+        <div style="height: 100vh; width: 100vw; position: absolute; top: 0; left: 0;">
+          <gd-line-chart [type]="type" [data]="timeSeriesData" />
+        </div>
+      `,
+      props: {
+        type: args.type,
+        timeSeriesData,
+      },
+    };
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
@@ -20,6 +20,7 @@ import 'chartjs-adapter-date-fns';
 
 import { LineConverterService } from './converter/line-converter.service';
 import { TimeSeriesResponse } from '../../widget/model/response/time-series-response';
+import { assignChartColors } from '../shared/chart-colors';
 
 export type LineType = 'line';
 
@@ -36,7 +37,7 @@ export class LineChartComponent {
 
   public readonly dataFormatted = computed(() => {
     const chartData = this.converter.convert(this.data());
-
+    assignChartColors(chartData.datasets);
     chartData.datasets.forEach(dataset => {
       dataset.tension = 0.4;
       dataset.fill = 'start';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/pie-chart/pie-chart.component.ts
@@ -19,6 +19,7 @@ import { BaseChartDirective } from 'ng2-charts';
 
 import { PieConverterService } from './converter/pie-converter.service';
 import { FacetsResponse } from '../../widget/model/response/facets-response';
+import { CHART_COLORS } from '../shared/chart-colors';
 
 export type PieType = 'doughnut' | 'pie' | 'polarArea';
 
@@ -36,7 +37,13 @@ export class PieChartComponent {
   converter = inject(PieConverterService);
 
   public dataFormatted = computed(() => {
-    return this.converter.convert(this.data());
+    const chartData = this.converter.convert(this.data());
+
+    chartData.datasets.forEach(dataset => {
+      dataset.backgroundColor = CHART_COLORS;
+    });
+
+    return chartData;
   });
 
   private getDefaultOptions(): ChartConfiguration<PieType>['options'] {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/shared/chart-colors.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/shared/chart-colors.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChartDataset } from 'chart.js';
+
+import { assignChartColors, CHART_COLORS, CHART_BORDER_COLORS } from './chart-colors';
+
+describe('ChartColors', () => {
+  it('should assign colors to datasets sequentially', () => {
+    const datasets: ChartDataset[] = [{ data: [] }, { data: [] }, { data: [] }];
+
+    assignChartColors(datasets);
+
+    expect(datasets[0].backgroundColor).toBe(CHART_COLORS[0]);
+    expect(datasets[1].backgroundColor).toBe(CHART_COLORS[1]);
+    expect(datasets[2].backgroundColor).toBe(CHART_COLORS[2]);
+
+    expect(datasets[0].borderColor).toBe(CHART_BORDER_COLORS[0]);
+    expect(datasets[1].borderColor).toBe(CHART_BORDER_COLORS[1]);
+    expect(datasets[2].borderColor).toBe(CHART_BORDER_COLORS[2]);
+  });
+
+  it('should cycle colors if datasets exceed palette length', () => {
+    const paletteLength = CHART_COLORS.length;
+    const datasets: ChartDataset[] = Array.from({ length: paletteLength + 2 }, () => ({ data: [] }));
+
+    assignChartColors(datasets);
+    expect(datasets[0].backgroundColor).toBe(CHART_COLORS[0]);
+    expect(datasets[paletteLength].backgroundColor).toBe(CHART_COLORS[0]);
+    expect(datasets[paletteLength + 1].backgroundColor).toBe(CHART_COLORS[1]);
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/shared/chart-colors.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/shared/chart-colors.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChartDataset } from 'chart.js';
+
+/**
+ * Default color palette ordered: blue > green > yellow > orange > red
+ * This ensures HTTP status codes display intuitively (2xx in blue/green, 5xx in red)
+ */
+export const CHART_COLORS = [
+  'rgba(54, 162, 235, 0.8)', // Blue
+  'rgba(75, 192, 192, 0.8)', // Teal/Green
+  'rgba(255, 206, 86, 0.8)', // Yellow
+  'rgba(255, 159, 64, 0.8)', // Orange
+  'rgba(255, 99, 132, 0.8)', // Red
+  'rgba(153, 102, 255, 0.8)', // Purple
+  'rgba(201, 203, 207, 0.8)', // Grey
+  'rgba(255, 105, 180, 0.8)', // Pink
+  'rgba(139, 69, 19, 0.8)', // Brown
+  'rgba(127, 255, 0, 0.8)', // Green Lemon
+];
+
+export const CHART_BORDER_COLORS = [
+  'rgba(54, 162, 235, 1)',
+  'rgba(75, 192, 192, 1)',
+  'rgba(255, 206, 86, 1)',
+  'rgba(255, 159, 64, 1)',
+  'rgba(255, 99, 132, 1)',
+  'rgba(153, 102, 255, 1)',
+  'rgba(201, 203, 207, 1)',
+  'rgba(255, 105, 180, 1)', // Pink
+  'rgba(139, 69, 19, 1)', // Brown
+  'rgba(127, 255, 0, 1)', // Green Lemon
+];
+
+export const assignChartColors = (datasets: ChartDataset[]) => {
+  datasets.forEach((dataset, index) => {
+    dataset.backgroundColor = CHART_COLORS[index % CHART_COLORS.length];
+    dataset.borderColor = CHART_BORDER_COLORS[index % CHART_BORDER_COLORS.length];
+  });
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1953
## Description

change color default order (blue > green >  yellow > orange > red) to avoid having status 200 in red and 500 in green

<img width="901" height="386" alt="Screenshot 2026-01-07 at 11 30 54 AM" src="https://github.com/user-attachments/assets/44e03e1d-766b-4ded-84a1-bf0ecfb5390b" />

## Additional context
I believe @samirtechlab said the rounded edges will go away, so take the screenshot with a grain of salt.
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

