### PR TITLE
fix(console): align all icons and titles in nav item flat tree

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -44,7 +44,7 @@
       tabindex="0"
       *matTreeNodeDef="let node"
       matTreeNodePadding
-      [matTreeNodePaddingIndent]="26"
+      [matTreeNodePaddingIndent]="25"
       cdkDrag
       [cdkDragData]="node"
       (cdkDragStarted)="onDragStarted($event)"
@@ -68,7 +68,7 @@
       tabindex="0"
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodePadding
-      [matTreeNodePaddingIndent]="26"
+      [matTreeNodePaddingIndent]="25"
       cdkDrag
       [cdkDragData]="node"
       (cdkDragStarted)="onDragStarted($event)"
@@ -85,7 +85,7 @@
 
       <mat-icon
         matTreeNodeToggle
-        class="tree__icon"
+        class="tree__icon expand-collapse-icon"
         [attr.data-test-icon]="'toggle'"
         [svgIcon]="treeBase.isExpanded(node) ? 'gio:nav-arrow-down' : 'gio:nav-arrow-right'"
         aria-hidden="true"

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
@@ -96,6 +96,10 @@ $disappear-on-drag-transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
     width: 16px;
     height: 16px;
     margin-left: 4px;
+
+    &.expand-collapse-icon {
+      margin-left: 9px;
+    }
   }
 
   &__label {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Fix icons that were not aligned in the nav item flat tree list

<img width="435" height="515" alt="Screenshot 2026-01-07 at 16 38 38" src="https://github.com/user-attachments/assets/cd7a2287-aac1-49eb-b2b3-05146dde3c37" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

