### PR TITLE
feat: refine default http2 settings for http proxy connector

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -51,5 +51,63 @@
         "ssl": {
             "$ref": "#/definitions/ssl"
         }
+    },
+    "gioExternalDefinitions": {
+      "clearTextUpgrade": {
+        "title": "Allow h2c Clear Text Upgrade",
+        "type": "boolean",
+        "default": false,
+        "gioConfig": {
+          "banner": {
+            "title": "HTTP/2 Cleartext (H2C)",
+            "text": "If enabled, an h2c connection is established using an HTTP/1.1 upgrade request. When disabled (recommended), h2c connection is established directly with prior knowledge. Disabled by default. ⚠️ Enabling clear text upgrade can cause failures when upgrading chunked HTTP/1.1 requests to HTTP/2."
+          }
+        }
+      },
+      "maxConcurrentConnections": {
+        "type": "integer",
+        "title": "Max Concurrent Connections",
+        "description": "Maximum pool size for connections.",
+        "default": 20,
+        "gioConfig": {
+          "banner": {
+            "title": "Max concurrent HTTP/2 connections",
+            "text": "HTTP/2 connections are multiplexed, so a single connection can handle multiple requests concurrently. However, to optimize performance and resource utilization, it's beneficial to establish multiple concurrent connections to the upstream server. This setting defines the maximum number of concurrent HTTP/2 connections that can be established to the upstream server. The default value is 20 connections. Total of (max concurrent stream) x (max concurrent connections) gives the maximum number of concurrent requests to the upstream. A new connection will be created if all existing connections have reached the maximum concurrent streams limit."
+          }
+        }
+      },
+      "http2MultiplexingLimit": {
+        "type": "integer",
+        "title": "Max concurrent stream for an HTTP/2 connection",
+        "default": 25,
+        "gioConfig": {
+          "banner": {
+            "title": "Max concurrent stream for an HTTP/2 connection",
+            "text": "The maximum number of concurrent streams allowed for each HTTP/2 connection. The actual number of streams per connection is the minimum of this value and the server's initial settings. For example, if set to 10 and the server's initial setting is 1000, the max number of streams will be 10. 25 is the default. Total of (max concurrent stream) x (max concurrent connections) gives the maximum number of concurrent requests to the upstream."
+          }
+        }
+      },
+      "http2ConnectionWindowSize": {
+        "type": "integer",
+        "title": "Connection Window Size for an HTTP/2 connection",
+        "default": 1048576,
+        "gioConfig": {
+          "banner": {
+            "title": "Connection Window Size for an HTTP/2 connection",
+            "text": "Connection Window Size in bytes can be increased to a larger value such as 5MB (5242880 bytes) to improve throughput. Default is 1MB (1048576 bytes)."
+          }
+        }
+      },
+      "http2StreamWindowSize": {
+        "type": "integer",
+        "title": "Stream initial window size for each HTTP/2 stream",
+        "default": 262144,
+        "gioConfig": {
+          "banner": {
+            "title": "Stream initial window size for each HTTP/2 stream",
+            "text": "Stream Window Size in bytes can be increased to a larger value such as 1MB (1048576 bytes) to improve throughput (initial settings). 256KB (262144) is the default."
+          }
+        }
+      }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.0.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.0.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-620

## Description

This PR ensures the HTTP/2 settings are best fitted when using the V4 HTTP Proxy API with HTTP/2.
Any newly created V4 HTTP Proxy API will benefit from the following default settings that are best suited for performance compared to the default previous ones (coming from Vertx's default):


- Max Concurrent Connections: 20 (unchanged, previously 20)
- Max Concurrent Stream: 25 (previously -1, e.g. no limit from the gateway perspective)
- Connection Window Size: 1MB (previously 65KB)
- Stream Window Size: 256KB (previously 65KB)
- Max Frame Size: 16KB (unchanged)

The above settings offer better network performance out of the box while keeping them to a reasonable level.

Additionally, some irrelevant settings for HTTP/2 have been changed:
- Clear-Text Upgrade: default moved to false to avoid falling in HTTP/1.1 + chunk issue
- Keep-Alive: disabled when HTTP/2 is chosen as HTTP/2 connections are always persistent.
- HTTP Pipelining: disabled when HTTP/2 is chosen, as it only applies to HTTP/1.1.

Before the changes
<img width="2026" height="2304" alt="image" src="https://github.com/user-attachments/assets/217d6994-db1a-47e2-a281-a4d535e23882" />

<img width="2020" height="1758" alt="image" src="https://github.com/user-attachments/assets/817e47f9-1935-42cb-aed9-dc9df95a80f3" />


After the changes

<img width="1816" height="2282" alt="image" src="https://github.com/user-attachments/assets/d79d1ee3-20ed-46e3-b760-e14193428e6c" />

<img width="1806" height="1940" alt="image" src="https://github.com/user-attachments/assets/66516f59-7d29-4a15-83fa-52c41aec4057" />

