### PR TITLE
Analytics engine: Allow filtering request by API type

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
@@ -22,6 +22,7 @@ package io.gravitee.repository.analytics.engine.api.query;
 public record Filter(Filter.Name name, Operator operator, Object value) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -173,6 +173,11 @@ paths:
                         type: "ENUM"
                         operators: [ "EQ", "IN" ]
                         enumValues: [ "1xx", "2xx", "3xx", "4xx", "5xx" ]
+                      - name: "API_NAME"
+                        label: "API name"
+                        type: "ENUM"
+                        operators: [ "EQ", "IN" ]
+                        enumValues: [ "HTTP_PROXY", "MESSAGE", "KAFKA", "LLM", "MCP" ]
         "400":
           description: Bad request - Invalid metric name for filters.
           content:
@@ -838,6 +843,7 @@ components:
             type: string
             enum:
                 - API
+                - API_NAME
                 - APPLICATION
                 - PLAN
                 - GATEWAY

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -20,6 +20,7 @@ import java.util.List;
 public record FilterSpec(Name name, String label, Type type, List<String> enumValues, NumberRange range, List<Operator> operators) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
@@ -25,7 +25,6 @@ import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -43,6 +43,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -96,6 +97,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -154,6 +156,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -211,6 +214,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -269,6 +273,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -326,6 +331,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -383,6 +389,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -1187,6 +1194,7 @@ spec:
               - APPLICATION
           filters:
               - API
+              - API_NAME
               - APPLICATION
 
         - name: APIS
@@ -1205,6 +1213,7 @@ spec:
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
           filters:
+              - API_NAME
               - API_STATE
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
@@ -1213,6 +1222,19 @@ spec:
         - name: API
           label: API
           type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
+        - name: API_NAME
+          label: API Name
+          type: ENUM
+          enumValues:
+              - HTTP_PROXY
+              - MESSAGE
+              - KAFKA
+              - LLM
+              - MCP
           operators:
               - EQ
               - IN


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/gko-1973

## Description

Updated the OpenAPI analytics spec to add support for a new filter `API_NAME`, which can take the following values:
- `HTTP_PROXY`
- `MESSAGE`
- `KAFKA`
- `LLM`
- `MCP`

Also, `definitions/*` APIs were updated to include the new filter option.

The filter name is called `API_NAME`, which is consistent with how the API type is referenced in the OpenAPI spec and other places.

Note: The logic that implements filtering will be done in another PR.

Example measures request with a filter:
```json
{
  "timeRange": {
    "from": "2026-01-08T21:24:00Z",
    "to": "2026-01-08T21:30:00Z"
  },
  "filters": [
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    }
  ],
  "metrics": [
    {
      "name": "HTTP_REQUESTS",
      "measures": [
        "COUNT"
      ]
    }
  ]
}
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

