### PR TITLE
fix: SSLSession for HTTP request is expected to be null

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/RequestAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/RequestAdapter.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.api.ws.WebSocket;
+import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.gravitee.reporter.api.http.Metrics;
@@ -155,7 +156,12 @@ public class RequestAdapter implements io.gravitee.gateway.api.Request {
 
     @Override
     public SSLSession sslSession() {
-        return request.tlsSession();
+        // V3 policies, such as SSLEnforcedPolicy, expect null for the SSLSession when the incoming request is an HTTP (non-SSL) connection.
+        TlsSession tlsSession = request.tlsSession();
+        if (tlsSession != null && tlsSession.isSSLConnection()) {
+            return tlsSession;
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12084

## Description
When SSLEnforcementPolicy is enabled and HTTP request(non-SSL connection) is made then instead of sending null sslSession we were sending a wrapper TLSSession. Hence it was not detecting an HTTP request correctly resulting in NullPointerException instead 403.

Before Fix:
HTTP Request:
https://github.com/user-attachments/assets/28931cce-e61b-4ea3-bd30-cc3960408cf1

HTTPS Request: 
<img width="2964" height="810" alt="image" src="https://github.com/user-attachments/assets/3c48a2b4-abce-42c0-9ae0-2bc8b02f17fa" />


After Fix: 
HTTP Request: 
https://github.com/user-attachments/assets/6f364299-bcfa-4686-95b1-71455bb673c2

HTTPS Request: 
<img width="1512" height="64" alt="image" src="https://github.com/user-attachments/assets/8d39965d-58c4-4dd2-9cda-5036fe326818" />
