### PR TITLE
feat(dashboard-lib): Add bar chart in dashboard and customize line width

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/bar-chart/bar-chart.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, computed, inject, input } from '@angular/core';
-import { ChartConfiguration } from 'chart.js';
+import { Chart, ChartConfiguration } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import 'chartjs-adapter-date-fns';
 
@@ -43,10 +43,9 @@ export class BarChartComponent {
     return {
       responsive: true,
       maintainAspectRatio: false,
-      datasets: {
+      elements: {
         bar: {
           borderWidth: 1,
-          borderRadius: 15,
         },
       },
       plugins: {
@@ -56,6 +55,13 @@ export class BarChartComponent {
           labels: {
             usePointStyle: true,
             pointStyle: 'rectRounded',
+            generateLabels: chart => {
+              const defaults = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+              return defaults.map(label => ({
+                ...label,
+                lineWidth: 1,
+              }));
+            },
           },
         },
         tooltip: {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/chart/line-chart/line-chart.component.ts
@@ -40,6 +40,7 @@ export class LineChartComponent {
     chartData.datasets.forEach(dataset => {
       dataset.tension = 0.4;
       dataset.fill = 'start';
+      dataset.borderWidth = 1;
     });
 
     return chartData;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/gravitee-dashboard.service.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/gravitee-dashboard.service.ts
@@ -169,7 +169,7 @@ export class GraviteeDashboardService {
         id: '7',
         title: 'Response Statuses',
         description: 'Number of response statuses over time',
-        type: 'line',
+        type: 'bar',
         layout: {
           cols: 3,
           rows: 2,
@@ -191,7 +191,7 @@ export class GraviteeDashboardService {
         id: '8',
         title: 'Top 5 Applications',
         description: 'Top 5 applications by number of HTTP requests',
-        type: 'doughnut',
+        type: 'pie',
         layout: {
           cols: 1,
           rows: 2,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1953

## Description

Add the new bar chart to the dashboard. Also change the top 5 app doughnut to a pie chart

## Additional context
<img width="3624" height="1504" alt="Screenshot 2026-01-07 at 21 34 05" src="https://github.com/user-attachments/assets/c6e4b45b-dc69-4e8f-ab86-fe81a717c20a" />

Before: 
<img width="2526" height="840" alt="Screenshot 2026-01-07 at 21 25 44" src="https://github.com/user-attachments/assets/0350b5c5-42bb-4b39-9606-7dee7a05ce94" />

