### PR TITLE
Introduce `ApiTypePreProcessor` for analytics filtering

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
@@ -22,6 +22,7 @@ package io.gravitee.repository.analytics.engine.api.query;
 public record Filter(Filter.Name name, Operator operator, Object value) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProc
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.infra.domain_service.analytics_engine.MetricsContextManagerImpl;
+import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ApiTypePreProcessor;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.BucketNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ManagementFilterPreProcessor;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
@@ -55,7 +56,7 @@ public class RestManagementConfiguration {
 
     @Bean
     public List<FilterPreProcessor> filterPreProcessors() {
-        return List.of(new ManagementFilterPreProcessor());
+        return List.of(new ManagementFilterPreProcessor(), new ApiTypePreProcessor());
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -173,6 +173,11 @@ paths:
                         type: "ENUM"
                         operators: [ "EQ", "IN" ]
                         enumValues: [ "1xx", "2xx", "3xx", "4xx", "5xx" ]
+                      - name: "API_NAME"
+                        label: "API name"
+                        type: "ENUM"
+                        operators: [ "EQ", "IN" ]
+                        enumValues: [ "HTTP_PROXY", "MESSAGE", "KAFKA", "LLM", "MCP" ]
         "400":
           description: Bad request - Invalid metric name for filters.
           content:
@@ -838,6 +843,7 @@ components:
             type: string
             enum:
                 - API
+                - API_NAME
                 - APPLICATION
                 - PLAN
                 - GATEWAY

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -97,7 +97,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
                 )
             );
 
-            when(filterPreProcessor.buildFilters(any(MetricsContext.class))).thenAnswer(caller -> caller.getArgument(0));
+            when(filterPreProcessor.buildFilters(any(MetricsContext.class), any())).thenAnswer(caller -> caller.getArgument(0));
         }
 
         @Test
@@ -178,7 +178,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
                 )
             ).thenAnswer(invocation -> invocation.getArgument(2));
 
-            when(filterPreProcessor.buildFilters(any(MetricsContext.class))).thenAnswer(caller -> caller.getArgument(0));
+            when(filterPreProcessor.buildFilters(any(MetricsContext.class), any())).thenAnswer(caller -> caller.getArgument(0));
         }
 
         @Test
@@ -296,7 +296,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
                 )
             ).thenAnswer(invocation -> invocation.getArgument(2));
 
-            when(filterPreProcessor.buildFilters(any(MetricsContext.class))).thenAnswer(caller -> caller.getArgument(0));
+            when(filterPreProcessor.buildFilters(any(MetricsContext.class), any())).thenAnswer(caller -> caller.getArgument(0));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterPreProcessor.java
@@ -23,5 +23,5 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface FilterPreProcessor {
-    List<Filter> buildFilters(MetricsContext context);
+    List<Filter> buildFilters(MetricsContext context, List<Filter> requestFilters);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -20,6 +20,7 @@ import java.util.List;
 public record FilterSpec(Name name, String label, Type type, List<String> enumValues, NumberRange range, List<Operator> operators) {
     public enum Name {
         API,
+        API_NAME,
         APPLICATION,
         PLAN,
         GATEWAY,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
@@ -93,7 +93,9 @@ public class ComputeFacetsUseCase {
         var responses = new ArrayList<FacetsResponse>();
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filterPreprocessors.forEach(filterPreprocessor -> filters.addAll(filterPreprocessor.buildFilters(metricsContext)));
+            filterPreprocessors.forEach(filterPreprocessor ->
+                filters.addAll(filterPreprocessor.buildFilters(metricsContext, request.filters()))
+            );
 
             responses.add(queryService.searchFacets(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
@@ -85,7 +86,9 @@ public class ComputeMeasuresUseCase {
 
         queryExecutions.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filterPreprocessors.forEach(filterPreprocessor -> filters.addAll(filterPreprocessor.buildFilters(metricsContext)));
+            filterPreprocessors.forEach(filterPreprocessor -> {
+                filters.addAll(filterPreprocessor.buildFilters(metricsContext, request.filters()));
+            });
 
             responses.add(queryService.searchMeasures(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
@@ -94,7 +94,9 @@ public class ComputeTimeSeriesUseCase {
 
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filterPreprocessors.forEach(filterPreprocessor -> filters.addAll(filterPreprocessor.buildFilters(metricsContext)));
+            filterPreprocessors.forEach(filterPreprocessor ->
+                filters.addAll(filterPreprocessor.buildFilters(metricsContext, request.filters()))
+            );
 
             responses.add(queryService.searchTimeSeries(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
@@ -25,7 +25,6 @@ import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypePreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypePreProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
+
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.model.ApiSpec;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class ApiTypePreProcessor implements FilterPreProcessor {
+
+    @Override
+    public List<Filter> buildFilters(MetricsContext context, List<Filter> requestFilters) {
+        if (context.apis().isEmpty()) {
+            return List.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Collections.emptyList()));
+        }
+
+        var apiTypes = getEffectiveFilterByApiType(requestFilters);
+        if (apiTypes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        if (apiTypes.get().isEmpty()) {
+            return List.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Collections.emptyList()));
+        }
+
+        var apiIds = context
+            .apis()
+            .get()
+            .stream()
+            .filter(api -> apiTypes.get().contains(api.getType()))
+            .map(Api::getId)
+            .toList();
+
+        return List.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, apiIds));
+    }
+
+    Optional<List<ApiType>> getEffectiveFilterByApiType(Collection<Filter> filters) {
+        if (filters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var apiNameFilters = filters
+            .stream()
+            .filter(filter -> filter.name() == FilterSpec.Name.API_NAME)
+            .toList();
+
+        if (apiNameFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var normalizedFilters = normalizeFilters(apiNameFilters);
+
+        if (normalizedFilters.size() != 1) {
+            // Filters are AND-eÏd, so two or more filters by API_NAME lead to no result.
+            return Optional.of(Collections.emptyList());
+        }
+
+        var filter = normalizedFilters.stream().findAny().get();
+        var filterValue = filter.value();
+
+        if (filterValue instanceof List<?> listValue) {
+            var apiTypes = listValue.stream().map(Object::toString).map(this::mapApiName).toList();
+            if (apiTypes.contains(null)) {
+                return Optional.of(Collections.emptyList());
+            }
+
+            return Optional.of(apiTypes);
+        }
+
+        return Optional.of(Collections.emptyList());
+    }
+
+    private Set<Filter> normalizeFilters(List<Filter> filters) {
+        return filters
+            .stream()
+            .map(filter ->
+                switch (filter.operator()) {
+                    case FilterSpec.Operator.EQ -> new Filter(filter.name(), IN, List.of(filter.value()));
+                    case FilterSpec.Operator.IN -> {
+                        if (filter.value() instanceof List<?> listValue) {
+                            var values = listValue.stream().filter(Objects::nonNull).map(Object::toString).sorted().toList();
+                            yield new Filter(filter.name(), IN, values);
+                        }
+                        yield new Filter(filter.name(), IN, Collections.emptyList());
+                    }
+                    default -> new Filter(filter.name(), IN, Collections.emptyList());
+                }
+            )
+            .collect(Collectors.toSet());
+    }
+
+    private ApiType mapApiName(String apiName) {
+        try {
+            return switch (ApiSpec.Name.valueOf(apiName)) {
+                case HTTP_PROXY -> ApiType.PROXY;
+                case MESSAGE -> ApiType.MESSAGE;
+                case KAFKA -> ApiType.NATIVE;
+                case LLM -> ApiType.LLM_PROXY;
+                case MCP -> ApiType.MCP_PROXY;
+            };
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
@@ -32,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class ManagementFilterPreProcessor implements FilterPreProcessor {
 
     @Override
-    public List<Filter> buildFilters(MetricsContext context) {
+    public List<Filter> buildFilters(MetricsContext context, List<Filter> requestFilters) {
         var apiIds = context
             .apis()
             .map(apis -> apis.stream().map(Api::getId).collect(Collectors.toList()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -43,6 +43,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -96,6 +97,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -154,6 +156,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -211,6 +214,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -269,6 +273,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -326,6 +331,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -383,6 +389,7 @@ spec:
               - CONSUMER_IP
           filters:
               - API
+              - API_NAME
               - APPLICATION
               - PLAN
               - GATEWAY
@@ -1187,6 +1194,7 @@ spec:
               - APPLICATION
           filters:
               - API
+              - API_NAME
               - APPLICATION
 
         - name: APIS
@@ -1205,6 +1213,7 @@ spec:
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
           filters:
+              - API_NAME
               - API_STATE
               - API_LIFECYCLE_STATE
               - API_VISIBILITY
@@ -1213,6 +1222,19 @@ spec:
         - name: API
           label: API
           type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
+        - name: API_NAME
+          label: API Name
+          type: ENUM
+          enumValues:
+              - HTTP_PROXY
+              - MESSAGE
+              - KAFKA
+              - LLM
+              - MCP
           operators:
               - EQ
               - IN

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/AbstractFilterProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/AbstractFilterProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
+
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import java.util.UUID;
+
+public class AbstractFilterProcessor {
+
+    AuditInfo auditInfo = buildAuditInfo(UUID.randomUUID().toString());
+
+    private static AuditInfo buildAuditInfo(String userId) {
+        var actor = AuditActor.builder().userId(userId).build();
+        return AuditInfo.builder().organizationId("DEFAULT").environmentId("DEFAULT").actor(actor).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypePreProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypePreProcessorTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
+
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.EQ;
+import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiTypePreProcessorTest extends AbstractFilterProcessor {
+
+    static final String PROXY_API_ID = "proxy-api-id";
+    static final String MESSAGE_API_ID = "message-api-id";
+    static final String NATIVE_API_ID = "native-api-id";
+    static final String LLM_API_ID = "llm-api-id";
+    static final String MCP_API_ID = "mcp-api-id";
+
+    List<Api> apis = List.of(
+        Api.builder().id(PROXY_API_ID).type(ApiType.PROXY).build(),
+        Api.builder().id(MESSAGE_API_ID).type(ApiType.MESSAGE).build(),
+        Api.builder().id(NATIVE_API_ID).type(ApiType.NATIVE).build()
+    );
+
+    MetricsContext metricsContext;
+
+    private final ApiTypePreProcessor apiTypePreProcessor = new ApiTypePreProcessor();
+
+    @BeforeEach
+    void setUp() {
+        metricsContext = new MetricsContext(auditInfo).withApis(apis);
+    }
+
+    @Test
+    void should_return_api_filter_empty_when_context_has_no_apis() {
+        metricsContext = new MetricsContext(auditInfo).withApis(Collections.emptyList());
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "HTTP_PROXY")));
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_no_filters() {
+        var results = apiTypePreProcessor.buildFilters(metricsContext, List.of());
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_no_api_name_filter_present() {
+        var filters = List.of(new Filter(FilterSpec.Name.APPLICATION, EQ, "some-app"));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void should_filter_apis_matching_single_api_name() {
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "HTTP_PROXY"));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).containsExactly(PROXY_API_ID);
+    }
+
+    @Test
+    void should_filter_apis_matching_multiple_api_names() {
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, IN, List.of("HTTP_PROXY", "MESSAGE")));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).containsExactlyInAnyOrder(PROXY_API_ID, MESSAGE_API_ID);
+    }
+
+    @Test
+    void should_return_empty_filter_when_api_name_matches_no_apis() {
+        // Context has PROXY, MESSAGE, NATIVE. Let's filter for LLM which is not in
+        // context
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "LLM"));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_filter_when_multiple_api_name_filters_conflict() {
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "HTTP_PROXY"), new Filter(FilterSpec.Name.API_NAME, EQ, "MESSAGE"));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("generateEquivalentFilters")
+    void should_return_apis_when_filters_are_equivalent(String name, List<Filter> filters, List<String> expectedApiTypes) {
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).containsExactlyInAnyOrderElementsOf(expectedApiTypes);
+    }
+
+    @Test
+    void should_return_empty_filter_when_api_names_are_unknown() {
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, IN, List.of("HTTP_PROXY", "UNKNOWN_TYPE")));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_filter_when_all_api_names_are_unknown() {
+        var filters = List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "UNKNOWN_TYPE"));
+
+        var results = apiTypePreProcessor.buildFilters(metricsContext, filters);
+
+        assertThat(results).hasSize(1);
+        var filter = results.getFirst();
+        assertThat(filter.name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filter.operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filter.value()).asInstanceOf(InstanceOfAssertFactories.LIST).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("generateApiTypeFilters")
+    void should_map_all_api_names_correctly(Filter filter, String expectedApiType) {
+        // This test verifies that we can filter by all supported types
+        // We add missing types to a specific context for this test
+        var allTypesApis = List.of(
+            Api.builder().id(PROXY_API_ID).type(ApiType.PROXY).build(),
+            Api.builder().id(MESSAGE_API_ID).type(ApiType.MESSAGE).build(),
+            Api.builder().id(NATIVE_API_ID).type(ApiType.NATIVE).build(),
+            Api.builder().id(LLM_API_ID).type(ApiType.LLM_PROXY).build(),
+            Api.builder().id(MCP_API_ID).type(ApiType.MCP_PROXY).build()
+        );
+
+        var context = new MetricsContext(auditInfo).withApis(allTypesApis);
+
+        assertThat(apiTypePreProcessor.buildFilters(context, List.of(filter)).getFirst().value())
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .containsExactly(expectedApiType);
+    }
+
+    public static Stream<Arguments> generateEquivalentFilters() {
+        return Stream.of(
+            Arguments.of(
+                "Multiple EQ filters",
+                List.of(new Filter(FilterSpec.Name.API_NAME, EQ, "MESSAGE"), new Filter(FilterSpec.Name.API_NAME, EQ, "MESSAGE")),
+                List.of(MESSAGE_API_ID)
+            ),
+            Arguments.of(
+                "Multiple IN filters with elements out of order",
+                List.of(
+                    new Filter(FilterSpec.Name.API_NAME, IN, List.of("MESSAGE", "HTTP_PROXY")),
+                    new Filter(FilterSpec.Name.API_NAME, IN, List.of("HTTP_PROXY", "MESSAGE"))
+                ),
+                List.of(MESSAGE_API_ID, PROXY_API_ID)
+            ),
+            Arguments.of(
+                "Filters contain EQ and IN operators",
+                List.of(
+                    new Filter(FilterSpec.Name.API_NAME, EQ, "HTTP_PROXY"),
+                    new Filter(FilterSpec.Name.API_NAME, IN, List.of("HTTP_PROXY"))
+                ),
+                List.of(PROXY_API_ID)
+            )
+        );
+    }
+
+    public static Stream<Arguments> generateApiTypeFilters() {
+        return Stream.of(
+            Arguments.of(new Filter(FilterSpec.Name.API_NAME, EQ, "HTTP_PROXY"), PROXY_API_ID),
+            Arguments.of(new Filter(FilterSpec.Name.API_NAME, EQ, "MESSAGE"), MESSAGE_API_ID),
+            Arguments.of(new Filter(FilterSpec.Name.API_NAME, EQ, "KAFKA"), NATIVE_API_ID),
+            Arguments.of(new Filter(FilterSpec.Name.API_NAME, EQ, "MCP"), MCP_API_ID),
+            Arguments.of(new Filter(FilterSpec.Name.API_NAME, EQ, "LLM"), LLM_API_ID)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
@@ -53,7 +53,7 @@ public class ManagementFilterPreProcessorTest {
         );
 
         MetricsContext context = new MetricsContext(auditInfo).withApis(adminApis);
-        var filters = filterPreProcessor.buildFilters(context);
+        var filters = filterPreProcessor.buildFilters(context, List.of());
 
         assertThat(filters).size().isEqualTo(1);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/gko-1973

## Description

Added support for filtering analytics requests by API type. Filter supports the `EQ` and `IN` operators and takes one or more of the following values:
- `HTTP_PROXY`
- `MESSAGE`
- `KAFKA`
- `LLM`
- `MCP`

Example measures request with a filter:
```json
{
  "timeRange": {
    "from": "2026-01-08T21:24:00Z",
    "to": "2026-01-08T21:30:00Z"
  },
  "filters": [
    {
      "name": "API_NAME",
      "operator": "EQ",
      "value": "HTTP_PROXY"
    }
  ],
  "metrics": [
    {
      "name": "HTTP_REQUESTS",
      "measures": [
        "COUNT"
      ]
    }
  ]
}
```

Note: Filter name `API_NAME` was chosen because it's consistent with the naming used in other analytics endpoints.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

