### PR TITLE
fix: ensure consistent URI construction by normalizing and joining paths 

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/UriHelper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/UriHelper.java
@@ -53,6 +53,18 @@ public class UriHelper {
         return requestOptions.setURI(buildFinalUri(uri, parameters));
     }
 
+    /**
+     * Joins two path segments, normalizing slashes to avoid double slashes.
+     * @param prefix the base path (trailing slash will be removed if present)
+     * @param suffix the path to append (will ensure it starts with /)
+     * @return the joined path
+     */
+    public static String joinPaths(String prefix, String suffix) {
+        String normalizedPrefix = prefix != null && prefix.endsWith("/") ? prefix.substring(0, prefix.length() - 1) : prefix;
+        String normalizedSuffix = suffix != null && !suffix.isEmpty() && !suffix.startsWith("/") ? "/" + suffix : suffix;
+        return (normalizedPrefix != null ? normalizedPrefix : "") + (normalizedSuffix != null ? normalizedSuffix : "");
+    }
+
     private static String buildFinalUri(String targetUri, MultiValueMap<String, String> parameters) {
         if (parameters != null && !parameters.isEmpty()) {
             final StringJoiner parametersAsString = new StringJoiner(URI_PARAM_SEPARATOR);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -305,11 +305,11 @@ public class HttpConnector implements ProxyConnector {
                 uri = customEndpointTarget;
                 isRelative = false;
             } else {
-                uri = endpointOverride ? customEndpointTarget : relativeTarget + customEndpointTarget;
+                uri = endpointOverride ? customEndpointTarget : UriHelper.joinPaths(relativeTarget, customEndpointTarget);
             }
         } else {
             // Just append the current request path.
-            uri = uri + request.pathInfo();
+            uri = UriHelper.joinPaths(uri, request.pathInfo());
         }
 
         if (isRelative) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/UriHelperTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/UriHelperTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -60,5 +62,23 @@ class UriHelperTest {
         assertThat(requestOptions.getHost()).isEqualTo("api.gravitee.io");
         assertThat(requestOptions.getPort()).isEqualTo(443);
         assertThat(requestOptions.isSsl()).isTrue();
+    }
+
+    @ParameterizedTest(name = "joinPaths(\"{0}\", \"{1}\") should return \"{2}\"")
+    @CsvSource(
+        nullValues = "null",
+        value = {
+            "/, /api/users, /api/users",
+            "/base/, /path, /base/path",
+            "/base, /path, /base/path",
+            "/base, path, /base/path",
+            "'', /path, /path",
+            "null, /path, /path",
+            "/base, null, /base",
+            "/base/, '', /base",
+        }
+    )
+    void should_join_paths(String prefix, String suffix, String expected) {
+        assertThat(UriHelper.joinPaths(prefix, suffix)).isEqualTo(expected);
     }
 }


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-12457

## Description

A double // could be noticed when using Service Discovery in v4 APIs. This PR fixes that behavior

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

