### PR TITLE
fix(subscription): preserve metadata when accepting subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
@@ -158,7 +158,13 @@ public class AcceptSubscriptionDomainService {
                 .blockingGet();
         }
 
-        var acceptedSubscription = subscription.acceptBy(auditInfo.actor().userId(), startingAt, endingAt, reason);
+        var acceptedSubscription = subscription.acceptBy(
+            auditInfo.actor().userId(),
+            startingAt,
+            endingAt,
+            reason,
+            subscription.getMetadata()
+        );
 
         if (plan.isApiKey()) {
             synchronized (this) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
@@ -251,6 +251,32 @@ class AcceptSubscriptionDomainServiceTest {
     }
 
     @Test
+    void should_preserve_metadata_when_accepting_subscription() {
+        // Given
+        var initialMetadata = Map.of("consumer_company", "Acme Corp", "consumer_department", "Engineering");
+        SubscriptionEntity subscription = givenExistingSubscription(
+            SubscriptionFixtures.aSubscription()
+                .toBuilder()
+                .subscribedBy("subscriber")
+                .planId(PLAN_PUBLISHED.getId())
+                .applicationId(APPLICATION_ID)
+                .status(SubscriptionEntity.Status.PENDING)
+                .metadata(initialMetadata)
+                .build()
+        );
+
+        // When
+        final SubscriptionEntity result = accept(subscription, PLAN_PUBLISHED);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getId()).isEqualTo("subscription-id");
+            softly.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+            softly.assertThat(result.getMetadata()).isEqualTo(initialMetadata);
+        });
+    }
+
+    @Test
     void should_generated_key_for_API_Key_plan() {
         // Given
         SubscriptionEntity subscription = givenExistingSubscription(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12466

## Description

Fix a critical bug where subscription metadata was lost after approval. The acceptBy() method was called without passing existing metadata, causing it to be overwritten with null.

## Additional context

As this is the first story covering the whole epic, there is no visual way to validate this fix. The only way to test it is by using mAPI. First, create a new subscription including metadata, and once it is accepted, retrieve it and verify that the metadata is still present.

To speed up the testing process, here are the required requests:

POST `{{baseUrl}}/management/v2/environments/{{env}}/apis/{{apiId}}/subscriptions/{{subscriptionId}}`

**body**: 
```
{
  "applicationId": "{{applicationId}}",
  "planId": "{{planId}}",
  "metadata": {
    "consumer_company": "Acme Corp",
    "consumer_department": "Engineering",
    "consumer_contact": "john.doe@acme.com",
    "consumer_region": "US-East"
  }
}
```

Once the subscription is approved, you can get the details using the following request:
GET `{{baseUrl}}/management/v2/environments/{{env}}/apis/{{apiId}}/subscriptions/{{subscriptionId}}`




