### PR TITLE
fix: fallback to default roles for INTEGRATION scope

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -383,13 +383,24 @@ public class GroupMembersResource extends AbstractResource {
     ) {
         String roleName = roleEntity.getName();
         if (!hasPermission && isLocked.test(groupEntity)) {
-            if (groupEntity.getRoles() != null && !groupEntity.getRoles().isEmpty()) {
-                roleName = groupEntity.getRoles().get(scope);
-            } else {
+            String overrideRole = null;
+
+            // Try to get a role from a group configuration
+            if (groupEntity.getRoles() != null) {
+                overrideRole = groupEntity.getRoles().get(scope);
+            }
+
+            // If a group doesn't have this scope configured, try default roles
+            if (overrideRole == null) {
                 final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(GraviteeContext.getCurrentOrganization(), scope);
                 if (defaultRoles != null && !defaultRoles.isEmpty()) {
-                    roleName = defaultRoles.get(0).getName();
+                    overrideRole = defaultRoles.getFirst().getName();
                 }
+            }
+
+            // Only override if we found a valid role
+            if (overrideRole != null) {
+                roleName = overrideRole;
             }
         }
         return roleName;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12391

## Description
When a Group Owner (non-admin) attempts to add a member to a group, an error is displayed in the UI.

Root Cause:
For the INTEGRATION role scope, no roles were defined at the group level. As a result, the system failed to assign a role during member addition.

Fix Implemented:
The existing logic has been updated to apply default roles when the group does not define any roles for the requested role scope (INTEGRATION). Since default roles already exist for this scenario, the code now correctly falls back to using them.

The fix has been implemented, but confirmation or feedback from the team is still awaited.

