### PR TITLE
gko-1973

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
@@ -22,6 +22,7 @@ package io.gravitee.repository.analytics.engine.api.query;
 public record Filter(Filter.Name name, Operator operator, Object value) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -173,6 +173,11 @@ paths:
                         type: "ENUM"
                         operators: [ "EQ", "IN" ]
                         enumValues: [ "1xx", "2xx", "3xx", "4xx", "5xx" ]
+                      - name: "API_NAME"
+                        label: "API name"
+                        type: "ENUM"
+                        operators: [ "EQ", "IN" ]
+                        enumValues: [ "HTTP_PROXY", "MESSAGE", "KAFKA", "LLM", "MCP" ]
         "400":
           description: Bad request - Invalid metric name for filters.
           content:
@@ -838,6 +843,7 @@ components:
             type: string
             enum:
                 - API
+                - API_NAME
                 - APPLICATION
                 - PLAN
                 - GATEWAY

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -193,6 +193,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
+import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
 import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
@@ -980,9 +981,10 @@ public class ResourceContextConfiguration {
     public ComputeMeasuresUseCase computeMeasuresUseCase(
         AnalyticsQueryContextProvider analyticsQueryContextProvider,
         AnalyticsQueryValidator analyticsQueryValidator,
-        FilterPreProcessor filterPreprocessor
+        FilterPreProcessor filterPreprocessor,
+        SearchEngineService searchEngineService
     ) {
-        return new ComputeMeasuresUseCase(analyticsQueryContextProvider, analyticsQueryValidator, filterPreprocessor);
+        return new ComputeMeasuresUseCase(analyticsQueryContextProvider, analyticsQueryValidator, filterPreprocessor, searchEngineService);
     }
 
     @Bean
@@ -1013,6 +1015,11 @@ public class ResourceContextConfiguration {
     @Bean
     public FilterPreProcessor filterPreProcessor() {
         return mock(FilterPreProcessor.class);
+    }
+
+    @Bean
+    public SearchEngineService searchEngineService() {
+        return mock(SearchEngineService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -20,6 +20,7 @@ import java.util.List;
 public record FilterSpec(Name name, String label, Type type, List<String> enumValues, NumberRange range, List<Operator> operators) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/AbstractComputeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/AbstractComputeUseCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.use_case;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics_engine.model.ApiSpec;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+@UseCase
+class AbstractComputeUseCase {
+
+    private final SearchEngineService searchEngineService;
+
+    AbstractComputeUseCase(SearchEngineService searchEngineService) {
+        this.searchEngineService = searchEngineService;
+    }
+
+    Optional<Filter> getFilterByApiName(Collection<Filter> filters) {
+        var apiTypes = getEffectiveFilterByApiType(filters);
+        if (apiTypes.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (apiTypes.get().isEmpty()) {
+            return Optional.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Collections.emptyList()));
+        }
+
+        var apiQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiQueryBuilder.addFilter(FIELD_API_TYPE, apiTypes.get());
+
+        var searchResult = searchEngineService.search(GraviteeContext.getExecutionContext(), apiQueryBuilder.build());
+
+        var apiIds = searchResult.getDocuments();
+
+        var filter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, apiIds);
+
+        return Optional.of(filter);
+    }
+
+    Optional<List<String>> getEffectiveFilterByApiType(Collection<Filter> filters) {
+        if (filters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var apiNameFilters = filters
+            .stream()
+            .filter(filter -> filter.name() == FilterSpec.Name.API_NAME)
+            .toList();
+
+        if (apiNameFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (apiNameFilters.size() > 1) {
+            // Filters are AND-ed so multiple filters by API_NAME lead to no result.
+            // TODO: Handle corner cases where multiple equivalent filters are added. e.g. EQ HTTP_PROXY and IN HTTP_PROXY.
+            return Optional.of(Collections.emptyList());
+        }
+
+        var operator = apiNameFilters.getFirst().operator();
+        switch (operator) {
+            case FilterSpec.Operator.EQ:
+                var stringValue = mapApiName(apiNameFilters.getFirst().value().toString());
+                return Optional.of(List.of(stringValue));
+            case FilterSpec.Operator.IN:
+                var value = apiNameFilters.getFirst().value();
+                if (value instanceof List) {
+                    List<String> values = ((List<?>) value).stream().map(Object::toString).map(this::mapApiName).toList();
+                    return Optional.of(values);
+                }
+                return Optional.of(Collections.emptyList());
+            default:
+                return Optional.of(Collections.emptyList());
+        }
+    }
+
+    private String mapApiName(String apiName) {
+        return switch (ApiSpec.Name.valueOf(apiName)) {
+            case HTTP_PROXY -> "V4_HTTP_PROXY";
+            case MESSAGE -> "V4_MESSAGE";
+            case KAFKA -> "V4_KAFKA";
+            case LLM -> "FEDERATED";
+            case MCP -> "FEDERATED_AGENT";
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQuery
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,7 @@ import java.util.Map;
  * @author GraviteeSource Team
  */
 @UseCase
-public class ComputeFacetsUseCase {
+public class ComputeFacetsUseCase extends AbstractComputeUseCase {
 
     private final AnalyticsQueryContextProvider queryContextProvider;
 
@@ -49,8 +50,10 @@ public class ComputeFacetsUseCase {
         AnalyticsQueryContextProvider queryContextResolver,
         AnalyticsQueryValidator validator,
         FilterPreProcessor filterPreprocessor,
-        BucketNamesPostProcessor bucketNamesPostprocessor
+        BucketNamesPostProcessor bucketNamesPostprocessor,
+        SearchEngineService searchEngineService
     ) {
+        super(searchEngineService);
         this.queryContextProvider = queryContextResolver;
         this.validator = validator;
         this.filterPreprocessor = filterPreprocessor;
@@ -88,6 +91,10 @@ public class ComputeFacetsUseCase {
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
             filters.addAll(metricsContext.filters());
+
+            //TODO: cache filters to reduce the number of searches
+            var filter = getFilterByApiName(request.filters());
+            filter.ifPresent(filters::add);
 
             responses.add(queryService.searchFacets(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
@@ -25,7 +25,6 @@ import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -43,6 +43,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -96,6 +97,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -154,6 +156,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -211,6 +214,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -269,6 +273,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -326,6 +331,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -383,6 +389,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -1187,6 +1194,7 @@ spec:
               - APPLICATION
           filters:
               - API
+              - API_NAME
               - APPLICATION
 
         - name: APIS
@@ -1205,6 +1213,7 @@ spec:
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
           filters:
+              - API_NAME
               - API_STATE
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
@@ -1213,6 +1222,19 @@ spec:
         - name: API
           label: API
           type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
+        - name: API_NAME
+          label: API Name
+          type: ENUM
+          enumValues:
+              - HTTP_PROXY
+              - MESSAGE
+              - KAFKA
+              - LLM
+              - MCP
           operators:
               - EQ
               - IN

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/AbstractComputeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/AbstractComputeUseCaseTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.model.ApiSpec;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class AbstractComputeUseCaseTest {
+
+    private final AnalyticsQueryContextProvider analyticsQueryContextProvider = mock(AnalyticsQueryContextProvider.class);
+    private final AnalyticsQueryValidator analyticsQueryValidator = mock(AnalyticsQueryValidator.class);
+    private final FilterPreProcessor filterPreprocessor = mock(FilterPreProcessor.class);
+    private final SearchEngineService searchEngineService = mock(SearchEngineService.class);
+
+    private final ComputeMeasuresUseCase computeMeasuresUseCase = new ComputeMeasuresUseCase(
+        analyticsQueryContextProvider,
+        analyticsQueryValidator,
+        filterPreprocessor,
+        searchEngineService
+    );
+
+    private static final List<String> allowedApiIds = List.of(UUID.randomUUID().toString());
+
+    private record GetFilterByApiNameTestCasesTestCase(List<Filter> filter, Optional<Filter> expected) {}
+
+    private record GetEffectiveFilterByApiTypeFilterTestCase(List<Filter> filter, Optional<List<String>> expected) {}
+
+    @BeforeEach
+    void setUp() {
+        var result = new SearchResult(allowedApiIds);
+        when(searchEngineService.search(any(), any())).thenReturn(result);
+    }
+
+    static Stream<GetFilterByApiNameTestCasesTestCase> getFilterByApiNameTestCases() {
+        Filter filterById = new Filter(FilterSpec.Name.API, FilterSpec.Operator.EQ, UUID.randomUUID().toString());
+        Filter filterByName1 = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.EQ, ApiSpec.Name.HTTP_PROXY);
+        Filter filterByName2 = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.EQ, ApiSpec.Name.MESSAGE);
+
+        return Stream.of(
+            // Filter is not by name
+            new GetFilterByApiNameTestCasesTestCase(List.of(filterById), Optional.empty()),
+            // EQ filter with a name should return the value
+            new GetFilterByApiNameTestCasesTestCase(
+                List.of(filterByName1),
+                Optional.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, allowedApiIds))
+            ),
+            // Multiple EQ filters should return no result
+            new GetFilterByApiNameTestCasesTestCase(
+                List.of(filterByName1, filterByName2),
+                Optional.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Collections.emptyList()))
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFilterByApiNameTestCases")
+    void should_return_filter_by_api_name(GetFilterByApiNameTestCasesTestCase testCase) {
+        var effectiveFilters = computeMeasuresUseCase.getFilterByApiName(testCase.filter);
+
+        assertThat(effectiveFilters).isEqualTo(testCase.expected);
+    }
+
+    static Stream<GetEffectiveFilterByApiTypeFilterTestCase> getEffectiveFilterByApiTypeTestCases() {
+        Filter filterById = new Filter(FilterSpec.Name.API, FilterSpec.Operator.EQ, UUID.randomUUID().toString());
+        Filter emptyFilterByName = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.IN, List.of());
+        Filter filterByName1 = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.EQ, ApiSpec.Name.HTTP_PROXY);
+        Filter filterByName2 = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.EQ, ApiSpec.Name.MESSAGE);
+        Filter filterByListOfNames1 = new Filter(
+            FilterSpec.Name.API_NAME,
+            FilterSpec.Operator.IN,
+            List.of(ApiSpec.Name.HTTP_PROXY, ApiSpec.Name.MESSAGE)
+        );
+        Filter filterByListOfNames2 = new Filter(FilterSpec.Name.API_NAME, FilterSpec.Operator.IN, List.of(ApiSpec.Name.HTTP_PROXY));
+
+        return Stream.of(
+            // Filter is not by name
+            new GetEffectiveFilterByApiTypeFilterTestCase(List.of(filterById), Optional.empty()),
+            // EQ filter with a name should return the value
+            new GetEffectiveFilterByApiTypeFilterTestCase(List.of(filterByName1), Optional.of(List.of("V4_HTTP_PROXY"))),
+            // IN filter without values should return no result
+            new GetEffectiveFilterByApiTypeFilterTestCase(List.of(emptyFilterByName), Optional.of(Collections.emptyList())),
+            // IN filter with values should return the list of values
+            new GetEffectiveFilterByApiTypeFilterTestCase(
+                List.of(filterByListOfNames1),
+                Optional.of(List.of("V4_HTTP_PROXY", "V4_MESSAGE"))
+            ),
+            // Multiple EQ filters should return no result
+            new GetEffectiveFilterByApiTypeFilterTestCase(List.of(filterByName1, filterByName2), Optional.of(Collections.emptyList())),
+            // Multiple IN filters should return no result
+            new GetEffectiveFilterByApiTypeFilterTestCase(
+                List.of(filterByListOfNames1, filterByListOfNames2),
+                Optional.of(Collections.emptyList())
+            ),
+            // Combine a filter by name and another filter
+            new GetEffectiveFilterByApiTypeFilterTestCase(List.of(filterById, filterByName1), Optional.of(List.of("V4_HTTP_PROXY")))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getEffectiveFilterByApiTypeTestCases")
+    void should_return_correct_filters(GetEffectiveFilterByApiTypeFilterTestCase testCase) {
+        var effectiveFilters = computeMeasuresUseCase.getEffectiveFilterByApiType(testCase.filter);
+
+        assertThat(effectiveFilters).isEqualTo(testCase.expected);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/gko-1973

## Description

Added support for filtering analytics requests by API type. Filter supports the `EQ` and `IN` operators and takes one or more of the following values:
- `HTTP_PROXY`
- `MESSAGE`
- `KAFKA`
- `LLM`
- `MCP`

Also, `definitions/*` APIs were updated to include the new filter option.

The filter name is called `API_NAME`, which is consistent with how the API type is referenced in the OpenAPI spec and other places. 

Example measures request with a filter:
```json
{
  "timeRange": {
    "from": "2026-01-08T21:24:00Z",
    "to": "2026-01-08T21:30:00Z"
  },
  "filters": [
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    }
  ],
  "metrics": [
    {
      "name": "HTTP_REQUESTS",
      "measures": [
        "COUNT"
      ]
    }
  ]
}
```

The current implementation has a few limitations:
1. If a request has the same filter multiple times or equivalent filters, no results are returned.
The following filters have this limitation:
```json
  "filters": [
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    },
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    }
  ]
```

```json
  "filters": [
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    },
    {
      "name": "API_NAME",
      "operator": "IN",
      "value": ["HTTP_PROXY"]
    }
  ]
```

This will be improved in a follow-up PR

2. If a request contains multiple queries, and they contain the same API type, there will be a Lucene query each time.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

