### PR TITLE
feat: allow api in api product

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/app.module.ajs.ts
@@ -236,6 +236,7 @@ import { Router } from '@angular/router';
 import SettingsAnalyticsComponentAjs from './management/settings/analytics/settings-analytics.component.ajs';
 import AnalyticsDashboardComponentAjs from './management/analytics/analytics-dashboard/analytics-dashboard.component.ajs';
 import { GroupV2Service } from './services-ngx/group-v2.service';
+import { ApiPlanV2Service } from './services-ngx/api-plan-v2.service';
 
 (<any>window).jQuery = jQuery;
 
@@ -538,6 +539,7 @@ graviteeManagementModule.service('FlowService', FlowService);
 graviteeManagementModule.factory('ngApiV2Service', downgradeInjectable(ApiV2Service));
 graviteeManagementModule.factory('ngGioPermissionService', downgradeInjectable(GioPermissionService));
 graviteeManagementModule.factory('ngGroupV2Service', downgradeInjectable(GroupV2Service));
+graviteeManagementModule.factory('ngApiPlanV2Service', downgradeInjectable(ApiPlanV2Service));
 
 graviteeManagementModule.controller('DialogGenerateTokenController', DialogGenerateTokenController);
 

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
@@ -108,6 +108,12 @@ export interface GenericApi extends BaseApi {
   properties?: Property[];
   primaryOwner?: PrimaryOwner;
   _links?: { [key: string]: string };
+  /**
+   * Indicates whether this API is allowed to be used in API Products.
+   *
+   * Present for V4 HTTP Proxy APIs; defaults to false when absent.
+   */
+  allowInApiProduct?: boolean;
 }
 
 export type ApiState = 'CLOSED' | 'INITIALIZED' | 'STARTED' | 'STOPPED' | 'STOPPING';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/updateApi/updateBaseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/updateApi/updateBaseApi.ts
@@ -75,4 +75,8 @@ export interface UpdateBaseApi {
    */
   disableMembershipNotifications?: boolean;
   properties?: Property[];
+  /**
+   * @description Whether this API can be used in API Products.
+   */
+  allowInApiProduct?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -22,6 +22,7 @@ import AnalyticsService from '../../../../services/analytics.service';
 import TenantService from '../../../../services/tenant.service';
 import { ApiService, LogsQuery } from '../../../../services/api.service';
 import { Constants } from '../../../../entities/Constants';
+import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
 
 class ApiAnalyticsLogsControllerAjs {
   private api: any;
@@ -42,6 +43,7 @@ class ApiAnalyticsLogsControllerAjs {
     private $timeout: ng.ITimeoutService,
     private AnalyticsService: AnalyticsService,
     private TenantService: TenantService,
+    private ngApiPlanV2Service: ApiPlanV2Service,
     private $q: ng.IQService,
     private Constants: Constants,
   ) {
@@ -52,7 +54,10 @@ class ApiAnalyticsLogsControllerAjs {
   $onInit() {
     this.$q
       .all({
-        plans: this.ApiService.getApiPlans(this.activatedRoute.snapshot.params.apiId, 'published,closed,deprecated'),
+        plans: this.ngApiPlanV2Service
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'CLOSED', 'DEPRECATED'], undefined, ['-flow'], 1)
+          .toPromise(),
+        // plans: this.ApiService.getApiPlans(this.activatedRoute.snapshot.params.apiId, 'published,closed,deprecated'),
         applications: this.ApiService.getSubscribers(this.activatedRoute.snapshot.params.apiId, null, null, null, ['owner']),
         tenants: this.TenantService.list(),
         resolvedApi: this.ApiService.get(this.activatedRoute.snapshot.params.apiId),
@@ -179,6 +184,7 @@ ApiAnalyticsLogsControllerAjs.$inject = [
   '$timeout',
   'AnalyticsService',
   'TenantService',
+  'ngApiPlanV2Service',
   '$q',
   'Constants',
 ];

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-mcp-proxy/api-analytics-mcp-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-mcp-proxy/api-analytics-mcp-proxy.component.spec.ts
@@ -372,7 +372,7 @@ describe('ApiAnalyticsMcpProxyComponent', () => {
   function expectPlanList(plans: PlanV4[] = []) {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED,CLOSED`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED,CLOSED&fields=-flow`,
         method: 'GET',
       })
       .flush(fakePagedResult(plans));

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-mcp-proxy/api-analytics-mcp-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-mcp-proxy/api-analytics-mcp-proxy.component.ts
@@ -306,7 +306,7 @@ export class ApiAnalyticsMcpProxyComponent implements OnInit, OnDestroy {
   ];
 
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, ['-flow'], 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
@@ -266,7 +266,7 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
   ];
 
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -348,7 +348,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
   ];
 
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -55,7 +55,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
   );
   apiLogsSubject$ = new ReplaySubject<ApiLogsResponse>(1);
   apiPlans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, 1, 9999)
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)
     .pipe(
       map((plans) => plans.data),
       shareReplay(1),

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -80,6 +80,23 @@
                 </mat-select>
               </mat-form-field>
 
+              <mat-form-field class="details-card__header__info-inputs__second-row__description-field">
+                <mat-label>Description</mat-label>
+                <textarea matInput formControlName="description" data-testid="api_info_descriptionfield"></textarea>
+              </mat-form-field>
+
+              @if (canDisplayAllowInApiProduct) {
+                <gio-form-slide-toggle class="details-card__header__info-inputs__second-row__allow-in-api-products-field">
+                  Allow in API Products
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    formControlName="allowInApiProduct"
+                    aria-label="Allow in API Products"
+                    name="allowInApiProduct"
+                  />
+                </gio-form-slide-toggle>
+              }
+
               @if (canDisplayV4EmulationEngineToggle) {
                 <gio-form-slide-toggle class="details-card__header__info-inputs__second-row__emulate-v4-engine-field">
                   Emulate v4 engine

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -80,11 +80,6 @@
                 </mat-select>
               </mat-form-field>
 
-              <mat-form-field class="details-card__header__info-inputs__second-row__description-field">
-                <mat-label>Description</mat-label>
-                <textarea matInput formControlName="description" data-testid="api_info_descriptionfield"></textarea>
-              </mat-form-field>
-
               @if (canDisplayAllowInApiProduct) {
                 <gio-form-slide-toggle class="details-card__header__info-inputs__second-row__allow-in-api-products-field">
                   Allow in API Products

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -94,12 +94,15 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
   };
   public cannotPromote = true;
   public canDisplayV4EmulationEngineToggle = false;
+  public canDisplayAllowInApiProduct = false;
 
   public isQualityEnabled = false;
   public isQualitySupported = false;
 
   public isReadOnly = false;
   public isKubernetesOrigin = false;
+
+  public isInApiProduct = false;
 
   public integrationName = '';
   public integrationId = '';
@@ -156,10 +159,16 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
             this.apiType = (api as ApiV4).type;
           }
 
+          const isV4HttpProxy = api.definitionVersion === 'V4' && (api as ApiV4).type === 'PROXY';
+          this.canDisplayAllowInApiProduct = isV4HttpProxy;
+
           this.isReadOnly =
             !this.permissionService.hasAnyMatching(['api-definition-u']) || this.isKubernetesOrigin || api.definitionVersion === 'V1';
 
           this.api = api;
+
+          const productIds = (api as { productIds?: string[] }).productIds;
+          this.isInApiProduct = Array.isArray(productIds) && productIds.length > 0;
 
           this.apiCategories = categories;
           this.apiOwner = api.primaryOwner.displayName;
@@ -225,6 +234,15 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
               value: api.definitionVersion === 'V2' && (api as ApiV2).executionMode === 'V4_EMULATION_ENGINE',
               disabled: this.isReadOnly,
             }),
+            // Only add allowInApiProduct control for V4 Proxy APIs
+            ...(this.canDisplayAllowInApiProduct
+              ? {
+                  allowInApiProduct: new UntypedFormControl({
+                    value: api.allowInApiProduct ?? false,
+                    disabled: this.isReadOnly || this.isInApiProduct,
+                  }),
+                }
+              : {}),
           });
           this.apiImagesForm = new UntypedFormGroup({
             picture: new UntypedFormControl({
@@ -285,6 +303,10 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
               ...(this.canDisplayV4EmulationEngineToggle
                 ? { executionMode: apiDetailsFormValue.emulateV4Engine ? 'V4_EMULATION_ENGINE' : 'V3' }
                 : {}),
+              // Only include allowInApiProduct for V4 Proxy APIs
+              ...(this.canDisplayAllowInApiProduct && apiDetailsFormValue.allowInApiProduct !== undefined
+                ? { allowInApiProduct: apiDetailsFormValue.allowInApiProduct }
+                : {}),
             };
             return apiToUpdate;
           }
@@ -295,6 +317,10 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
             description: apiDetailsFormValue.description,
             labels: apiDetailsFormValue.labels,
             categories: apiDetailsFormValue.categories,
+            // Only include allowInApiProduct for V4 Proxy APIs
+            ...(this.canDisplayAllowInApiProduct && apiDetailsFormValue.allowInApiProduct !== undefined
+              ? { allowInApiProduct: apiDetailsFormValue.allowInApiProduct }
+              : {}),
           };
           return apiToUpdate;
         }),

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
@@ -777,7 +777,7 @@ describe('ApiPlanListComponent', () => {
       .expectOne(
         `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&${
           statuses ? `statuses=${castArray(statuses).join(',')}` : 'statuses=PUBLISHED'
-        }${security ? `securities=${security}` : ''}`,
+        }${security ? `securities=${security}` : ''}&fields=-flow`,
         'GET',
       )
       .flush(response);

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -259,7 +259,7 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
   }
 
   private publishNativeKafkaPlan$(plan: Plan): Observable<Plan> {
-    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, ['-flow'], 1, 9999).pipe(
       switchMap((plansResponse) => {
         const publishedKeylessPlan = plansResponse.data.filter((plan) => plan.security.type === 'KEY_LESS');
         const publishedAuthPlans = plansResponse.data.filter((plan) => plan.security.type !== 'KEY_LESS');
@@ -308,7 +308,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
   private initPlansTableDS(selectedStatus: PlanStatus, fullReload = false): void {
     // For full reload, we need to reset the number of plans for each status
     const getApiPlans$: Observable<Plan[]> = fullReload
-      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, undefined, 1, 9999).pipe(
+      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, ['-flow'], 1, 9999).pipe(
           map((plans) => {
             // Update the number of plans for each status
             const plansNumber = plans.data.reduce(
@@ -329,7 +329,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
           }),
         )
       : this.plansService
-          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, undefined, 1, 9999)
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, ['-flow'], 1, 9999)
           .pipe(map((response) => response.data));
 
     getApiPlans$

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -259,7 +259,7 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
   }
 
   private publishNativeKafkaPlan$(plan: Plan): Observable<Plan> {
-    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, 1, 9999).pipe(
+    return this.plansService.list(this.api.id, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
       switchMap((plansResponse) => {
         const publishedKeylessPlan = plansResponse.data.filter((plan) => plan.security.type === 'KEY_LESS');
         const publishedAuthPlans = plansResponse.data.filter((plan) => plan.security.type !== 'KEY_LESS');
@@ -308,7 +308,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
   private initPlansTableDS(selectedStatus: PlanStatus, fullReload = false): void {
     // For full reload, we need to reset the number of plans for each status
     const getApiPlans$: Observable<Plan[]> = fullReload
-      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, 1, 9999).pipe(
+      ? this.plansService.list(this.activatedRoute.snapshot.params.apiId, undefined, [...PLAN_STATUS], undefined, undefined, 1, 9999).pipe(
           map((plans) => {
             // Update the number of plans for each status
             const plansNumber = plans.data.reduce(
@@ -329,7 +329,7 @@ Your published ${plan.security.type === 'KEY_LESS' ? plansWithAuthentication : '
           }),
         )
       : this.plansService
-          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, 1, 9999)
+          .list(this.activatedRoute.snapshot.params.apiId, undefined, [selectedStatus], undefined, undefined, 1, 9999)
           .pipe(map((response) => response.data));
 
     getApiPlans$

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/gio-policy-studio-layout.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/gio-policy-studio-layout.component.ts
@@ -79,7 +79,15 @@ export class GioPolicyStudioLayoutComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.apiService.get(this.activatedRoute.snapshot.params.apiId).pipe(onlyApiV2Filter(this.snackBarService)),
-      this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, 1, 9999),
+      this.apiPlanService.list(
+        this.activatedRoute.snapshot.params.apiId,
+        undefined,
+        ['PUBLISHED', 'DEPRECATED'],
+        undefined,
+        undefined,
+        1,
+        9999,
+      ),
     ])
       .pipe(
         tap(([api, plansResponse]) => {
@@ -103,7 +111,7 @@ export class GioPolicyStudioLayoutComponent implements OnInit, OnDestroy {
     this.isSubmitting = true;
 
     const updatePlans$ = this.apiPlanService
-      .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, 1, 9999)
+      .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, undefined, 1, 9999)
       .pipe(
         switchMap((plansResponse) => {
           const plans = plansResponse.data as PlanV2[];

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -103,15 +103,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
             this.connectorPluginsV2Service.listEntrypointPlugins(),
             this.connectorPluginsV2Service.listEndpointPlugins(),
             this.apiPlanV2Service
-              .list(
-                this.activatedRoute.snapshot.params.apiId,
-                undefined,
-                ['PUBLISHED'],
-                undefined,
-                1,
-                // No pagination here. Policy Studio doesn't support it for now.
-                9999,
-              )
+              .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999)
               .pipe(map((apiPlansResponse) => apiPlansResponse.data)),
             this.policyV2Service.list(),
             this.sharedPolicyGroupsService.getSharedPolicyGroupPolicyPlugin(),

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/transfer/api-portal-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/transfer/api-portal-subscription-transfer-dialog.component.ts
@@ -63,7 +63,7 @@ export class ApiPortalSubscriptionTransferDialogComponent implements OnInit {
     this.form = new UntypedFormGroup({ selectedPlanId: new UntypedFormControl('', { validators: Validators.required }) });
 
     this.apiPlanService
-      .list(this.data.apiId, [this.data.securityType], ['PUBLISHED'], this.data.mode, 1, 9999)
+      .list(this.data.apiId, [this.data.securityType], ['PUBLISHED'], this.data.mode, undefined, 1, 9999)
       .pipe(
         map((response) => response.data.filter((plan) => plan.id !== this.data.currentPlanId)),
 

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -148,7 +148,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
             !this.isKubernetesOrigin &&
             this.api.definitionVersion !== 'V1';
         }),
-        switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, 1, 9999)),
+        switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, undefined, 1, 9999)),
         tap((plansResponse) => (this.plans = plansResponse.data.filter((plan) => plan.security?.type !== 'KEY_LESS'))),
         catchError((error) => {
           this.snackBarService.error(error.message);

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
@@ -60,7 +60,7 @@ describe('ApiPlanV2Service', () => {
         ],
       };
 
-      apiPlanV2Service.list(API_ID).subscribe((apiPlansResponse) => {
+      apiPlanV2Service.list(API_ID, undefined, undefined, undefined, undefined).subscribe((apiPlansResponse) => {
         expect(apiPlansResponse.data).toEqual([
           fakePlanV4({
             id: PLAN_ID,
@@ -89,7 +89,7 @@ describe('ApiPlanV2Service', () => {
         ],
       };
 
-      apiPlanV2Service.list(API_ID, security, statuses, mode).subscribe((apiPlansResponse) => {
+      apiPlanV2Service.list(API_ID, security, statuses, mode, undefined).subscribe((apiPlansResponse) => {
         expect(apiPlansResponse.data).toEqual([
           fakePlanV4({
             id: PLAN_ID,

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
@@ -33,6 +33,7 @@ export class ApiPlanV2Service {
     securities?: string[],
     statuses?: PlanStatus[],
     mode?: PlanMode,
+    fields?: ('flow' | '-flow')[],
     page = 1,
     perPage = 10,
   ): Observable<ApiPlansResponse> {
@@ -43,6 +44,7 @@ export class ApiPlanV2Service {
         ...(securities ? { securities: securities.join(',') } : {}),
         ...(statuses ? { statuses: statuses.join(',') } : {}),
         ...(mode ? { mode } : {}),
+        ...(fields ? { fields: fields.join(',') } : {}),
       },
     });
   }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -88,6 +88,11 @@ public class Api extends AbstractApi {
 
     private ApiServices services;
 
+    /**
+     * Indicates whether this API is allowed to be used in API Products.
+     */
+    private boolean allowInApiProduct;
+
     public Api(Api other) {
         super(other.id, other.name, other.type, other.apiVersion, other.definitionVersion, other.tags, other.properties, other.resources);
         this.listeners = other.listeners;
@@ -99,6 +104,34 @@ public class Api extends AbstractApi {
         this.flows = other.flows;
         this.responseTemplates = other.responseTemplates;
         this.services = other.services;
+        this.allowInApiProduct = other.allowInApiProduct;
+    }
+
+    /**
+     * Backward-compatible constructor kept for callers that don't know about {@code allowInApiProduct}.
+     * Defaults {@code allowInApiProduct} to {@code false}.
+     */
+    public Api(
+        List<@NotNull Listener> listeners,
+        List<EndpointGroup> endpointGroups,
+        Analytics analytics,
+        Failover failover,
+        Map<String, Plan> plans,
+        FlowExecution flowExecution,
+        List<Flow> flows,
+        Map<String, Map<String, ResponseTemplate>> responseTemplates,
+        ApiServices services
+    ) {
+        this.listeners = listeners;
+        this.endpointGroups = endpointGroups;
+        this.analytics = analytics;
+        this.failover = failover;
+        this.plans = plans;
+        this.flowExecution = flowExecution != null ? flowExecution : new FlowExecution();
+        this.flows = flows;
+        this.responseTemplates = responseTemplates;
+        this.services = services;
+        this.allowInApiProduct = false;
     }
 
     public Plan getPlan(final String plan) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -51,5 +51,63 @@
         "ssl": {
             "$ref": "#/definitions/ssl"
         }
+    },
+    "gioExternalDefinitions": {
+      "clearTextUpgrade": {
+        "title": "Allow h2c Clear Text Upgrade",
+        "type": "boolean",
+        "default": false,
+        "gioConfig": {
+          "banner": {
+            "title": "HTTP/2 Cleartext (H2C)",
+            "text": "If enabled, an h2c connection is established using an HTTP/1.1 upgrade request. When disabled (recommended), h2c connection is established directly with prior knowledge. Disabled by default. ⚠️ Enabling clear text upgrade can cause failures when upgrading chunked HTTP/1.1 requests to HTTP/2."
+          }
+        }
+      },
+      "maxConcurrentConnections": {
+        "type": "integer",
+        "title": "Max Concurrent Connections",
+        "description": "Maximum pool size for connections.",
+        "default": 20,
+        "gioConfig": {
+          "banner": {
+            "title": "Max concurrent HTTP/2 connections",
+            "text": "HTTP/2 connections are multiplexed, so a single connection can handle multiple requests concurrently. However, to optimize performance and resource utilization, it's beneficial to establish multiple concurrent connections to the upstream server. This setting defines the maximum number of concurrent HTTP/2 connections that can be established to the upstream server. The default value is 20 connections. Total of (max concurrent stream) x (max concurrent connections) gives the maximum number of concurrent requests to the upstream. A new connection will be created if all existing connections have reached the maximum concurrent streams limit."
+          }
+        }
+      },
+      "http2MultiplexingLimit": {
+        "type": "integer",
+        "title": "Max concurrent stream for an HTTP/2 connection",
+        "default": 25,
+        "gioConfig": {
+          "banner": {
+            "title": "Max concurrent stream for an HTTP/2 connection",
+            "text": "The maximum number of concurrent streams allowed for each HTTP/2 connection. The actual number of streams per connection is the minimum of this value and the server's initial settings. For example, if set to 10 and the server's initial setting is 1000, the max number of streams will be 10. 25 is the default. Total of (max concurrent stream) x (max concurrent connections) gives the maximum number of concurrent requests to the upstream."
+          }
+        }
+      },
+      "http2ConnectionWindowSize": {
+        "type": "integer",
+        "title": "Connection Window Size for an HTTP/2 connection",
+        "default": 1048576,
+        "gioConfig": {
+          "banner": {
+            "title": "Connection Window Size for an HTTP/2 connection",
+            "text": "Connection Window Size in bytes can be increased to a larger value such as 5MB (5242880 bytes) to improve throughput. Default is 1MB (1048576 bytes)."
+          }
+        }
+      },
+      "http2StreamWindowSize": {
+        "type": "integer",
+        "title": "Stream initial window size for each HTTP/2 stream",
+        "default": 262144,
+        "gioConfig": {
+          "banner": {
+            "title": "Stream initial window size for each HTTP/2 stream",
+            "text": "Stream Window Size in bytes can be increased to a larger value such as 1MB (1048576 bytes) to improve throughput (initial settings). 256KB (262144) is the default."
+          }
+        }
+      }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -85,6 +85,8 @@ import java.util.stream.Stream;
  */
 public class ApiPlansResource extends AbstractResource {
 
+    private static final String FLOW = "flow";
+
     private final PlanMapper planMapper = PlanMapper.INSTANCE;
     private final FlowMapper flowMapper = FlowMapper.INSTANCE;
 
@@ -123,8 +125,13 @@ public class ApiPlansResource extends AbstractResource {
         @QueryParam("securities") @Nonnull Set<PlanSecurityType> securities,
         @QueryParam("mode") PlanMode planMode,
         @QueryParam("subscribableBy") String subscribableBy,
+        @QueryParam("fields") Set<String> fields,
         @BeanParam @Valid PaginationParam paginationParam
     ) {
+        if (fields == null || fields.isEmpty()) {
+            fields = Set.of(FLOW);
+        }
+
         var planQuery = PlanQuery.builder()
             .apiId(apiId)
             .securityType(
@@ -141,8 +148,10 @@ public class ApiPlansResource extends AbstractResource {
             )
             .mode(planMode);
 
+        boolean withFlow = fields.contains(FLOW);
+
         Stream<GenericPlanEntity> plansStream = planSearchService
-            .search(GraviteeContext.getExecutionContext(), planQuery.build(), getAuthenticatedUser(), isAdmin())
+            .search(GraviteeContext.getExecutionContext(), planQuery.build(), getAuthenticatedUser(), isAdmin(), withFlow)
             .stream()
             .sorted(comparingInt(GenericPlanEntity::getOrder))
             .map(this::filterSensitiveData);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3320,6 +3320,10 @@ components:
                           description: The list of path mappings associated with this API.
                           items:
                               type: string
+                      allowInApiProduct:
+                          type: boolean
+                          description: Indicates whether this API is allowed to be used in API Products.
+                          default: false
                       entrypoints:
                           type: array
                           description: The list of entrypoints associated with this API.
@@ -3354,6 +3358,10 @@ components:
                               $ref: "#/components/schemas/FlowV4"
                       services:
                           $ref: "#/components/schemas/ApiServices"
+                      allowInApiProduct:
+                          type: boolean
+                          description: Indicates whether this API is allowed to be used in API Products.
+                          default: false
 
         ApiFederated:
             type: object
@@ -3785,6 +3793,10 @@ components:
                         - awesome
                     items:
                         type: string
+                allowInApiProduct:
+                    type: boolean
+                    description: Indicates whether this API is allowed to be used in API Products.
+                    default: false
                 lifecycleState:
                     $ref: "#/components/schemas/ApiLifecycleState"
                 disableMembershipNotifications:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3282,6 +3282,10 @@ components:
                           description: The list of path mappings associated with this API.
                           items:
                               type: string
+                      allowInApiProduct:
+                          type: boolean
+                          description: Indicates whether this API is allowed to be used in API Products.
+                          default: false
                       entrypoints:
                           type: array
                           description: The list of entrypoints associated with this API.
@@ -3316,6 +3320,10 @@ components:
                               $ref: "#/components/schemas/FlowV4"
                       services:
                           $ref: "#/components/schemas/ApiServices"
+                      allowInApiProduct:
+                          type: boolean
+                          description: Indicates whether this API is allowed to be used in API Products.
+                          default: false
 
         ApiFederated:
             type: object
@@ -3747,6 +3755,10 @@ components:
                         - awesome
                     items:
                         type: string
+                allowInApiProduct:
+                    type: boolean
+                    description: Indicates whether this API is allowed to be used in API Products.
+                    default: false
                 lifecycleState:
                     $ref: "#/components/schemas/ApiLifecycleState"
                 disableMembershipNotifications:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1019,6 +1019,19 @@ paths:
                   description: Application's identifier. Allow user to get API's plans subscribable by an application.
                   schema:
                       type: string
+                - name: fields
+                  in: query
+                  description: Nested fields of data to return in plans.
+                  schema:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - flow
+                        - -flow
+                    default: ['flow']
+                  explode: false
+                  style: form
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
             tags:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -60,14 +60,12 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanSecurity;
 import io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType;
 import io.gravitee.rest.api.management.v2.rest.model.PlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
-import io.gravitee.rest.api.management.v2.rest.model.PlanValidation;
 import io.gravitee.rest.api.management.v2.rest.model.PlansResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV4;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.PlanType;
-import io.gravitee.rest.api.model.PlanValidationType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
@@ -173,9 +171,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_empty_page_if_no_plans() {
             var planQuery = PlanQuery.builder().apiId(API).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                new ArrayList<>()
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(new ArrayList<>());
 
             final Response response = target.request().get();
 
@@ -193,9 +191,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             PlanEntity plan3 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-3").order(1).build();
 
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan3));
 
             final Response response = target.request().get();
 
@@ -225,9 +223,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             var plan2 = PlanFixtures.aNativePlanEntityV4().toBuilder().id("plan-3").order(1).build();
 
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2));
 
             final Response response = target.request().get();
 
@@ -278,9 +276,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .status(List.of(PlanStatus.DEPRECATED))
                 .mode(io.gravitee.definition.model.v4.plan.PlanMode.STANDARD)
                 .build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan3));
 
             target = target
                 .queryParam("securities", "JWT")
@@ -327,9 +325,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .security(null)
                 .build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2, plan3)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2, plan3));
 
             var plan1Subscription = SubscriptionEntity.builder()
                 .apiId(API)
@@ -383,9 +381,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .build();
             var plan2 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-2").apiId(API).build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2));
 
             var subscription = SubscriptionEntity.builder()
                 .apiId(API)
@@ -427,9 +425,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             var plan4 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-4").apiId(API).build();
             var plan5 = PlanFixtures.aPlanEntityV4().toBuilder().id("plan-5").apiId(API).build();
             var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
-            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true))).thenReturn(
-                List.of(plan1, plan2, plan3, plan4, plan5)
-            );
+            when(
+                planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true), eq(true))
+            ).thenReturn(List.of(plan1, plan2, plan3, plan4, plan5));
 
             subscriptionQueryService.initWith(
                 List.of(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
@@ -19,6 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -383,13 +383,24 @@ public class GroupMembersResource extends AbstractResource {
     ) {
         String roleName = roleEntity.getName();
         if (!hasPermission && isLocked.test(groupEntity)) {
-            if (groupEntity.getRoles() != null && !groupEntity.getRoles().isEmpty()) {
-                roleName = groupEntity.getRoles().get(scope);
-            } else {
+            String overrideRole = null;
+
+            // Try to get a role from a group configuration
+            if (groupEntity.getRoles() != null) {
+                overrideRole = groupEntity.getRoles().get(scope);
+            }
+
+            // If a group doesn't have this scope configured, try default roles
+            if (overrideRole == null) {
                 final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(GraviteeContext.getCurrentOrganization(), scope);
                 if (defaultRoles != null && !defaultRoles.isEmpty()) {
-                    roleName = defaultRoles.get(0).getName();
+                    overrideRole = defaultRoles.getFirst().getName();
                 }
+            }
+
+            // Only override if we found a valid role
+            if (overrideRole != null) {
+                roleName = overrideRole;
             }
         }
         return roleName;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.api;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.gravitee.common.component.Lifecycle;
@@ -236,6 +237,24 @@ public class ApiEntity implements GenericApiEntity {
 
     @JsonProperty("disable_membership_notifications")
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    /**
+     * Custom getter that returns null for non-V4-Proxy APIs to ensure the key is omitted from JSON.
+     * Jackson's @JsonInclude(NON_NULL) will skip serializing this field when null.
+     * This is the V2 ApiEntity class, so it will always return null (V2 APIs don't support allowInApiProduct).
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        // V2 ApiEntity: always return null since allowInApiProduct is only for V4 Proxy APIs
+        // V4 APIs use io.gravitee.rest.api.model.v4.api.ApiEntity which has its own getter
+        return null;
+    }
 
     private List<ApiEntrypointEntity> entrypoints;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model.v4.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
@@ -201,6 +202,25 @@ public class ApiEntity implements GenericApiEntity {
     private WorkflowState workflowState;
 
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    /**
+     * Custom getter that returns null for non-V4-Proxy APIs to ensure the key is omitted from JSON.
+     * Jackson's @JsonInclude(NON_NULL) will skip serializing this field when null.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        // Strict enforcement: if it's not V4 or not PROXY, return null so Jackson skips the key
+        if (this.definitionVersion == DefinitionVersion.V4 && this.type == ApiType.PROXY) {
+            return allowInApiProduct;
+        }
+        return null;
+    }
 
     @Schema(description = "the API background encoded in base64")
     private String background;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model.v4.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
@@ -190,6 +191,25 @@ public class UpdateApiEntity {
     private ApiLifecycleState lifecycleState;
 
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    /**
+     * Custom getter that returns null for non-V4-Proxy APIs to ensure the key is omitted from JSON.
+     * Jackson's @JsonInclude(NON_NULL) will skip serializing this field when null.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        // Strict enforcement: if it's not V4 or not PROXY, return null so Jackson skips the key
+        if (this.definitionVersion == DefinitionVersion.V4 && this.type == ApiType.PROXY) {
+            return allowInApiProduct;
+        }
+        return null;
+    }
 
     @Schema(description = "the API background encoded in base64")
     private String background;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_PLAN;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
-import static java.util.Collections.emptyList;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -73,7 +72,7 @@ public class ApiPlansResource extends AbstractResource {
         }
 
         List<Plan> plans = planSearchService
-            .findByApi(executionContext, apiId)
+            .findByApi(executionContext, apiId, true)
             .stream()
             .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
             .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -110,7 +110,7 @@ public class ApiResource extends AbstractResource {
             }
             if (include.contains(INCLUDE_PLANS)) {
                 List<Plan> plans = planSearchService
-                    .findByApi(executionContext, apiId)
+                    .findByApi(executionContext, apiId, true)
                     .stream()
                     .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
                     .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
@@ -80,7 +80,9 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         planWrongStatus.setValidation(PlanValidationType.MANUAL);
         planWrongStatus.setStatus(PlanStatus.STAGING);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(plan1, plan2, planWrongStatus));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API, true)).thenReturn(
+            Set.of(plan1, plan2, planWrongStatus)
+        );
 
         when(planMapper.convert(any(GenericPlanEntity.class), any())).thenCallRealMethod();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
@@ -85,7 +85,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
 
         doReturn(new HashSet<GenericPlanEntity>(Arrays.asList(plan1, plan2, plan3)))
             .when(planSearchService)
-            .findByApi(GraviteeContext.getExecutionContext(), API);
+            .findByApi(GraviteeContext.getExecutionContext(), API, true);
 
         doReturn(new Api()).when(apiMapper).convert(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(new Page()).when(pageMapper).convert(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -125,7 +125,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         doReturn(new HashSet<>(Arrays.asList(plan1, plan2, plan3)))
             .when(planSearchService)
-            .findByApi(GraviteeContext.getExecutionContext(), API);
+            .findByApi(GraviteeContext.getExecutionContext(), API, true);
 
         // For pages
         doReturn(true).when(accessControlService).canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
@@ -111,7 +111,8 @@ public sealed interface ApiDescriptor {
         List<Property> properties,
         List<Resource> resources,
         ApiServices services,
-        Failover failover
+        Failover failover,
+        Boolean allowInApiProduct
     ) implements ApiDescriptor {
         @JsonProperty("definitionVersion")
         @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
@@ -109,6 +109,7 @@ public class ApiExport {
     private ApiLifecycleState lifecycleState;
     private WorkflowState workflowState;
     private boolean disableMembershipNotifications;
+    private Boolean allowInApiProduct;
     private String background;
     private String backgroundUrl;
 
@@ -140,7 +141,7 @@ public class ApiExport {
         if (ApiType.NATIVE.equals(type)) {
             return null;
         }
-        return io.gravitee.definition.model.v4.Api.builder()
+        var builder = io.gravitee.definition.model.v4.Api.builder()
             .analytics(analytics)
             .apiVersion(apiVersion)
             .definitionVersion(DefinitionVersion.V4)
@@ -156,6 +157,11 @@ public class ApiExport {
             .tags(tags)
             .type(type)
             .services((ApiServices) services);
+        // Only set allowInApiProduct for V4 Proxy APIs
+        if (type == ApiType.PROXY && allowInApiProduct != null) {
+            builder.allowInApiProduct(allowInApiProduct);
+        }
+        return builder;
     }
 
     public io.gravitee.definition.model.v4.nativeapi.NativeApi.NativeApiBuilder<?, ?> toNativeApiDefinitionBuilder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
@@ -158,7 +158,13 @@ public class AcceptSubscriptionDomainService {
                 .blockingGet();
         }
 
-        var acceptedSubscription = subscription.acceptBy(auditInfo.actor().userId(), startingAt, endingAt, reason);
+        var acceptedSubscription = subscription.acceptBy(
+            auditInfo.actor().userId(),
+            startingAt,
+            endingAt,
+            reason,
+            subscription.getMetadata()
+        );
 
         if (plan.isApiKey()) {
             synchronized (this) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -107,6 +107,7 @@ public interface GraviteeDefinitionAdapter {
         expression = "java(apiEntity.getApiDefinitionHttpV4() != null ? apiEntity.getApiDefinitionHttpV4().getFailover() : null)"
     )
     @Mapping(target = "endpointGroups", source = "apiEntity.apiDefinitionHttpV4.endpointGroups")
+    @Mapping(target = "allowInApiProduct", source = "apiEntity.apiDefinitionHttpV4.allowInApiProduct")
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -490,7 +490,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         boolean result = false;
         if (MARKDOWN.name().equals(page.getType())) {
             Optional<GenericPlanEntity> optPlan = planSearchService
-                .findByApi(executionContext, apiId)
+                .findByApi(executionContext, apiId, false)
                 .stream()
                 .filter(p -> p.getGeneralConditions() != null)
                 .filter(p -> !(PlanStatus.CLOSED == p.getPlanStatus() || PlanStatus.STAGING == p.getPlanStatus()))
@@ -1343,7 +1343,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             if (PageReferenceType.API.equals(pageToUpdate.getReferenceType())) {
                 if (updatePageEntity.isPublished() != null && !updatePageEntity.isPublished()) {
                     Optional<GenericPlanEntity> activePlan = planSearchService
-                        .findByApi(executionContext, pageToUpdate.getReferenceId())
+                        .findByApi(executionContext, pageToUpdate.getReferenceId(), false)
                         .stream()
                         .filter(plan -> plan.getGeneralConditions() != null)
                         .filter(plan -> pageToUpdate.getId().equals(plan.getGeneralConditions()))
@@ -2192,7 +2192,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             // we can't remove it until the plan is closed
             if (page.getReferenceType() != null && page.getReferenceType().equals(PageReferenceType.API)) {
                 Optional<GenericPlanEntity> activePlan = planSearchService
-                    .findByApi(executionContext, page.getReferenceId())
+                    .findByApi(executionContext, page.getReferenceId(), false)
                     .stream()
                     .filter(plan -> plan.getGeneralConditions() != null)
                     .filter(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -161,7 +161,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
     @Override
     public Set<PlanEntity> findByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().flatMap(this::map).collect(Collectors.toSet());
+        return planSearchService.findByApi(executionContext, api, true).stream().flatMap(this::map).collect(Collectors.toSet());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
@@ -32,9 +32,15 @@ public interface PlanSearchService {
 
     Set<GenericPlanEntity> findByIdIn(final ExecutionContext executionContext, final Set<String> ids);
 
-    Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId);
+    Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId, boolean withFlow);
 
-    List<GenericPlanEntity> search(final ExecutionContext executionContext, final PlanQuery query, String user, boolean isAdmin);
+    List<GenericPlanEntity> search(
+        final ExecutionContext executionContext,
+        final PlanQuery query,
+        String user,
+        boolean isAdmin,
+        boolean expandWithFlow
+    );
 
     boolean anyPlanMismatchWithApi(List<String> planIds, String apiId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -461,7 +461,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             if (io.gravitee.rest.api.model.api.ApiLifecycleState.DEPRECATED == updateApiEntity.getLifecycleState()) {
                 planSearchService
-                    .findByApi(executionContext, apiId)
+                    .findByApi(executionContext, apiId, false)
                     .forEach(plan -> {
                         if (PlanStatus.PUBLISHED == plan.getPlanStatus() || PlanStatus.STAGING == plan.getPlanStatus()) {
                             planService.deprecate(executionContext, plan.getId(), true);
@@ -590,7 +590,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 throw new ApiRunningStateException(apiId);
             }
 
-            Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, apiId);
+            Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, apiId, false);
             if (closePlans) {
                 plans
                     .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -574,7 +574,7 @@ public class ApiStateServiceImpl implements ApiStateService {
                     // 2 - If API definition is synchronized, check if there is any modification for API's plans
                     // but only for published or closed plan
                     if (sync) {
-                        Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, genericApiEntity.getId());
+                        Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, genericApiEntity.getId(), false);
                         sync = plans
                             .stream()
                             .noneMatch(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl.java
@@ -102,7 +102,7 @@ public class PlanSearchServiceImpl extends TransactionalService implements PlanS
     }
 
     @Override
-    public Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId) {
+    public Set<GenericPlanEntity> findByApi(final ExecutionContext executionContext, final String apiId, boolean withFlow) {
         try {
             log.debug("Find plan by api : {}", apiId);
             Optional<Api> apiOptional = apiRepository.findById(apiId);
@@ -111,7 +111,11 @@ public class PlanSearchServiceImpl extends TransactionalService implements PlanS
                 return planRepository
                     .findByApi(apiId)
                     .stream()
-                    .map(plan -> genericPlanMapper.toGenericPlan(api, plan))
+                    .map(plan ->
+                        withFlow
+                            ? genericPlanMapper.toGenericPlanWithFlow(api, plan)
+                            : genericPlanMapper.toGenericPlanWithoutFlow(api, plan)
+                    )
                     .collect(Collectors.toSet());
             } else {
                 return Set.of();
@@ -122,14 +126,20 @@ public class PlanSearchServiceImpl extends TransactionalService implements PlanS
     }
 
     @Override
-    public List<GenericPlanEntity> search(final ExecutionContext executionContext, final PlanQuery query, String user, boolean isAdmin) {
+    public List<GenericPlanEntity> search(
+        final ExecutionContext executionContext,
+        final PlanQuery query,
+        String user,
+        boolean isAdmin,
+        boolean withFlow
+    ) {
         if (query.getApiId() == null) {
             return emptyList();
         }
 
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, query.getApiId());
 
-        return findByApi(executionContext, query.getApiId())
+        return findByApi(executionContext, query.getApiId(), withFlow)
             .stream()
             .filter(p -> {
                 boolean filtered = true;
@@ -189,7 +199,7 @@ public class PlanSearchServiceImpl extends TransactionalService implements PlanS
         try {
             Optional<Api> apiOptional = apiRepository.findById(plan.getApi());
             final Api api = apiOptional.orElseThrow(() -> new ApiNotFoundException(plan.getApi()));
-            return genericPlanMapper.toGenericPlan(api, plan);
+            return genericPlanMapper.toGenericPlanWithFlow(api, plan);
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("An error occurs while trying to find an API using its ID: " + plan.getApi(), e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -187,12 +187,16 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
     @Override
     public Set<PlanEntity> findByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().map(PlanEntity.class::cast).collect(Collectors.toSet());
+        return planSearchService.findByApi(executionContext, api, true).stream().map(PlanEntity.class::cast).collect(Collectors.toSet());
     }
 
     @Override
     public Set<NativePlanEntity> findNativePlansByApi(final ExecutionContext executionContext, final String api) {
-        return planSearchService.findByApi(executionContext, api).stream().map(NativePlanEntity.class::cast).collect(Collectors.toSet());
+        return planSearchService
+            .findByApi(executionContext, api, true)
+            .stream()
+            .map(NativePlanEntity.class::cast)
+            .collect(Collectors.toSet());
     }
 
     private PlanEntity create(ExecutionContext executionContext, NewPlanEntity newPlan, boolean validatePathParams) {
@@ -513,7 +517,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             String apiId = plan.getApi();
             Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
 
-            return genericPlanMapper.toGenericPlan(api, plan);
+            return genericPlanMapper.toGenericPlanWithFlow(api, plan);
         } catch (TechnicalException ex) {
             log.error("An error occurs while trying to close plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to close plan: %s", planId), ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -276,7 +276,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     @Override
     public boolean canDeploy(ExecutionContext executionContext, String apiId) {
         return planSearchService
-            .findByApi(executionContext, apiId)
+            .findByApi(executionContext, apiId, false)
             .stream()
             .anyMatch(
                 planEntity ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -129,6 +129,15 @@ public class ApiMapper {
                 apiEntity.setFlows(apiDefinition.getFlows());
 
                 apiEntity.setResponseTemplates(apiDefinition.getResponseTemplates());
+                // Only set allowInApiProduct for V4 Proxy APIs - the custom getter will return null for others
+                if (
+                    apiDefinition.getType() == ApiType.PROXY &&
+                    apiDefinition.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+                ) {
+                    apiEntity.setAllowInApiProduct(apiDefinition.isAllowInApiProduct());
+                } else {
+                    apiEntity.setAllowInApiProduct(null);
+                }
             } catch (IOException ioe) {
                 log.error(API_DEFINITION_UNEXPECTED_ERROR_MESSAGE, ioe);
             }
@@ -384,6 +393,13 @@ public class ApiMapper {
             apiDefinition.setFailover(newApiEntity.getFailover());
             apiDefinition.setFlowExecution(newApiEntity.getFlowExecution());
             apiDefinition.setFlows(newApiEntity.getFlows());
+            // Default allowInApiProduct to true for new V4 Proxy APIs
+            if (
+                newApiEntity.getType() == ApiType.PROXY &&
+                newApiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                apiDefinition.setAllowInApiProduct(true);
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {
@@ -465,6 +481,16 @@ public class ApiMapper {
             apiDefinition.setFlows(updateApiEntity.getFlows());
             apiDefinition.setResponseTemplates(updateApiEntity.getResponseTemplates());
             apiDefinition.setServices(updateApiEntity.getServices());
+            // Only set allowInApiProduct for V4 Proxy APIs - use the custom getter which returns null for others
+            if (
+                updateApiEntity.getType() == ApiType.PROXY &&
+                updateApiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                Boolean allowInApiProduct = updateApiEntity.getAllowInApiProduct();
+                apiDefinition.setAllowInApiProduct(allowInApiProduct != null ? allowInApiProduct : false);
+            } else {
+                // Don't set it for non-V4-Proxy APIs (will default to false in definition model)
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {
@@ -544,6 +570,16 @@ public class ApiMapper {
             apiDefinition.setFlows(apiEntity.getFlows());
             apiDefinition.setResponseTemplates(apiEntity.getResponseTemplates());
             apiDefinition.setServices(apiEntity.getServices());
+            // Only set allowInApiProduct for V4 Proxy APIs - use the custom getter which returns null for others
+            if (
+                apiEntity.getType() == ApiType.PROXY &&
+                apiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                Boolean allowInApiProduct = apiEntity.getAllowInApiProduct();
+                apiDefinition.setAllowInApiProduct(allowInApiProduct != null ? allowInApiProduct : false);
+            } else {
+                // Don't set it for non-V4-Proxy APIs (will default to false in definition model)
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
@@ -53,7 +53,7 @@ public class GenericPlanMapper {
         this.flowCrudService = flowCrudService;
     }
 
-    public GenericPlanEntity toGenericPlan(final Api api, final Plan plan) {
+    public GenericPlanEntity toGenericPlanWithFlow(final Api api, final Plan plan) {
         var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
@@ -65,6 +65,18 @@ public class GenericPlanMapper {
             };
             case FEDERATED, FEDERATED_AGENT -> planMapper.toEntity(plan, null);
             default -> planConverter.toPlanEntity(plan, flowServiceV2.findByReference(FlowReferenceType.PLAN, plan.getId()));
+        };
+    }
+
+    public GenericPlanEntity toGenericPlanWithoutFlow(final Api api, final Plan plan) {
+        var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
+        return switch (apiDefinitionVersion) {
+            case V4 -> switch (api.getType()) {
+                case PROXY, MESSAGE -> planMapper.toEntity(plan, null);
+                case NATIVE -> planMapper.toNativeEntity(plan, null);
+            };
+            case FEDERATED, FEDERATED_AGENT -> planMapper.toEntity(plan, null);
+            default -> planConverter.toPlanEntity(plan, null);
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
@@ -72,7 +72,7 @@ public class GenericPlanMapper {
         var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
-                case PROXY, MESSAGE -> planMapper.toEntity(plan, null);
+                case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> planMapper.toEntity(plan, null);
                 case NATIVE -> planMapper.toNativeEntity(plan, null);
             };
             case FEDERATED, FEDERATED_AGENT -> planMapper.toEntity(plan, null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
@@ -251,6 +251,32 @@ class AcceptSubscriptionDomainServiceTest {
     }
 
     @Test
+    void should_preserve_metadata_when_accepting_subscription() {
+        // Given
+        var initialMetadata = Map.of("consumer_company", "Acme Corp", "consumer_department", "Engineering");
+        SubscriptionEntity subscription = givenExistingSubscription(
+            SubscriptionFixtures.aSubscription()
+                .toBuilder()
+                .subscribedBy("subscriber")
+                .planId(PLAN_PUBLISHED.getId())
+                .applicationId(APPLICATION_ID)
+                .status(SubscriptionEntity.Status.PENDING)
+                .metadata(initialMetadata)
+                .build()
+        );
+
+        // When
+        final SubscriptionEntity result = accept(subscription, PLAN_PUBLISHED);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getId()).isEqualTo("subscription-id");
+            softly.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+            softly.assertThat(result.getMetadata()).isEqualTo(initialMetadata);
+        });
+    }
+
+    @Test
     void should_generated_key_for_API_Key_plan() {
         // Given
         SubscriptionEntity subscription = givenExistingSubscription(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateOrUpdatePagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateOrUpdatePagesTest.java
@@ -28,7 +28,6 @@ import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.PageRevisionService;
-import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.PageConverter;
@@ -109,7 +108,9 @@ public class PageService_CreateOrUpdatePagesTest {
         // Simulate the fact that page 1 is already created
         when(pageRepository.findById(updatedPageId)).thenReturn(Optional.of(page));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), anyString())).thenReturn(Collections.emptySet());
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), anyString(), eq(false))).thenReturn(
+            Collections.emptySet()
+        );
 
         pageService.createOrUpdatePages(GraviteeContext.getExecutionContext(), List.of(page1, page2, page3), API_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_DeleteTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Sets;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.search.PageCriteria;
@@ -168,7 +167,7 @@ public class PageService_DeleteTest {
         page.setReferenceId(API_ID);
         page.setVisibility("PUBLIC");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.emptySet());
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Collections.emptySet());
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
 
@@ -184,7 +183,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.CLOSED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
 
@@ -199,7 +198,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }
@@ -216,7 +215,7 @@ public class PageService_DeleteTest {
         planEntity.setStatus(PlanStatus.PUBLISHED);
 
         when(pageRepository.findById(TRANSLATE_PAGE_ID)).thenReturn(Optional.of(translationPage));
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), TRANSLATE_PAGE_ID);
     }
@@ -229,7 +228,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.DEPRECATED);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }
@@ -242,7 +241,7 @@ public class PageService_DeleteTest {
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(PlanStatus.STAGING);
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.delete(GraviteeContext.getExecutionContext(), PAGE_ID);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
@@ -46,9 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -584,12 +582,12 @@ public class PageService_UpdateTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(planStatus);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
         verify(pageRepository).update(argThat(p -> p.getId().equals(PAGE_ID) && !p.isPublished()));
-        verify(planSearchService).findByApi(eq(GraviteeContext.getExecutionContext()), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(eq(GraviteeContext.getExecutionContext()), argThat(p -> p.equals(API_ID)), eq(false));
     }
 
     @Test(expected = PageUsedByCategoryException.class)
@@ -614,7 +612,7 @@ public class PageService_UpdateTest {
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
-        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)), true);
     }
 
     @Test(expected = PageUsedAsGeneralConditionsException.class)
@@ -647,10 +645,10 @@ public class PageService_UpdateTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setGeneralConditions(PAGE_ID);
         planEntity.setStatus(planStatus);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(Set.of(planEntity));
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, updatePageEntity);
 
-        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)));
+        verify(planSearchService).findByApi(GraviteeContext.getExecutionContext(), argThat(p -> p.equals(API_ID)), false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
@@ -20,19 +20,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.definition.model.flow.Flow;
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
-import io.gravitee.repository.management.model.Plan;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PlanType;
 import io.gravitee.rest.api.model.PlanValidationType;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.configuration.flow.FlowService;
-import io.gravitee.rest.api.service.converter.PlanConverter;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +60,7 @@ public class PlanService_FindByApiTest {
         PlanEntity plan1 = createPlanEntity("plan1");
         PlanEntity plan2 = createPlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         List<PlanEntity> plans = new ArrayList<>(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -469,7 +469,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
@@ -485,7 +485,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.CLOSED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -504,7 +504,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.STAGING);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -526,7 +526,7 @@ public class ApiServiceImplTest {
         io.gravitee.rest.api.model.PlanEntity planEntity = new io.gravitee.rest.api.model.PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(io.gravitee.rest.api.model.PlanStatus.STAGING);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -570,7 +570,9 @@ public class ApiServiceImplTest {
         final PlanEntity closedPlan = new PlanEntity();
         closedPlan.setId(PLAN_ID);
         closedPlan.setStatus(PlanStatus.CLOSED);
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, false)).thenReturn(
+            Collections.singleton(planEntity)
+        );
         when(planService.close(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(closedPlan);
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -653,7 +653,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         // Date after API but not published -> No redeploy needed
         planStaging.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()))).thenReturn(
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()), eq(false))).thenReturn(
             Set.of(planPublished, planStaging)
         );
 
@@ -678,7 +678,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             1L
         );
         verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
-        verify(planSearchService, times(1)).findByApi(any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any(), eq(false));
     }
 
     @Test
@@ -729,7 +729,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         // Date after API -> Redeploy needed
         planPublished.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
 
-        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()))).thenReturn(
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId()), eq(false))).thenReturn(
             Set.of(planPublished)
         );
 
@@ -754,7 +754,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             1L
         );
         verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
-        verify(planSearchService, times(1)).findByApi(any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any(), eq(false));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImplTest.java
@@ -108,7 +108,7 @@ public class PlanSearchServiceImplTest {
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         PlanEntity planEntity = new PlanEntity();
-        when(genericPlanMapper.toGenericPlan(api, plan)).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan)).thenReturn(planEntity);
 
         final GenericPlanEntity resultPlanEntity = planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -126,11 +126,11 @@ public class PlanSearchServiceImplTest {
         apiRepository.findById(plan.getApi());
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(plan.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan)).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan)).thenReturn(planEntity);
 
         PlanEntity planEntity2 = new PlanEntity();
         planEntity2.setId(plan2.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(planEntity2);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(planEntity2);
 
         final Set<GenericPlanEntity> entities = planSearchService.findByIdIn(GraviteeContext.getExecutionContext(), ids);
 
@@ -162,10 +162,10 @@ public class PlanSearchServiceImplTest {
         planEntity1.setId(plan1.getId());
         PlanEntity planEntity2 = new PlanEntity();
         planEntity2.setId(plan2.getId());
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(planEntity1);
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(planEntity2);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(planEntity1);
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(planEntity2);
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2));
-        Set<GenericPlanEntity> plans = planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID);
+        Set<GenericPlanEntity> plans = planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true);
 
         assertNotNull(plans);
         assertEquals(2, plans.size());
@@ -184,7 +184,7 @@ public class PlanSearchServiceImplTest {
     public void shouldNotFindByApiBecauseTechnicalException() throws TechnicalException {
         when(planRepository.findByApi(API_ID)).thenThrow(TechnicalException.class);
 
-        planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID);
+        planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl_SearchTest.java
@@ -98,6 +98,7 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().build(),
             USER,
+            true,
             true
         );
 
@@ -114,13 +115,13 @@ public class PlanSearchServiceImpl_SearchTest {
         Plan plan3 = createPlan("plan-3");
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2, plan3));
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV4PlanEntity("plan-1", 3, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV4PlanEntity("plan-2", 2, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.STAGING)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV4PlanEntity("plan-3", 1, null, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
 
@@ -128,6 +129,7 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().apiId(API_ID).securityType(List.of(PlanSecurityType.API_KEY)).build(),
             USER,
+            true,
             true
         );
 
@@ -150,7 +152,7 @@ public class PlanSearchServiceImpl_SearchTest {
         rule.setEnabled(true);
         var rules = List.of(rule);
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV2PlanEntity(
                 "plan-1",
                 1,
@@ -160,7 +162,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 rules
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV2PlanEntity(
                 "plan-2",
                 2,
@@ -170,7 +172,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 null
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV2PlanEntity(
                 "plan-3",
                 3,
@@ -180,7 +182,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 null
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan4)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan4)).thenReturn(
             fakeV2PlanEntity(
                 "plan-4",
                 4,
@@ -190,7 +192,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 rules
             )
         );
-        when(genericPlanMapper.toGenericPlan(api, plan5)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan5)).thenReturn(
             fakeV2PlanEntity(
                 "plan-5",
                 5,
@@ -214,6 +216,7 @@ public class PlanSearchServiceImpl_SearchTest {
                 .mode(PlanMode.STANDARD)
                 .build(),
             USER,
+            true,
             true
         );
 
@@ -228,13 +231,13 @@ public class PlanSearchServiceImpl_SearchTest {
         Plan plan3 = createPlan("plan-3");
         when(planRepository.findByApi(API_ID)).thenReturn(Set.of(plan1, plan2, plan3));
 
-        when(genericPlanMapper.toGenericPlan(api, plan1)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan1)).thenReturn(
             fakeV4PlanEntity("plan-1", 3, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan2)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan2)).thenReturn(
             fakeV4PlanEntity("plan-2", 2, PlanSecurityType.API_KEY, "{\"nice\": \"config\"}", PlanStatus.STAGING)
         );
-        when(genericPlanMapper.toGenericPlan(api, plan3)).thenReturn(
+        when(genericPlanMapper.toGenericPlanWithFlow(api, plan3)).thenReturn(
             fakeV4PlanEntity("plan-3", 1, null, "{\"nice\": \"config\"}", PlanStatus.PUBLISHED)
         );
 
@@ -248,7 +251,8 @@ public class PlanSearchServiceImpl_SearchTest {
             GraviteeContext.getExecutionContext(),
             PlanQuery.builder().apiId(API_ID).build(),
             USER,
-            false
+            false,
+            true
         );
 
         assertNotNull(plans);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
@@ -139,7 +139,7 @@ public class PlanService_CloseTest {
         var planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setApiId(API_ID);
-        when(genericPlanMapper.toGenericPlan(eq(api), eq(plan))).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(eq(api), eq(plan))).thenReturn(planEntity);
 
         GenericPlanEntity genericPlanEntity = planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -174,7 +174,7 @@ public class PlanService_CloseTest {
         var planEntity = new io.gravitee.rest.api.model.PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setApi(API_ID);
-        when(genericPlanMapper.toGenericPlan(eq(api), eq(plan))).thenReturn(planEntity);
+        when(genericPlanMapper.toGenericPlanWithFlow(eq(api), eq(plan))).thenReturn(planEntity);
 
         GenericPlanEntity genericPlanEntity = planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindByApiTest.java
@@ -59,7 +59,7 @@ public class PlanService_FindByApiTest {
         PlanEntity plan1 = createPlanEntity("plan1");
         PlanEntity plan2 = createPlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         List<PlanEntity> plans = new ArrayList<>(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindNativePlansByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_FindNativePlansByApiTest.java
@@ -52,7 +52,7 @@ public class PlanService_FindNativePlansByApiTest {
         var plan1 = createNativePlanEntity("plan1");
         var plan2 = createNativePlanEntity("plan2");
 
-        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Set.of(plan1, plan2));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID, true)).thenReturn(Set.of(plan1, plan2));
 
         var plans = planService.findNativePlansByApi(GraviteeContext.getExecutionContext(), API_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -330,7 +330,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.PUBLISHED).build())
         );
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
@@ -341,7 +341,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.DEPRECATED).build())
         );
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
@@ -352,7 +352,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(Set.of());
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(Set.of());
         assertFalse(apiValidationService.canDeploy(executionContext, apiId));
     }
 
@@ -361,7 +361,7 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(
+        when(planSearchService.findByApi(executionContext, apiId, false)).thenReturn(
             Set.of(PlanEntity.builder().status(PlanStatus.STAGING).build(), PlanEntity.builder().status(PlanStatus.CLOSED).build())
         );
         assertFalse(apiValidationService.canDeploy(executionContext, apiId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapperTest.java
@@ -67,7 +67,7 @@ public class GenericPlanMapperTest {
         api.setType(ApiType.MESSAGE);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planMapper).toEntity(plan, List.of());
     }
 
@@ -78,7 +78,7 @@ public class GenericPlanMapperTest {
         api.setType(ApiType.NATIVE);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planMapper).toNativeEntity(plan, List.of());
     }
 
@@ -88,7 +88,7 @@ public class GenericPlanMapperTest {
         api.setDefinitionVersion(DefinitionVersion.V2);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 
@@ -98,7 +98,7 @@ public class GenericPlanMapperTest {
         api.setDefinitionVersion(DefinitionVersion.V1);
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 
@@ -107,7 +107,7 @@ public class GenericPlanMapperTest {
         Api api = new Api();
 
         Plan plan = new Plan();
-        genericPlanMapper.toGenericPlan(api, plan);
+        genericPlanMapper.toGenericPlanWithFlow(api, plan);
         verify(planConverter).toPlanEntity(plan, List.of());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.0.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.0.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12363

## Description

Toggle “Allow API Products” added to V4 HTTP Proxy APIs

Default:

1. OFF for existing APIs
2. ON for new APIs

- APIs with toggle OFF cannot be added to products
- Toggle disabled if API already belongs to a product
- API Product search only returns APIs with toggle ON

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

