### PR TITLE
Allow to sort endpoints inside endpoint group

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.module.ts
@@ -25,6 +25,7 @@ import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular'
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterModule } from '@angular/router';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { ApiEndpointGroupsComponent } from './api-endpoint-groups.component';
 import { ApiEndpointGroupsLlmComponent } from './llm/api-endpoint-groups-llm.component';
@@ -51,6 +52,7 @@ import { GioLicenseBannerModule } from '../../../../shared/components/gio-licens
     GioPermissionModule,
     GioBannerModule,
     GioLicenseBannerModule,
+    DragDropModule,
   ],
 })
 export class ApiEndpointGroupsModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
@@ -15,12 +15,13 @@
  */
 import { get, isEmpty, remove } from 'lodash';
 
-import { ApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiV4, EndpointGroupV4, EndpointV4 } from '../../../../../entities/management-api-v2';
 
 export type EndpointGroup = {
   name: string;
   type: string;
   loadBalancerType: string;
+  generalColumnName?: string;
   endpoints: Endpoint[];
   endpointsDisplayedColumns: string[];
 };
@@ -31,6 +32,7 @@ export type Endpoint = {
     title: string;
     tooltip?: string;
   };
+  general?: string;
   options: {
     class: string;
     tooltip: string;
@@ -53,7 +55,7 @@ const toEndpointsFromApiV4 = (api: ApiV4): EndpointGroup[] => {
 
   return api.endpointGroups.flatMap((endpointGroup, endpointGroupIndex) => {
     const loadBalancerType = endpointGroup?.loadBalancer?.type?.replace(/_/g, ' ');
-    const endpointsDisplayedColumns = ['drag-icon', 'name', 'options', 'weight', 'actions'];
+    const endpointsDisplayedColumns = ['drag-icon', 'name', 'general', 'options', 'weight', 'actions'];
     if (api.type === 'NATIVE') {
       remove(endpointsDisplayedColumns, (o) => o === 'weight');
     }
@@ -63,6 +65,7 @@ const toEndpointsFromApiV4 = (api: ApiV4): EndpointGroup[] => {
       name: endpointGroup.name,
       type: endpointGroup.type,
       loadBalancerType: loadBalancerType ? loadBalancerType.charAt(0).toUpperCase() + loadBalancerType.slice(1).toLowerCase() : '',
+      generalColumnName: toGeneralColumnName(api, endpointGroup),
       endpoints:
         endpointGroup.endpoints && endpointGroup.endpoints.length > 0
           ? endpointGroup.endpoints.map((endpoint, endpointIndex) => {
@@ -73,18 +76,7 @@ const toEndpointsFromApiV4 = (api: ApiV4): EndpointGroup[] => {
                   tooltip: 'The default endpoint used by the API is the first one',
                 };
               }
-              const options = [];
-
-              const groupHealthCheckEnabled = get(endpointGroup, 'services.healthCheck.enabled', false);
-              const endpointHealthCheckEnabled = get(endpoint, 'services.healthCheck.enabled', false);
-              if (groupHealthCheckEnabled || endpointHealthCheckEnabled)
-                options.push({
-                  class: 'gio-badge-neutral',
-                  tooltip: endpointHealthCheckEnabled
-                    ? 'Health check enabled by endpoint configuration'
-                    : 'Health check enabled via inherited group configuration',
-                  textContent: 'Health Check',
-                });
+              const options = toEndpointOptions(api, endpointGroup, endpoint);
 
               if (!isEmpty(options)) {
                 hasOptions = true;
@@ -92,6 +84,7 @@ const toEndpointsFromApiV4 = (api: ApiV4): EndpointGroup[] => {
 
               return {
                 name: endpoint.name,
+                general: toGeneralInfo(api, endpoint),
                 nameBadge,
                 options,
                 weight: endpoint.weight,
@@ -106,9 +99,74 @@ const toEndpointsFromApiV4 = (api: ApiV4): EndpointGroup[] => {
       remove(endpointsDisplayedColumns, (o) => o === 'options');
     }
 
+    if (isEmpty(partialEndpointGroup.generalColumnName)) {
+      remove(endpointsDisplayedColumns, (o) => o === 'general');
+    }
+
     return {
       ...partialEndpointGroup,
       endpointsDisplayedColumns,
     } satisfies EndpointGroup;
   });
+};
+
+const toGeneralColumnName = (api: ApiV4, endpointGroup: EndpointGroupV4): string | undefined => {
+  switch (api.type + '.' + endpointGroup.type) {
+    case 'PROXY.http-proxy':
+      return 'Target URL';
+    case 'NATIVE.native-kafka':
+      return 'Bootstrap Servers';
+    case 'MESSAGE.kafka':
+      return 'Bootstrap Servers';
+  }
+};
+
+const toGeneralInfo = (api: ApiV4, endpoint: EndpointV4): string | undefined => {
+  switch (api.type + '.' + endpoint.type) {
+    case 'PROXY.http-proxy':
+      return get(endpoint.configuration, 'target', '');
+    case 'NATIVE.native-kafka':
+      return get(endpoint.configuration, 'bootstrapServers', '');
+    case 'MESSAGE.kafka':
+      return get(endpoint.configuration, 'bootstrapServers', '');
+  }
+};
+
+const toEndpointOptions = (api: ApiV4, endpointGroup: EndpointGroupV4, endpoint: EndpointV4): Endpoint['options'] => {
+  switch (api.type + '.' + endpoint.type) {
+    case 'PROXY.http-proxy': {
+      const groupHealthCheckEnabled = get(endpointGroup, 'services.healthCheck.enabled', false);
+      const endpointHealthCheckEnabled = get(endpoint, 'services.healthCheck.enabled', false);
+      if (groupHealthCheckEnabled || endpointHealthCheckEnabled) {
+        return [
+          {
+            class: 'gio-badge-neutral',
+            tooltip: endpointHealthCheckEnabled
+              ? 'Health check enabled by endpoint configuration'
+              : 'Health check enabled via inherited group configuration',
+            textContent: 'Health Check',
+          },
+        ];
+      }
+      return [];
+    }
+    case 'NATIVE.native-kafka': {
+      const groupSecurityProtocol = get(endpointGroup.sharedConfiguration, 'security.protocol');
+      const endpointSecurityProtocol = endpoint.inheritConfiguration
+        ? undefined
+        : get(endpoint.sharedConfigurationOverride, 'security.protocol');
+      if (groupSecurityProtocol || endpointSecurityProtocol) {
+        return [
+          {
+            class: 'gio-badge-neutral',
+            tooltip: endpointSecurityProtocol
+              ? `Security protocol override by endpoint configuration`
+              : 'Security protocol inherited from group configuration',
+            textContent: endpointSecurityProtocol ?? groupSecurityProtocol,
+          },
+        ];
+      }
+    }
+  }
+  return [];
 };

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
@@ -96,10 +96,20 @@
         <table
           mat-table
           [dataSource]="group.endpoints"
-          [attr.id]="'groupsTable-' + i"
+          [attr.data-testid]="'groupsTable-' + i"
           aria-label="Endpoint group table"
+          cdkDropList
+          (cdkDropListDropped)="dropRow($event, group.name)"
           class="gio-table-light"
         >
+          <!-- Drag icon Column -->
+          <ng-container matColumnDef="drag-icon" *ngIf="!isReadOnly">
+            <th mat-header-cell *matHeaderCellDef id="drag-icon"></th>
+            <td mat-cell *matCellDef="let element" [class.plans__table__drag-icon]="!isReadOnly">
+              <mat-icon class="plans__table__drag-icon" svgIcon="gio:drag-indicator"></mat-icon>
+            </td>
+          </ng-container>
+
           <!-- Name Column -->
           <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef id="name">Name</th>
@@ -164,7 +174,7 @@
           </ng-container>
 
           <tr mat-header-row *matHeaderRowDef="endpointsDisplayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: endpointsDisplayedColumns"></tr>
+          <tr mat-row cdkDrag [cdkDragDisabled]="isReadOnly || isReordering" *matRowDef="let row; columns: endpointsDisplayedColumns"></tr>
 
           <!-- Row shown when there is no data -->
           <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
@@ -100,14 +100,14 @@
           aria-label="Endpoint group table"
           cdkDropList
           (cdkDropListDropped)="dropRow($event, group.name)"
-          class="gio-table-light"
+          class="gio-table-light endpoint-group-card__table"
         >
           <!-- Drag icon Column -->
           <ng-container matColumnDef="drag-icon">
             <th mat-header-cell *matHeaderCellDef id="drag-icon"></th>
             <td mat-cell *matCellDef="let element">
               @if (!isReadOnly) {
-                <mat-icon class="plans__table__drag-icon" svgIcon="gio:drag-indicator"></mat-icon>
+                <mat-icon svgIcon="gio:drag-indicator"></mat-icon>
               }
             </td>
           </ng-container>
@@ -123,6 +123,14 @@
                   {{ element.nameBadge.title }}
                 </span>
               }
+            </td>
+          </ng-container>
+
+          <!-- General Column -->
+          <ng-container matColumnDef="general">
+            <th mat-header-cell *matHeaderCellDef id="general">{{ group.generalColumnName }}</th>
+            <td mat-cell *matCellDef="let element">
+              {{ element.general }}
             </td>
           </ng-container>
 
@@ -192,7 +200,6 @@
             <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="group.endpointsDisplayedColumns.length">No Endpoints</td>
           </tr>
         </table>
-        {{ group.endpointsDisplayedColumns }}
         @if (api?.type !== 'MCP_PROXY') {
           <a
             *gioPermission="{ anyOf: ['api-definition-u'] }"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
@@ -103,10 +103,12 @@
           class="gio-table-light"
         >
           <!-- Drag icon Column -->
-          <ng-container matColumnDef="drag-icon" *ngIf="!isReadOnly">
+          <ng-container matColumnDef="drag-icon">
             <th mat-header-cell *matHeaderCellDef id="drag-icon"></th>
-            <td mat-cell *matCellDef="let element" [class.plans__table__drag-icon]="!isReadOnly">
-              <mat-icon class="plans__table__drag-icon" svgIcon="gio:drag-indicator"></mat-icon>
+            <td mat-cell *matCellDef="let element">
+              @if (!isReadOnly) {
+                <mat-icon class="plans__table__drag-icon" svgIcon="gio:drag-indicator"></mat-icon>
+              }
             </td>
           </ng-container>
 
@@ -128,7 +130,11 @@
           <ng-container matColumnDef="options">
             <th mat-header-cell *matHeaderCellDef id="options">Options</th>
             <td mat-cell *matCellDef="let element">
-              <span class="neutral" *ngIf="element.options.healthCheck"> Health-check </span>
+              @for (option of element.options; track option.textContent) {
+                <span [class]="option.class" [matTooltip]="option.tooltip">
+                  {{ option.textContent }}
+                </span>
+              }
             </td>
           </ng-container>
 
@@ -173,14 +179,20 @@
             </td>
           </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="endpointsDisplayedColumns"></tr>
-          <tr mat-row cdkDrag [cdkDragDisabled]="isReadOnly || isReordering" *matRowDef="let row; columns: endpointsDisplayedColumns"></tr>
+          <tr mat-header-row *matHeaderRowDef="group.endpointsDisplayedColumns"></tr>
+          <tr
+            mat-row
+            cdkDrag
+            [cdkDragDisabled]="isReadOnly || isReordering"
+            *matRowDef="let row; columns: group.endpointsDisplayedColumns"
+          ></tr>
 
           <!-- Row shown when there is no data -->
           <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="endpointsDisplayedColumns.length">No Endpoints</td>
+            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="group.endpointsDisplayedColumns.length">No Endpoints</td>
           </tr>
         </table>
+        {{ group.endpointsDisplayedColumns }}
         @if (api?.type !== 'MCP_PROXY') {
           <a
             *gioPermission="{ anyOf: ['api-definition-u'] }"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.scss
@@ -77,6 +77,12 @@
     }
   }
 
+  .mat-column-drag-icon {
+    width: 0%;
+    vertical-align: bottom;
+    cursor: move;
+  }
+
   .mat-column-actions {
     width: 0%;
     text-align: end;
@@ -87,4 +93,19 @@
   .mat-column-weight {
     width: 30%;
   }
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow:
+    0 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0 8px 10px 1px rgba(0, 0, 0, 0.14),
+    0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  display: table;
+  vertical-align: middle;
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.scss
@@ -71,6 +71,8 @@
   }
 
   &__table {
+    table-layout: fixed;
+
     &__actions {
       display: flex;
       justify-content: center;
@@ -78,20 +80,23 @@
   }
 
   .mat-column-drag-icon {
-    width: 0%;
+    width: 48px;
     vertical-align: bottom;
     cursor: move;
   }
 
-  .mat-column-actions {
-    width: 0%;
-    text-align: end;
+  .mat-column-general {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .mat-column-weight {
+    width: 80px;
   }
 
-  .mat-column-name,
-  .mat-column-options,
-  .mat-column-weight {
-    width: 30%;
+  .mat-column-actions {
+    width: 96px;
+    text-align: end;
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
@@ -23,6 +23,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioLicenseTestingModule } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
 import { deepClone } from '@gravitee/ui-components/src/lib/utils';
+import { cloneDeep } from 'lodash';
 
 import { ApiEndpointGroupsStandardComponent } from './api-endpoint-groups-standard.component';
 import { ApiEndpointGroupsStandardHarness } from './api-endpoint-groups-standard.harness';
@@ -182,8 +183,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['an endpoint', '', '1', ''],
-        ['another endpoint', '', '5', ''],
+        ['', 'an endpoint', '', '1', ''],
+        ['', 'another endpoint', '', '5', ''],
       ]);
     });
     it('should a warning in kafka endpoint group if failover is enabled', async () => {
@@ -197,8 +198,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['an endpoint', '', '1', ''],
-        ['another endpoint', '', '5', ''],
+        ['', 'an endpoint', '', '1', ''],
+        ['', 'another endpoint', '', '5', ''],
       ]);
 
       const warningFailoverBanner = await componentHarness.getWarningFailoverBanner();
@@ -252,6 +253,25 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       fixture.componentInstance.isA2ASelcted = true;
       fixture.detectChanges();
       expect(await componentHarness.isAddEndpointGroupDisplayed()).toEqual(false);
+    });
+
+    it('should allow to drop endpoint and update his order in a group', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        type: 'NATIVE',
+        endpointGroups: [cloneDeep(group1)],
+      });
+      await initComponent(apiV4);
+
+      fixture.componentInstance.dropRow({ previousIndex: 1, currentIndex: 0 } as any, group1.name);
+
+      expectApiGetRequest(apiV4);
+      expectApiPutRequest({
+        ...apiV4,
+        endpointGroups: [{ ...group1, endpoints: [{ ...group1.endpoints[1] }, { ...group1.endpoints[0] }] }],
+      });
+      expectApiGetRequest(apiV4);
+      expectEndpointsGetRequest();
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
@@ -183,8 +183,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['', 'an endpoint', '', '1', ''],
-        ['', 'another endpoint', '', '5', ''],
+        ['', 'an endpoint', '1', ''],
+        ['', 'another endpoint', '5', ''],
       ]);
     });
     it('should a warning in kafka endpoint group if failover is enabled', async () => {
@@ -198,8 +198,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['', 'an endpoint', '', '1', ''],
-        ['', 'another endpoint', '', '5', ''],
+        ['', 'an endpoint', '1', ''],
+        ['', 'another endpoint', '5', ''],
       ]);
 
       const warningFailoverBanner = await componentHarness.getWarningFailoverBanner();

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
@@ -183,8 +183,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['', 'an endpoint', '1', ''],
-        ['', 'another endpoint', '5', ''],
+        ['', 'an endpoint', 'localhost:9092', '1', ''],
+        ['', 'another endpoint', 'localhost:9093', '5', ''],
       ]);
     });
     it('should a warning in kafka endpoint group if failover is enabled', async () => {
@@ -198,8 +198,8 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       await initComponent(apiV4);
 
       expect(await componentHarness.getTableRows(0)).toEqual([
-        ['', 'an endpoint', '1', ''],
-        ['', 'another endpoint', '5', ''],
+        ['', 'an endpoint', 'localhost:9092', '1', ''],
+        ['', 'another endpoint', 'localhost:9093', '5', ''],
       ]);
 
       const warningFailoverBanner = await componentHarness.getWarningFailoverBanner();

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.ts
@@ -64,7 +64,6 @@ export class ApiEndpointGroupsStandardComponent implements OnInit, OnDestroy {
     context: UTMTags.GENERAL_ENDPOINT_CONFIG,
   };
 
-  public endpointsDisplayedColumns = ['drag-icon', 'name', 'options', 'weight', 'actions'];
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
   constructor(

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.harness.ts
@@ -32,7 +32,7 @@ export class ApiEndpointGroupsStandardHarness extends ComponentHarness {
   public getWarningFailoverBanner = this.locatorForAll(DivHarness.with({ selector: '.banner__wrapper__title' }));
 
   public async getTableRows(index: number) {
-    const table = this.locatorFor(MatTableHarness.with({ selector: `#groupsTable-${index}` }));
+    const table = this.locatorFor(MatTableHarness.with({ selector: `[data-testid=groupsTable-${index}]` }));
     return await table().then((t) => t.getCellTextByIndex());
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12384

## Description


Allow to sort endpoints inside endpoint group for any API type
Improve endpoints page for some api type to quickly view important information


## Additional context

For Native Kafka API :
<img width="2236" height="1180" alt="image" src="https://github.com/user-attachments/assets/954922e7-df54-4d23-a6c9-f1904ccc0d95" />


For Proxy API :
<img width="2228" height="1189" alt="image" src="https://github.com/user-attachments/assets/ae7fa1c1-6c27-4612-ab8a-bc5270b4d62e" />


For Message API : 

<img width="2227" height="1162" alt="image" src="https://github.com/user-attachments/assets/c8fd3d20-7dfb-4bad-8d65-e79f93558f36" />




<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

