### PR TITLE
chore: cleanup getter API definition

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -36,6 +36,7 @@ import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.AbstractApiServices;
 import io.gravitee.node.logging.NodeLoggerFactory;
@@ -83,6 +84,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -258,10 +260,11 @@ public interface ApiMapper {
     ApiV4 mapToV4(NativeApiEntity apiEntity);
 
     default ApiV4 mapToV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState) {
-        if (ApiType.NATIVE.equals(source.getType())) {
-            return mapToNativeV4(source, uriInfo, deploymentState);
-        }
-        return mapToHttpV4(source, uriInfo, deploymentState);
+        return switch (source.getApiDefinitionValue()) {
+            case NativeApi nativeApi -> mapToNativeV4(source, nativeApi, uriInfo, deploymentState);
+            case io.gravitee.definition.model.v4.Api v4Api -> mapToHttpV4(source, v4Api, uriInfo, deploymentState);
+            default -> throw new IllegalStateException("Unexpected API definition value: " + source.getApiDefinitionValue());
+        };
     }
 
     default PrimaryOwner map(PrimaryOwnerEntity entity) {
@@ -275,60 +278,90 @@ public interface ApiMapper {
             .type(entity.type() != null ? MembershipMemberType.valueOf(entity.type().name()) : null);
     }
 
+    @Nullable
     default ApiV4 mapToV4(GenericApiEntity genericApiEntity) {
-        if (genericApiEntity instanceof ApiEntity asApiEntity) {
-            return mapToV4(asApiEntity);
-        } else if (genericApiEntity instanceof NativeApiEntity asNativeApiEntity) {
-            return mapToV4(asNativeApiEntity);
-        }
-        return null;
+        return switch (genericApiEntity) {
+            case ApiEntity asApiEntity -> mapToV4(asApiEntity);
+            case NativeApiEntity asNativeApiEntity -> mapToV4(asNativeApiEntity);
+            case null, default -> null;
+        };
     }
 
+    @Mapping(target = "name", source = "source.name")
+    @Mapping(target = "definitionVersion", source = "source.definitionVersion")
+    @Mapping(target = "tags", source = "source.tags")
+    @Mapping(target = "type", source = "source.type")
+    @Mapping(target = "id", source = "source.id")
     @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
-    @Mapping(target = "analytics", source = "source.apiDefinitionHttpV4.analytics")
-    @Mapping(target = "allowedInApiProducts", source = "source.apiDefinitionHttpV4.allowedInApiProducts", defaultValue = "false")
+    @Mapping(target = "analytics", source = "definition.analytics")
+    @Mapping(target = "allowedInApiProducts", source = "definition.allowedInApiProducts", defaultValue = "false")
     @Mapping(target = "deploymentState", source = "deploymentState")
-    @Mapping(target = "endpointGroups", source = "source.apiDefinitionHttpV4.endpointGroups")
-    @Mapping(target = "failover", source = "source.apiDefinitionHttpV4.failover")
-    @Mapping(target = "flowExecution", source = "source.apiDefinitionHttpV4.flowExecution")
-    @Mapping(target = "flows", source = "source.apiDefinitionHttpV4.flows")
+    @Mapping(target = "endpointGroups", source = "definition.endpointGroups")
+    @Mapping(target = "failover", source = "definition.failover")
+    @Mapping(target = "flowExecution", source = "definition.flowExecution")
+    @Mapping(target = "flows", source = "definition.flows")
     @Mapping(target = "lifecycleState", source = "source.apiLifecycleState")
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
-    @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromHttpListeners")
+    @Mapping(target = "listeners", source = "definition.listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(
         target = "responseTemplates",
-        expression = "java(source != null && source.getApiDefinitionHttpV4() != null ? responseTemplateMapper.mapResponseTemplateToApiModel(source.getApiDefinitionHttpV4().getResponseTemplates()) : null)"
+        expression = "java(definition != null ? responseTemplateMapper.mapResponseTemplateToApiModel(definition.getResponseTemplates()) : null)"
     )
-    @Mapping(target = "properties", source = "source.apiDefinitionHttpV4.properties")
-    @Mapping(target = "services", source = "source.apiDefinitionHttpV4.services")
+    @Mapping(target = "properties", source = "definition.properties")
+    @Mapping(target = "services", source = "definition.services")
     @Mapping(target = "state", source = "source.lifecycleState")
-    ApiV4 mapToHttpV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
+    ApiV4 mapToHttpV4(
+        io.gravitee.apim.core.api.model.Api source,
+        io.gravitee.definition.model.v4.Api definition,
+        UriInfo uriInfo,
+        GenericApi.DeploymentStateEnum deploymentState
+    );
 
     @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
     @Mapping(target = "deploymentState", source = "deploymentState")
-    @Mapping(target = "endpointGroups", source = "source.apiDefinitionNativeV4.endpointGroups")
-    @Mapping(target = "flows", source = "source.apiDefinitionNativeV4.flows")
+    @Mapping(target = "endpointGroups", source = "definition.endpointGroups")
+    @Mapping(target = "flows", source = "definition.flows")
     @Mapping(target = "lifecycleState", source = "source.apiLifecycleState")
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
-    @Mapping(target = "listeners", source = "source.apiDefinitionNativeV4.listeners", qualifiedByName = "fromNativeListeners")
+    @Mapping(target = "listeners", source = "definition.listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
-    @Mapping(target = "analytics", source = "source.apiDefinitionNativeV4.analytics")
-    ApiV4 mapToNativeV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
+    @Mapping(target = "analytics", source = "definition.analytics")
+    @Mapping(target = "id", source = "source.id")
+    @Mapping(target = "name", source = "source.name")
+    @Mapping(target = "definitionVersion", source = "source.definitionVersion")
+    @Mapping(target = "tags", source = "source.tags")
+    @Mapping(target = "type", source = "source.type")
+    ApiV4 mapToNativeV4(
+        io.gravitee.apim.core.api.model.Api source,
+        NativeApi definition,
+        UriInfo uriInfo,
+        GenericApi.DeploymentStateEnum deploymentState
+    );
 
+    @Mapping(target = "id", source = "source.id")
+    @Mapping(target = "name", source = "source.name")
+    @Mapping(target = "definitionVersion", source = "source.definitionVersion")
+    @Mapping(target = "tags", source = "source.tags")
+    @Mapping(target = "type", source = "source.type")
     @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
-    @Mapping(target = "analytics", source = "source.apiDefinitionHttpV4.analytics")
+    @Mapping(target = "analytics", source = "definition.analytics")
     @Mapping(target = "deploymentState", source = "deploymentState")
-    @Mapping(target = "endpointGroups", source = "source.apiDefinitionHttpV4.endpointGroups")
-    @Mapping(target = "flowExecution", source = "source.apiDefinitionHttpV4.flowExecution")
+    @Mapping(target = "endpointGroups", source = "definition.endpointGroups")
+    @Mapping(target = "flowExecution", source = "definition.flowExecution")
     @Mapping(target = "flows", source = "source.flows", qualifiedByName = "mapToFlowV4List")
     @Mapping(target = "lifecycleState", source = "source.apiLifecycleState")
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
-    @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromHttpListeners")
+    @Mapping(target = "listeners", source = "definition.listeners", qualifiedByName = "fromHttpListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
-    ApiV4 mapToV4(io.gravitee.apim.core.api.model.ApiWithFlows source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
+    ApiV4 mapToV4(
+        io.gravitee.apim.core.api.model.ApiWithFlows source,
+        io.gravitee.definition.model.v4.Api definition,
+        UriInfo uriInfo,
+        GenericApi.DeploymentStateEnum deploymentState
+    );
 
     @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -57,6 +57,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiCRDMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
@@ -600,7 +601,10 @@ public class ApiResource extends AbstractResource {
         }
 
         var result = updateNativeApiUseCase.execute(new UpdateNativeApiUseCase.Input(apiToUpdate, getAuditInfo()));
-        return ApiAdapter.INSTANCE.toNativeApiEntity(result.updatedApi());
+        return switch (result.updatedApi().getApiDefinitionValue()) {
+            case NativeApi nativeApi -> ApiAdapter.INSTANCE.toNativeApiEntity(result.updatedApi(), nativeApi);
+            default -> throw new IllegalStateException("Update native API produce a non-native API");
+        };
     }
 
     private ApiEntity updateHttpApiV4(GenericApiEntity currentEntity, UpdateApiV4 updateApiV4) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -180,13 +180,14 @@ public class ApisResource extends AbstractResource {
         var createdApi = api.getType() == ApiType.NATIVE
             ? createNativeApiUseCase.execute(new CreateNativeApiUseCase.Input(ApiMapper.INSTANCE.mapToNewNativeApi(api), audit)).api()
             : createHttpApiUseCase.execute(new CreateHttpApiUseCase.Input(ApiMapper.INSTANCE.mapToNewHttpApi(api), audit)).api();
+        var v4Definition = createdApi.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api def ? def : null;
 
         boolean isSynchronized = apiStateDomainService.isSynchronized(createdApi, audit);
         GenericApi.DeploymentStateEnum deploymentState = isSynchronized
             ? GenericApi.DeploymentStateEnum.DEPLOYED
             : GenericApi.DeploymentStateEnum.NEED_REDEPLOY;
         return Response.created(this.getLocationHeader(createdApi.getId()))
-            .entity(ApiMapper.INSTANCE.mapToV4(createdApi, uriInfo, deploymentState))
+            .entity(ApiMapper.INSTANCE.mapToV4(createdApi, v4Definition, uriInfo, deploymentState))
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -44,6 +44,7 @@ import io.gravitee.apim.core.category.model.Category;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
@@ -84,10 +85,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -374,7 +373,10 @@ class ApisResourceTest extends AbstractResourceTest {
 
             when(createApiDomainService.create(any(Api.class), any(), any(AuditInfo.class), any(), any())).thenAnswer(invocation -> {
                 Api api = invocation.getArgument(0);
-                return new ApiWithFlows(api.toBuilder().id("api-id").build(), api.getApiDefinitionHttpV4().getFlows());
+                return new ApiWithFlows(
+                    api.toBuilder().id("api-id").build(),
+                    ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()).getFlows()
+                );
             });
 
             var newApi = aValidV4Api();
@@ -418,7 +420,7 @@ class ApisResourceTest extends AbstractResourceTest {
                 Api apiWithId = api.toBuilder().id("api-id").build();
                 return new ApiWithFlows(
                     apiWithId,
-                    api.getApiDefinitionNativeV4() != null ? api.getApiDefinitionNativeV4().getFlows() : List.of()
+                    api.getApiDefinitionValue() instanceof NativeApi definition ? definition.getFlows() : List.of()
                 );
             });
 
@@ -471,7 +473,9 @@ class ApisResourceTest extends AbstractResourceTest {
                 Api apiWithId = api.toBuilder().id("api-id").build();
                 return new ApiWithFlows(
                     apiWithId,
-                    api.getApiDefinitionNativeV4() != null ? api.getApiDefinitionNativeV4().getFlows() : List.of()
+                    api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api definition
+                        ? definition.getFlows()
+                        : List.of()
                 );
             });
 
@@ -807,7 +811,7 @@ class ApisResourceTest extends AbstractResourceTest {
 
         private ApiCRDStatus doImport(String crdResource, boolean dryRun) {
             try (var response = target.queryParam("dryRun", dryRun).request().put(Entity.json(readJSON(crdResource)))) {
-                Assertions.assertThat(response.getStatus()).isEqualTo(200);
+                assertThat(response.getStatus()).isEqualTo(200);
                 return response.readEntity(ApiCRDStatus.class);
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -23,7 +23,6 @@ import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
-import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.rest.api.model.context.OriginContext;
 import java.time.ZonedDateTime;
@@ -193,33 +192,6 @@ public class Api {
             apiDefinitionValue.setId(id);
         }
         return this;
-    }
-
-    /**
-     * @deprecated use {@link #getApiDefinitionValue()} instead.
-     * @return the api definition value or null.
-     */
-    @Deprecated
-    public io.gravitee.definition.model.v4.Api getApiDefinitionHttpV4() {
-        return apiDefinitionValue instanceof io.gravitee.definition.model.v4.Api api ? api : null;
-    }
-
-    /**
-     * @deprecated use {@link #getApiDefinitionValue()} instead.
-     * @return the api definition value or null.
-     */
-    @Deprecated
-    public NativeApi getApiDefinitionNativeV4() {
-        return apiDefinitionValue instanceof NativeApi api ? api : null;
-    }
-
-    /**
-     * @deprecated use {@link #getApiDefinitionValue()} instead.
-     * @return the api definition value or null.
-     */
-    @Deprecated
-    public io.gravitee.definition.model.Api getApiDefinition() {
-        return apiDefinitionValue instanceof io.gravitee.definition.model.Api api ? api : null;
     }
 
     public Api setApiDefinitionValue(ApiDefinition apiDefinition) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
@@ -192,11 +191,12 @@ public class PatchApiUseCase {
         }
 
         var persisted = updateApiDomainService.updateV4(updatedApi, input.auditInfo());
-        var httpV4 = persisted.getApiDefinitionHttpV4();
-        if (httpV4 != null && httpV4.getFlows() != null) {
+        if (
+            persisted.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api v4Definition && v4Definition.getFlows() != null
+        ) {
             var flows = flowCrudService.getApiV4Flows(persisted.getId());
             return new Output(
-                persisted.toBuilder().apiDefinitionValue(httpV4.toBuilder().flows(flows).build()).build(),
+                persisted.toBuilder().apiDefinitionValue(v4Definition.toBuilder().flows(flows).build()).build(),
                 primaryOwner,
                 workflowState
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCase.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.api.use_case;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
@@ -36,7 +38,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.CustomLog;
 
 /**
@@ -107,25 +108,26 @@ public class UpdateDynamicPropertiesUseCase {
         // We can force a redeployment only if:
         // - the API was synchronized before the properties are updated (i.e. no manual changes have been done by a user)
         // - and the properties have changed
-        if (isApiSynchronized && needRedployment(api.getApiDefinitionHttpV4().getProperties(), previousProperties)) {
+        var apiDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+        if (isApiSynchronized && needRedployment(apiDefinition.getProperties(), previousProperties)) {
             // Get the api from latest deployment event of the api to deploy the api with the same dynamic properties configuration
             // It avoids to deploy changes on the configuration that has not been explicitly deployed by the user
             apiEventQueryService
                 .findLastPublishedApi(auditInfo.organizationId(), auditInfo.environmentId(), api.getId())
                 .ifPresent(deployedApi -> {
+                    var deployedDefinitionValue = (io.gravitee.definition.model.v4.Api) deployedApi.getApiDefinitionValue();
                     if (
-                        deployedApi.getApiDefinitionHttpV4().getServices() == null ||
-                        deployedApi.getApiDefinitionHttpV4().getServices().getDynamicProperty() == null
+                        deployedDefinitionValue.getServices() == null || deployedDefinitionValue.getServices().getDynamicProperty() == null
                     ) {
                         return;
                     }
-                    final Service deployedDynamicPropertiesService = deployedApi
-                        .getApiDefinitionHttpV4()
-                        .getServices()
-                        .getDynamicProperty();
+                    final Service deployedDynamicPropertiesService = deployedDefinitionValue.getServices().getDynamicProperty();
                     // If the deployed api has the service enabled, then redeploy with the service enabled.
-                    if (deployedDynamicPropertiesService.isEnabled()) {
-                        updated.getApiDefinitionHttpV4().getServices().setDynamicProperty(deployedDynamicPropertiesService);
+                    if (
+                        deployedDynamicPropertiesService.isEnabled() &&
+                        updated.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4
+                    ) {
+                        apiDefinitionV4.getServices().setDynamicProperty(deployedDynamicPropertiesService);
                     }
                 });
             apiStateDomainService.deploy(updated, String.format("%s sync", input.pluginId()), auditInfo);
@@ -150,7 +152,9 @@ public class UpdateDynamicPropertiesUseCase {
      * @return the copy of the list of properties
      */
     private static List<Property> getCurrentProperties(Api api) {
-        return Optional.ofNullable(api.getApiDefinitionHttpV4().getProperties()).orElse(Collections.emptyList()).stream().toList();
+        return api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4
+            ? stream(apiDefinitionV4.getProperties()).toList()
+            : Collections.emptyList();
     }
 
     private AuditInfo buildAuditInfo(Input input, Api apiForUpdate) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.plan.domain_service;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.exception.ApiDeprecatedException;
 import io.gravitee.apim.core.api.model.Api;
@@ -36,6 +38,7 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -43,7 +46,6 @@ import java.sql.Date;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 @DomainService
 public class CreatePlanDomainService {
@@ -101,11 +103,17 @@ public class CreatePlanDomainService {
         planValidatorDomainService.validatePlanTagsAgainstApiTags(plan.getTags(), api.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
 
-        if (api.isNative()) {
-            return createNativeV4ApiPlan(plan, (List<NativeFlow>) flows, api, auditInfo);
-        }
-
-        return createHttpV4ApiPlan(plan, (List<Flow>) flows, api, auditInfo);
+        return switch (api.getApiDefinitionValue()) {
+            case io.gravitee.definition.model.v4.Api apiDefinitionV4 -> createHttpV4ApiPlan(
+                plan,
+                (List<Flow>) flows,
+                api,
+                apiDefinitionV4,
+                auditInfo
+            );
+            case NativeApi ignore -> createNativeV4ApiPlan(plan, (List<NativeFlow>) flows, api, auditInfo);
+            default -> throw new IllegalStateException(api.getDefinitionVersion() + " is not supported");
+        };
     }
 
     private PlanWithFlows createNativeV4ApiPlan(Plan plan, List<NativeFlow> flows, Api api, AuditInfo auditInfo) {
@@ -137,13 +145,15 @@ public class CreatePlanDomainService {
         return new PlanWithFlows(createdPlan, createdFlows);
     }
 
-    private PlanWithFlows createHttpV4ApiPlan(Plan plan, List<Flow> flows, Api api, AuditInfo auditInfo) {
+    private PlanWithFlows createHttpV4ApiPlan(
+        Plan plan,
+        List<Flow> flows,
+        Api api,
+        io.gravitee.definition.model.v4.Api apiDefinitionV4,
+        AuditInfo auditInfo
+    ) {
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
-        flowValidationDomainService.validatePathParameters(
-            api.getType(),
-            api.getApiDefinitionHttpV4().getFlows() != null ? api.getApiDefinitionHttpV4().getFlows().stream() : Stream.empty(),
-            sanitizedFlows.stream()
-        );
+        flowValidationDomainService.validatePathParameters(api.getType(), stream(apiDefinitionV4.getFlows()), sanitizedFlows.stream());
 
         var createdPlan = planCrudService.create(
             plan

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.plan.domain_service;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static java.util.stream.Collectors.toMap;
 
 import io.gravitee.apim.core.DomainService;
@@ -37,6 +38,7 @@ import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
@@ -166,11 +168,26 @@ public class UpdatePlanDomainService {
         Plan existingPlan = planCrudService.getById(planToUpdate.getId());
         Plan updatePlan = existingPlan.update(planToUpdate);
 
-        if (api.isNative()) {
-            return updateNativeV4ApiPlan(existingPlan, updatePlan, (List<NativeFlow>) flows, api, auditInfo, updateFunction);
-        }
-
-        return updateHttpV4ApiPlan(existingPlan, updatePlan, (List<Flow>) flows, api, auditInfo, updateFunction);
+        return switch (api.getApiDefinitionValue()) {
+            case io.gravitee.definition.model.v4.Api apiDefinitionV4 -> updateHttpV4ApiPlan(
+                existingPlan,
+                updatePlan,
+                (List<Flow>) flows,
+                api,
+                apiDefinitionV4,
+                auditInfo,
+                updateFunction
+            );
+            case NativeApi ignore -> updateNativeV4ApiPlan(
+                existingPlan,
+                updatePlan,
+                (List<NativeFlow>) flows,
+                api,
+                auditInfo,
+                updateFunction
+            );
+            default -> throw new IllegalStateException(api.getDefinitionVersion() + " is not supported");
+        };
     }
 
     private Plan updateV2ApiPlan(Plan planToUpdate, Map<String, PlanStatus> existingPlanStatuses, Api api, AuditInfo auditInfo) {
@@ -196,6 +213,7 @@ public class UpdatePlanDomainService {
         Plan updatePlan,
         List<Flow> flows,
         Api api,
+        io.gravitee.definition.model.v4.Api apiDefinitionV4,
         AuditInfo auditInfo,
         BinaryOperator<Plan> updateFunction
     ) {
@@ -216,11 +234,10 @@ public class UpdatePlanDomainService {
 
     private List<Flow> validateAndSanitizeHttpV4Flows(List<Flow> flows, Api api) {
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
-        flowValidationDomainService.validatePathParameters(
-            api.getType(),
-            api.getApiDefinitionHttpV4().getFlows() != null ? api.getApiDefinitionHttpV4().getFlows().stream() : Stream.empty(),
-            sanitizedFlows.stream()
-        );
+        var flows2 = api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4
+            ? stream(apiDefinitionV4.getFlows())
+            : Stream.<Flow>empty();
+        flowValidationDomainService.validatePathParameters(api.getType(), flows2, sanitizedFlows.stream());
         return sanitizedFlows;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -75,15 +75,18 @@ public interface ApiAdapter {
 
     Stream<io.gravitee.repository.management.model.Api> toRepositoryStream(Stream<Api> source);
 
-    @Mapping(target = "apiVersion", source = "version")
-    @Mapping(target = "tags", source = "apiDefinitionHttpV4.tags")
-    @Mapping(target = "listeners", source = "apiDefinitionHttpV4.listeners")
-    @Mapping(target = "endpointGroups", source = "apiDefinitionHttpV4.endpointGroups")
-    @Mapping(target = "analytics", source = "apiDefinitionHttpV4.analytics")
-    @Mapping(target = "flowExecution", source = "apiDefinitionHttpV4.flowExecution")
-    @Mapping(target = "flows", source = "apiDefinitionHttpV4.flows")
-    @Mapping(target = "failover", source = "apiDefinitionHttpV4.failover")
-    NewApiEntity toNewApiEntity(Api source);
+    @Mapping(target = "name", source = "source.name")
+    @Mapping(target = "definitionVersion", source = "source.definitionVersion")
+    @Mapping(target = "type", source = "source.type")
+    @Mapping(target = "apiVersion", source = "source.version")
+    @Mapping(target = "tags", source = "apiDefinition.tags")
+    @Mapping(target = "listeners", source = "apiDefinition.listeners")
+    @Mapping(target = "endpointGroups", source = "apiDefinition.endpointGroups")
+    @Mapping(target = "analytics", source = "apiDefinition.analytics")
+    @Mapping(target = "flowExecution", source = "apiDefinition.flowExecution")
+    @Mapping(target = "flows", source = "apiDefinition.flows")
+    @Mapping(target = "failover", source = "apiDefinition.failover")
+    NewApiEntity toNewApiEntity(Api source, io.gravitee.definition.model.v4.Api apiDefinition);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     @Mapping(source = "version", target = "apiVersion")
@@ -120,7 +123,7 @@ public interface ApiAdapter {
     ApiEntity toApiEntity(Api api);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
-    @Mapping(source = "version", target = "apiVersion")
+    @Mapping(target = "apiVersion", source = "api.version")
     @Mapping(target = "metadata", ignore = true)
     @Mapping(target = "tags", source = "apiDefinitionNativeV4.tags")
     @Mapping(target = "listeners", source = "apiDefinitionNativeV4.listeners")
@@ -129,9 +132,13 @@ public interface ApiAdapter {
     @Mapping(target = "resources", source = "apiDefinitionNativeV4.resources")
     @Mapping(target = "services", source = "apiDefinitionNativeV4.services")
     @Mapping(target = "properties", source = "apiDefinitionNativeV4.properties")
-    @Mapping(target = "state", source = "lifecycleState")
-    @Mapping(target = "lifecycleState", source = "apiLifecycleState")
-    NativeApiEntity toNativeApiEntity(Api api);
+    @Mapping(target = "state", source = "api.lifecycleState")
+    @Mapping(target = "lifecycleState", source = "api.apiLifecycleState")
+    @Mapping(target = "id", source = "api.id")
+    @Mapping(target = "name", source = "api.name")
+    @Mapping(target = "type", source = "api.type")
+    @Mapping(target = "definitionVersion", source = "api.definitionVersion")
+    NativeApiEntity toNativeApiEntity(Api api, NativeApi apiDefinitionNativeV4);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     @Mapping(source = "source.version", target = "apiVersion")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -31,6 +31,7 @@ import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.federation.FederatedApi;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.node.logging.NodeLoggerFactory;
@@ -97,26 +98,26 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "type", source = "apiEntity.type")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
-    @Mapping(target = "listeners", source = "apiEntity.apiDefinitionHttpV4.listeners")
-    @Mapping(target = "analytics", source = "apiEntity.apiDefinitionHttpV4.analytics")
-    @Mapping(target = "flowExecution", source = "apiEntity.apiDefinitionHttpV4.flowExecution")
-    @Mapping(target = "flows", source = "apiEntity.apiDefinitionHttpV4.flows")
-    @Mapping(target = "responseTemplates", source = "apiEntity.apiDefinitionHttpV4.responseTemplates")
-    @Mapping(target = "properties", source = "apiEntity.apiDefinitionHttpV4.properties")
-    @Mapping(target = "resources", source = "apiEntity.apiDefinitionHttpV4.resources")
-    @Mapping(target = "services", source = "apiEntity.apiDefinitionHttpV4.services")
-    @Mapping(
-        target = "failover",
-        expression = "java(apiEntity.getApiDefinitionHttpV4() != null ? apiEntity.getApiDefinitionHttpV4().getFailover() : null)"
-    )
-    @Mapping(target = "endpointGroups", source = "apiEntity.apiDefinitionHttpV4.endpointGroups")
-    @Mapping(target = "allowedInApiProducts", expression = "java(exportedAllowedInApiProducts(apiEntity.getApiDefinitionHttpV4()))")
+    @Mapping(target = "listeners", source = "apiDefinitionV4.listeners")
+    @Mapping(target = "analytics", source = "apiDefinitionV4.analytics")
+    @Mapping(target = "flowExecution", source = "apiDefinitionV4.flowExecution")
+    @Mapping(target = "flows", source = "apiDefinitionV4.flows")
+    @Mapping(target = "responseTemplates", source = "apiDefinitionV4.responseTemplates")
+    @Mapping(target = "properties", source = "apiDefinitionV4.properties")
+    @Mapping(target = "resources", source = "apiDefinitionV4.resources")
+    @Mapping(target = "services", source = "apiDefinitionV4.services")
+    @Mapping(target = "failover", expression = "java(apiDefinitionV4 != null ? apiDefinitionV4.getFailover() : null)")
+    @Mapping(target = "endpointGroups", source = "apiDefinitionV4.endpointGroups")
+    @Mapping(target = "allowedInApiProducts", expression = "java(exportedAllowedInApiProducts(apiDefinitionV4))")
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")
     @Mapping(target = "metadata", source = "metadata")
+    @Mapping(target = "name", source = "apiEntity.name")
+    @Mapping(target = "tags", source = "apiEntity.tags")
     ApiDescriptor.ApiDescriptorV4 mapV4(
         Api apiEntity,
+        io.gravitee.definition.model.v4.Api apiDefinitionV4,
         PrimaryOwnerEntity primaryOwner,
         WorkflowState workflowState,
         Set<String> groups,
@@ -129,18 +130,21 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "apiVersion", source = "apiEntity.version")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
-    @Mapping(target = "listeners", source = "apiEntity.apiDefinitionNativeV4.listeners")
-    @Mapping(target = "analytics", source = "apiEntity.apiDefinitionNativeV4.analytics")
-    @Mapping(target = "flows", source = "apiEntity.apiDefinitionNativeV4.flows")
-    @Mapping(target = "properties", source = "apiEntity.apiDefinitionNativeV4.properties")
-    @Mapping(target = "resources", source = "apiEntity.apiDefinitionNativeV4.resources")
-    @Mapping(target = "endpointGroups", source = "apiEntity.apiDefinitionNativeV4.endpointGroups")
+    @Mapping(target = "listeners", source = "definition.listeners")
+    @Mapping(target = "analytics", source = "definition.analytics")
+    @Mapping(target = "flows", source = "definition.flows")
+    @Mapping(target = "properties", source = "definition.properties")
+    @Mapping(target = "resources", source = "definition.resources")
+    @Mapping(target = "endpointGroups", source = "definition.endpointGroups")
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")
     @Mapping(target = "metadata", source = "metadata")
+    @Mapping(target = "name", source = "apiEntity.name")
+    @Mapping(target = "tags", source = "apiEntity.tags")
     ApiDescriptor.Native mapNative(
         Api apiEntity,
+        NativeApi definition,
         PrimaryOwnerEntity primaryOwner,
         WorkflowState workflowState,
         Set<String> groups,
@@ -157,7 +161,7 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "type", source = "apiEntity.type")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
-    @Mapping(target = "providerId", expression = "java(providerId(apiEntity.getApiDefinitionValue()))")
+    @Mapping(target = "providerId", expression = "java(providerId(apiDefinition))")
     @Mapping(target = "originContext.integrationId", source = "integration.id")
     @Mapping(target = "originContext.integrationName", source = "integration.name")
     @Mapping(target = "originContext.provider", source = "integration.provider")
@@ -166,8 +170,10 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "groups", source = "groups")
     @Mapping(target = "metadata", source = "metadata")
     @Mapping(target = "originContext", source = "integration")
+    @Mapping(target = "tags", source = "apiEntity.tags")
     ApiDescriptor.Federated mapFederated(
         Api apiEntity,
+        FederatedApi apiDefinition,
         PrimaryOwnerEntity primaryOwner,
         WorkflowState workflowState,
         Set<String> groups,
@@ -190,22 +196,24 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "apiVersion", source = "apiEntity.version")
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
-    @Mapping(target = "proxy", source = "apiEntity.apiDefinition.proxy")
-    @Mapping(target = "services", source = "apiEntity.apiDefinition.services")
-    @Mapping(target = "resources", source = "apiEntity.apiDefinition.resources")
-    @Mapping(target = "flows", source = "apiEntity.apiDefinition.flows")
-    @Mapping(target = "properties", source = "apiEntity.apiDefinition.properties")
-    @Mapping(target = "tags", source = "apiEntity.apiDefinition.tags")
-    @Mapping(target = "pathMappings", source = "apiEntity.apiDefinition.pathMappings")
-    @Mapping(target = "responseTemplates", source = "apiEntity.apiDefinition.responseTemplates")
-    @Mapping(target = "plans", source = "apiEntity.apiDefinition.plans")
-    @Mapping(target = "executionMode", source = "apiEntity.apiDefinition.executionMode")
+    @Mapping(target = "name", source = "apiEntity.name")
+    @Mapping(target = "proxy", source = "definition.proxy")
+    @Mapping(target = "services", source = "definition.services")
+    @Mapping(target = "resources", source = "definition.resources")
+    @Mapping(target = "flows", source = "definition.flows")
+    @Mapping(target = "properties", source = "definition.properties")
+    @Mapping(target = "tags", source = "definition.tags")
+    @Mapping(target = "pathMappings", source = "definition.pathMappings")
+    @Mapping(target = "responseTemplates", source = "definition.responseTemplates")
+    @Mapping(target = "plans", source = "definition.plans")
+    @Mapping(target = "executionMode", source = "definition.executionMode")
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")
     @Mapping(target = "metadata", source = "metadata")
     ApiDescriptor.ApiDescriptorV2 mapV2(
         Api apiEntity,
+        io.gravitee.definition.model.Api definition,
         PrimaryOwnerEntity primaryOwner,
         WorkflowState workflowState,
         Set<String> groups,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
@@ -19,6 +19,7 @@ import static io.gravitee.apim.core.audit.model.Excludable.GROUPS;
 import static io.gravitee.apim.core.audit.model.Excludable.MEMBERS;
 import static io.gravitee.apim.core.audit.model.Excludable.METADATA;
 import static io.gravitee.apim.core.audit.model.Excludable.PAGES_MEDIA;
+import static io.gravitee.apim.core.utils.CollectionUtils.isEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_DOCUMENTATION;
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_MEMBER;
@@ -119,18 +120,18 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
             .orElse(null);
 
         var groups = !excluded.contains(GROUPS) ? api1.getGroups() : null;
-        return switch (apiType(api1)) {
-            case V2 -> {
+        return switch (api1.getApiDefinitionValue()) {
+            case io.gravitee.definition.model.Api v2 -> {
                 Function<Plan, PlanDescriptor.V2> mapPlanV2 = plan -> {
                     var mapped = DEFINITION_ADAPTER.mapPlanV2(plan, excludeIds);
                     return planWithFlowV2(mapped, plan.getId(), excludeIds);
                 };
                 var plans = mapPlan(apiId, mapPlanV2, excluded);
                 var flows = getApiV2Flows(apiId, excludeIds);
-                var api = DEFINITION_ADAPTER.mapV2(api1, apiPrimaryOwner, workflowState, groups, metadata, flows, excludeIds);
+                var api = DEFINITION_ADAPTER.mapV2(api1, v2, apiPrimaryOwner, workflowState, groups, metadata, flows, excludeIds);
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
-            case V4 -> {
+            case io.gravitee.definition.model.v4.Api apiV4 -> {
                 Function<Plan, PlanDescriptor.V4> mapPlanV4 = plan -> {
                     var mapped = DEFINITION_ADAPTER.mapPlanV4(plan, excludeIds);
                     return planWithFlowV4(mapped, plan.getId(), excludeIds);
@@ -140,6 +141,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
                 var apiWithCategoryKeys = apiWithCategoryKeys(api1);
                 var api = DEFINITION_ADAPTER.mapV4(
                     apiWithCategoryKeys,
+                    apiV4,
                     apiPrimaryOwner,
                     workflowState,
                     groups,
@@ -149,7 +151,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
                 );
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
-            case V4_NATIVE -> {
+            case NativeApi nativeApi -> {
                 Function<Plan, PlanDescriptor.Native> mapPlanNative = plan -> {
                     var mapped = DEFINITION_ADAPTER.mapPlanNative(plan, excludeIds);
                     return planWithFlowNative(mapped, plan.getId(), excludeIds);
@@ -159,6 +161,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
                 var apiWithCategoryKeys = apiWithCategoryKeys(api1);
                 var api = DEFINITION_ADAPTER.mapNative(
                     apiWithCategoryKeys,
+                    nativeApi,
                     apiPrimaryOwner,
                     workflowState,
                     groups,
@@ -168,16 +171,17 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
                 );
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
-            case FEDERATED -> {
+            case FederatedApi federatedApi -> {
                 Function<Plan, PlanDescriptor.Federated> mapPlanFederated = DEFINITION_ADAPTER::mapPlanFederated;
                 var plans = mapPlan(apiId, mapPlanFederated, excluded);
                 var integ = api1.getOriginContext() instanceof OriginContext.Integration ori && ori.integrationName() == null
                     ? integrationCrudService.findApiIntegrationById(ori.integrationId()).orElse(null)
                     : null;
-                var api = DEFINITION_ADAPTER.mapFederated(api1, apiPrimaryOwner, workflowState, groups, metadata, integ);
+                var api = DEFINITION_ADAPTER.mapFederated(api1, federatedApi, apiPrimaryOwner, workflowState, groups, metadata, integ);
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
-            case FEDERATED_AGENT -> null; // TODO
+            case FederatedAgent agent -> null; // TODO
+            default -> throw new ApiDefinitionVersionNotSupportedException(api1.getDefinitionVersion().toString());
         };
     }
 
@@ -230,27 +234,6 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
         return permissionService.hasPermission(executionContext, auditInfo.actor().userId(), API_DOCUMENTATION, apiId, READ)
             ? mediaService.findAllByApiId(apiId)
             : null;
-    }
-
-    private enum ValidatedType {
-        V2,
-        V4,
-        V4_NATIVE,
-        FEDERATED,
-        FEDERATED_AGENT,
-    }
-
-    private ValidatedType apiType(Api api1) {
-        return switch (api1.getApiDefinitionValue()) {
-            case io.gravitee.definition.model.v4.Api api -> ValidatedType.V4;
-            case NativeApi nativeApi -> ValidatedType.V4_NATIVE;
-            case FederatedApi federatedApi -> ValidatedType.FEDERATED;
-            case FederatedAgent federatedAgent -> ValidatedType.FEDERATED_AGENT;
-            case io.gravitee.definition.model.Api api -> ValidatedType.V2;
-            case null, default -> throw new ApiDefinitionVersionNotSupportedException(
-                api1.getDefinitionVersion() != null ? api1.getDefinitionVersion().getLabel() : null
-            );
-        };
     }
 
     @Nullable
@@ -310,7 +293,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
 
     private Api apiWithCategoryKeys(Api api) {
         var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(api);
-        if (categoryKeys.isEmpty() && (api.getCategories() == null || api.getCategories().isEmpty())) {
+        if (categoryKeys.isEmpty() && isEmpty(api.getCategories())) {
             return api;
         }
         return api.toBuilder().categories(Set.copyOf(categoryKeys)).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExposedEntrypointDomainServiceLegacyWrapper.java
@@ -19,7 +19,7 @@ import io.gravitee.apim.core.api.domain_service.ApiExposedEntrypointDomainServic
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ExposedEntrypoint;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
-import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
@@ -35,8 +35,8 @@ public class ApiExposedEntrypointDomainServiceLegacyWrapper implements ApiExpose
 
     @Override
     public List<ExposedEntrypoint> get(String organizationId, String environmentId, Api api) {
-        GenericApiEntity genericApiEntity = api.getType() == ApiType.NATIVE
-            ? ApiAdapter.INSTANCE.toNativeApiEntity(api)
+        GenericApiEntity genericApiEntity = api.getApiDefinitionValue() instanceof NativeApi nativeApi
+            ? ApiAdapter.INSTANCE.toNativeApiEntity(api, nativeApi)
             : ApiAdapter.INSTANCE.toApiEntity(api);
 
         return apiEntrypointService

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -54,8 +54,9 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
     @Override
     public Api updateV4(Api api, AuditInfo auditInfo) {
         var executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
+        var apiDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
 
-        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, apiDefinition);
 
         delegate.update(executionContext, api.getId(), updateApiEntity, false, auditInfo.actor().userId());
 
@@ -65,15 +66,19 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
     @Override
     public Api validateV4(Api api, AuditInfo auditInfo) {
         var executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
-        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+        var apiDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, apiDefinition);
 
         delegate.validate(executionContext, api.getId(), updateApiEntity, auditInfo.actor().userId());
 
-        return applySanitizedValues(api, updateApiEntity);
+        return applySanitizedValues(api, updateApiEntity, apiDefinition);
     }
 
-    private Api applySanitizedValues(Api original, io.gravitee.rest.api.model.v4.api.UpdateApiEntity sanitized) {
-        var originalDefinition = original.getApiDefinitionHttpV4();
+    private Api applySanitizedValues(
+        Api original,
+        io.gravitee.rest.api.model.v4.api.UpdateApiEntity sanitized,
+        io.gravitee.definition.model.v4.Api originalDefinition
+    ) {
         var sanitizedLifecycle = sanitized.getLifecycleState() != null
             ? Api.ApiLifecycleState.valueOf(sanitized.getLifecycleState().name())
             : original.getApiLifecycleState();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -61,10 +61,10 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
             throw new ValidationDomainException("Definition not supported, should be V4");
         }
 
-        if (api.getType() == ApiType.NATIVE) {
-            this.validateAndSanitizeNativeV4ForCreation(api, primaryOwner, environmentId, organizationId);
+        if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4) {
+            this.validateAndSanitizeHttpV4ForCreation(api, apiDefinitionV4, primaryOwner, environmentId, organizationId);
         } else {
-            this.validateAndSanitizeHttpV4ForCreation(api, primaryOwner, environmentId, organizationId);
+            this.validateAndSanitizeNativeV4ForCreation(api, primaryOwner, environmentId, organizationId);
         }
 
         api.setCategories(categoryDomainService.toCategoryId(api, environmentId));
@@ -102,11 +102,12 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
 
     private void validateAndSanitizeHttpV4ForCreation(
         final Api api,
+        io.gravitee.definition.model.v4.Api apiDefinition,
         PrimaryOwnerEntity primaryOwner,
         String environmentId,
         String organizationId
     ) {
-        var newApiEntity = ApiAdapter.INSTANCE.toNewApiEntity(api);
+        var newApiEntity = ApiAdapter.INSTANCE.toNewApiEntity(api, apiDefinition);
 
         apiValidationService.validateAndSanitizeNewApi(
             new ExecutionContext(organizationId, environmentId),
@@ -121,19 +122,19 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         api.setGroups(newApiEntity.getGroups());
         api.setTags(newApiEntity.getTags());
 
-        api.getApiDefinitionHttpV4().setListeners(newApiEntity.getListeners());
-        api.getApiDefinitionHttpV4().setEndpointGroups(newApiEntity.getEndpointGroups());
-        api.getApiDefinitionHttpV4().setAnalytics(newApiEntity.getAnalytics());
-        api.getApiDefinitionHttpV4().setFlowExecution(newApiEntity.getFlowExecution());
-        api.getApiDefinitionHttpV4().setFailover(newApiEntity.getFailover());
+        apiDefinition.setListeners(newApiEntity.getListeners());
+        apiDefinition.setEndpointGroups(newApiEntity.getEndpointGroups());
+        apiDefinition.setAnalytics(newApiEntity.getAnalytics());
+        apiDefinition.setFlowExecution(newApiEntity.getFlowExecution());
+        apiDefinition.setFailover(newApiEntity.getFailover());
 
-        api.getApiDefinitionHttpV4().setResources(apiValidationService.validateAndSanitize(api.getApiDefinitionHttpV4().getResources()));
+        apiDefinition.setResources(apiValidationService.validateAndSanitize(apiDefinition.getResources()));
 
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), newApiEntity.getFlows());
-        api.getApiDefinitionHttpV4().setFlows(sanitizedFlows);
+        apiDefinition.setFlows(sanitizedFlows);
 
         apiValidationService.validateDynamicProperties(
-            api.getApiDefinitionHttpV4().getServices() != null ? api.getApiDefinitionHttpV4().getServices().getDynamicProperty() : null
+            apiDefinition.getServices() != null ? apiDefinition.getServices().getDynamicProperty() : null
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.infra.plugin;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.isEmpty;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.rest.api.common.apiservices.DefaultManagementDeploymentContext;
@@ -105,16 +107,14 @@ public class ManagementApiServicesManager extends AbstractService {
     }
 
     public void startDynamicProperties(Api api) {
-        if (!api.getDefinitionVersion().equals(DefinitionVersion.V4)) {
+        if (!(api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4)) {
             return;
         }
         List<ManagementApiService> services = apiServicePluginManager
             .<ManagementApiServiceFactory<?>>getAllFactories(ManagementApiServiceFactory.class)
             .stream()
             .map(managementApiServiceFactory ->
-                managementApiServiceFactory.createService(
-                    new DefaultManagementDeploymentContext(api.getApiDefinitionHttpV4(), applicationContext)
-                )
+                managementApiServiceFactory.createService(new DefaultManagementDeploymentContext(apiDefinitionV4, applicationContext))
             )
             .filter(Objects::nonNull)
             .filter(service -> "http-dynamic-properties".equals(service.id()))
@@ -132,11 +132,11 @@ public class ManagementApiServicesManager extends AbstractService {
     public void updateServices(Api api) {
         log.debug("Restarting services for api: {}", api.getId());
         final List<ManagementApiService> managedApi = servicesByApi.get(api.getId());
-        if (managedApi != null && !managedApi.isEmpty()) {
+        if (!isEmpty(managedApi) && api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api apiDefinitionV4) {
             Completable.concat(
                 managedApi
                     .stream()
-                    .map(managementApiService -> managementApiService.update(api.getApiDefinitionHttpV4()))
+                    .map(managementApiService -> managementApiService.update(apiDefinitionV4))
                     .collect(Collectors.toList())
             ).blockingAwait();
             return;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
@@ -46,6 +46,7 @@ import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.nativeapi.NativePlan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -198,11 +199,11 @@ class UpdateNativeApiDomainServiceTest {
             oneShotIndexation(auditInfo)
         );
         //then
-        assertThat(apiCrudService.storage().get(0)).extracting("apiDefinitionNativeV4").isNotNull();
+        assertThat(apiCrudService.storage().getFirst().getApiDefinitionValue()).isNotNull();
         SoftAssertions.assertSoftly(soft -> {
             assertThat(updatedApi.getName()).isEqualTo("updated-name");
             assertThat(updatedApi.getDescription()).isEqualTo("updated-description");
-            assertThat(updatedApi.getApiDefinitionNativeV4()).isNotNull();
+            assertThat(updatedApi.getApiDefinitionValue()).isNotNull();
             assertThat(updatedApi.getVersion()).isEqualTo("2.0.0");
             assertThat(updatedApi.getLabels()).containsExactly("label-1");
             assertThat(updatedApi.getCategories()).containsExactly(categoryKey);
@@ -359,7 +360,7 @@ class UpdateNativeApiDomainServiceTest {
         var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
         var apiToUpdate = ApiFixtures.aNativeApi();
         var nativeFlow = NativeFlow.builder().id("native-flow").build();
-        apiToUpdate.setApiDefinitionValue(apiToUpdate.getApiDefinitionNativeV4().toBuilder().flows(List.of(nativeFlow)).build());
+        apiToUpdate.setApiDefinitionValue(((NativeApi) apiToUpdate.getApiDefinitionValue()).toBuilder().flows(List.of(nativeFlow)).build());
         var ownerEntity = buildPrimaryOwnerEntity();
 
         var updatedApi = cut.update(
@@ -372,7 +373,9 @@ class UpdateNativeApiDomainServiceTest {
         );
 
         assertThat(flowCrudService.storage()).isNotEmpty().containsExactly(nativeFlow);
-        assertThat(updatedApi.getApiDefinitionNativeV4().getFlows()).containsExactly(nativeFlow);
+        assertThat(updatedApi.getApiDefinitionValue()).isInstanceOfSatisfying(NativeApi.class, nativeApi ->
+            assertThat(nativeApi.getFlows()).containsExactly(nativeFlow)
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
@@ -50,7 +50,6 @@ import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.v4.ApiImagesService;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.util.ArrayList;
 import java.util.List;
@@ -223,7 +222,9 @@ class ImportDefinitionUpdateDomainServiceTest {
         var updated = service.update(importDefinition, existingApi, AUDIT_INFO);
 
         assertThat(updated).isNotNull();
-        assertThat(updated.getApiDefinitionNativeV4().getProperties()).usingRecursiveComparison().isEqualTo(existingProperties);
+        assertThat(updated.getApiDefinitionValue()).isInstanceOfSatisfying(NativeApi.class, definition ->
+            assertThat(definition.getProperties()).usingRecursiveComparison().isEqualTo(existingProperties)
+        );
     }
 
     @Test
@@ -463,7 +464,7 @@ class ImportDefinitionUpdateDomainServiceTest {
         assertThat(api.isDisableMembershipNotifications()).isEqualTo(apiExport.isDisableMembershipNotifications());
         assertThat(api.getType()).isEqualTo(apiExport.getType());
 
-        var definition = api.getApiDefinitionNativeV4();
+        var definition = ((NativeApi) api.getApiDefinitionValue());
         assertThat(definition.getProperties()).usingRecursiveComparison().isEqualTo(apiExport.getProperties());
         assertThat(definition.getResources()).usingRecursiveComparison().isEqualTo(apiExport.getResources());
         assertThat(definition.getListeners()).usingRecursiveComparison().isEqualTo(apiExport.getListeners());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/ApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/ApiTest.java
@@ -39,20 +39,22 @@ class ApiTest {
     @Test
     void does_not_need_to_update() {
         final Api api = ApiFixtures.aProxyApiV4();
-        api
-            .getApiDefinitionHttpV4()
-            .setProperties(List.of(new Property("key", "value", false, false), new Property("dynamic", "value", false, true)));
+        var apiDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+        apiDefinition.setProperties(List.of(new Property("key", "value", false, false), new Property("dynamic", "value", false, true)));
         assertThat(
             api.updateDynamicProperties(List.of(new Property("key", "value", false, true), new Property("dynamic", "value", false, true)))
         ).isFalse();
         // keys must be sorted by natural order
-        assertThat(api.getApiDefinitionHttpV4().getProperties()).extracting(Property::getKey).containsExactly("dynamic", "key");
+        assertThat(((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()).getProperties())
+            .extracting(Property::getKey)
+            .containsExactly("dynamic", "key");
     }
 
     @Test
     void needs_to_update() {
         final Api api = ApiFixtures.aProxyApiV4();
-        api.getApiDefinitionHttpV4().setProperties(List.of(new Property("key", "value", false, false)));
+        var apiDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+        apiDefinition.setProperties(List.of(new Property("key", "value", false, false)));
         assertThat(
             api.updateDynamicProperties(
                 List.of(
@@ -63,6 +65,8 @@ class ApiTest {
             )
         ).isTrue();
         // keys must be sorted by natural order
-        assertThat(api.getApiDefinitionHttpV4().getProperties()).extracting(Property::getKey).containsExactly("X-Other", "dynamic", "key");
+        assertThat(((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()).getProperties())
+            .extracting(Property::getKey)
+            .containsExactly("X-Other", "dynamic", "key");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
@@ -53,7 +53,7 @@ class ApiModelFactoryTest {
 
         Api api = ApiModelFactory.fromApiExport(apiExport, ENVIRONMENT_ID);
 
-        var definition = api.getApiDefinitionHttpV4();
+        var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
         assertThat(definition.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
         assertThat(definition.getAllowedInApiProducts()).isNull();
@@ -71,7 +71,7 @@ class ApiModelFactoryTest {
 
         Api api = ApiModelFactory.fromApiExport(apiExport, ENVIRONMENT_ID);
 
-        var definition = api.getApiDefinitionHttpV4();
+        var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
         assertThat(definition.getAllowedInApiProducts()).isTrue();
     }
 
@@ -87,7 +87,7 @@ class ApiModelFactoryTest {
 
         Api api = ApiModelFactory.fromApiExport(apiExport, ENVIRONMENT_ID);
 
-        var definition = api.getApiDefinitionHttpV4();
+        var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
         assertThat(definition.getAllowedInApiProducts()).isFalse();
     }
 
@@ -103,7 +103,7 @@ class ApiModelFactoryTest {
 
         Api api = ApiModelFactory.fromApiExport(apiExport, ENVIRONMENT_ID);
 
-        var definition = api.getApiDefinitionHttpV4();
+        var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
         assertThat(definition.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
         assertThat(definition.getType()).isEqualTo(ApiType.MESSAGE);
         assertThat(definition.getAllowedInApiProducts()).isNull();
@@ -121,7 +121,7 @@ class ApiModelFactoryTest {
 
         Api api = ApiModelFactory.fromApiExport(apiExport, ENVIRONMENT_ID);
 
-        var definition = api.getApiDefinitionHttpV4();
+        var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
         assertThat(definition.getAllowedInApiProducts()).isNull();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -32,6 +32,7 @@ import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.Cors;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Endpoint;
@@ -55,7 +56,6 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.definition.model.v4.service.Service;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -89,8 +89,8 @@ class V2ToV4MigrationOperatorTest {
         void should_preserve_api_metadata_when_mapping() {
             // Given
             var originalApi = ApiFixtures.aProxyApiV2();
-            originalApi
-                .getApiDefinition()
+            Api apiDefinition = (Api) originalApi.getApiDefinitionValue();
+            apiDefinition
                 .getProxy()
                 .getGroups()
                 .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -124,8 +124,8 @@ class V2ToV4MigrationOperatorTest {
         @Test
         void should_upgrade_definition_version_to_v4() {
             var v2Api = ApiFixtures.aProxyApiV2().toBuilder().definitionVersion(DefinitionVersion.V2).build();
-            v2Api
-                .getApiDefinition()
+            Api apiDefinition = (Api) v2Api.getApiDefinitionValue();
+            apiDefinition
                 .getProxy()
                 .getGroups()
                 .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -150,7 +150,7 @@ class V2ToV4MigrationOperatorTest {
             var proxy = new Proxy();
             proxy.setVirtualHosts(List.of(virtualHost));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -162,7 +162,10 @@ class V2ToV4MigrationOperatorTest {
             var result = get(mapper.mapApi(api));
 
             // Then
-            if (result.getApiDefinitionHttpV4().getListeners().getFirst() instanceof HttpListener httpListener) {
+            if (
+                result.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api definition &&
+                definition.getListeners().getFirst() instanceof HttpListener httpListener
+            ) {
                 assertThat(httpListener.getPaths().getFirst().getPath()).endsWith("/");
             } else {
                 fail("Listener is not an HttpListener");
@@ -178,7 +181,7 @@ class V2ToV4MigrationOperatorTest {
             var proxy = new Proxy();
             proxy.setVirtualHosts(List.of(virtualHost));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -188,7 +191,8 @@ class V2ToV4MigrationOperatorTest {
 
             var result = get(mapper.mapApi(api));
 
-            var httpListener = (HttpListener) result.getApiDefinitionHttpV4().getListeners().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            var httpListener = (HttpListener) apiDefinitionValue.getListeners().getFirst();
             var path = httpListener.getPaths().getFirst();
 
             assertThat(path.getHost()).isEqualTo("api.example.com");
@@ -208,7 +212,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setVirtualHosts(List.of(virtualHost1, virtualHost2));
             proxy.setServers(List.of("server1", "server2"));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -218,8 +222,9 @@ class V2ToV4MigrationOperatorTest {
 
             var result = get(mapper.mapApi(api));
 
-            assertThat(result.getApiDefinitionHttpV4().getListeners()).hasSize(1);
-            var listener = result.getApiDefinitionHttpV4().getListeners().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            assertThat(apiDefinitionValue.getListeners()).hasSize(1);
+            var listener = apiDefinitionValue.getListeners().getFirst();
             assertThat(listener.getType()).isEqualTo(ListenerType.HTTP);
 
             var httpListener = (HttpListener) listener;
@@ -255,7 +260,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setVirtualHosts(List.of(new VirtualHost()));
             proxy.setGroups(Set.of(endpointGroup));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -265,7 +270,8 @@ class V2ToV4MigrationOperatorTest {
 
             var result = get(mapper.mapApi(api));
 
-            var mappedEndpointGroup = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            var mappedEndpointGroup = apiDefinitionValue.getEndpointGroups().getFirst();
             if (expectedV4Type != null) {
                 assertThat(mappedEndpointGroup.getLoadBalancer().getType()).isEqualTo(expectedV4Type);
             } else {
@@ -285,7 +291,7 @@ class V2ToV4MigrationOperatorTest {
 
         @Test
         void should_set_api_properties_correctly() {
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api-id");
             apiDef.setName("Test API Name");
             apiDef.setVersion("2.0.1");
@@ -295,7 +301,7 @@ class V2ToV4MigrationOperatorTest {
             var api = ApiFixtures.aProxyApiV2().toBuilder().apiDefinition(apiDef).build();
 
             var result = get(mapper.mapApi(api));
-            var v4Definition = result.getApiDefinitionHttpV4();
+            var v4Definition = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
 
             assertThat(v4Definition.getId()).isEqualTo("test-api-id");
             assertThat(v4Definition.getName()).isEqualTo("Test API Name");
@@ -328,7 +334,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setVirtualHosts(List.of(new VirtualHost()));
             proxy.setGroups(Set.of(endpointGroup));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -338,7 +344,8 @@ class V2ToV4MigrationOperatorTest {
 
             var result = get(mapper.mapApi(api));
 
-            var mappedEndpoint = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst().getEndpoints().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            var mappedEndpoint = apiDefinitionValue.getEndpointGroups().getFirst().getEndpoints().getFirst();
             assertThat(mappedEndpoint.isSecondary()).isEqualTo(isBackup);
             assertThat(mappedEndpoint.getWeight()).isEqualTo(10);
             assertThat(mappedEndpoint.getTenants()).containsExactlyInAnyOrder("tenant1", "tenant2");
@@ -360,7 +367,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setVirtualHosts(List.of(new VirtualHost()));
             proxy.setGroups(Set.of(endpointGroup));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -370,7 +377,8 @@ class V2ToV4MigrationOperatorTest {
 
             var result = get(mapper.mapApi(api));
 
-            var mappedEndpoint = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst().getEndpoints().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            var mappedEndpoint = apiDefinitionValue.getEndpointGroups().getFirst().getEndpoints().getFirst();
             assertSoftly(softly -> {
                 softly.assertThat(mappedEndpoint.getName()).isEqualTo("test-endpoint");
                 softly.assertThat(mappedEndpoint.getType()).isEqualTo("http-proxy");
@@ -442,7 +450,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setServers(List.of("localhost"));
 
             // Setup Api V2
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -453,11 +461,12 @@ class V2ToV4MigrationOperatorTest {
             var result = get(mapper.mapApi(api));
 
             // Check Endpoint Group
-            var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            var group = apiDefinitionValue.getEndpointGroups().getFirst();
             String configJson =
                 "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"openSsl\":false,\"alpn\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}]}";
             assertSoftly(softly -> {
-                softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+                softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
                 softly.assertThat(group.getName()).isEqualTo("default-group");
                 softly.assertThat(group.getType()).isEqualTo("http-proxy");
                 softly.assertThat(group.getSharedConfiguration()).isNotNull();
@@ -542,7 +551,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setServers(List.of("localhost"));
 
             // Setup Api V2
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -555,11 +564,12 @@ class V2ToV4MigrationOperatorTest {
             // Check Endpoint Group
             String configJson =
                 "{\"http\":{\"idleTimeout\":1000,\"keepAliveTimeout\":5,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":true,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"openSsl\":false,\"alpn\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/a/b/c\",\"content\":\"abc\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/a/b/c\",\"keyContent\":\"abc\"}},\"headers\":[{\"name\":\"X-Test\",\"value\":\"yes\"}]}";
-            assertThat(result.getApiDefinitionHttpV4().getEndpointGroups())
+            var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            assertThat(apiDefinitionValue.getEndpointGroups())
                 .singleElement()
                 .satisfies(group -> {
                     assertSoftly(softly -> {
-                        softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+                        softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
                         softly.assertThat(group.getName()).isEqualTo("default-group");
                         softly.assertThat(group.getType()).isEqualTo("http-proxy");
                         softly.assertThat(group.getSharedConfiguration()).isNotNull();
@@ -632,7 +642,7 @@ class V2ToV4MigrationOperatorTest {
         proxy.setServers(List.of("localhost"));
 
         // Setup Api V2
-        var apiDef = new io.gravitee.definition.model.Api();
+        var apiDef = new Api();
         apiDef.setId("test-api");
         apiDef.setName("Test API");
         apiDef.setVersion("1.0");
@@ -646,7 +656,7 @@ class V2ToV4MigrationOperatorTest {
         step.setRequest(request);
         // Configure the expected response
         HealthCheckResponse response = new HealthCheckResponse();
-        response.setAssertions(java.util.List.of("#status == 200"));
+        response.setAssertions(List.of("#status == 200"));
         step.setResponse(response);
         HealthCheckService healthCheckService = HealthCheckService.builder()
             .enabled(true) // comes from ScheduledService (superclass)
@@ -662,11 +672,12 @@ class V2ToV4MigrationOperatorTest {
         var result = get(mapper.mapApi(api));
 
         // Check Endpoint Group
-        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+        var group = apiDefinitionValue.getEndpointGroups().getFirst();
         String configJson =
             "{\"schedule\":\"*/30 * * * * *\",\"failureThreshold\":2,\"successThreshold\":2,\"headers\":[],\"method\":\"POST\",\"target\":\"/hc\",\"assertion\":\"{#status == 200}\",\"overrideEndpointPath\":false}";
         assertSoftly(softly -> {
-            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
             softly.assertThat(group.getName()).isEqualTo("default-group");
             softly.assertThat(group.getType()).isEqualTo("http-proxy");
             softly.assertThat(group.getSharedConfiguration()).isNotNull();
@@ -722,7 +733,7 @@ class V2ToV4MigrationOperatorTest {
         proxy.setServers(List.of("localhost"));
 
         // Setup Api V2
-        var apiDef = new io.gravitee.definition.model.Api();
+        var apiDef = new Api();
         apiDef.setId("test-api");
         apiDef.setName("Test API");
         apiDef.setVersion("1.0");
@@ -734,9 +745,10 @@ class V2ToV4MigrationOperatorTest {
         var result = get(mapper.mapApi(api));
 
         // Check Endpoint Group
-        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+        var group = apiDefinitionValue.getEndpointGroups().getFirst();
         assertSoftly(softly -> {
-            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
             softly.assertThat(group.getName()).isEqualTo("default-group");
             softly.assertThat(group.getType()).isEqualTo("http-proxy");
         });
@@ -809,7 +821,7 @@ class V2ToV4MigrationOperatorTest {
         proxy.setServers(List.of("localhost"));
 
         // Setup Api V2
-        var apiDef = new io.gravitee.definition.model.Api();
+        var apiDef = new Api();
         apiDef.setId("test-api");
         apiDef.setName("Test API");
         apiDef.setVersion("1.0");
@@ -821,9 +833,10 @@ class V2ToV4MigrationOperatorTest {
         var result = get(mapper.mapApi(api));
 
         // Check Endpoint Group
-        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+        var group = apiDefinitionValue.getEndpointGroups().getFirst();
         assertSoftly(softly -> {
-            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
             softly.assertThat(group.getName()).isEqualTo("default-group");
             softly.assertThat(group.getType()).isEqualTo("http-proxy");
         });
@@ -881,7 +894,7 @@ class V2ToV4MigrationOperatorTest {
         proxy.setVirtualHosts(List.of(new VirtualHost("localhost", "/api", false)));
 
         // Setup Api V2
-        var apiDef = new io.gravitee.definition.model.Api();
+        var apiDef = new Api();
         apiDef.setId("test-api");
         apiDef.setName("Test API");
         apiDef.setVersion("1.0");
@@ -893,9 +906,10 @@ class V2ToV4MigrationOperatorTest {
         var result = get(mapper.mapApi(api));
 
         // Check Endpoint Group
-        var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+        var apiDefinitionValue = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+        var group = apiDefinitionValue.getEndpointGroups().getFirst();
         assertSoftly(softly -> {
-            softly.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+            softly.assertThat(apiDefinitionValue.getEndpointGroups()).hasSize(1);
             softly.assertThat(group.getName()).isEqualTo("default-group");
             softly.assertThat(group.getType()).isEqualTo("http-proxy");
         });
@@ -941,7 +955,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setGroups(Set.of(v2Group));
             proxy.setVirtualHosts(List.of(new VirtualHost()));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -954,7 +968,7 @@ class V2ToV4MigrationOperatorTest {
             var result = get(mapper.mapApi(api));
 
             // Assert: healthCheck must not have been migrated because schedule is null
-            var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+            var group = ((io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue()).getEndpointGroups().getFirst();
             assertThat(group.getServices()).isNotNull();
             assertThat(group.getServices().getHealthCheck()).isNull();
         }
@@ -992,7 +1006,7 @@ class V2ToV4MigrationOperatorTest {
             proxy.setGroups(Set.of(v2Group));
             proxy.setVirtualHosts(List.of(new VirtualHost()));
 
-            var apiDef = new io.gravitee.definition.model.Api();
+            var apiDef = new Api();
             apiDef.setId("test-api");
             apiDef.setName("Test API");
             apiDef.setVersion("1.0");
@@ -1004,7 +1018,7 @@ class V2ToV4MigrationOperatorTest {
             var result = get(mapper.mapApi(api));
 
             // Assert: endpoint HC must not be migrated since schedule is null
-            var group = result.getApiDefinitionHttpV4().getEndpointGroups().getFirst();
+            var group = ((io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue()).getEndpointGroups().getFirst();
             var endpoint = group.getEndpoints().getFirst();
             assertThat(endpoint.getServices()).isNotNull();
             assertThat(endpoint.getServices().getHealthCheck()).isNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
@@ -71,7 +71,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionHttpV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
         }
 
         @Test
@@ -103,7 +103,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionHttpV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
             if (output.apiDefinition() instanceof io.gravitee.definition.model.v4.Api definition) {
                 assertThat(definition.getFlows()).isEqualTo(flows);
                 assertThat(definition.getPlans()).hasSize(2);
@@ -132,7 +132,7 @@ class GetApiDefinitionUseCaseTest {
 
             // Then
             assertNotNull(output);
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionNativeV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
         }
 
         @Test
@@ -162,7 +162,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionNativeV4());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
             if (output.apiDefinition() instanceof NativeApi definition) {
                 assertThat(definition.getFlows()).isEqualTo(flows);
                 assertThat(definition.getPlans()).hasSize(2);
@@ -190,7 +190,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinition());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
         }
 
         @Test
@@ -220,7 +220,7 @@ class GetApiDefinitionUseCaseTest {
             var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
 
             // Then
-            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinition());
+            assertThat(output.apiDefinition()).isEqualTo(API.getApiDefinitionValue());
 
             if (output.apiDefinition() instanceof io.gravitee.definition.model.Api definition) {
                 assertThat(definition.getFlows()).isEqualTo(flows);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fixtures.ApplicationModelFixtures;
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.PlanFixtures;
 import fixtures.definition.ApiDefinitionFixtures;
@@ -529,7 +528,7 @@ class ImportApiCRDUseCaseTest {
 
         applicationCrudService.initWith(
             List.of(
-                ApplicationModelFixtures.anApplicationEntity()
+                anApplicationEntity()
                     .toBuilder()
                     .id(APPLICATION_ID)
                     .primaryOwner(io.gravitee.rest.api.model.PrimaryOwnerEntity.builder().id(USER_ID).displayName("Jane").build())
@@ -616,7 +615,8 @@ class ImportApiCRDUseCaseTest {
         @Test
         void should_create_and_index_a_new_api() {
             var expected = expectedApiV4Proxy().toBuilder().id(API_ID).crossId(API_CROSS_ID).build();
-            expected.getApiDefinitionHttpV4().setPlans(List.of());
+            ((io.gravitee.definition.model.v4.Api) expected.getApiDefinitionValue()).setPlans(List.of());
+            expected.setHrid(expected.getCrossId());
 
             useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().plans(Map.of()).build()));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -647,7 +647,7 @@ class ImportApiDefinitionUseCaseTest {
             // Then
             var expected = expectedNativeApi();
             expected.setId(customId);
-            expected.getApiDefinitionNativeV4().setId(customId);
+            expected.getApiDefinitionValue().setId(customId);
 
             SoftAssertions.assertSoftly(soft -> {
                 var createdApi = apiCrudService.get(customId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
@@ -74,10 +74,17 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Failover;
+import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.Logging;
+import io.gravitee.definition.model.LoggingContent;
+import io.gravitee.definition.model.LoggingMode;
+import io.gravitee.definition.model.LoggingScope;
 import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.Property;
+import io.gravitee.definition.model.ProtocolVersion;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration;
 import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
@@ -85,14 +92,17 @@ import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckResponse;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.definition.model.v4.resource.Resource;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
@@ -269,9 +279,9 @@ class MigrateApiUseCaseTest {
         // Given
         when(apiService.isSynchronized(any(), any())).thenReturn(false);
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        api
-            .getApiDefinition()
+        var apiDefinition = ((io.gravitee.definition.model.Api) api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -292,9 +302,7 @@ class MigrateApiUseCaseTest {
     void should_return_fail_when_api_dont_use_v4_emulation_engine() {
         // Given
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api
-            .getApiDefinition()
-            .getProxy()
+        ((io.gravitee.definition.model.Api) api.getApiDefinitionValue()).getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
         apiCrudService.initWith(List.of(api));
@@ -315,9 +323,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_when_api_has_documentation_page(Page.Type type) {
         // Given
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        api
-            .getApiDefinition()
+        var apiDefinition = ((io.gravitee.definition.model.Api) api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -344,9 +352,9 @@ class MigrateApiUseCaseTest {
     void should_return_fail_when_api_has_doc_with_translations() {
         // Given
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        api
-            .getApiDefinition()
+        var apiDefinition = ((io.gravitee.definition.model.Api) api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -381,9 +389,9 @@ class MigrateApiUseCaseTest {
     void should_return_fail_when_api_has_doc_with_AccessControls() {
         // Given
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        api
-            .getApiDefinition()
+        var apiDefinition = ((io.gravitee.definition.model.Api) api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -417,9 +425,9 @@ class MigrateApiUseCaseTest {
     void should_return_fail_when_api_has_doc_with_AttachedResources() {
         // Given
         var api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -458,9 +466,9 @@ class MigrateApiUseCaseTest {
     void should_not_upgrade_api_in_dry_run_mode() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -494,9 +502,9 @@ class MigrateApiUseCaseTest {
     void should_upgrade_api_definition() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -538,9 +546,9 @@ class MigrateApiUseCaseTest {
     void should_upgrade_api_with_multiple_plans() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -587,9 +595,9 @@ class MigrateApiUseCaseTest {
     void should_upgrade_api_with_closed_plans_but_not_upgrade_closed_plan() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -628,9 +636,9 @@ class MigrateApiUseCaseTest {
     void should_upgrade_api_with_no_plans() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -658,9 +666,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_and_plan_flows() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -700,16 +708,16 @@ class MigrateApiUseCaseTest {
     void should_return_issue_when_migrating_flow_with_incompatible_policy() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
 
         apiCrudService.initWith(List.of(v2Api));
 
-        var step = new io.gravitee.definition.model.flow.Step();
+        var step = new Step();
         step.setPolicy("cloud-events");
         var apiFlow = new io.gravitee.definition.model.flow.Flow();
         apiFlow.setPre(List.of(step));
@@ -729,16 +737,16 @@ class MigrateApiUseCaseTest {
     void should_return_issue_when_migrating_flow_with_unknown_policy() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
         apiCrudService.initWith(List.of(v2Api));
 
         var apiFlow = new io.gravitee.definition.model.flow.Flow();
-        var step = new io.gravitee.definition.model.flow.Step();
+        var step = new Step();
         step.setPolicy("unknown-policy");
         apiFlow.setPre(List.of(step));
         flowCrudService.saveApiFlowsV2(API_ID, List.of(apiFlow));
@@ -757,7 +765,8 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_with_properties() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        var apiDefinition = ((io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
 
         var properties = new Properties(
             List.of(
@@ -766,9 +775,8 @@ class MigrateApiUseCaseTest {
                 new Property("key3", "value3", false, true)
             )
         );
-        v2Api.getApiDefinition().setProperties(properties);
-        v2Api
-            .getApiDefinition()
+        apiDefinition.setProperties(properties);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -792,9 +800,9 @@ class MigrateApiUseCaseTest {
 
         var upgradedApiOpt = apiCrudService.findById(API_ID);
         assertThat(upgradedApiOpt).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            io.gravitee.definition.model.v4.Api upgradedApiDefinition = assertApiV4(api);
 
-            var migratedProperties = api.getApiDefinitionHttpV4().getProperties();
+            var migratedProperties = upgradedApiDefinition.getProperties();
 
             assertThat(migratedProperties).containsExactlyInAnyOrder(
                 new io.gravitee.definition.model.v4.property.Property("key1", "value1", false, false),
@@ -807,16 +815,16 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_null_dp_and_disable_dynamicProps() {
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        var apiDefinition = ((io.gravitee.definition.model.Api) v2api.getApiDefinitionValue());
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
         Services services = new Services();
-        v2api.getApiDefinition().setServices(services);
-        v2api
-            .getApiDefinition()
+        apiDefinition.setServices(services);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -827,12 +835,10 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
-
-            var migratedServices = api.getApiDefinitionHttpV4().getServices();
+            var migratedServices = assertApiV4(api);
 
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().getServices().getDynamicProperty()).isNull();
+                softly.assertThat(migratedServices.getServices().getDynamicProperty()).isNull();
             });
         });
     }
@@ -840,9 +846,9 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_valid_dynamicprops_and_enable_dynamicprops() {
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -860,8 +866,8 @@ class MigrateApiUseCaseTest {
         dynamicPropertyService.setConfiguration(httpDynamicPropertyProviderConfiguration);
         Services services = new Services();
         services.setDynamicPropertyService(dynamicPropertyService);
-        v2api.getApiDefinition().setServices(services);
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiDefinition.setServices(services);
+        apiCrudService.initWith(List.of(v2api));
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -872,12 +878,12 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var upgradedDefinition = assertApiV4(api);
 
-            var migratedDP = api.getApiDefinitionHttpV4().getServices().getDynamicProperty();
+            var migratedDP = upgradedDefinition.getServices().getDynamicProperty();
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().getServices().getDynamicProperty()).isNotNull();
-                softly.assertThat(api.getApiDefinitionHttpV4().getServices().getDynamicProperty().isEnabled()).isTrue();
+                softly.assertThat(upgradedDefinition.getServices().getDynamicProperty()).isNotNull();
+                softly.assertThat(upgradedDefinition.getServices().getDynamicProperty().isEnabled()).isTrue();
                 softly.assertThat(migratedDP).isNotNull();
                 softly.assertThat(migratedDP.isEnabled()).isTrue();
                 softly
@@ -892,15 +898,15 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_null_failover_and_disable_failover() {
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api.getApiDefinition().getProxy().setFailover(null);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.getProxy().setFailover(null);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -911,12 +917,12 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var upgradedDefinition = assertApiV4(api);
 
-            var migratedFailOver = api.getApiDefinitionHttpV4().getFailover();
+            var migratedFailOver = upgradedDefinition.getFailover();
 
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().failoverEnabled()).isFalse();
+                softly.assertThat(upgradedDefinition.failoverEnabled()).isFalse();
                 softly.assertThat(migratedFailOver).isNull();
             });
         });
@@ -925,9 +931,9 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_valid_failover_and_enable_failover() {
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -936,8 +942,8 @@ class MigrateApiUseCaseTest {
         failover.setMaxAttempts(5);
         failover.setRetryTimeout(1000L);
 
-        v2api.getApiDefinition().getProxy().setFailover(failover);
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiDefinition.getProxy().setFailover(failover);
+        apiCrudService.initWith(List.of(v2api));
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -948,12 +954,12 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var upgradedDefinition = assertApiV4(api);
 
-            var migratedFailOver = api.getApiDefinitionHttpV4().getFailover();
+            var migratedFailOver = upgradedDefinition.getFailover();
 
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().failoverEnabled()).isTrue();
+                softly.assertThat(upgradedDefinition.failoverEnabled()).isTrue();
                 softly.assertThat(migratedFailOver).isNotNull();
                 softly.assertThat(migratedFailOver.isEnabled()).isTrue();
                 softly.assertThat(migratedFailOver.getMaxFailures()).isEqualTo(5);
@@ -968,9 +974,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_with_hc_in_endpointgroups() {
         // Given
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -984,7 +990,7 @@ class MigrateApiUseCaseTest {
         step.setRequest(request);
         // Configure the expected response
         HealthCheckResponse response = new HealthCheckResponse();
-        response.setAssertions(java.util.List.of("#status == 200"));
+        response.setAssertions(List.of("#status == 200"));
         step.setResponse(response);
         HealthCheckService healthCheckService = HealthCheckService.builder()
             .enabled(true) // comes from ScheduledService (superclass)
@@ -993,9 +999,9 @@ class MigrateApiUseCaseTest {
             .build();
         Services services = new Services();
         services.setHealthCheckService(healthCheckService);
-        v2api.getApiDefinition().setServices(services);
+        apiDefinition.setServices(services);
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -1006,11 +1012,11 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var upgradedDefinition = assertApiV4(api);
 
-            var migratedEndpointGroup = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var migratedEndpointGroup = upgradedDefinition.getEndpointGroups();
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+                softly.assertThat(upgradedDefinition.getEndpointGroups()).hasSize(1);
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck()).isNotNull();
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck().isEnabled()).isTrue();
                 softly
@@ -1026,9 +1032,9 @@ class MigrateApiUseCaseTest {
     void should_not_migrate_api_with_hc_more_than_one_Assertion_in_endpointgroups() {
         // Given
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1042,7 +1048,7 @@ class MigrateApiUseCaseTest {
         step.setRequest(request);
         // Configure the expected response
         HealthCheckResponse response = new HealthCheckResponse();
-        response.setAssertions(java.util.List.of("status == 200", "status == 201"));
+        response.setAssertions(List.of("status == 200", "status == 201"));
         step.setResponse(response);
         HealthCheckService healthCheckService = HealthCheckService.builder()
             .enabled(true) // comes from ScheduledService (superclass)
@@ -1051,9 +1057,9 @@ class MigrateApiUseCaseTest {
             .build();
         Services services = new Services();
         services.setHealthCheckService(healthCheckService);
-        v2api.getApiDefinition().setServices(services);
+        apiDefinition.setServices(services);
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -1065,9 +1071,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_endpoints_api_with_hc_in_endpointgroups() {
         // Given
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api
-            .getApiDefinition()
+        io.gravitee.definition.model.Api apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1081,7 +1087,7 @@ class MigrateApiUseCaseTest {
         step.setRequest(request);
         // Configure the expected response
         HealthCheckResponse response = new HealthCheckResponse();
-        response.setAssertions(java.util.List.of("status == 200"));
+        response.setAssertions(List.of("status == 200"));
         step.setResponse(response);
         HealthCheckService healthCheckService = EndpointHealthCheckService.builder()
             .enabled(true) // comes from ScheduledService (superclass)
@@ -1090,9 +1096,8 @@ class MigrateApiUseCaseTest {
             .build();
         Services services = new Services();
         services.setHealthCheckService(healthCheckService);
-        v2api.getApiDefinition().setServices(services);
-        v2api
-            .getApiDefinition()
+        apiDefinition.setServices(services);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group ->
@@ -1108,7 +1113,7 @@ class MigrateApiUseCaseTest {
                     })
             );
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -1119,12 +1124,12 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var migratedApi = assertApiV4(api);
 
-            var migratedEndpointGroup = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var migratedEndpointGroup = migratedApi.getEndpointGroups();
             var migratedEndpoint = migratedEndpointGroup.getFirst().getEndpoints().getFirst();
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+                softly.assertThat(migratedApi.getEndpointGroups()).hasSize(1);
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck()).isNotNull();
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck().isEnabled()).isTrue();
                 softly
@@ -1145,7 +1150,8 @@ class MigrateApiUseCaseTest {
     void should_migrate_endpoints_with_different_hc_than_in_endpointgroups() {
         // Given
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
 
         HealthCheckStep step1 = new HealthCheckStep();
         step1.setName("hc-step");
@@ -1155,7 +1161,7 @@ class MigrateApiUseCaseTest {
         request1.setMethod(HttpMethod.POST);
         step1.setRequest(request1);
         HealthCheckResponse response1 = new HealthCheckResponse();
-        response1.setAssertions(java.util.List.of("{#status == 200}"));
+        response1.setAssertions(List.of("{#status == 200}"));
         step1.setResponse(response1);
 
         HealthCheckStep step2 = new HealthCheckStep();
@@ -1168,7 +1174,7 @@ class MigrateApiUseCaseTest {
         // Configure the expected response
 
         HealthCheckResponse response2 = new HealthCheckResponse();
-        response2.setAssertions(java.util.List.of("{#status == 202}"));
+        response2.setAssertions(List.of("{#status == 202}"));
         step2.setResponse(response2);
         HealthCheckService healthCheckService = HealthCheckService.builder()
             .enabled(true) // comes from ScheduledService (superclass)
@@ -1178,9 +1184,8 @@ class MigrateApiUseCaseTest {
 
         Services services1 = new Services();
         services1.setHealthCheckService(healthCheckService);
-        v2api.getApiDefinition().setServices(services1);
-        v2api
-            .getApiDefinition()
+        apiDefinition.setServices(services1);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> {
@@ -1202,7 +1207,7 @@ class MigrateApiUseCaseTest {
                     });
             });
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
 
@@ -1213,12 +1218,12 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var migratedDefinition = assertApiV4(api);
 
-            var migratedEndpointGroup = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var migratedEndpointGroup = migratedDefinition.getEndpointGroups();
             var migratedEndpoint = migratedEndpointGroup.getFirst().getEndpoints().getFirst();
             assertSoftly(softly -> {
-                softly.assertThat(api.getApiDefinitionHttpV4().getEndpointGroups()).hasSize(1);
+                softly.assertThat(migratedDefinition.getEndpointGroups()).hasSize(1);
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck()).isNotNull();
                 softly.assertThat(migratedEndpointGroup.getFirst().getServices().getHealthCheck().isEnabled()).isTrue();
                 softly
@@ -1238,22 +1243,22 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_logging_configuration() {
         // Given
-        var logging = new io.gravitee.definition.model.Logging();
-        logging.setMode(io.gravitee.definition.model.LoggingMode.CLIENT_PROXY);
-        logging.setContent(io.gravitee.definition.model.LoggingContent.HEADERS_PAYLOADS);
-        logging.setScope(io.gravitee.definition.model.LoggingScope.REQUEST_RESPONSE);
+        var logging = new Logging();
+        logging.setMode(LoggingMode.CLIENT_PROXY);
+        logging.setContent(LoggingContent.HEADERS_PAYLOADS);
+        logging.setScope(LoggingScope.REQUEST_RESPONSE);
         logging.setCondition("my-condition");
 
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api.getApiDefinition().getProxy().setLogging(logging);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.getProxy().setLogging(logging);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
 
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
@@ -1265,9 +1270,9 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var migratedApi = assertApiV4(api);
 
-            var migratedAnalytics = api.getApiDefinitionHttpV4().getAnalytics();
+            var migratedAnalytics = migratedApi.getAnalytics();
 
             assertSoftly(softly -> {
                 softly.assertThat(migratedAnalytics.isEnabled()).isTrue();
@@ -1289,18 +1294,18 @@ class MigrateApiUseCaseTest {
     @Test
     void should_enable_analytics_and_null_logging_when_v2_logging_is_never_set() {
         // Given
-        var logging = new io.gravitee.definition.model.Logging();
-        logging.setMode(io.gravitee.definition.model.LoggingMode.NONE);
+        var logging = new Logging();
+        logging.setMode(LoggingMode.NONE);
 
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api.getApiDefinition().getProxy().setLogging(logging);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.getProxy().setLogging(logging);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
@@ -1312,9 +1317,9 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var migratedApi = assertApiV4(api);
 
-            var migratedAnalytics = api.getApiDefinitionHttpV4().getAnalytics();
+            var migratedAnalytics = migratedApi.getAnalytics();
             assertThat(migratedAnalytics.isEnabled()).isTrue();
             assertThat(migratedAnalytics.getLogging()).isNull();
         });
@@ -1324,14 +1329,14 @@ class MigrateApiUseCaseTest {
     void should_enable_analytics_and_null_logging_when_v2_logging_disabled() {
         // Given
         var v2api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).definitionVersion(DefinitionVersion.V2).build();
-        v2api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2api.getApiDefinition().getProxy().setLogging(null);
-        v2api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.getProxy().setLogging(null);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
-        apiCrudService.initWith(java.util.List.of(v2api));
+        apiCrudService.initWith(List.of(v2api));
 
         // When
         var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, FORCE, AUDIT_INFO));
@@ -1343,9 +1348,9 @@ class MigrateApiUseCaseTest {
         var migrated = apiCrudService.findById(API_ID);
 
         assertThat(migrated).hasValueSatisfying(api -> {
-            assertApiV4(api);
+            var migratedApi = assertApiV4(api);
 
-            var migratedAnalytics = api.getApiDefinitionHttpV4().getAnalytics();
+            var migratedAnalytics = migratedApi.getAnalytics();
             assertThat(migratedAnalytics.isEnabled()).isTrue();
             assertThat(migratedAnalytics.getLogging()).isNull();
         });
@@ -1355,10 +1360,10 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_with_best_match_flow_mode() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api.getApiDefinition().setFlowMode(io.gravitee.definition.model.FlowMode.BEST_MATCH);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.setFlowMode(io.gravitee.definition.model.FlowMode.BEST_MATCH);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1379,8 +1384,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var migratedDefinition = api.getApiDefinitionHttpV4().getFlowExecution().getMode();
+            var migratedDefinition = assertApiV4(api).getFlowExecution().getMode();
             assertThat(migratedDefinition).isEqualTo(FlowMode.BEST_MATCH);
         });
     }
@@ -1395,10 +1399,10 @@ class MigrateApiUseCaseTest {
         resource.setEnabled(true);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api.getApiDefinition().setResources(List.of(resource));
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.setResources(List.of(resource));
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1419,8 +1423,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var migratedResources = api.getApiDefinitionHttpV4().getResources();
+            var migratedResources = assertApiV4(api).getResources();
             assertThat(migratedResources).map(Resource::getName).containsExactly("cache-resource");
         });
     }
@@ -1429,10 +1432,10 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_with_empty_resources() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api.getApiDefinition().setResources(List.of());
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.setResources(List.of());
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1453,8 +1456,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var migratedResources = api.getApiDefinitionHttpV4().getResources();
+            var migratedResources = assertApiV4(api).getResources();
             assertThat(migratedResources).isEmpty();
         });
     }
@@ -1463,10 +1465,10 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_with_null_resources() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api.getApiDefinition().setResources(null);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition.setResources(null);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1487,8 +1489,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var migratedResources = api.getApiDefinitionHttpV4().getResources();
+            var migratedResources = assertApiV4(api).getResources();
             assertThat(migratedResources).isEmpty();
         });
     }
@@ -1497,9 +1498,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_api_without_discovery_service() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -1520,8 +1521,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var endpointGroups = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var endpointGroups = assertApiV4(api).getEndpointGroups();
             assertThat(endpointGroups).map(EndpointGroup::getServices).map(EndpointGroupServices::getDiscovery).singleElement().isNull();
         });
     }
@@ -1529,18 +1529,18 @@ class MigrateApiUseCaseTest {
     @Test
     void should_warn_about_migration_with_consul_discovery_service_on_dry_run() {
         // Given
-        var consulDiscoveryService = new io.gravitee.definition.model.services.discovery.EndpointDiscoveryService();
+        var consulDiscoveryService = new EndpointDiscoveryService();
         consulDiscoveryService.setEnabled(true);
         consulDiscoveryService.setProvider("consul-service-discovery");
         consulDiscoveryService.setConfiguration("{\"url\":\"http://localhost:8500\",\"service\":\"my-service\",\"dc\":\"dc1\"}");
 
-        var services = new io.gravitee.definition.model.services.Services();
+        var services = new Services();
         services.setDiscoveryService(consulDiscoveryService);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> {
@@ -1566,18 +1566,18 @@ class MigrateApiUseCaseTest {
     @Test
     void should_forced_migrate_api_with_consul_discovery_service() {
         // Given
-        var consulDiscoveryService = new io.gravitee.definition.model.services.discovery.EndpointDiscoveryService();
+        var consulDiscoveryService = new EndpointDiscoveryService();
         consulDiscoveryService.setEnabled(true);
         consulDiscoveryService.setProvider("consul-service-discovery");
         consulDiscoveryService.setConfiguration("{\"url\":\"http://localhost:8500\",\"service\":\"my-service\",\"dc\":\"dc1\"}");
 
-        var services = new io.gravitee.definition.model.services.Services();
+        var services = new Services();
         services.setDiscoveryService(consulDiscoveryService);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> {
@@ -1601,8 +1601,7 @@ class MigrateApiUseCaseTest {
         var migratedApi = apiCrudService.findById(API_ID);
 
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var endpointGroups = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var endpointGroups = assertApiV4(api).getEndpointGroups();
             assertThat(endpointGroups).hasSize(1);
             var migratedServices = endpointGroups.getFirst().getServices();
             assertThat(migratedServices.getDiscovery().getType()).isEqualTo("consul-service-discovery");
@@ -1616,18 +1615,18 @@ class MigrateApiUseCaseTest {
     @Test
     void should_fail_migration_with_forbidden_discovery_service() {
         // Given
-        var forbiddenDiscoveryService = new io.gravitee.definition.model.services.discovery.EndpointDiscoveryService();
+        var forbiddenDiscoveryService = new EndpointDiscoveryService();
         forbiddenDiscoveryService.setEnabled(true);
         forbiddenDiscoveryService.setProvider("kubernetes-service-discovery");
         forbiddenDiscoveryService.setConfiguration("{\"url\":\"http://localhost:8080\",\"service\":\"my-service\"}");
 
-        var services = new io.gravitee.definition.model.services.Services();
+        var services = new Services();
         services.setDiscoveryService(forbiddenDiscoveryService);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> {
@@ -1657,8 +1656,8 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_http11_endpoint_configuration() {
         // Given
-        var httpClientOptions = new io.gravitee.definition.model.HttpClientOptions();
-        httpClientOptions.setVersion(io.gravitee.definition.model.ProtocolVersion.HTTP_1_1);
+        var httpClientOptions = new HttpClientOptions();
+        httpClientOptions.setVersion(ProtocolVersion.HTTP_1_1);
         httpClientOptions.setKeepAlive(true);
         httpClientOptions.setKeepAliveTimeout(30000);
         httpClientOptions.setConnectTimeout(5000);
@@ -1672,9 +1671,9 @@ class MigrateApiUseCaseTest {
         httpClientOptions.setMaxConcurrentConnections(100);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group -> {
@@ -1701,8 +1700,7 @@ class MigrateApiUseCaseTest {
 
         var migratedApi = apiCrudService.findById(API_ID);
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var endpointGroups = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var endpointGroups = assertApiV4(api).getEndpointGroups();
 
             assertThat(endpointGroups)
                 .map(AbstractEndpointGroup::getSharedConfiguration)
@@ -1729,8 +1727,8 @@ class MigrateApiUseCaseTest {
     @Test
     void should_migrate_api_with_http2_endpoint_configuration() {
         // Given
-        var httpClientOptions = new io.gravitee.definition.model.HttpClientOptions();
-        httpClientOptions.setVersion(io.gravitee.definition.model.ProtocolVersion.HTTP_2);
+        var httpClientOptions = new HttpClientOptions();
+        httpClientOptions.setVersion(ProtocolVersion.HTTP_2);
         httpClientOptions.setKeepAlive(true);
         httpClientOptions.setKeepAliveTimeout(30000);
         httpClientOptions.setConnectTimeout(5000);
@@ -1745,10 +1743,8 @@ class MigrateApiUseCaseTest {
         httpClientOptions.setClearTextUpgrade(true);
 
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
-            .getProxy()
+        ((io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue()).setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        ((io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue()).getProxy()
             .getGroups()
             .forEach(group -> {
                 group.setHttpClientOptions(httpClientOptions);
@@ -1774,8 +1770,7 @@ class MigrateApiUseCaseTest {
 
         var migratedApi = apiCrudService.findById(API_ID);
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            assertApiV4(api);
-            var endpointGroups = api.getApiDefinitionHttpV4().getEndpointGroups();
+            var endpointGroups = assertApiV4(api).getEndpointGroups();
 
             // Verify HTTP 2 configuration contains all required fields
             assertThat(endpointGroups)
@@ -1804,9 +1799,9 @@ class MigrateApiUseCaseTest {
     void should_migrate_endpoint_shared_configuration_override_filtering_extraneous_http_fields() {
         // Given
         var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-        v2Api
-            .getApiDefinition()
+        var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+        apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        apiDefinition
             .getProxy()
             .getGroups()
             .forEach(group ->
@@ -1840,8 +1835,8 @@ class MigrateApiUseCaseTest {
 
         var migratedApi = apiCrudService.findById(API_ID);
         assertThat(migratedApi).hasValueSatisfying(api -> {
-            var endpoints = api
-                .getApiDefinitionHttpV4()
+            var migratedDefinition = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+            var endpoints = migratedDefinition
                 .getEndpointGroups()
                 .stream()
                 .flatMap(g -> g.getEndpoints().stream())
@@ -1877,9 +1872,9 @@ class MigrateApiUseCaseTest {
             @BeforeEach
             void setUp() {
                 var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
-                v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
-                v2Api
-                    .getApiDefinition()
+                var apiDefinition = (io.gravitee.definition.model.Api) v2Api.getApiDefinitionValue();
+                apiDefinition.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+                apiDefinition
                     .getProxy()
                     .getGroups()
                     .forEach(group -> group.getEndpoints().forEach(e -> e.setInherit(false)));
@@ -2013,7 +2008,7 @@ class MigrateApiUseCaseTest {
         }
     }
 
-    private static void assertApiV4(Api upgradedApi) {
+    private static io.gravitee.definition.model.v4.Api assertApiV4(Api upgradedApi) {
         assertSoftly(softly -> {
             softly.assertThat(upgradedApi.getId()).as("id").isEqualTo(API_ID);
             softly.assertThat(upgradedApi.getName()).as("name").isEqualTo("My Api");
@@ -2021,12 +2016,9 @@ class MigrateApiUseCaseTest {
             softly.assertThat(upgradedApi.getCrossId()).as("cross id").isEqualTo("my-api-crossId");
             softly.assertThat(upgradedApi.getDescription()).as("description").isEqualTo("api-description");
             softly.assertThat(upgradedApi.getVersion()).as("version").isEqualTo("1.0.0");
-            softly
-                .assertThat(upgradedApi.getOriginContext())
-                .as("origin context")
-                .isEqualTo(new io.gravitee.rest.api.model.context.OriginContext.Management());
+            softly.assertThat(upgradedApi.getOriginContext()).as("origin context").isEqualTo(new OriginContext.Management());
             softly.assertThat(upgradedApi.getDefinitionVersion()).as("definition version").isEqualTo(DefinitionVersion.V4);
-            softly.assertThat(upgradedApi.getType()).as("type").isEqualTo(io.gravitee.definition.model.v4.ApiType.PROXY);
+            softly.assertThat(upgradedApi.getType()).as("type").isEqualTo(ApiType.PROXY);
             softly.assertThat(upgradedApi.getVisibility()).as("visibility").isEqualTo(Api.Visibility.PUBLIC);
             softly.assertThat(upgradedApi.getApiLifecycleState()).as("api lifecycle state").isEqualTo(Api.ApiLifecycleState.PUBLISHED);
             softly.assertThat(upgradedApi.getPicture()).as("picture").isEqualTo("api-picture");
@@ -2036,6 +2028,7 @@ class MigrateApiUseCaseTest {
             softly.assertThat(upgradedApi.getLabels()).as("labels").containsOnly("label-1");
             softly.assertThat(upgradedApi.isDisableMembershipNotifications()).as("disable membership notifications").isTrue();
         });
+        return ((io.gravitee.definition.model.v4.Api) upgradedApi.getApiDefinitionValue());
     }
 
     private static void assertPlanV4(Plan upgradedPlan) {
@@ -2045,18 +2038,15 @@ class MigrateApiUseCaseTest {
             softly.assertThat(upgradedPlan.getApiId()).as("plan api id").isEqualTo(API_ID);
             softly.assertThat(upgradedPlan.getCrossId()).as("plan cross id").isNotBlank();
             softly.assertThat(upgradedPlan.getOrder()).as("plan order").isEqualTo(1);
-            softly.assertThat(upgradedPlan.getType()).as("plan type").isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanType.API);
-            softly
-                .assertThat(upgradedPlan.getValidation())
-                .as("plan validation")
-                .isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanValidationType.AUTO);
+            softly.assertThat(upgradedPlan.getType()).as("plan type").isEqualTo(Plan.PlanType.API);
+            softly.assertThat(upgradedPlan.getValidation()).as("plan validation").isEqualTo(Plan.PlanValidationType.AUTO);
             softly.assertThat(upgradedPlan.getDefinitionVersion()).as("plan definition version").isEqualTo(DefinitionVersion.V4);
-            softly.assertThat(upgradedPlan.getApiType()).as("plan api type").isEqualTo(io.gravitee.definition.model.v4.ApiType.PROXY);
+            softly.assertThat(upgradedPlan.getApiType()).as("plan api type").isEqualTo(ApiType.PROXY);
             softly.assertThat(upgradedPlan.getPlanDefinitionV2()).as("plan v2 definition").isNull();
             softly.assertThat(upgradedPlan.getPlanDefinitionHttpV4()).as("plan v4 definition").isNotNull();
             softly.assertThat(upgradedPlan.getPlanDefinitionHttpV4().getSecurity()).as("plan v4 security").isNotNull();
             softly.assertThat(upgradedPlan.getPlanDefinitionHttpV4().getStatus()).as("plan v4 status").isNotNull();
-            softly.assertThat(upgradedPlan.getPlanMode()).as("plan mode").isEqualTo(io.gravitee.definition.model.v4.plan.PlanMode.STANDARD);
+            softly.assertThat(upgradedPlan.getPlanMode()).as("plan mode").isEqualTo(PlanMode.STANDARD);
         });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import fixtures.core.model.AuditInfoFixtures;
 import initializers.ImportDefinitionCreateDomainServiceTestInitializer;
@@ -41,6 +40,7 @@ import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.repository.management.model.Parameter;
@@ -50,6 +50,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,7 +143,7 @@ class OAIToImportApiUseCaseTest {
         // Given
         var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
         var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-        importSwaggerDescriptor.setPayload(Resources.toString(resource, Charsets.UTF_8));
+        importSwaggerDescriptor.setPayload(Resources.toString(resource, StandardCharsets.UTF_8));
 
         // When
         var output = useCase.execute(new OAIToImportApiUseCase.Input(importSwaggerDescriptor, AUDIT_INFO));
@@ -161,7 +162,7 @@ class OAIToImportApiUseCaseTest {
         // Given
         var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
         var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-        importSwaggerDescriptor.setPayload(Resources.toString(resource, Charsets.UTF_8));
+        importSwaggerDescriptor.setPayload(Resources.toString(resource, StandardCharsets.UTF_8));
 
         // When
         var output = useCase.execute(new OAIToImportApiUseCase.Input(importSwaggerDescriptor, AUDIT_INFO));
@@ -180,7 +181,7 @@ class OAIToImportApiUseCaseTest {
         // Given
         var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
         var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-        importSwaggerDescriptor.setPayload(Resources.toString(resource, Charsets.UTF_8));
+        importSwaggerDescriptor.setPayload(Resources.toString(resource, StandardCharsets.UTF_8));
 
         // When
         var output = useCase.execute(new OAIToImportApiUseCase.Input(importSwaggerDescriptor, AUDIT_INFO));
@@ -190,7 +191,7 @@ class OAIToImportApiUseCaseTest {
 
         var importDefinition = output.apiWithFlows();
         assertThat(importDefinition).isNotNull();
-        assertThat(importDefinition.getApiDefinitionHttpV4().getEndpointGroups())
+        assertThat(((Api) importDefinition.getApiDefinitionValue()).getEndpointGroups())
             .hasSize(1)
             .extracting(EndpointGroup::getSharedConfiguration)
             .containsExactly(SHARED_CONFIGURATION);
@@ -222,7 +223,7 @@ class OAIToImportApiUseCaseTest {
             // Given
             var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
             var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-            final String openApiAsString = Resources.toString(resource, Charsets.UTF_8);
+            final String openApiAsString = Resources.toString(resource, StandardCharsets.UTF_8);
             importSwaggerDescriptor.setPayload(openApiAsString);
 
             // When
@@ -249,7 +250,7 @@ class OAIToImportApiUseCaseTest {
             // Given
             var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
             var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-            final String openApiAsString = Resources.toString(resource, Charsets.UTF_8);
+            final String openApiAsString = Resources.toString(resource, StandardCharsets.UTF_8);
             importSwaggerDescriptor.setPayload(openApiAsString);
 
             // When
@@ -273,7 +274,7 @@ class OAIToImportApiUseCaseTest {
             // Given
             var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
             var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-            final String openApiAsString = Resources.toString(resource, Charsets.UTF_8);
+            final String openApiAsString = Resources.toString(resource, StandardCharsets.UTF_8);
             importSwaggerDescriptor.setPayload(openApiAsString);
             policyPluginCrudService.initWith(
                 List.of(PolicyPlugin.builder().id("oas-validation").name("OpenAPI Specification Validation").build())
@@ -294,20 +295,21 @@ class OAIToImportApiUseCaseTest {
             var importDefinition = output.apiWithFlows();
             assertThat(importDefinition).isNotNull();
             // Check that the OAS validation policy is added
-            assertThat(importDefinition.getApiDefinitionHttpV4().getFlows())
+            Api apiDefinitionHttpV4 = ((Api) importDefinition.getApiDefinitionValue());
+            assertThat(apiDefinitionHttpV4.getFlows())
                 .first()
                 .satisfies(flow -> {
                     assertThat(flow.getName()).isEqualTo("OpenAPI Specification Validation");
                     assertThat(flow.getRequest()).isNotNull();
-                    assertThat(((HttpSelector) flow.getSelectors().get(0)).getPath()).isEqualTo("/");
-                    assertThat(((HttpSelector) flow.getSelectors().get(0)).getPathOperator()).isEqualTo(Operator.STARTS_WITH);
-                    var oasValidationStep = flow.getRequest().get(0);
+                    assertThat(((HttpSelector) flow.getSelectors().getFirst()).getPath()).isEqualTo("/");
+                    assertThat(((HttpSelector) flow.getSelectors().getFirst()).getPathOperator()).isEqualTo(Operator.STARTS_WITH);
+                    var oasValidationStep = flow.getRequest().getFirst();
                     assertThat(oasValidationStep.getPolicy()).isEqualTo("oas-validation");
                     assertThat(oasValidationStep.getConfiguration()).isEqualTo("{\"resourceName\":\"OpenAPI Specification\"}");
                 });
 
             // Check that the Resource is added
-            assertThat(importDefinition.getApiDefinitionHttpV4().getResources())
+            assertThat(apiDefinitionHttpV4.getResources())
                 .hasSize(1)
                 .first()
                 .satisfies(resource1 -> {
@@ -323,7 +325,7 @@ class OAIToImportApiUseCaseTest {
             // Given
             var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
             var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-            final String openApiAsString = Resources.toString(resource, Charsets.UTF_8);
+            final String openApiAsString = Resources.toString(resource, StandardCharsets.UTF_8);
             importSwaggerDescriptor.setPayload(openApiAsString);
 
             // When
@@ -349,7 +351,7 @@ class OAIToImportApiUseCaseTest {
             // Given
             var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
             var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
-            final String openApiAsString = Resources.toString(resource, Charsets.UTF_8);
+            final String openApiAsString = Resources.toString(resource, StandardCharsets.UTF_8);
             importSwaggerDescriptor.setPayload(openApiAsString);
 
             // When
@@ -367,11 +369,10 @@ class OAIToImportApiUseCaseTest {
             var importDefinition = output.apiWithFlows();
             assertThat(importDefinition).isNotNull();
             // Check that the OAS validation policy is not added
-            assertThat(importDefinition.getApiDefinitionHttpV4().getFlows()).noneMatch(flow ->
-                flow.getName().equals("OpenAPI Specification Validation")
-            );
+            Api apiDefinition = ((Api) importDefinition.getApiDefinitionValue());
+            assertThat(apiDefinition.getFlows()).noneMatch(flow -> flow.getName().equals("OpenAPI Specification Validation"));
             // Check that the Resource is not added
-            assertThat(importDefinition.getApiDefinitionHttpV4().getResources()).isEmpty();
+            assertThat(apiDefinition.getResources()).isEmpty();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
@@ -71,9 +71,15 @@ import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.*;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
@@ -326,8 +332,8 @@ class RollbackApiUseCaseTest {
             .apiVersion("api-previous-version")
             .listeners(
                 List.of(
-                    io.gravitee.definition.model.v4.listener.http.HttpListener.builder()
-                        .paths(List.of(io.gravitee.definition.model.v4.listener.http.Path.builder().path("/api-previous-path").build()))
+                    HttpListener.builder()
+                        .paths(List.of(Path.builder().path("/api-previous-path").build()))
                         .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
                         .build()
                 )
@@ -336,13 +342,13 @@ class RollbackApiUseCaseTest {
             .build();
 
         // Api repository contained in the Event payload
-        var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+        var apiRepositoryModel = Api.builder()
             .id(eventApiDefinition.getId())
             .name(eventApiDefinition.getName())
             .version(eventApiDefinition.getApiVersion())
             .definitionVersion(eventApiDefinition.getDefinitionVersion())
             .description("api-previous-api-description")
-            .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+            .visibility(Visibility.PUBLIC)
             .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(eventApiDefinition))
             .build();
 
@@ -389,11 +395,9 @@ class RollbackApiUseCaseTest {
                 assertThat(updateApiEntity.getListeners().getFirst().getEntrypoints().getFirst()).isEqualTo(
                     Entrypoint.builder().type("http-proxy").configuration("{}").build()
                 );
-                assertThat(
-                    ((io.gravitee.definition.model.v4.listener.http.HttpListener) updateApiEntity.getListeners().getFirst()).getPaths()
-                        .getFirst()
-                        .getPath()
-                ).isEqualTo("/api-previous-path");
+                assertThat(((HttpListener) updateApiEntity.getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                    "/api-previous-path"
+                );
                 assertThat(updateApiEntity.getFlows()).map(AbstractFlow::getName).first().isEqualTo("api-previous-flow-name");
 
                 // Not rollbacked
@@ -522,7 +526,7 @@ class RollbackApiUseCaseTest {
                         .flows(List.of(io.gravitee.definition.model.v4.flow.Flow.builder().name("flow-name").build()))
                         .tags(Set.of("tag"))
                         .selectionRule("selection-rule")
-                        .security(io.gravitee.definition.model.v4.plan.PlanSecurity.builder().type("KEY_LESS").build())
+                        .security(PlanSecurity.builder().type("KEY_LESS").build())
                         .build(),
                     "plan-to-update",
                     io.gravitee.definition.model.v4.plan.Plan.builder()
@@ -542,7 +546,7 @@ class RollbackApiUseCaseTest {
             .build();
 
         // Api repository contained in the Event payload
-        var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+        var apiRepositoryModel = Api.builder()
             .id(eventApiDefinition.getId())
             .name(eventApiDefinition.getName())
             .version(eventApiDefinition.getApiVersion())
@@ -661,18 +665,18 @@ class RollbackApiUseCaseTest {
             failOverV2.setMaxAttempts(5);
             failOverV2.setRetryTimeout(1000);
 
-            var resource = new io.gravitee.definition.model.plugins.resources.Resource();
+            var resource = new Resource();
             resource.setName("cache-resource");
             resource.setType("cache");
             resource.setConfiguration("{\"timeToLiveSeconds\": 3600}");
             resource.setEnabled(true);
 
-            var consulDiscoveryService = new io.gravitee.definition.model.services.discovery.EndpointDiscoveryService();
+            var consulDiscoveryService = new EndpointDiscoveryService();
             consulDiscoveryService.setEnabled(true);
             consulDiscoveryService.setProvider("consul-service-discovery");
             consulDiscoveryService.setConfiguration("{\"url\":\"http://localhost:8500\",\"service\":\"my-service\",\"dc\":\"dc1\"}");
 
-            var services = new io.gravitee.definition.model.services.Services();
+            var services = new Services();
             services.setDiscoveryService(consulDiscoveryService);
 
             var eventV2ApiDefinition = io.gravitee.definition.model.Api.builder()
@@ -681,8 +685,8 @@ class RollbackApiUseCaseTest {
                 .version("api-previous-version")
                 .definitionVersion(DefinitionVersion.V2)
                 .proxy(
-                    io.gravitee.definition.model.Proxy.builder()
-                        .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/api-previous-path")))
+                    Proxy.builder()
+                        .virtualHosts(List.of(new VirtualHost("/api-previous-path")))
                         .groups(
                             Set.of(
                                 EndpointGroup.builder()
@@ -711,12 +715,12 @@ class RollbackApiUseCaseTest {
                 .flowMode(FlowMode.BEST_MATCH)
                 .build();
 
-            var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+            var apiRepositoryModel = Api.builder()
                 .id(eventV2ApiDefinition.getId())
                 .name(eventV2ApiDefinition.getName())
                 .version(eventV2ApiDefinition.getVersion())
                 .definitionVersion(DefinitionVersion.V2)
-                .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+                .visibility(Visibility.PUBLIC)
                 .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(eventV2ApiDefinition))
                 .build();
 
@@ -740,7 +744,7 @@ class RollbackApiUseCaseTest {
                 softly.assertThat(rolledBackApi.getUpdatedAt()).isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()));
             });
 
-            var apiDefinition = rolledBackApi.getApiDefinition();
+            var apiDefinition = ((io.gravitee.definition.model.Api) rolledBackApi.getApiDefinitionValue());
             assertSoftly(softly -> {
                 softly.assertThat(apiDefinition.getName()).isEqualTo("api-previous-name");
                 softly.assertThat(apiDefinition.getVersion()).isEqualTo("api-previous-version");
@@ -755,7 +759,7 @@ class RollbackApiUseCaseTest {
                 softly.assertThat(apiDefinition.getProxy().getFailover().getRetryTimeout()).isEqualTo(1000);
                 softly.assertThat(apiDefinition.getFlowMode().name()).isEqualTo(FlowMode.BEST_MATCH.name());
 
-                var rolledBackResource = apiDefinition.getResources().get(0);
+                var rolledBackResource = apiDefinition.getResources().getFirst();
                 softly.assertThat(rolledBackResource.getName()).isEqualTo("cache-resource");
                 softly.assertThat(rolledBackResource.getType()).isEqualTo("cache");
                 softly.assertThat(rolledBackResource.getConfiguration()).isEqualTo("{\"timeToLiveSeconds\":3600}");
@@ -805,8 +809,8 @@ class RollbackApiUseCaseTest {
                 .version("api-previous-version")
                 .definitionVersion(DefinitionVersion.V2)
                 .proxy(
-                    io.gravitee.definition.model.Proxy.builder()
-                        .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/api-previous-path")))
+                    Proxy.builder()
+                        .virtualHosts(List.of(new VirtualHost("/api-previous-path")))
                         .groups(
                             Set.of(
                                 EndpointGroup.builder()
@@ -831,12 +835,12 @@ class RollbackApiUseCaseTest {
                 )
                 .build();
 
-            var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+            var apiRepositoryModel = Api.builder()
                 .id(eventV2ApiDefinition.getId())
                 .name(eventV2ApiDefinition.getName())
                 .version(eventV2ApiDefinition.getVersion())
                 .definitionVersion(DefinitionVersion.V2)
-                .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+                .visibility(Visibility.PUBLIC)
                 .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(eventV2ApiDefinition))
                 .build();
 
@@ -860,7 +864,7 @@ class RollbackApiUseCaseTest {
                 softly.assertThat(rolledBackApi.getUpdatedAt()).isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()));
             });
 
-            var apiDefinition = rolledBackApi.getApiDefinition();
+            var apiDefinition = ((io.gravitee.definition.model.Api) rolledBackApi.getApiDefinitionValue());
             assertSoftly(softly -> {
                 softly.assertThat(apiDefinition.getName()).isEqualTo("api-previous-name");
                 softly.assertThat(apiDefinition.getVersion()).isEqualTo("api-previous-version");
@@ -906,8 +910,8 @@ class RollbackApiUseCaseTest {
                 .version("api-previous-version")
                 .definitionVersion(DefinitionVersion.V2)
                 .proxy(
-                    io.gravitee.definition.model.Proxy.builder()
-                        .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/api-previous-path")))
+                    Proxy.builder()
+                        .virtualHosts(List.of(new VirtualHost("/api-previous-path")))
                         .groups(
                             Set.of(
                                 EndpointGroup.builder()
@@ -932,12 +936,12 @@ class RollbackApiUseCaseTest {
                 )
                 .build();
 
-            var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+            var apiRepositoryModel = Api.builder()
                 .id(eventV2ApiDefinition.getId())
                 .name(eventV2ApiDefinition.getName())
                 .version(eventV2ApiDefinition.getVersion())
                 .definitionVersion(DefinitionVersion.V2)
-                .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+                .visibility(Visibility.PUBLIC)
                 .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(eventV2ApiDefinition))
                 .build();
 
@@ -961,7 +965,7 @@ class RollbackApiUseCaseTest {
                 softly.assertThat(rolledBackApi.getUpdatedAt()).isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()));
             });
 
-            var apiDefinition = rolledBackApi.getApiDefinition();
+            var apiDefinition = ((io.gravitee.definition.model.Api) rolledBackApi.getApiDefinitionValue());
             assertSoftly(softly -> {
                 softly.assertThat(apiDefinition.getName()).isEqualTo("api-previous-name");
                 softly.assertThat(apiDefinition.getVersion()).isEqualTo("api-previous-version");
@@ -1086,7 +1090,7 @@ class RollbackApiUseCaseTest {
                 softly.assertThat(rolledBackApi.getUpdatedAt()).isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()));
             });
 
-            var apiDefinition = rolledBackApi.getApiDefinition();
+            var apiDefinition = ((io.gravitee.definition.model.Api) rolledBackApi.getApiDefinitionValue());
             assertSoftly(softly -> {
                 softly.assertThat(apiDefinition.getName()).isEqualTo("api-previous-name");
                 softly.assertThat(apiDefinition.getVersion()).isEqualTo("api-previous-version");
@@ -1134,8 +1138,8 @@ class RollbackApiUseCaseTest {
                 .version("api-previous-version")
                 .definitionVersion(DefinitionVersion.V2)
                 .proxy(
-                    io.gravitee.definition.model.Proxy.builder()
-                        .virtualHosts(List.of(new io.gravitee.definition.model.VirtualHost("/api-previous-path")))
+                    Proxy.builder()
+                        .virtualHosts(List.of(new VirtualHost("/api-previous-path")))
                         .groups(
                             Set.of(
                                 EndpointGroup.builder()
@@ -1148,12 +1152,12 @@ class RollbackApiUseCaseTest {
                 )
                 .build();
 
-            var apiRepositoryModel = io.gravitee.repository.management.model.Api.builder()
+            var apiRepositoryModel = Api.builder()
                 .id(eventV2ApiDefinition.getId())
                 .name(eventV2ApiDefinition.getName())
                 .version(eventV2ApiDefinition.getVersion())
                 .definitionVersion(DefinitionVersion.V2)
-                .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+                .visibility(Visibility.PUBLIC)
                 .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(eventV2ApiDefinition))
                 .build();
 
@@ -1246,7 +1250,7 @@ class RollbackApiUseCaseTest {
             .createdAt(java.util.Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
             .updatedAt(java.util.Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
             .deployedAt(java.util.Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
-            .visibility(io.gravitee.repository.management.model.Visibility.PUBLIC)
+            .visibility(Visibility.PUBLIC)
             .lifecycleState(LifecycleState.STARTED)
             .picture("my-picture")
             .groups(Set.of("group-1"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
@@ -148,7 +148,11 @@ class UpdateDynamicPropertiesUseCaseTest {
 
         var receivedProperties = new ArrayList<>();
         when(apiStateDomainService.isSynchronized(any(), any())).thenAnswer(invocationOnMock -> {
-            receivedProperties.addAll(((Api) invocationOnMock.getArgument(0)).getApiDefinitionHttpV4().getProperties().stream().toList());
+            receivedProperties.addAll(
+                ((io.gravitee.definition.model.v4.Api) ((Api) invocationOnMock.getArgument(0)).getApiDefinitionValue()).getProperties()
+                    .stream()
+                    .toList()
+            );
             return true;
         });
 
@@ -183,7 +187,9 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties()).containsExactlyInAnyOrder(
+            assertThat(
+                ((io.gravitee.definition.model.v4.Api) apiCrudServiceInMemory.get(api.getId()).getApiDefinitionValue()).getProperties()
+            ).containsExactlyInAnyOrder(
                 Property.builder().key("user-prop").value("value").dynamic(false).build(),
                 Property.builder().key("key").value("value").dynamic(true).build()
             );
@@ -206,7 +212,9 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties()).containsExactlyInAnyOrder(
+            assertThat(
+                ((io.gravitee.definition.model.v4.Api) apiCrudServiceInMemory.get(api.getId()).getApiDefinitionValue()).getProperties()
+            ).containsExactlyInAnyOrder(
                 Property.builder().key("user-prop").value("value").dynamic(false).build(),
                 Property.builder().key("key").value("value").dynamic(true).build()
             );
@@ -256,7 +264,9 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties()).containsExactlyInAnyOrder(
+            assertThat(
+                ((io.gravitee.definition.model.v4.Api) apiCrudServiceInMemory.get(api.getId()).getApiDefinitionValue()).getProperties()
+            ).containsExactlyInAnyOrder(
                 Property.builder().key("user-prop").value("value").dynamic(false).build(),
                 Property.builder().key("key").value("value").dynamic(true).build()
             );
@@ -282,7 +292,7 @@ class UpdateDynamicPropertiesUseCaseTest {
             verify(apiStateDomainService).deploy(apiCaptor.capture(), any(String.class), auditInfoCaptor.capture());
             assertSoftly(softly -> {
                 softly
-                    .assertThat(apiCaptor.getValue().getApiDefinitionHttpV4().getProperties())
+                    .assertThat(((io.gravitee.definition.model.v4.Api) apiCaptor.getValue().getApiDefinitionValue()).getProperties())
                     .containsExactlyInAnyOrder(
                         Property.builder().key("user-prop").value("value").dynamic(false).build(),
                         Property.builder().key("key").value("value").dynamic(true).build()
@@ -303,11 +313,13 @@ class UpdateDynamicPropertiesUseCaseTest {
         void should_redeploy_using_the_last_deployed_api_definition() {
             // Case were a user disable and save the API, but without deploying it
             var api = givenApi(buildApiWithProperties(List.of(Property.builder().key("user-prop").value("value").dynamic(false).build())));
-            api.getApiDefinitionHttpV4().getServices().getDynamicProperty().setEnabled(false);
+            ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()).getServices().getDynamicProperty().setEnabled(false);
 
             // Last event of the deployed api is with the service enabled
             final Api lastDeployedApi = api.toBuilder().build();
-            lastDeployedApi.getApiDefinitionHttpV4().getServices().getDynamicProperty().setEnabled(true);
+            ((io.gravitee.definition.model.v4.Api) lastDeployedApi.getApiDefinitionValue()).getServices()
+                .getDynamicProperty()
+                .setEnabled(true);
             apiEventQueryServiceInMemory.initWith(List.of(lastDeployedApi));
 
             cut.execute(
@@ -324,7 +336,7 @@ class UpdateDynamicPropertiesUseCaseTest {
 
             verify(apiStateDomainService).deploy(apiCaptor.capture(), any(String.class), auditInfoCaptor.capture());
             assertSoftly(softly -> {
-                var definition = api.getApiDefinitionHttpV4();
+                var definition = ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue());
                 softly.assertThat(definition.getServices().getDynamicProperty().isEnabled()).isTrue();
                 softly
                     .assertThat(definition.getProperties())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
@@ -276,8 +276,6 @@ class UpdateFederatedApiUseCaseTest {
         assertThat(result.getCrossId()).isEqualTo("old");
         assertThat(result.getOriginContext()).isEqualTo(new OriginContext.Integration("old"));
         assertThat(result.getDefinitionVersion()).isEqualTo(DefinitionVersion.FEDERATED);
-        assertThat(result.getApiDefinitionHttpV4()).isEqualTo(null);
-        assertThat(result.getApiDefinition()).isEqualTo(null);
         assertThat(result.getApiDefinitionValue()).isEqualTo(FederatedApi.builder().build());
         assertThat(result.getType()).isEqualTo(ApiType.PROXY);
         assertThat(result.getDeployedAt()).isEqualTo(oldDate);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
@@ -67,6 +67,7 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
@@ -292,10 +293,8 @@ public class UpdateNativeApiUseCaseTest {
             .groups(Set.of("new"))
             .disableMembershipNotifications(true)
             .allowMultiJwtOauth2Subscriptions(true)
-            .apiDefinitionNativeV4(
-                existingApi
-                    .getApiDefinitionNativeV4()
-                    .toBuilder()
+            .apiDefinitionValue(
+                ((NativeApi) existingApi.getApiDefinitionValue()).toBuilder()
                     .name("new")
                     .apiVersion("new")
                     .tags(Set.of("new"))
@@ -341,8 +340,9 @@ public class UpdateNativeApiUseCaseTest {
                 assertThat(api.isDisableMembershipNotifications()).isEqualTo(true);
                 assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isEqualTo(true);
             })
-            .extracting(Api::getApiDefinitionNativeV4)
-            .satisfies(definition -> {
+            .extracting(Api::getApiDefinitionValue)
+            .satisfies(def -> {
+                NativeApi definition = (NativeApi) def;
                 assertThat(definition.getName()).isEqualTo("new");
                 assertThat(definition.getApiVersion()).isEqualTo("new");
                 assertThat(definition.getTags()).containsExactly("new");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/VerifyApiHostsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/VerifyApiHostsUseCaseTest.java
@@ -20,9 +20,7 @@ import static fixtures.core.model.ApiFixtures.aTcpApiV4;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
-import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.exception.DuplicatedHostException;
 import io.gravitee.apim.core.api.exception.HostAlreadyExistsException;
@@ -31,7 +29,6 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
 import java.util.List;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -50,9 +47,7 @@ class VerifyApiHostsUseCaseTest {
         .id("tcp-api-uppercase-host")
         .environmentId(ENVIRONMENT_ID)
         .apiDefinitionHttpV4(
-            aTcpApiV4()
-                .getApiDefinitionHttpV4()
-                .toBuilder()
+            ((io.gravitee.definition.model.v4.Api) aTcpApiV4().getApiDefinitionValue()).toBuilder()
                 .listeners(List.of(TcpListener.builder().hosts(List.of("Tcp-API")).build()))
                 .build()
         )
@@ -121,7 +116,7 @@ class VerifyApiHostsUseCaseTest {
         var throwable = catchThrowable(() -> verifyApiHostsUseCase.execute(input));
 
         // then
-        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(InvalidHostException.class);
+        assertThat(throwable).isInstanceOf(InvalidHostException.class);
     }
 
     @Test
@@ -138,7 +133,7 @@ class VerifyApiHostsUseCaseTest {
         var throwable = catchThrowable(() -> verifyApiHostsUseCase.execute(input));
 
         // then
-        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(InvalidHostException.class);
+        assertThat(throwable).isInstanceOf(InvalidHostException.class);
     }
 
     @Test
@@ -155,7 +150,7 @@ class VerifyApiHostsUseCaseTest {
         var throwable = catchThrowable(() -> verifyApiHostsUseCase.execute(input));
 
         // then
-        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(HostAlreadyExistsException.class);
+        assertThat(throwable).isInstanceOf(HostAlreadyExistsException.class);
     }
 
     @Test
@@ -172,7 +167,7 @@ class VerifyApiHostsUseCaseTest {
         var throwable = catchThrowable(() -> verifyApiHostsUseCase.execute(input));
 
         // then
-        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(HostAlreadyExistsException.class);
+        assertThat(throwable).isInstanceOf(HostAlreadyExistsException.class);
     }
 
     @Test
@@ -189,6 +184,6 @@ class VerifyApiHostsUseCaseTest {
         var throwable = catchThrowable(() -> verifyApiHostsUseCase.execute(input));
 
         // then
-        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(DuplicatedHostException.class);
+        assertThat(throwable).isInstanceOf(DuplicatedHostException.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplateTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.documentation.model;
 
 import fixtures.core.model.ApiFixtures;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.management.model.ApiLifecycleState;
@@ -77,7 +78,7 @@ public class ApiFreemarkerTemplateTest {
             soft.assertThat(api.getName()).isEqualTo("My Api");
             soft.assertThat(api.getPicture()).isEqualTo("api-picture");
             soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
-            soft.assertThat(api.getProxy()).isEqualTo(model.getApiDefinition().getProxy());
+            soft.assertThat(api.getProxy()).isEqualTo(((Api) model.getApiDefinitionValue()).getProxy());
             soft.assertThat(api.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
             soft.assertThat(api.getDeployedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
             soft.assertThat(api.getVisibility().toString()).isEqualTo(Visibility.PUBLIC.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
@@ -1887,8 +1887,6 @@ class IngestFederatedApisUseCaseTest {
         assertThat(result.getCrossId()).isEqualTo("old");
         assertThat(result.getOriginContext()).isEqualTo(new OriginContext.Integration("old"));
         assertThat(result.getDefinitionVersion()).isEqualTo(DefinitionVersion.FEDERATED);
-        assertThat(result.getApiDefinitionHttpV4()).isNull();
-        assertThat(result.getApiDefinition()).isNull();
         assertThat(result.getType()).isEqualTo(ApiType.PROXY);
         assertThat(result.getDeployedAt()).isEqualTo(oldDate);
         assertThat(result.getCreatedAt()).isEqualTo(oldDate);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
@@ -250,7 +250,7 @@ class CreatePlanDomainServiceTest {
         void should_throw_when_plan_tags_mismatch_with_tags_defined_in_api(Api api, Plan plan, List<Flow> flows) {
             // Given: use a copy so we do not mutate the static api
             var apiWithNoTags = api.toBuilder().build();
-            apiWithNoTags.setTags(Set.of());
+            apiWithNoTags.getApiDefinitionValue().setTags(Set.of());
 
             // When
             var throwable = Assertions.catchThrowable(() -> service.create(plan, flows, apiWithNoTags, AUDIT_INFO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import assertions.CoreAssertions;
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.PlanFixtures;
 import inmemory.AuditCrudServiceInMemory;
@@ -311,7 +310,7 @@ class UpdatePlanDomainServiceTest {
             );
 
             // Then
-            CoreAssertions.assertThat(planCrudService.getById(plan.getId()))
+            assertThat(planCrudService.getById(plan.getId()))
                 .isEqualTo(result)
                 .extracting(
                     Plan::getName,
@@ -343,12 +342,12 @@ class UpdatePlanDomainServiceTest {
             );
 
             // When
-            var toUpdate = plans.get(0).toBuilder().order(2).build();
+            var toUpdate = plans.getFirst().toBuilder().order(2).build();
 
             service.update(toUpdate, List.of(), null, null, AUDIT_INFO);
 
             // Then
-            Assertions.assertThat(planCrudService.storage())
+            assertThat(planCrudService.storage())
                 .extracting(Plan::getId, Plan::getOrder)
                 .containsOnly(tuple("plan2", 1), tuple("plan1", 2), tuple("plan3", 3));
         }
@@ -381,7 +380,7 @@ class UpdatePlanDomainServiceTest {
             );
 
             // Then
-            Assertions.assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+            assertThat(throwable).isInstanceOf(ValidationDomainException.class);
         }
     }
 
@@ -417,7 +416,7 @@ class UpdatePlanDomainServiceTest {
             var result = service.update(toUpdate, flows, null, api, AUDIT_INFO);
 
             // Then
-            Assertions.assertThat(planCrudService.storage()).hasSize(1).contains(result);
+            assertThat(planCrudService.storage()).hasSize(1).contains(result);
             assertThat(result)
                 .usingRecursiveComparison(RecursiveComparisonConfiguration.builder().build())
                 .isEqualTo(toUpdate.toBuilder().updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build());
@@ -428,13 +427,13 @@ class UpdatePlanDomainServiceTest {
         void should_throw_when_a_plan_have_no_tag_matching_api_tags(Api api, Plan plan, List<Flow> flows) {
             // Given
             givenExistingPlan(plan);
-            api.getApiDefinitionHttpV4().setTags(Set.of("tag1", "tag2"));
+            api.getApiDefinitionValue().setTags(Set.of("tag1", "tag2"));
 
             // When
             var throwable = Assertions.catchThrowable(() -> service.update(plan.setPlanTags(Set.of("tag3")), flows, null, api, AUDIT_INFO));
 
             // Then
-            Assertions.assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+            assertThat(throwable).isInstanceOf(ValidationDomainException.class);
         }
 
         @ParameterizedTest
@@ -546,7 +545,7 @@ class UpdatePlanDomainServiceTest {
             var throwable = Assertions.catchThrowable(() -> service.update(plan, flows, null, api, AUDIT_INFO));
 
             // Then
-            Assertions.assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+            assertThat(throwable).isInstanceOf(ValidationDomainException.class);
         }
 
         @ParameterizedTest
@@ -625,11 +624,11 @@ class UpdatePlanDomainServiceTest {
             );
 
             // When
-            var toUpdate = plans.get(0).toBuilder().order(2).build();
+            var toUpdate = plans.getFirst().toBuilder().order(2).build();
             service.update(toUpdate, List.of(), null, API_PROXY_V4, AUDIT_INFO);
 
             // Then
-            Assertions.assertThat(planCrudService.storage())
+            assertThat(planCrudService.storage())
                 .extracting(Plan::getId, Plan::getOrder)
                 .containsOnly(tuple("plan2", 1), tuple("plan1", 2), tuple("plan3", 3));
         }
@@ -644,11 +643,11 @@ class UpdatePlanDomainServiceTest {
             );
 
             // When
-            var toUpdate = plans.get(0).toBuilder().order(2).build();
+            var toUpdate = plans.getFirst().toBuilder().order(2).build();
             service.update(toUpdate, List.of(), null, NATIVE_API, AUDIT_INFO);
 
             // Then
-            Assertions.assertThat(planCrudService.storage())
+            assertThat(planCrudService.storage())
                 .extracting(Plan::getId, Plan::getOrder)
                 .containsOnly(tuple("plan2", 1), tuple("plan1", 2), tuple("plan3", 3));
         }
@@ -746,7 +745,7 @@ class UpdatePlanDomainServiceTest {
             );
 
             // Then
-            CoreAssertions.assertThat(planCrudService.getById(plan.getId()))
+            assertThat(planCrudService.getById(plan.getId()))
                 .isEqualTo(result)
                 .extracting(
                     Plan::getName,
@@ -778,7 +777,7 @@ class UpdatePlanDomainServiceTest {
                     .build()
                     .setPlanStatus(PlanStatus.CLOSED)
             );
-            HashMap statusMap = new HashMap();
+            var statusMap = new HashMap<String, PlanStatus>();
             statusMap.put("plan-1", PlanStatus.CLOSED);
             // When
             var throwable = Assertions.catchThrowable(() ->
@@ -786,7 +785,7 @@ class UpdatePlanDomainServiceTest {
             );
 
             // Then
-            Assertions.assertThat(throwable).isInstanceOf(ValidationDomainException.class).hasMessageContaining("Invalid status for plan");
+            assertThat(throwable).isInstanceOf(ValidationDomainException.class).hasMessageContaining("Invalid status for plan");
         }
 
         @Test
@@ -868,13 +867,13 @@ class UpdatePlanDomainServiceTest {
                     .build()
                     .setPlanStatus(PlanStatus.PUBLISHED)
             );
-            HashMap statusMap = new HashMap();
+            var statusMap = new HashMap<String, PlanStatus>();
             // When
-            var toUpdate = plans.get(0).toBuilder().order(2).build();
+            var toUpdate = plans.getFirst().toBuilder().order(2).build();
             service.updatePlanForApiProduct(toUpdate, statusMap, API_PRODUCT, AUDIT_INFO);
 
             // Then
-            Assertions.assertThat(planCrudService.storage())
+            assertThat(planCrudService.storage())
                 .extracting(Plan::getId, Plan::getOrder)
                 .contains(tuple("plan12", 1), tuple("plan11", 2), tuple("plan13", 3));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -70,9 +70,8 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
-                soft.assertThat(api.getApiDefinition()).isNull();
                 soft
-                    .assertThat(api.getApiDefinitionHttpV4())
+                    .assertThat(api.getApiDefinitionValue())
                     .isEqualTo(
                         io.gravitee.definition.model.v4.Api.builder()
                             .id("my-id")
@@ -153,8 +152,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
-                soft.assertThat(api.getApiDefinition()).isNull();
-                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
+                soft.assertThat(api.getApiDefinitionValue()).isNull();
                 soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
                 soft.assertThat(api.getName()).isEqualTo("api-name");
                 soft.assertThat(api.getDeployedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
@@ -185,9 +183,8 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V2);
-                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
                 soft
-                    .assertThat(api.getApiDefinition())
+                    .assertThat(api.getApiDefinitionValue())
                     // V2 Api definition is defining a equals/hashcode checking only the id
                     .isEqualTo(io.gravitee.definition.model.Api.builder().id("my-id").name("api-name").version("1.0.0").build());
                 soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
@@ -220,8 +217,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isNull();
-                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
-                soft.assertThat(api.getApiDefinition()).isNull();
+                soft.assertThat(api.getApiDefinitionValue()).isNull();
                 soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
                 soft.assertThat(api.getName()).isEqualTo("api-name");
                 soft.assertThat(api.getDeployedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
@@ -273,18 +269,16 @@ class ApiAdapterTest {
         @Test
         void should_convert_v4_api_to_repository() {
             var model = ApiFixtures.aProxyApiV4();
-            model
-                .getApiDefinitionHttpV4()
-                .setFailover(
-                    Failover.builder()
-                        .enabled(true)
-                        .maxRetries(7)
-                        .slowCallDuration(500)
-                        .openStateDuration(11000)
-                        .maxFailures(3)
-                        .perSubscription(false)
-                        .build()
-                );
+            ((io.gravitee.definition.model.v4.Api) model.getApiDefinitionValue()).setFailover(
+                Failover.builder()
+                    .enabled(true)
+                    .maxRetries(7)
+                    .slowCallDuration(500)
+                    .openStateDuration(11000)
+                    .maxFailures(3)
+                    .perSubscription(false)
+                    .build()
+            );
 
             var api = ApiAdapter.INSTANCE.toRepository(model);
 
@@ -297,7 +291,7 @@ class ApiAdapterTest {
                 try {
                     soft
                         .assertThat(api.getDefinition())
-                        .isEqualTo(GraviteeJacksonMapper.getInstance().writeValueAsString(model.getApiDefinitionHttpV4()));
+                        .isEqualTo(GraviteeJacksonMapper.getInstance().writeValueAsString(model.getApiDefinitionValue()));
                 } catch (JsonProcessingException e) {
                     soft.fail(e.getMessage());
                 }
@@ -405,7 +399,10 @@ class ApiAdapterTest {
                 .apiLifecycleState(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.PUBLISHED)
                 .build();
 
-            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, model.getApiDefinitionHttpV4());
+            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(
+                model,
+                ((io.gravitee.definition.model.v4.Api) model.getApiDefinitionValue())
+            );
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(updateApiEntity.getId()).isEqualTo("my-api");
@@ -425,11 +422,11 @@ class ApiAdapterTest {
                 soft.assertThat(updateApiEntity.getEndpointGroups()).hasSize(1);
                 soft
                     .assertThat(updateApiEntity.getEndpointGroups().getFirst())
-                    .isEqualTo(model.getApiDefinitionHttpV4().getEndpointGroups().getFirst());
+                    .isEqualTo(((io.gravitee.definition.model.v4.Api) model.getApiDefinitionValue()).getEndpointGroups().getFirst());
                 soft.assertThat(updateApiEntity.getListeners()).hasSize(1);
                 soft
                     .assertThat(updateApiEntity.getListeners().getFirst())
-                    .isEqualTo(model.getApiDefinitionHttpV4().getListeners().getFirst());
+                    .isEqualTo(((io.gravitee.definition.model.v4.Api) model.getApiDefinitionValue()).getListeners().getFirst());
             });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -32,6 +32,7 @@ import io.gravitee.definition.model.v4.nativeapi.NativePlan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.WorkflowState;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
@@ -67,15 +68,16 @@ class GraviteeDefinitionAdapterTest {
             .displayName("PO")
             .type(PrimaryOwnerEntity.Type.USER)
             .build();
-        var metadata = java.util.Collections.<NewApiMetadata>emptyList();
+        var metadata = Collections.<NewApiMetadata>emptyList();
 
         // When
         ApiDescriptor.ApiDescriptorV4 descriptor = GraviteeDefinitionAdapter.INSTANCE.mapV4(
             coreApi,
+            ((io.gravitee.definition.model.v4.Api) coreApi.getApiDefinitionValue()),
             primaryOwner,
             WorkflowState.REVIEW_OK,
             Set.of("group-1"),
-            (java.util.Collection<NewApiMetadata>) metadata,
+            metadata,
             List.of(new Flow()),
             false
         );
@@ -108,14 +110,15 @@ class GraviteeDefinitionAdapterTest {
             .displayName("PO")
             .type(PrimaryOwnerEntity.Type.USER)
             .build();
-        var metadata = java.util.Collections.<NewApiMetadata>emptyList();
+        var metadata = Collections.<NewApiMetadata>emptyList();
 
         ApiDescriptor.ApiDescriptorV4 descriptor = GraviteeDefinitionAdapter.INSTANCE.mapV4(
             coreApi,
+            ((io.gravitee.definition.model.v4.Api) coreApi.getApiDefinitionValue()),
             primaryOwner,
             WorkflowState.REVIEW_OK,
             Set.of("group-1"),
-            (java.util.Collection<NewApiMetadata>) metadata,
+            metadata,
             List.of(new Flow()),
             false
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -204,7 +204,7 @@ public class ApiCrudServiceImplTest {
                         .deployedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
                         .definitionVersion(DefinitionVersion.V4)
                         .definition(
-                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4())
+                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionValue())
                         )
                         .build()
                 );
@@ -367,7 +367,7 @@ public class ApiCrudServiceImplTest {
                         .deployedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
                         .definitionVersion(DefinitionVersion.V4)
                         .definition(
-                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4())
+                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionValue())
                         )
                         .build()
                 );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -89,7 +91,7 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getTags()).containsExactly("sanitized-tag");
+        assertThat(result.getApiDefinitionValue().getTags()).containsExactly("sanitized-tag");
     }
 
     @Test
@@ -120,7 +122,7 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(sanitizedAnalytics);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getAnalytics).isEqualTo(sanitizedAnalytics);
     }
 
     @Test
@@ -139,23 +141,23 @@ class UpdateApiDomainServiceImplTest {
     @Test
     void should_preserve_original_tags_when_validator_returns_null() {
         var api = ApiFixtures.aProxyApiV4();
-        var originalTags = api.getApiDefinitionHttpV4().getTags();
+        var originalTags = api.getApiDefinitionValue().getTags();
         stubValidate(entity -> entity.setTags(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getTags()).isEqualTo(originalTags);
+        assertThat(result.getApiDefinitionValue().getTags()).isEqualTo(originalTags);
     }
 
     @Test
     void should_preserve_original_analytics_when_validator_returns_null() {
         var api = ApiFixtures.aProxyApiV4();
-        var originalAnalytics = api.getApiDefinitionHttpV4().getAnalytics();
+        var originalAnalytics = asV4ApiDefinition(api).getAnalytics();
         stubValidate(entity -> entity.setAnalytics(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(originalAnalytics);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getAnalytics).isEqualTo(originalAnalytics);
     }
 
     @Test
@@ -187,7 +189,7 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getFailover()).isEqualTo(sanitizedFailover);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getFailover).isEqualTo(sanitizedFailover);
     }
 
     @Test
@@ -198,7 +200,7 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getFlowExecution()).isEqualTo(sanitizedFlowExecution);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getFlowExecution).isEqualTo(sanitizedFlowExecution);
     }
 
     @Test
@@ -209,7 +211,7 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getServices()).isEqualTo(sanitizedServices);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getServices).isEqualTo(sanitizedServices);
     }
 
     @Test
@@ -220,7 +222,9 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getResponseTemplates()).isEqualTo(sanitizedResponseTemplates);
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getResponseTemplates)
+            .isEqualTo(sanitizedResponseTemplates);
     }
 
     @Test
@@ -231,32 +235,35 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getFlows()).isEqualTo(sanitizedFlows);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getFlows).isEqualTo(sanitizedFlows);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_preserve_original_flows_when_validator_returns_null() {
         var originalFlows = List.of(new Flow());
-        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().flows(originalFlows).build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().flows(originalFlows).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
         stubValidate(entity -> entity.setFlows(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getFlows()).isEqualTo(originalFlows);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getFlows).isEqualTo(originalFlows);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_return_null_flows_when_erased_definition_has_null_flows() {
-        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().flows(null).build();
+        var erasedDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().flows(null).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
         stubValidate(entity -> entity.setFlows(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getFlows()).isNull();
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getFlows)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Flow.class))
+            .isNull();
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
@@ -268,29 +275,28 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getResources()).isEqualTo(sanitizedResources);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getResources).isEqualTo(sanitizedResources);
     }
 
     @Test
     void should_preserve_original_resources_when_validator_returns_null() {
         var existingResource = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
-        var originalDefinition = ApiFixtures.aProxyApiV4()
-            .getApiDefinitionHttpV4()
-            .toBuilder()
-            .resources(List.of(existingResource))
-            .build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().resources(List.of(existingResource)).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
         stubValidate(entity -> entity.setResources(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getResources()).containsExactly(existingResource);
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getResources)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Resource.class))
+            .containsExactly(existingResource);
     }
 
     @Test
     void should_return_sanitized_endpoint_groups_from_mutated_update_api_entity() {
         var api = ApiFixtures.aProxyApiV4();
-        var sanitizedGroups = List.of(
+        List<EndpointGroup> sanitizedGroups = List.of(
             EndpointGroup.builder()
                 .name("sanitized-group")
                 .type("http-proxy")
@@ -302,13 +308,13 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEqualTo(sanitizedGroups);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getEndpointGroups).isEqualTo(sanitizedGroups);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_preserve_original_endpoint_groups_when_validator_returns_null() {
-        var originalGroups = List.of(
+        List<EndpointGroup> originalGroups = List.of(
             EndpointGroup.builder()
                 .name("original-group")
                 .type("http-proxy")
@@ -316,37 +322,40 @@ class UpdateApiDomainServiceImplTest {
                 .endpoints(List.of(Endpoint.builder().name("ep").type("http-proxy").weight(1).build()))
                 .build()
         );
-        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().endpointGroups(originalGroups).build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().endpointGroups(originalGroups).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
         stubValidate(entity -> entity.setEndpointGroups(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEqualTo(originalGroups);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getEndpointGroups).isEqualTo(originalGroups);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_return_null_endpoint_groups_when_erased_definition_has_null_endpoint_groups() {
-        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().endpointGroups(null).build();
+        var erasedDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().endpointGroups(null).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
         stubValidate(entity -> entity.setEndpointGroups(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isNull();
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getEndpointGroups).isNull();
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_preserve_original_allowed_in_api_products_when_validator_returns_null() {
-        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(true).build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().allowedInApiProducts(true).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
         stubValidate(entity -> entity.setAllowedInApiProducts(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getAllowedInApiProducts()).isTrue();
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getAllowedInApiProducts)
+            .asInstanceOf(InstanceOfAssertFactories.BOOLEAN)
+            .isTrue();
     }
 
     @Test
@@ -357,9 +366,10 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getProperties())
-            .hasSize(1)
-            .first()
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getProperties)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Property.class))
+            .singleElement()
             .satisfies(p -> {
                 assertThat(p.getKey()).isEqualTo("k1");
                 assertThat(p.getValue()).isEqualTo("v1");
@@ -372,30 +382,26 @@ class UpdateApiDomainServiceImplTest {
         var existingProperty = new Property();
         existingProperty.setKey("k1");
         existingProperty.setValue("v1");
-        var originalDefinition = ApiFixtures.aProxyApiV4()
-            .getApiDefinitionHttpV4()
-            .toBuilder()
-            .properties(List.of(existingProperty))
-            .build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().properties(List.of(existingProperty)).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
-        var originalProperties = api.getApiDefinitionHttpV4().getProperties();
+        var originalProperties = asV4ApiDefinition(api).getProperties();
         stubValidate(entity -> entity.setProperties(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getProperties()).isEqualTo(originalProperties);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getProperties).isEqualTo(originalProperties);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void should_return_null_properties_when_erased_definition_has_null_properties() {
-        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().properties(null).build();
+        var erasedDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().properties(null).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
         stubValidate(entity -> entity.setProperties(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getProperties()).isNull();
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getProperties).isNull();
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
@@ -406,9 +412,10 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getProperties())
-            .hasSize(1)
-            .first()
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getProperties)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Property.class))
+            .singleElement()
             .satisfies(p -> {
                 assertThat(p.isEncrypted()).isTrue();
                 assertThat(p.isDynamic()).isTrue();
@@ -423,7 +430,11 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getProperties()).hasSize(1).first().isNotInstanceOf(PropertyEntity.class);
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getProperties)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Property.class))
+            .singleElement()
+            .isNotInstanceOf(PropertyEntity.class);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
@@ -433,17 +444,16 @@ class UpdateApiDomainServiceImplTest {
             .paths(List.of(Path.builder().path("/original").build()))
             .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
             .build();
-        var originalDefinition = ApiFixtures.aProxyApiV4()
-            .getApiDefinitionHttpV4()
-            .toBuilder()
-            .listeners(List.of(existingListener))
-            .build();
+        var originalDefinition = asV4ApiDefinition(ApiFixtures.aProxyApiV4()).toBuilder().listeners(List.of(existingListener)).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
         stubValidate(entity -> entity.setListeners(null));
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getListeners()).containsExactly(existingListener);
+        assertApiDefinition(result)
+            .extracting(io.gravitee.definition.model.v4.Api::getListeners)
+            .asInstanceOf(InstanceOfAssertFactories.collection(Listener.class))
+            .containsExactly(existingListener);
     }
 
     @Test
@@ -459,7 +469,17 @@ class UpdateApiDomainServiceImplTest {
 
         var result = cut.validateV4(api, auditInfo);
 
-        assertThat(result.getApiDefinitionHttpV4().getListeners()).isEqualTo(sanitizedListeners);
+        assertApiDefinition(result).extracting(io.gravitee.definition.model.v4.Api::getListeners).isEqualTo(sanitizedListeners);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    private static io.gravitee.definition.model.v4.Api asV4ApiDefinition(Api result) {
+        return (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+    }
+
+    private static ObjectAssert<io.gravitee.definition.model.v4.Api> assertApiDefinition(Api result) {
+        return assertThat(result.getApiDefinitionValue()).asInstanceOf(
+            InstanceOfAssertFactories.type(io.gravitee.definition.model.v4.Api.class)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -29,11 +29,9 @@ import fixtures.definition.FlowFixtures;
 import io.gravitee.apim.core.api.domain_service.ApiLifecycleStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.GroupValidationService;
-import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.exception.InvalidApiLifecycleStateException;
 import io.gravitee.apim.core.api.exception.NativeApiWithMultipleFlowsException;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
@@ -43,6 +41,7 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
@@ -114,7 +113,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
     private static Api nativeApiWithAnalytics(NativeAnalytics analytics) {
         var base = ApiFixtures.aNativeApi();
-        return base.toBuilder().apiDefinitionNativeV4(base.getApiDefinitionNativeV4().toBuilder().analytics(analytics).build()).build();
+        return base.getApiDefinitionValue() instanceof NativeApi nativ
+            ? base.toBuilder().apiDefinitionNativeV4(nativ.toBuilder().analytics(analytics).build()).build()
+            : base;
     }
 
     @Nested
@@ -127,7 +128,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             verify(apiValidationService).validateAndSanitizeNewApi(
                 eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
-                eq(ApiAdapter.INSTANCE.toNewApiEntity(api)),
+                eq(ApiAdapter.INSTANCE.toNewApiEntity(api, ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()))),
                 eq(PrimaryOwnerAdapter.INSTANCE.toRestEntity(PRIMARY_OWNER))
             );
         }
@@ -137,9 +138,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             var api = ApiFixtures.aProxyApiV4()
                 .toBuilder()
                 .apiDefinitionHttpV4(
-                    ApiFixtures.aProxyApiV4()
-                        .getApiDefinitionHttpV4()
-                        .toBuilder()
+                    ((io.gravitee.definition.model.v4.Api) ApiFixtures.aProxyApiV4().getApiDefinitionValue()).toBuilder()
                         .services(
                             ApiServices.builder()
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
@@ -193,15 +192,14 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .hasOnlyTags(Set.of("sanitized"));
 
             SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result.getApiDefinitionHttpV4().getListeners()).isEmpty();
-                soft.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEmpty();
-                soft.assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
-                soft.assertThat(result.getApiDefinitionHttpV4().getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
-                soft.assertThat(result.getApiDefinitionHttpV4().getFlowExecution()).isNull();
-                soft
-                    .assertThat(result.getApiDefinitionHttpV4().getServices().getDynamicProperty().getConfiguration())
-                    .isEqualTo("sanitized");
-                soft.assertThat(result.getApiDefinitionHttpV4().getResources()).isEqualTo(sanitizedResources);
+                io.gravitee.definition.model.v4.Api definitionHttpV4 = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+                soft.assertThat(definitionHttpV4.getListeners()).isEmpty();
+                soft.assertThat(definitionHttpV4.getEndpointGroups()).isEmpty();
+                soft.assertThat(definitionHttpV4.getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
+                soft.assertThat(definitionHttpV4.getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
+                soft.assertThat(definitionHttpV4.getFlowExecution()).isNull();
+                soft.assertThat(definitionHttpV4.getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
+                soft.assertThat(definitionHttpV4.getResources()).isEqualTo(sanitizedResources);
             });
         }
 
@@ -213,7 +211,8 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 
-            Assertions.assertThat(result.getApiDefinitionHttpV4().getResources()).isEqualTo(sanitizedResources);
+            io.gravitee.definition.model.v4.Api definitionHttpV4 = (io.gravitee.definition.model.v4.Api) result.getApiDefinitionValue();
+            Assertions.assertThat(definitionHttpV4.getResources()).isEqualTo(sanitizedResources);
         }
 
         @Test
@@ -244,10 +243,8 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             var api = ApiFixtures.aNativeApi()
                 .toBuilder()
                 .description("sani<img src=\"../../../image.png\">tized")
-                .apiDefinitionNativeV4(
-                    ApiFixtures.aNativeApi()
-                        .getApiDefinitionNativeV4()
-                        .toBuilder()
+                .apiDefinitionValue(
+                    ((NativeApi) ApiFixtures.aNativeApi().getApiDefinitionValue()).toBuilder()
                         .services(
                             NativeApiServices.builder()
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
@@ -314,8 +311,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .hasOnlyCategories(Set.of("sanitized"));
 
             SoftAssertions.assertSoftly(soft -> {
+                NativeApi apiDefinitionNativeV4 = (NativeApi) result.getApiDefinitionValue();
                 soft
-                    .assertThat(result.getApiDefinitionNativeV4().getListeners())
+                    .assertThat(apiDefinitionNativeV4.getListeners())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(KafkaListener.class)
@@ -323,7 +321,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .extracting(l -> l.getEntrypoints().getFirst())
                     .hasFieldOrPropertyWithValue("type", "sanitized");
                 soft
-                    .assertThat(result.getApiDefinitionNativeV4().getEndpointGroups())
+                    .assertThat(apiDefinitionNativeV4.getEndpointGroups())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(NativeEndpointGroup.class)
@@ -332,12 +330,10 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .isInstanceOf(NativeEndpoint.class)
                     .hasFieldOrPropertyWithValue("name", "sanitized")
                     .hasFieldOrPropertyWithValue("type", "sanitized");
-                soft.assertThat(result.getApiDefinitionNativeV4().getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
-                soft
-                    .assertThat(result.getApiDefinitionNativeV4().getServices().getDynamicProperty().getConfiguration())
-                    .isEqualTo("sanitized");
-                soft.assertThat(result.getApiDefinitionNativeV4().getAnalytics().isEnabled()).isTrue();
-                soft.assertThat(result.getApiDefinitionNativeV4().getResources()).isEqualTo(sanitizedResources);
+                soft.assertThat(apiDefinitionNativeV4.getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
+                soft.assertThat(apiDefinitionNativeV4.getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
+                soft.assertThat(apiDefinitionNativeV4.getAnalytics().isEnabled()).isTrue();
+                soft.assertThat(apiDefinitionNativeV4.getResources()).isEqualTo(sanitizedResources);
             });
         }
 
@@ -349,26 +345,22 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 
-            Assertions.assertThat(result.getApiDefinitionNativeV4().getResources()).isEqualTo(sanitizedResources);
+            NativeApi apiDefinitionNativeV4 = (NativeApi) result.getApiDefinitionValue();
+            Assertions.assertThat(apiDefinitionNativeV4.getResources()).isEqualTo(sanitizedResources);
         }
 
         @Test
         void should_throw_when_multiple_api_flows() {
-            var baseApi = ApiFixtures.aNativeApi();
-            var nativeApi = baseApi
-                .toBuilder()
-                .apiDefinitionNativeV4(
-                    baseApi
-                        .getApiDefinitionNativeV4()
-                        .toBuilder()
-                        .flows(List.of(NativeFlow.builder().id("flow-1").build(), NativeFlow.builder().id("flow-1").build()))
-                        .build()
-                )
-                .build();
+            var nativeApi = ApiFixtures.aNativeApi();
+            nativeApi.setApiDefinitionValue(
+                ((NativeApi) nativeApi.getApiDefinitionValue()).toBuilder()
+                    .flows(List.of(NativeFlow.builder().id("flow-1").build(), NativeFlow.builder().id("flow-1").build()))
+                    .build()
+            );
 
             doThrow(new NativeApiWithMultipleFlowsException())
                 .when(flowValidationDomainService)
-                .validateAndSanitizeNativeV4(eq(nativeApi.getApiDefinitionNativeV4().getFlows()));
+                .validateAndSanitizeNativeV4(eq(((NativeApi) nativeApi.getApiDefinitionValue()).getFlows()));
 
             var throwable = Assertions.catchThrowable(() ->
                 service.validateAndSanitizeForCreation(nativeApi, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)
@@ -383,7 +375,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 
-            var analytics = result.getApiDefinitionNativeV4().getAnalytics();
+            var analytics = ((NativeApi) result.getApiDefinitionValue()).getAnalytics();
             Assertions.assertThat(analytics).isNotNull();
             Assertions.assertThat(analytics.isEnabled()).isTrue();
             Assertions.assertThat(analytics.isReporterMetricsEnabled()).isTrue();
@@ -409,9 +401,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED)
                 .description("old description")
                 .apiDefinitionNativeV4(
-                    ApiFixtures.aNativeApi()
-                        .getApiDefinitionNativeV4()
-                        .toBuilder()
+                    ((NativeApi) ApiFixtures.aNativeApi().getApiDefinitionValue()).toBuilder()
                         .services(
                             NativeApiServices.builder()
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
@@ -426,9 +416,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
                 .description("sani<img src=\"../../../image.png\">tized")
                 .apiDefinitionNativeV4(
-                    ApiFixtures.aNativeApi()
-                        .getApiDefinitionNativeV4()
-                        .toBuilder()
+                    ((NativeApi) ApiFixtures.aNativeApi().getApiDefinitionValue()).toBuilder()
                         .services(
                             NativeApiServices.builder()
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
@@ -495,8 +483,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .hasOnlyTags(Set.of("sanitized"));
 
             SoftAssertions.assertSoftly(soft -> {
+                NativeApi apiDefinitionNativeV4 = (NativeApi) result.getApiDefinitionValue();
                 soft
-                    .assertThat(result.getApiDefinitionNativeV4().getListeners())
+                    .assertThat(apiDefinitionNativeV4.getListeners())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(KafkaListener.class)
@@ -504,7 +493,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .extracting(l -> l.getEntrypoints().getFirst())
                     .hasFieldOrPropertyWithValue("type", "sanitized");
                 soft
-                    .assertThat(result.getApiDefinitionNativeV4().getEndpointGroups())
+                    .assertThat(apiDefinitionNativeV4.getEndpointGroups())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(NativeEndpointGroup.class)
@@ -513,11 +502,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .isInstanceOf(NativeEndpoint.class)
                     .hasFieldOrPropertyWithValue("name", "sanitized")
                     .hasFieldOrPropertyWithValue("type", "sanitized");
-                soft.assertThat(result.getApiDefinitionNativeV4().getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
-                soft
-                    .assertThat(result.getApiDefinitionNativeV4().getServices().getDynamicProperty().getConfiguration())
-                    .isEqualTo("sanitized");
-                soft.assertThat(result.getApiDefinitionNativeV4().getResources()).isEqualTo(sanitizedResourcesFromValidationService);
+                soft.assertThat(apiDefinitionNativeV4.getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
+                soft.assertThat(apiDefinitionNativeV4.getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
+                soft.assertThat(apiDefinitionNativeV4.getResources()).isEqualTo(sanitizedResourcesFromValidationService);
             });
         }
 
@@ -530,26 +517,22 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             var result = service.validateAndSanitizeForUpdate(existingApi, newApi, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 
-            Assertions.assertThat(result.getApiDefinitionNativeV4().getResources()).isEqualTo(sanitizedResources);
+            NativeApi apiDefinitionNativeV4 = (NativeApi) result.getApiDefinitionValue();
+            Assertions.assertThat(apiDefinitionNativeV4.getResources()).isEqualTo(sanitizedResources);
         }
 
         @Test
         void should_throw_when_multiple_api_flows() {
-            var baseApi = ApiFixtures.aNativeApi();
-            var nativeApi = baseApi
-                .toBuilder()
-                .apiDefinitionNativeV4(
-                    baseApi
-                        .getApiDefinitionNativeV4()
-                        .toBuilder()
-                        .flows(List.of(NativeFlow.builder().id("flow-1").build(), NativeFlow.builder().id("flow-1").build()))
-                        .build()
-                )
-                .build();
+            var nativeApi = ApiFixtures.aNativeApi();
+            nativeApi.setApiDefinitionValue(
+                ((NativeApi) nativeApi.getApiDefinitionValue()).toBuilder()
+                    .flows(List.of(NativeFlow.builder().id("flow-1").build(), NativeFlow.builder().id("flow-1").build()))
+                    .build()
+            );
 
             doThrow(new NativeApiWithMultipleFlowsException())
                 .when(flowValidationDomainService)
-                .validateAndSanitizeNativeV4(eq(nativeApi.getApiDefinitionNativeV4().getFlows()));
+                .validateAndSanitizeNativeV4(eq(((NativeApi) nativeApi.getApiDefinitionValue()).getFlows()));
 
             var throwable = Assertions.catchThrowable(() ->
                 service.validateAndSanitizeForUpdate(ApiFixtures.aNativeApi(), nativeApi, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiEventQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiEventQueryServiceImplTest.java
@@ -93,9 +93,9 @@ class ApiEventQueryServiceImplTest {
         );
         when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), eq(0L), eq(1L))).thenReturn(List.of(event));
         final Optional<Api> lastPublishedApi = cut.findLastPublishedApi("org-id", "env-id", "api-id");
-        assertThat(lastPublishedApi).hasValueSatisfying(result -> {
-            assertThat(result.getApiDefinitionHttpV4()).isEqualTo(api.getApiDefinitionHttpV4());
-        });
+        assertThat(lastPublishedApi).hasValueSatisfying(result ->
+            assertThat(result.getApiDefinitionValue()).isEqualTo(api.getApiDefinitionValue())
+        );
         verifyEventCriteria();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -47,14 +47,12 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_SPLIT;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.model.IndexableApi;
 import io.gravitee.common.component.Lifecycle;
@@ -701,7 +699,7 @@ public class IndexableApiDocumentTransformerTest {
 
                 @Override
                 public java.util.Set<String> getTags() {
-                    return api.getApiDefinition() != null ? api.getApiDefinition().getTags() : Set.of();
+                    return api.getTags() != null ? api.getTags() : Set.of();
                 }
 
                 @Override
@@ -736,7 +734,9 @@ public class IndexableApiDocumentTransformerTest {
 
                 @Override
                 public io.gravitee.definition.model.Proxy getProxy() {
-                    return api.getApiDefinition() != null ? api.getApiDefinition().getProxy() : null;
+                    return api.getApiDefinitionValue() instanceof io.gravitee.definition.model.Api definition
+                        ? definition.getProxy()
+                        : null;
                 }
             };
         }


### PR DESCRIPTION
Continue work to replace the pattern

```java
if (api.getType() == ApiType.NATIVE) {
   api.getApiDefinitionNativeV4();
}
```

by

```java
if (api.getApiDefinitionValue() instanceof NativeApiEntity asNativeApiEntity) {
   asNativeApiEntity;
}
```

### 1. **Stronger Type Safety**

The new pattern relies on the **actual class** of the object rather than a separate enum flag (`ApiType.NATIVE`).

* **Old way:** You trust that if the flag is `NATIVE`, the specific getter `getApiDefinitionNativeV4()` will return valid data. This is brittle.
* **New way:** The compiler guarantees the object is exactly what you expect before you use it.

### 2. **Modern Java Syntax (Pattern Matching)**

It utilizes **Pattern Matching for `instanceof`** (introduced in Java 16). This combines the **check** and the **cast** into a single, concise operation.

### 3. **Cleaner Interface**

It removes API pollution. You no longer need specific getter methods for every type (like `getApiDefinitionNativeV4()`, `getApiDefinitionHttp()`, etc.) on the parent object. You only need one generic accessor (`getApiDefinitionValue()`).