### PR TITLE
add new fields to include / exclude flow into plan list detail

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/app.module.ajs.ts
@@ -236,6 +236,7 @@ import { Router } from '@angular/router';
 import SettingsAnalyticsComponentAjs from './management/settings/analytics/settings-analytics.component.ajs';
 import AnalyticsDashboardComponentAjs from './management/analytics/analytics-dashboard/analytics-dashboard.component.ajs';
 import { GroupV2Service } from './services-ngx/group-v2.service';
+import { ApiPlanV2Service } from './services-ngx/api-plan-v2.service';
 
 (<any>window).jQuery = jQuery;
 
@@ -538,6 +539,7 @@ graviteeManagementModule.service('FlowService', FlowService);
 graviteeManagementModule.factory('ngApiV2Service', downgradeInjectable(ApiV2Service));
 graviteeManagementModule.factory('ngGioPermissionService', downgradeInjectable(GioPermissionService));
 graviteeManagementModule.factory('ngGroupV2Service', downgradeInjectable(GroupV2Service));
+graviteeManagementModule.factory('ngApiPlanV2Service', downgradeInjectable(ApiPlanV2Service));
 
 graviteeManagementModule.controller('DialogGenerateTokenController', DialogGenerateTokenController);
 

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -22,6 +22,7 @@ import AnalyticsService from '../../../../services/analytics.service';
 import TenantService from '../../../../services/tenant.service';
 import { ApiService, LogsQuery } from '../../../../services/api.service';
 import { Constants } from '../../../../entities/Constants';
+import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
 
 class ApiAnalyticsLogsControllerAjs {
   private api: any;
@@ -42,6 +43,7 @@ class ApiAnalyticsLogsControllerAjs {
     private $timeout: ng.ITimeoutService,
     private AnalyticsService: AnalyticsService,
     private TenantService: TenantService,
+    private ngApiPlanV2Service: ApiPlanV2Service,
     private $q: ng.IQService,
     private Constants: Constants,
   ) {
@@ -52,7 +54,10 @@ class ApiAnalyticsLogsControllerAjs {
   $onInit() {
     this.$q
       .all({
-        plans: this.ApiService.getApiPlans(this.activatedRoute.snapshot.params.apiId, 'published,closed,deprecated'),
+        plans: this.ngApiPlanV2Service
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'CLOSED', 'DEPRECATED'], undefined, ['-flow'], 1)
+          .toPromise(),
+        // plans: this.ApiService.getApiPlans(this.activatedRoute.snapshot.params.apiId, 'published,closed,deprecated'),
         applications: this.ApiService.getSubscribers(this.activatedRoute.snapshot.params.apiId, null, null, null, ['owner']),
         tenants: this.TenantService.list(),
         resolvedApi: this.ApiService.get(this.activatedRoute.snapshot.params.apiId),
@@ -179,6 +184,7 @@ ApiAnalyticsLogsControllerAjs.$inject = [
   '$timeout',
   'AnalyticsService',
   'TenantService',
+  'ngApiPlanV2Service',
   '$q',
   'Constants',
 ];

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
@@ -262,7 +262,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
   ];
 
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -347,7 +347,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
   ];
 
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -55,7 +55,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
   );
   apiLogsSubject$ = new ReplaySubject<ApiLogsResponse>(1);
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
@@ -777,7 +777,7 @@ describe('ApiPlanListComponent', () => {
       .expectOne(
         `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&${
           statuses ? `statuses=${castArray(statuses).join(',')}` : 'statuses=PUBLISHED'
-        }${security ? `securities=${security}` : ''}`,
+        }${security ? `securities=${security}` : ''}&fields=-flow`,
         'GET',
       )
       .flush(response);

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -259,7 +259,7 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
   }
 
   private publishNativeKafkaPlan$(plan: Plan): Observable<Plan> {
-    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, ['-flow'], 1, 9999).pipe(
       switchMap((plansResponse) => {
         const publishedKeylessPlan = plansResponse.data.filter((plan) => plan.security.type === 'KEY_LESS');
         const publishedAuthPlans = plansResponse.data.filter((plan) => plan.security.type !== 'KEY_LESS');
@@ -308,7 +308,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
   private initPlansTableDS(selectedStatus: PlanStatus, fullReload = false): void {
     // For full reload, we need to reset the number of plans for each status
     const getApiPlans$: Observable<Plan[]> = fullReload
-      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, undefined, 1, 9999).pipe(
+      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, ['-flow'], 1, 9999).pipe(
           map((plans) => {
             // Update the number of plans for each status
             const plansNumber = plans.data.reduce(
@@ -329,7 +329,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
           }),
         )
       : this.plansService
-          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, undefined, 1, 9999)
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, ['-flow'], 1, 9999)
           .pipe(map((response) => response.data));
 
     getApiPlans$

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -259,7 +259,7 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
   }
 
   private publishNativeKafkaPlan$(plan: Plan): Observable<Plan> {
-    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, 1, 9999).pipe(
+    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
       switchMap((plansResponse) => {
         const publishedKeylessPlan = plansResponse.data.filter((plan) => plan.security.type === 'KEY_LESS');
         const publishedAuthPlans = plansResponse.data.filter((plan) => plan.security.type !== 'KEY_LESS');
@@ -308,7 +308,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
   private initPlansTableDS(selectedStatus: PlanStatus, fullReload = false): void {
     // For full reload, we need to reset the number of plans for each status
     const getApiPlans$: Observable<Plan[]> = fullReload
-      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, 1, 9999).pipe(
+      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, undefined, 1, 9999).pipe(
           map((plans) => {
             // Update the number of plans for each status
             const plansNumber = plans.data.reduce(
@@ -329,7 +329,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
           }),
         )
       : this.plansService
-          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, 1, 9999)
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, undefined, 1, 9999)
           .pipe(map((response) => response.data));
 
     getApiPlans$

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/gio-policy-studio-layout.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/gio-policy-studio-layout.component.ts
@@ -79,7 +79,15 @@ export class GioPolicyStudioLayoutComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.apiService.get(this.activatedRoute.snapshot.params.apiId).pipe(onlyApiV2Filter(this.snackBarService)),
-      this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, 1, 9999),
+      this.apiPlanService.list(
+        this.activatedRoute.snapshot.params.apiId,
+        undefined,
+        ['PUBLISHED', 'DEPRECATED'],
+        undefined,
+        undefined,
+        1,
+        9999,
+      ),
     ])
       .pipe(
         tap(([api, plansResponse]) => {
@@ -103,7 +111,7 @@ export class GioPolicyStudioLayoutComponent implements OnInit, OnDestroy {
     this.isSubmitting = true;
 
     const updatePlans$ = this.apiPlanService
-      .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, 1, 9999)
+      .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, undefined, 1, 9999)
       .pipe(
         switchMap((plansResponse) => {
           const plans = plansResponse.data as PlanV2[];

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -101,15 +101,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
             this.connectorPluginsV2Service.listEntrypointPlugins(),
             this.connectorPluginsV2Service.listEndpointPlugins(),
             this.apiPlanV2Service
-              .list(
-                this.activatedRoute.snapshot.params.apiId,
-                undefined,
-                ['PUBLISHED'],
-                undefined,
-                1,
-                // No pagination here. Policy Studio doesn't support it for now.
-                9999,
-              )
+              .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999)
               .pipe(map((apiPlansResponse) => apiPlansResponse.data)),
             this.policyV2Service.list(),
             this.sharedPolicyGroupsService.getSharedPolicyGroupPolicyPlugin(),

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/transfer/api-portal-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/transfer/api-portal-subscription-transfer-dialog.component.ts
@@ -63,7 +63,7 @@ export class ApiPortalSubscriptionTransferDialogComponent implements OnInit {
     this.form = new UntypedFormGroup({ selectedPlanId: new UntypedFormControl('', { validators: Validators.required }) });
 
     this.apiPlanService
-      .list(this.data.apiId, [this.data.securityType], ['PUBLISHED'], this.data.mode, 1, 9999)
+      .list(this.data.apiId, [this.data.securityType], ['PUBLISHED'], this.data.mode, undefined, 1, 9999)
       .pipe(
         map((response) => response.data.filter((plan) => plan.id !== this.data.currentPlanId)),
 

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -148,7 +148,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
             !this.isKubernetesOrigin &&
             this.api.definitionVersion !== 'V1';
         }),
-        switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, 1, 9999)),
+        switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, undefined, 1, 9999)),
         tap((plansResponse) => (this.plans = plansResponse.data.filter((plan) => plan.security?.type !== 'KEY_LESS'))),
         catchError((error) => {
           this.snackBarService.error(error.message);

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
@@ -60,7 +60,7 @@ describe('ApiPlanV2Service', () => {
         ],
       };
 
-      apiPlanV2Service.list(API_ID).subscribe((apiPlansResponse) => {
+      apiPlanV2Service.list(API_ID, undefined, undefined, undefined, undefined).subscribe((apiPlansResponse) => {
         expect(apiPlansResponse.data).toEqual([
           fakePlanV4({
             id: PLAN_ID,
@@ -89,7 +89,7 @@ describe('ApiPlanV2Service', () => {
         ],
       };
 
-      apiPlanV2Service.list(API_ID, security, statuses, mode).subscribe((apiPlansResponse) => {
+      apiPlanV2Service.list(API_ID, security, statuses, mode, undefined).subscribe((apiPlansResponse) => {
         expect(apiPlansResponse.data).toEqual([
           fakePlanV4({
             id: PLAN_ID,

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
@@ -33,6 +33,7 @@ export class ApiPlanV2Service {
     securities?: string[],
     statuses?: PlanStatus[],
     mode?: PlanMode,
+    fields?: ('flow' | '-flow')[],
     page = 1,
     perPage = 10,
   ): Observable<ApiPlansResponse> {
@@ -43,6 +44,7 @@ export class ApiPlanV2Service {
         ...(securities ? { securities: securities.join(',') } : {}),
         ...(statuses ? { statuses: statuses.join(',') } : {}),
         ...(mode ? { mode } : {}),
+        ...(fields ? { fields: fields.join(',') } : {}),
       },
     });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -85,6 +85,8 @@ import java.util.stream.Stream;
  */
 public class ApiPlansResource extends AbstractResource {
 
+    private static final String FLOW = "flow";
+
     private final PlanMapper planMapper = PlanMapper.INSTANCE;
     private final FlowMapper flowMapper = FlowMapper.INSTANCE;
 
@@ -123,8 +125,13 @@ public class ApiPlansResource extends AbstractResource {
         @QueryParam("securities") @Nonnull Set<PlanSecurityType> securities,
         @QueryParam("mode") PlanMode planMode,
         @QueryParam("subscribableBy") String subscribableBy,
+        @QueryParam("fields") Set<String> fields,
         @BeanParam @Valid PaginationParam paginationParam
     ) {
+        if (fields == null || fields.isEmpty()) {
+            fields = Set.of(FLOW);
+        }
+
         var planQuery = PlanQuery.builder()
             .apiId(apiId)
             .securityType(
@@ -141,8 +148,10 @@ public class ApiPlansResource extends AbstractResource {
             )
             .mode(planMode);
 
+        boolean withFlow = fields.contains(FLOW);
+
         Stream<GenericPlanEntity> plansStream = planSearchService
-            .search(GraviteeContext.getExecutionContext(), planQuery.build(), getAuthenticatedUser(), isAdmin())
+            .search(GraviteeContext.getExecutionContext(), planQuery.build(), getAuthenticatedUser(), isAdmin(), withFlow)
             .stream()
             .sorted(comparingInt(GenericPlanEntity::getOrder))
             .map(this::filterSensitiveData);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -988,6 +988,19 @@ paths:
                   description: Application's identifier. Allow user to get API's plans subscribable by an application.
                   schema:
                       type: string
+                - name: fields
+                  in: query
+                  description: Nested fields of data to return in plans.
+                  schema:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - flow
+                        - -flow
+                    default: ['flow']
+                  explode: false
+                  style: form
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
             tags:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -60,14 +60,12 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanSecurity;
 import io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType;
 import io.gravitee.rest.api.management.v2.rest.model.PlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
-import io.gravitee.rest.api.management.v2.rest.model.PlanValidation;
 import io.gravitee.rest.api.management.v2.rest.model.PlansResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV4;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.PlanType;
-import io.gravitee.rest.api.model.PlanValidationType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
@@ -173,9 +171,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_empty_page_if_no_plans() {
             var planQuery = PlanQuery.builder().apiId(API).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                new ArrayList<>()
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(new ArrayList<>());
 
             final Response response = target.request().get();
 
@@ -193,9 +191,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             PlanEntity plan3 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-3").order(1).build();
 
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan3));
 
             final Response response = target.request().get();
 
@@ -225,9 +223,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             var plan2 = PlanFixtures.aNativePlanEntityV4().toBuilder().id("plan-3").order(1).build();
 
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2));
 
             final Response response = target.request().get();
 
@@ -278,9 +276,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .status(List.of(PlanStatus.DEPRECATED))
                 .mode(io.gravitee.definition.model.v4.plan.PlanMode.STANDARD)
                 .build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan3));
 
             target = target
                 .queryParam("securities", "JWT")
@@ -327,9 +325,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .security(null)
                 .build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2, plan3));
 
             var plan1Subscription = SubscriptionEntity.builder()
                 .apiId(API)
@@ -383,9 +381,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .build();
             var plan2 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-2").apiId(API).build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2));
 
             var subscription = SubscriptionEntity.builder()
                 .apiId(API)
@@ -427,9 +425,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             var plan4 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-4").apiId(API).build();
             var plan5 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-5").apiId(API).build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2, plan3, plan4, plan5)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2, plan3, plan4, plan5));
 
             subscriptionQueryService.initWith(
                 List.of(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
@@ -19,6 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_PLAN;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
-import static java.util.Collections.emptyList;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -73,7 +72,7 @@ public class ApiPlansResource extends AbstractResource {
         }
 
         List<Plan> plans = planSearchService
-            .findByApi(executionContext, apiId)
+            .findByApi(executionContext, apiId, true)
             .stream()
             .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
             .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -110,7 +110,7 @@ public class ApiResource extends AbstractResource {
             }
             if (include.contains(INCLUDE_PLANS)) {
                 List<Plan> plans = planSearchService
-                    .findByApi(executionContext, apiId)
+                    .findByApi(executionContext, apiId, true)
                     .stream()
                     .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
                     .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
@@ -80,7 +80,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         planWrongStatus.setValidation(PlanValidationType.MANUAL);
         planWrongStatus.setStatus(PlanStatus.STAGING);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(plan1, plan2, planWrongStatus));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API, true)).thenReturn(
+            Set.of(plan1, plan2, planWrongStatus)
+        );
 
         when(planMapper.convert(any(GenericPlanEntity.class), any())).thenCallRealMethod();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
@@ -85,7 +85,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
 
         doReturn(new HashSet<GenericPlanEntity>(Arrays.asList(plan1, plan2, plan3)))
             .when(planSearchService)
-            .findByApi(GraviteeContext.getExecutionContext(), API);
+            .findByApi(GraviteeContext.getExecutionContext(), API, true);
 
         doReturn(new Api()).when(apiMapper).convert(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(new Page()).when(pageMapper).convert(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -125,7 +125,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         doReturn(new HashSet<>(Arrays.asList(plan1, plan2, plan3)))
             .when(planSearchService)
-            .findByApi(GraviteeContext.getExecutionContext(), API);
+            .findByApi(GraviteeContext.getExecutionContext(), API, true);
 
         // For pages
         doReturn(true).when(accessControlService).canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -490,7 +490,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         boolean result = false;
         if (MARKDOWN.name().equals(page.getType())) {
             Optional<GenericPlanEntity> optPlan = planSearchService
-                .findByApi(executionContext, apiId)
+                .findByApi(executionContext, apiId, false)
                 .stream()
                 .filter(p -> p.getGeneralConditions() != null)
                 .filter(p -> !(PlanStatus.CLOSED == p.getPlanStatus() || PlanStatus.STAGING == p.getPlanStatus()))
@@ -1343,7 +1343,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             if (PageReferenceType.API.equals(pageToUpdate.getReferenceType())) {
                 if (updatePageEntity.isPublished() != null && !updatePageEntity.isPublished()) {
                     Optional<GenericPlanEntity> activePlan = planSearchService
-                        .findByApi(executionContext, pageToUpdate.getReferenceId())
+                        .findByApi(executionContext, pageToUpdate.getReferenceId(), false)
                         .stream()
                         .filter(plan -> plan.getGeneralConditions() != null)
                         .filter(plan -> pageToUpdate.getId().equals(plan.getGeneralConditions()))
@@ -2192,7 +2192,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             // we can't remove it until the plan is closed
             if (page.getReferenceType() != null && page.getReferenceType().equals(PageReferenceType.API)) {
                 Optional<GenericPlanEntity> activePlan = planSearchService
-                    .findByApi(executionContext, page.getReferenceId())
+                    .findByApi(executionContext, page.getReferenceId(), false)
                     .stream()
                     .filter(plan -> plan.getGeneralConditions() != null)
                     .filter(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -162,7 +162,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
     @Override
     public Set<PlanEntity> findByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().flatMap(this::map).collect(Collectors.toSet());
+        return planSearchService.findByApi(executionContext, api, true).stream().flatMap(this::map).collect(Collectors.toSet());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
@@ -32,9 +32,15 @@ public interface PlanSearchService {
 
     Set<GenericPlanEntity> findByIdIn(final ExecutionContext executionContext, final Set<String> ids);
 
-    Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId);
+    Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId, boolean withFlow);
 
-    List<GenericPlanEntity> search(final ExecutionContext executionContext, final PlanQuery query, String user, boolean isAdmin);
+    List<GenericPlanEntity> search(
+        final ExecutionContext executionContext,
+        final PlanQuery query,
+        String user,
+        boolean isAdmin,
+        boolean expandWithFlow
+    );
 
     boolean anyPlanMismatchWithApi(List<String> planIds, String apiId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -461,7 +461,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             if (io.gravitee.rest.api.model.api.ApiLifecycleState.DEPRECATED == updateApiEntity.getLifecycleState()) {
                 planSearchService
-                    .findByApi(executionContext, apiId)
+                    .findByApi(executionContext, apiId, false)
                     .forEach(plan -> {
                         if (PlanStatus.PUBLISHED == plan.getPlanStatus() || PlanStatus.STAGING == plan.getPlanStatus()) {
                             planService.deprecate(executionContext, plan.getId(), true);
@@ -590,7 +590,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 throw new ApiRunningStateException(apiId);
             }
 
-            Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, apiId);
+            Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, apiId, false);
             if (closePlans) {
                 plans
                     .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -571,7 +571,7 @@ public class ApiStateServiceImpl implements ApiStateService {
                     // 2 - If API definition is synchronized, check if there is any modification for API's plans
                     // but only for published or closed plan
                     if (sync) {
-                        Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, genericApiEntity.getId());
+                        Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, genericApiEntity.getId(), false);
                         sync = plans
                             .stream()
                             .noneMatch(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -188,12 +188,16 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
     @Override
     public Set<PlanEntity> findByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().map(PlanEntity.class::cast).collect(Collectors.toSet());
+        return planSearchService.findByApi(executionContext, api, true).stream().map(PlanEntity.class::cast).collect(Collectors.toSet());
     }
 
     @Override
     public Set<NativePlanEntity> findNativePlansByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().map(NativePlanEntity.class::cast).collect(Collectors.toSet());
+        return planSearchService
+            .findByApi(executionContext, api, true)
+            .stream()
+            .map(NativePlanEntity.class::cast)
+            .collect(Collectors.toSet());
     }
 
     private PlanEntity create(ExecutionContext executionContext, NewPlanEntity newPlan, boolean validatePathParams) {
@@ -514,7 +518,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             String apiId = plan.getApi();
             Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
 
-            return genericPlanMapper.toGenericPlan(api, plan);
+            return genericPlanMapper.toGenericPlanWithFlow(api, plan);
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to close plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to close plan: %s", planId), ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -276,7 +276,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     @Override
     public boolean canDeploy(ExecutionContext executionContext, String apiId) {
         return planSearchService
-            .findByApi(executionContext, apiId)
+            .findByApi(executionContext, apiId, false)
             .stream()
             .anyMatch(
                 planEntity ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
@@ -53,7 +53,7 @@ public class GenericPlanMapper {
         this.flowCrudService = flowCrudService;
     }
 
-    public GenericPlanEntity toGenericPlan(final Api api, final Plan plan) {
+    public GenericPlanEntity toGenericPlanWithFlow(final Api api, final Plan plan) {
         var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
@@ -62,6 +62,18 @@ public class GenericPlanMapper {
             };
             case FEDERATED, FEDERATED_AGENT -> planMapper.toEntity(plan, null);
             default -> planConverter.toPlanEntity(plan, flowServiceV2.findByReference(FlowReferenceType.PLAN, plan.getId()));
+        };
+    }
+
+    public GenericPlanEntity toGenericPlanWithoutFlow(final Api api, final Plan plan) {
+        var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
+        return switch (apiDefinitionVersion) {
+            case V4 -> switch (api.getType()) {
+                case PROXY, MESSAGE -> planMapper.toEntity(plan, null);
+                case NATIVE -> planMapper.toNativeEntity(plan, null);
+            };
+            case FEDERATED, FEDERATED_AGENT -> planMapper.toEntity(plan, null);
+            default -> planConverter.toPlanEntity(plan, null);
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateOrUpdatePagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateOrUpdatePagesTest.java
@@ -28,7 +28,6 @@ import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.PageRevisionService;
-import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.PageConverter;
@@ -109,7 +108,9 @@ public class PageService_CreateOrUpdatePagesTest {
         // Simulate the fact that page 1 is already created
         when(pageRepository.findById(updatedPageId)).thenReturn(Optional.of(page));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), anyString())).thenReturn(Collections.emptySet());
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), anyString(), eq(false))).thenReturn(
+            Collections.emptySet()
+        );
 
         pageService.createOrUpdatePages(GraviteeContext.getExecutionContext(), List.of(page1, page2, page3), API_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_DeleteTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Sets;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.search.PageCriteria;
@@ -168,7 +167,7 @@ public class PageService_DeleteTest {
         page.setReferenceId(API_ID);
         page.setVisibility("PUBLIC");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.emptySet());
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Collections.emptySet());
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
 
@@ -184,7 +183,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.CLOSED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
 
@@ -199,7 +198,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }
@@ -216,7 +215,7 @@ public class PageService_DeleteTest {
         planEntity.setStatus(PlanStatus.PUBLISHED);
 
         when(pageRepository.findById(TRANSLATE_PAGE_ID)).thenReturn(Optional.of(translationPage));
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), TRANSLATE_PAGE_ID);
     }
@@ -229,7 +228,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.DEPRECATED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }
@@ -242,7 +241,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.STAGING);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
@@ -46,9 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -584,12 +582,12 @@ public class PageService_UpdateTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(planStatus);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
         verify(pageRepository).update(argThat(p -> p.getId().equals(PAGE_ID) && !p.isPublished()));
-        verify(planSearchService).findByApi(eq(GraviteeContext.getExecutionContext()), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(eq(GraviteeContext.getExecutionContext()), argThat(p -> p.equals(API_ID)), eq(false));
     }
 
     @Test(expected = PageUsedByCategoryException.class)
@@ -614,7 +612,7 @@ public class PageService_UpdateTest {
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
-        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)), true);
     }
 
     @Test(expected = PageUsedAsGeneralConditionsException.class)
@@ -647,10 +645,10 @@ public class PageService_UpdateTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(planStatus);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
-        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)), false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
@@ -20,19 +20,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.definition.model.flow.Flow;
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
-import io.gravitee.repository.management.model.Plan;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PlanType;
 import io.gravitee.rest.api.model.PlanValidationType;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.configuration.flow.FlowService;
-import io.gravitee.rest.api.service.converter.PlanConverter;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +60,7 @@ public class PlanService_FindByApiTest {
         PlanEntity plan1 = createPlanEntity("plan1");
         PlanEntity plan2 = createPlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         List<PlanEntity> plans = new ArrayList<>(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -469,7 +469,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
@@ -485,7 +485,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.CLOSED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -504,7 +504,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.STAGING);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -526,7 +526,7 @@ public class ApiServiceImplTest {
         io.gravitee.rest.api.model.PlanEntity planEntity = new io.gravitee.rest.api.model.PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(io.gravitee.rest.api.model.PlanStatus.STAGING);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -570,7 +570,9 @@ public class ApiServiceImplTest {
         final PlanEntity closedPlan = new PlanEntity();
         closedPlan.setId(PLAN_ID);
         closedPlan.setStatus(PlanStatus.CLOSED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(
+            Collections.singleton(planEntity)
+        );
         when(planService.close(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(closedPlan);
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -653,7 +653,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         // Date after API but not published -> No redeploy needed
         planStaging.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()))).thenReturn(
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()), eq(false))).thenReturn(
             Set.of(planPublished, planStaging)
         );
 
@@ -678,7 +678,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             1L
         );
         verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
-        verify(planSearchService, times(1)).findByApi(any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any(), eq(false));
     }
 
     @Test
@@ -729,7 +729,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         // Date after API -> Redeploy needed
         planPublished.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()))).thenReturn(
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()), eq(false))).thenReturn(
             Set.of(planPublished)
         );
 
@@ -754,7 +754,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             1L
         );
         verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
-        verify(planSearchService, times(1)).findByApi(any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any(), eq(false));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImplTest.java
@@ -108,7 +108,7 @@ public class PlanSearchServiceImplTest {
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         PlanEntity planEntity = new PlanEntity();
-        when(genericPlanMapper.toGenericPlan(api, plan)).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan)).thenReturn(planEntity);
 
         final GenericPlanEntity resultPlanEntity = planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -126,11 +126,11 @@ public class PlanSearchServiceImplTest {
         apiRepository.findById(plan.getApi());
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(plan.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan)).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan)).thenReturn(planEntity);
 
         PlanEntity planEntity2 = new PlanEntity();
         planEntity2.setId(plan2.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(planEntity2);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(planEntity2);
 
         final Set<GenericPlanEntity> entities = planSearchService.findByIdIn(GraviteeContext.getExecutionContext(), ids);
 
@@ -162,10 +162,10 @@ public class PlanSearchServiceImplTest {
         planEntity1.setId(plan1.getId());
         PlanEntity planEntity2 = new PlanEntity();
         planEntity2.setId(plan2.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(planEntity1);
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(planEntity2);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(planEntity1);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(planEntity2);
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2));
-        Set<GenericPlanEntity> plans = planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID);
+        Set<GenericPlanEntity> plans = planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true);
 
         assertNotNull(plans);
         assertEquals(2, plans.size());
@@ -184,7 +184,7 @@ public class PlanSearchServiceImplTest {
     public void shouldNotFindByApiBecauseTechnicalException() throws TechnicalException {
         when(planRepository.findByApi(API_ID)).thenThrow(TechnicalException.class);
 
-        planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID);
+        planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl_SearchTest.java
@@ -98,6 +98,7 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().build(),
             USER,
+            true,
             true
         );
 
@@ -114,13 +115,13 @@ public class PlanSearchServiceImpl_SearchTest {
         Plan plan3 = createPlan("plan-3");
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2, plan3));
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV4PlanEntity("plan-1", 3, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV4PlanEntity("plan-2", 2, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.STAGING)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV4PlanEntity("plan-3", 1, null, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
 
@@ -128,6 +129,7 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().apiId(API_ID).securityType(List.of(PlanSecurityType.API_KEY)).build(),
             USER,
+            true,
             true
         );
 
@@ -150,7 +152,7 @@ public class PlanSearchServiceImpl_SearchTest {
         rule.setEnabled(true);
         var rules = List.of(rule);
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV2PlanEntity(
                 "plan-1",
                 1,
@@ -160,7 +162,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 rules
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV2PlanEntity(
                 "plan-2",
                 2,
@@ -170,7 +172,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 null
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV2PlanEntity(
                 "plan-3",
                 3,
@@ -180,7 +182,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 null
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan4)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan4)).thenReturn(
             fakeV2PlanEntity(
                 "plan-4",
                 4,
@@ -190,7 +192,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 rules
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan5)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan5)).thenReturn(
             fakeV2PlanEntity(
                 "plan-5",
                 5,
@@ -214,6 +216,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 .mode(PlanMode.STANDARD)
                 .build(),
             USER,
+            true,
             true
         );
 
@@ -228,13 +231,13 @@ public class PlanSearchServiceImpl_SearchTest {
         Plan plan3 = createPlan("plan-3");
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2, plan3));
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV4PlanEntity("plan-1", 3, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV4PlanEntity("plan-2", 2, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.STAGING)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV4PlanEntity("plan-3", 1, null, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
 
@@ -248,7 +251,8 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().apiId(API_ID).build(),
             USER,
-            false
+            false,
+            true
         );
 
         assertNotNull(plans);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
@@ -139,7 +139,7 @@ public class PlanService_CloseTest {
         var planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setApiId(API_ID);
-        when(genericPlanMapper.toGenericPlan(eq(api), eq(plan))).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(eq(api), eq(plan))).thenReturn(planEntity);
 
         GenericPlanEntity genericPlanEntity = planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -174,7 +174,7 @@ public class PlanService_CloseTest {
         var planEntity = new io.gravitee.rest.api.model.PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setApi(API_ID);
-        when(genericPlanMapper.toGenericPlan(eq(api), eq(plan))).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(eq(api), eq(plan))).thenReturn(planEntity);
 
         GenericPlanEntity genericPlanEntity = planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindByApiTest.java
@@ -59,7 +59,7 @@ public class PlanService_FindByApiTest {
         PlanEntity plan1 = createPlanEntity("plan1");
         PlanEntity plan2 = createPlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         List<PlanEntity> plans = new ArrayList<>(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindNativePlansByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindNativePlansByApiTest.java
@@ -52,7 +52,7 @@ public class PlanService_FindNativePlansByApiTest {
         var plan1 = createNativePlanEntity("plan1");
         var plan2 = createNativePlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         var plans = planService.findNativePlansByApi(GraviteeContext.getExecutionContext(), API_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -330,7 +330,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.PUBLISHED).build())
         );
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
@@ -341,7 +341,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.DEPRECATED).build())
         );
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
@@ -352,7 +352,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(Set.of());
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(Set.of());
         assertFalse(apiValidationService.canDeploy(executionContext, apiId));
     }
 
@@ -361,7 +361,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.STAGING).build(), PlanEntity.builder().status(PlanStatus.CLOSED).build())
         );
         assertFalse(apiValidationService.canDeploy(executionContext, apiId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapperTest.java
@@ -67,7 +67,7 @@ public class GenericPlanMapperTest {
         api.setType(ApiType.MESSAGE);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planMapper).toEntity(plan, List.of());
     }
 
@@ -78,7 +78,7 @@ public class GenericPlanMapperTest {
         api.setType(ApiType.NATIVE);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planMapper).toNativeEntity(plan, List.of());
     }
 
@@ -88,7 +88,7 @@ public class GenericPlanMapperTest {
         api.setDefinitionVersion(DefinitionVersion.V2);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 
@@ -98,7 +98,7 @@ public class GenericPlanMapperTest {
         api.setDefinitionVersion(DefinitionVersion.V1);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 
@@ -107,7 +107,7 @@ public class GenericPlanMapperTest {
         Api api = new Api();
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12281
https://gravitee.atlassian.net/browse/APIM-12489

## Description
First PR for improvement

- add new fields to include / exclude flow into plan list page.
- use this to load only what is needed in plan list and in api log filter
- use mAPI v2 resources to remove the "10sec" timeout of getPlans from API log screen
