### PR TITLE
Decouple API loading from filter building in analytics engine

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -39,6 +39,7 @@ import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -964,5 +965,10 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public MetricsContextManager metricsContextManager() {
+        return mock(MetricsContextManager.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.management.v2.rest.spring;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
+import io.gravitee.apim.infra.domain_service.analytics_engine.MetricsContextManagerImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.BucketNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ManagementFilterPreProcessor;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
@@ -25,6 +27,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -51,10 +54,12 @@ public class RestManagementConfiguration {
     }
 
     @Bean
-    public FilterPreProcessor managementFilterPreProcessor(
-        ApiAuthorizationService apiAuthorizationService,
-        @Lazy ApiRepository apiRepository
-    ) {
-        return new ManagementFilterPreProcessor(apiAuthorizationService, apiRepository);
+    public List<FilterPreProcessor> filterPreProcessors() {
+        return List.of(new ManagementFilterPreProcessor());
+    }
+
+    @Bean
+    public MetricsContextManager metricsContextManager(ApiAuthorizationService apiAuthorizationService, @Lazy ApiRepository apiRepository) {
+        return new MetricsContextManagerImpl(apiAuthorizationService, apiRepository);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -41,9 +41,8 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
-import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
-import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
@@ -977,15 +976,6 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ComputeMeasuresUseCase computeMeasuresUseCase(
-        AnalyticsQueryContextProvider analyticsQueryContextProvider,
-        AnalyticsQueryValidator analyticsQueryValidator,
-        FilterPreProcessor filterPreprocessor
-    ) {
-        return new ComputeMeasuresUseCase(analyticsQueryContextProvider, analyticsQueryValidator, filterPreprocessor);
-    }
-
-    @Bean
     public ProcessPromotionUseCase processPromotionUseCase() {
         return mock(ProcessPromotionUseCase.class);
     }
@@ -1023,5 +1013,10 @@ public class ResourceContextConfiguration {
     @Bean
     public DeletePortalNavigationItemUseCase deletePortalNavigationItemUseCase() {
         return mock(DeletePortalNavigationItemUseCase.class);
+    }
+
+    @Bean
+    public MetricsContextManager metricsContextManager() {
+        return mock(MetricsContextManager.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -34,6 +34,7 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -1103,5 +1104,10 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public MetricsContextManager metricsContextManager() {
+        return mock(MetricsContextManager.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -32,6 +32,7 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
@@ -1060,5 +1061,10 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public MetricsContextManager metricsContextManager() {
+        return mock(MetricsContextManager.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/MetricsContextManager.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/MetricsContextManager.java
@@ -15,13 +15,8 @@
  */
 package io.gravitee.apim.core.analytics_engine.domain_service;
 
-import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
-import java.util.List;
 
-/**
- * @author GraviteeSource Team
- */
-public interface FilterPreProcessor {
-    List<Filter> buildFilters(MetricsContext context);
+public interface MetricsContextManager {
+    MetricsContext loadApis(MetricsContext context);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/MetricsContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/MetricsContext.java
@@ -15,35 +15,40 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.Getter;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
 public record MetricsContext(
-    @Getter AuditInfo auditInfo,
+    AuditInfo auditInfo,
     Optional<Map<String, String>> apiNameById,
     Optional<Map<String, String>> applicationNameById,
-    List<Filter> filters
+    List<Filter> filters,
+    Optional<List<Api>> apis
 ) {
     public MetricsContext(AuditInfo auditInfo) {
-        this(auditInfo, Optional.empty(), Optional.empty(), List.of());
+        this(auditInfo, Optional.empty(), Optional.empty(), List.of(), Optional.empty());
     }
 
     public MetricsContext withApiNamesById(Map<String, String> apiNameById) {
-        return new MetricsContext(auditInfo, Optional.ofNullable(apiNameById), applicationNameById, filters);
+        return new MetricsContext(auditInfo, Optional.ofNullable(apiNameById), applicationNameById, filters, apis);
     }
 
     public MetricsContext withApplicationNameById(Map<String, String> applicationNameById) {
-        return new MetricsContext(auditInfo, apiNameById, Optional.ofNullable(applicationNameById), filters);
+        return new MetricsContext(auditInfo, apiNameById, Optional.ofNullable(applicationNameById), filters, apis);
     }
 
     public MetricsContext withFilters(List<Filter> filters) {
-        return new MetricsContext(auditInfo, apiNameById, applicationNameById, filters);
+        return new MetricsContext(auditInfo, apiNameById, applicationNameById, filters, apis);
+    }
+
+    public MetricsContext withApis(List<Api> apis) {
+        return new MetricsContext(auditInfo, apiNameById, applicationNameById, filters, Optional.ofNullable(apis));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
@@ -41,20 +42,24 @@ public class ComputeFacetsUseCase {
 
     private final AnalyticsQueryValidator validator;
 
-    private final FilterPreProcessor filterPreprocessor;
+    private final List<FilterPreProcessor> filterPreprocessors;
 
     private final BucketNamesPostProcessor bucketNamesPostprocessor;
+
+    private final MetricsContextManager metricsContextManager;
 
     public ComputeFacetsUseCase(
         AnalyticsQueryContextProvider queryContextResolver,
         AnalyticsQueryValidator validator,
-        FilterPreProcessor filterPreprocessor,
-        BucketNamesPostProcessor bucketNamesPostprocessor
+        List<FilterPreProcessor> filterPreprocessors,
+        BucketNamesPostProcessor bucketNamesPostprocessor,
+        MetricsContextManager metricsContextManager
     ) {
         this.queryContextProvider = queryContextResolver;
         this.validator = validator;
-        this.filterPreprocessor = filterPreprocessor;
+        this.filterPreprocessors = filterPreprocessors;
         this.bucketNamesPostprocessor = bucketNamesPostprocessor;
+        this.metricsContextManager = metricsContextManager;
     }
 
     public record Input(AuditInfo auditInfo, FacetsRequest request) {}
@@ -66,15 +71,16 @@ public class ComputeFacetsUseCase {
 
         var executionContext = new ExecutionContext(input.auditInfo.organizationId(), input.auditInfo.environmentId());
 
-        var metricsContextWithPermissions = filterPreprocessor.buildFilters(new MetricsContext(input.auditInfo));
+        MetricsContext metricsContext = new MetricsContext(input.auditInfo);
+        metricsContext = metricsContextManager.loadApis(metricsContext);
 
         var queryContext = queryContextProvider.resolve(input.request);
 
-        var responses = executeQueries(executionContext, metricsContextWithPermissions, queryContext);
+        var responses = executeQueries(executionContext, metricsContext, queryContext);
 
         var response = FacetsResponse.merge(responses);
 
-        var mappedResponse = bucketNamesPostprocessor.mapBucketNames(metricsContextWithPermissions, input.request.facets(), response);
+        var mappedResponse = bucketNamesPostprocessor.mapBucketNames(metricsContext, input.request.facets(), response);
 
         return new ComputeFacetsUseCase.Output(mappedResponse);
     }
@@ -87,7 +93,7 @@ public class ComputeFacetsUseCase {
         var responses = new ArrayList<FacetsResponse>();
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filters.addAll(metricsContext.filters());
+            filterPreprocessors.forEach(filterPreprocessor -> filters.addAll(filterPreprocessor.buildFilters(metricsContext)));
 
             responses.add(queryService.searchFacets(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/MetricsContextManagerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/MetricsContextManagerImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.MetricsContextManager;
+import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.infra.domain_service.analytics_engine.mapper.ApiMapper;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class MetricsContextManagerImpl implements MetricsContextManager {
+
+    private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
+
+    private final ApiAuthorizationService apiAuthorizationService;
+    private final ApiRepository apiRepository;
+
+    private boolean isAdmin() {
+        return SecurityContextHolder.getContext()
+            .getAuthentication()
+            .getAuthorities()
+            .stream()
+            .anyMatch(
+                (Predicate<GrantedAuthority>) grantedAuthority -> grantedAuthority.getAuthority().equalsIgnoreCase(ORGANIZATION_ADMIN)
+            );
+    }
+
+    @Override
+    public MetricsContext loadApis(MetricsContext context) {
+        var organizationId = context.auditInfo().organizationId();
+        var environmentId = context.auditInfo().environmentId();
+        var userId = context.auditInfo().actor().userId();
+
+        ExecutionContext executionContext = new ExecutionContext(organizationId, environmentId);
+
+        ApiCriteria.Builder apiCriteriaBuilder = new ApiCriteria.Builder().environmentId(environmentId);
+
+        if (!isAdmin()) {
+            Set<String> userApiIds = apiAuthorizationService.findApiIdsByUserId(executionContext, userId, null, true);
+
+            apiCriteriaBuilder.ids(userApiIds);
+        }
+
+        var apis = ApiMapper.INSTANCE.map(apiRepository.search(apiCriteriaBuilder.build(), ApiFieldFilter.defaultFields()));
+        var apiIdsToNames = mapApiIdsToNames(apis);
+
+        return context.withApis(apis).withApiNamesById(apiIdsToNames);
+    }
+
+    private static Map<String, String> mapApiIdsToNames(Collection<Api> apis) {
+        return apis.stream().collect(Collectors.toMap(Api::getId, Api::getName));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/mapper/ApiMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.mapper;
+
+import io.gravitee.apim.core.api.model.Api;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApiMapper {
+    ApiMapper INSTANCE = Mappers.getMapper(ApiMapper.class);
+
+    List<Api> map(List<io.gravitee.repository.management.model.Api> api);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
@@ -15,29 +15,15 @@
  */
 package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
 
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name.API;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
-
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
-import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.repository.management.api.search.ApiCriteria;
-import io.gravitee.repository.management.api.search.ApiFieldFilter;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
-import java.util.Collection;
+import io.gravitee.apim.core.api.model.Api;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * @author GraviteeSource Team
@@ -45,56 +31,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 @RequiredArgsConstructor
 public class ManagementFilterPreProcessor implements FilterPreProcessor {
 
-    private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
-
-    private final ApiAuthorizationService apiAuthorizationService;
-    private final ApiRepository apiRepository;
-
     @Override
-    public MetricsContext buildFilters(MetricsContext context) {
-        var userApis = findUserApis(
-            context.auditInfo().organizationId(),
-            context.auditInfo().environmentId(),
-            context.auditInfo().actor().userId()
-        );
+    public List<Filter> buildFilters(MetricsContext context) {
+        var apiIds = context
+            .apis()
+            .map(apis -> apis.stream().map(Api::getId).collect(Collectors.toList()))
+            .orElse(Collections.emptyList());
 
-        var userApisIds = userApis.keySet();
+        var permissionsFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, apiIds);
 
-        var permissionsFilter = new Filter(API, IN, userApisIds);
-
-        return context.withFilters(List.of(permissionsFilter)).withApiNamesById(userApis);
-    }
-
-    private static Map<String, String> mapApiIdsToNames(Collection<Api> apis) {
-        return apis.stream().collect(Collectors.toMap(Api::getId, Api::getName));
-    }
-
-    protected boolean isAdmin() {
-        return SecurityContextHolder.getContext()
-            .getAuthentication()
-            .getAuthorities()
-            .stream()
-            .anyMatch(
-                (Predicate<GrantedAuthority>) grantedAuthority -> {
-                    var authority = grantedAuthority.getAuthority();
-                    return authority.equalsIgnoreCase(ORGANIZATION_ADMIN);
-                }
-            );
-    }
-
-    private Map<String, String> findUserApis(String organizationId, String environmentId, String userId) {
-        ExecutionContext executionContext = new ExecutionContext(organizationId, environmentId);
-
-        ApiCriteria.Builder apiCriteriaBuilder = new ApiCriteria.Builder().environmentId(environmentId);
-
-        if (!isAdmin()) {
-            Set<String> userApiIds = apiAuthorizationService.findApiIdsByUserId(executionContext, userId, null, true);
-
-            apiCriteriaBuilder.ids(userApiIds);
-        }
-
-        List<Api> apis = apiRepository.search(apiCriteriaBuilder.build(), ApiFieldFilter.defaultFields());
-
-        return mapApiIdsToNames(apis);
+        return List.of(permissionsFilter);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/MetricsContextManagerImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/MetricsContextManagerImplTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.infra.domain_service.analytics_engine.MetricsContextManagerImpl;
+import io.gravitee.apim.infra.domain_service.analytics_engine.mapper.ApiMapper;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MetricsContextManagerImplTest {
+
+    record TestCase(
+        String userId,
+        String role,
+        List<io.gravitee.apim.core.api.model.Api> expectedApis,
+        Map<String, String> expectedApiNamesById
+    ) {}
+
+    private final ApiAuthorizationService apiAuthorizationService = mock(ApiAuthorizationService.class);
+    private final ApiRepository apiRepository = mock(ApiRepository.class);
+    private final Authentication authentication = mock(Authentication.class);
+
+    private final MetricsContextManagerImpl metricsContextManager = new MetricsContextManagerImpl(apiAuthorizationService, apiRepository);
+
+    // Test data
+    private static final Api api1 = Api.builder().id("id1").name("api1").build();
+    private static final Api api2 = Api.builder().id("id2").name("api2").build();
+    private static final Api api3 = Api.builder().id("id3").name("api3").build();
+
+    private static final String adminUserId = UUID.randomUUID().toString();
+    private static final List<Api> adminApis = List.of(api1, api2, api3);
+
+    private static final String nonAdminUserId = UUID.randomUUID().toString();
+    private static final List<Api> nonAdminApis = List.of(api2);
+
+    @BeforeEach
+    void setUp() {
+        when(apiAuthorizationService.findApiIdsByUserId(any(), eq(adminUserId), any(), anyBoolean())).thenThrow(
+            new RuntimeException("should not be called")
+        );
+
+        when(apiAuthorizationService.findApiIdsByUserId(any(), eq(nonAdminUserId), any(), anyBoolean())).thenReturn(
+            nonAdminApis.stream().map(Api::getId).collect(Collectors.toSet())
+        );
+
+        when(apiRepository.search(any(), any())).thenAnswer(invocation -> {
+            ApiCriteria criteria = invocation.getArgument(0);
+            if (criteria.getIds() == null) {
+                return adminApis;
+            }
+
+            return nonAdminApis;
+        });
+    }
+
+    AuditInfo buildAuditInfo(String userId) {
+        var actor = AuditActor.builder().userId(userId).build();
+        return AuditInfo.builder().organizationId("DEFAULT").environmentId("DEFAULT").actor(actor).build();
+    }
+
+    void setUpSecurityContext(String role) {
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+
+        var grantedAuthority = new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return role;
+            }
+        };
+
+        Collection<? extends GrantedAuthority> authorities = new ArrayList<>(List.of(grantedAuthority));
+
+        doReturn(authorities).when(authentication).getAuthorities();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void should_return_allowed_apis(TestCase testCase) {
+        var auditInfo = buildAuditInfo(testCase.userId);
+        setUpSecurityContext(testCase.role);
+
+        var contextWithFilters = metricsContextManager.loadApis(new MetricsContext(auditInfo));
+
+        assertThat(contextWithFilters.apis())
+            .isPresent()
+            .hasValueSatisfying(s -> assertThat(s).containsAll(testCase.expectedApis));
+        assertThat(contextWithFilters.apiNameById())
+            .isPresent()
+            .hasValueSatisfying(s -> assertThat(s).containsAllEntriesOf(testCase.expectedApiNamesById));
+    }
+
+    private static Stream<TestCase> testCases() {
+        return Stream.of(
+            new TestCase(
+                adminUserId,
+                "ORGANIZATION:ADMIN",
+                ApiMapper.INSTANCE.map(adminApis),
+                Map.of(api1.getId(), api1.getName(), api2.getId(), api2.getName(), api3.getId(), api3.getName())
+            ),
+            new TestCase(nonAdminUserId, "ORGANIZATION:USER", ApiMapper.INSTANCE.map(nonAdminApis), Map.of(api2.getId(), api2.getName()))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
@@ -16,117 +16,49 @@
 package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.repository.management.api.search.ApiCriteria;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.List;
+import java.util.UUID;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextImpl;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class ManagementFilterPreProcessorTest {
+public class ManagementFilterPreProcessorTest {
 
-    record TestCase(String userId, String role, List<String> expectedApiIds) {}
-
-    private final ApiAuthorizationService apiAuthorizationService = mock(ApiAuthorizationService.class);
-    private final ApiRepository apiRepository = mock(ApiRepository.class);
-    private final Authentication authentication = mock(Authentication.class);
-
-    private final FilterPreProcessor filterPreProcessor = new ManagementFilterPreProcessor(apiAuthorizationService, apiRepository);
-
-    // Test data
-    private static final Api api1 = Api.builder().id("id1").name("api1").build();
-    private static final Api api2 = Api.builder().id("id2").name("api2").build();
-    private static final Api api3 = Api.builder().id("id3").name("api3").build();
-
-    private static final String adminUserId = UUID.randomUUID().toString();
-    private static final List<Api> adminApis = List.of(api1, api2, api3);
-
-    private static final String nonAdminUserId = UUID.randomUUID().toString();
-    private static final List<Api> nonAdminApis = List.of(api2);
-
-    @BeforeEach
-    void setUp() {
-        when(apiAuthorizationService.findApiIdsByUserId(any(), eq(adminUserId), any(), anyBoolean())).thenThrow(
-            new RuntimeException("should not be called")
-        );
-
-        when(apiAuthorizationService.findApiIdsByUserId(any(), eq(nonAdminUserId), any(), anyBoolean())).thenReturn(
-            nonAdminApis.stream().map(Api::getId).collect(Collectors.toSet())
-        );
-
-        when(apiRepository.search(any(), any())).thenAnswer(invocation -> {
-            ApiCriteria criteria = invocation.getArgument(0);
-            if (criteria.getIds() == null) {
-                return adminApis;
-            }
-
-            return nonAdminApis;
-        });
-    }
+    private final FilterPreProcessor filterPreProcessor = new ManagementFilterPreProcessor();
 
     AuditInfo buildAuditInfo(String userId) {
         var actor = AuditActor.builder().userId(userId).build();
         return AuditInfo.builder().organizationId("DEFAULT").environmentId("DEFAULT").actor(actor).build();
     }
 
-    void setUpSecurityContext(String role) {
-        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    @Test
+    public void should_return_allowed_apis() {
+        var auditInfo = buildAuditInfo(UUID.randomUUID().toString());
 
-        var grantedAuthority = new GrantedAuthority() {
-            @Override
-            public String getAuthority() {
-                return role;
-            }
-        };
-
-        Collection<? extends GrantedAuthority> authorities = new ArrayList<>(List.of(grantedAuthority));
-
-        doReturn(authorities).when(authentication).getAuthorities();
-    }
-
-    @ParameterizedTest
-    @MethodSource("testCases")
-    void should_return_allowed_apis(TestCase testCase) {
-        var auditInfo = buildAuditInfo(testCase.userId);
-        setUpSecurityContext(testCase.role);
-
-        var contextWithFilters = filterPreProcessor.buildFilters(new MetricsContext(auditInfo));
-
-        assertThat(contextWithFilters.filters()).size().isEqualTo(1);
-
-        var value = contextWithFilters.filters().getFirst().value();
-        assertThat(value)
-            .isInstanceOf(Set.class)
-            .asInstanceOf(InstanceOfAssertFactories.SET)
-            .containsExactlyInAnyOrderElementsOf(testCase.expectedApiIds);
-    }
-
-    private static Stream<TestCase> testCases() {
-        return Stream.of(
-            new TestCase(adminUserId, "ORGANIZATION:ADMIN", apiIds(adminApis)),
-            new TestCase(nonAdminUserId, "ORGANIZATION:USER", apiIds(nonAdminApis))
+        List<Api> adminApis = List.of(
+            Api.builder().id("id1").name("api1").build(),
+            Api.builder().id("id2").name("api2").build(),
+            Api.builder().id("id3").name("api3").build()
         );
+
+        MetricsContext context = new MetricsContext(auditInfo).withApis(adminApis);
+        var filters = filterPreProcessor.buildFilters(context);
+
+        assertThat(filters).size().isEqualTo(1);
+
+        var value = filters.getFirst().value();
+        assertThat(value).asInstanceOf(InstanceOfAssertFactories.LIST).containsExactlyInAnyOrderElementsOf(apiIds(adminApis));
     }
 
     private static List<String> apiIds(List<Api> apis) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/gko-1973

## Description

This pull request refactors the analytics engine to decouple API loading from filter building in compute use cases.

It extends the `MetricsContext` class to include a new `apis` field along with related methods, which is used to store state from the DB, so data can be reused by pre/post-processors.

Loading of APIs is now handled by the `MetricsContextManager` class.
The `FilterPreProcessor` was updated to only compute filters.

## Additional context

These changes are just a refactoring, so existing functionality for the facets, measures and, time series endpoints should be unchanged.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->