### PR TITLE
fix: update plan sorting logic to include `status` as a secondary comparator

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.OriginContextMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiCRDSpec;
 import io.gravitee.rest.api.management.v2.rest.model.PageCRD;
 import io.gravitee.rest.api.management.v2.rest.model.PlanCRD;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -257,7 +258,8 @@ public interface ApiMapper {
             return List.of();
         }
 
-        return apiCRD.getPlans().values().stream().sorted(comparingInt(PlanCRD::getOrder)).map(this::map).toList();
+        Comparator<PlanCRD> comparator = comparingInt(PlanCRD::getOrder).thenComparing(PlanCRD::getStatus);
+        return apiCRD.getPlans().values().stream().sorted(comparator).map(this::map).toList();
     }
 
     default Map<String, PageCRD> mapApiV4SpecPages(ApiV4Spec apiV4Spec) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1976

## Description

This PR fixes an intermittent ordering issue in API plans, which the Terraform provider interprets as a change, even when there are no updates to an API.

I ran tests locally with the Terraform provider and this fixes [these failures](https://graviteeio.slack.com/archives/C0A2R4W3MLM/p1767772801955239)

## Additional context

The issue happens because the field used for ordering is the `plan.order`, which may be duplicated for plans in different states.

For example, if an API with plans `plan1`, `plan2`, and `plan3`is created, plans will have the following order:
`plan1`: order = 1
`plan2`: order = 2
`plan3`: order = 3 

If then plan 2 is deprecated, and the update request has the plans in this order: `plan1`, `plan3`, and `plan2`, the plan order will be:
`plan1`: order = 1
`plan2`: order = 2
`plan3`: order = 2

Since plan 2 and 3 have the same order, the order of the plans in the response may change, causing this issue.

The fix was done by ordering plans first by order and then by status.

