### PR TITLE
fix: upgrade gravitee-endpoint-kafka 2.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <gravitee-entrypoint-sse.version>4.1.0</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>3.1.3</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
-        <gravitee-endpoint-kafka.version>2.10.2</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>2.10.6</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.2.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>1.3.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.4.1</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-640

## Description

Upgrade gravitee-endpoint-kafka to 2.10.6 to fix message ordering issue
