### PR TITLE
fix: add page crossId when importing an API V4

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionCreateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionCreateDomainService.java
@@ -185,6 +185,7 @@ public class ImportDefinitionCreateDomainService {
                         page
                             .toBuilder()
                             .id(page.getId() == null ? UuidString.generateRandom() : page.getId())
+                            .crossId(page.getCrossId() == null ? UuidString.generateRandom() : page.getCrossId())
                             .referenceType(Page.ReferenceType.API)
                             .referenceId(apiId)
                             .createdAt(now)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -470,6 +470,7 @@ class ImportApiDefinitionUseCaseTest {
                 var expectedPage = page
                     .toBuilder()
                     .referenceId(API_ID)
+                    .crossId(API_ID)
                     .createdAt(Date.from(INSTANT_NOW))
                     .updatedAt(Date.from(INSTANT_NOW))
                     .build();
@@ -793,7 +794,7 @@ class ImportApiDefinitionUseCaseTest {
         @Test
         void should_create_a_new_api_with_a_page() {
             // Given
-            var page = PageFixtures.aPage().toBuilder().referenceId(null).build();
+            var page = PageFixtures.aPage().toBuilder().referenceId(null).crossId(API_CROSS_ID).build();
             var importDefinition = anApiNativeImportDefinition().toBuilder().pages(List.of(page)).build();
             // When
             useCase.execute(new ImportApiDefinitionUseCase.Input(importDefinition, AUDIT_INFO));
@@ -811,6 +812,7 @@ class ImportApiDefinitionUseCaseTest {
                 var expectedPage = page
                     .toBuilder()
                     .referenceId(API_ID)
+                    .crossId(API_CROSS_ID)
                     .createdAt(Date.from(INSTANT_NOW))
                     .updatedAt(Date.from(INSTANT_NOW))
                     .build();


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1949