### PR TITLE
Create GMD Form Components and Editor Preview

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.spec.ts
@@ -78,8 +78,13 @@ describe('PortalNavigationService', () => {
           routerLink: 'homepage',
           icon: 'gio:box',
         },
+        {
+          displayName: 'Subscription Form',
+          routerLink: 'subscription-form',
+          icon: 'gio:list-check',
+        },
       ]);
-      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(6);
+      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(7);
     });
 
     it('should return only allowed menu items when some permissions are not granted', () => {
@@ -95,7 +100,7 @@ describe('PortalNavigationService', () => {
           icon: 'gio:report-columns',
         },
       ]);
-      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(6);
+      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(7);
     });
 
     it('should include menu items with empty permission list', () => {
@@ -128,7 +133,7 @@ describe('PortalNavigationService', () => {
 
       const menuItems = service.getMainMenuItems();
       expect(menuItems).toEqual([]);
-      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(6);
+      expect(permissionService.hasAnyMatching).toHaveBeenCalledTimes(7);
     });
 
     it('should call hasAnyMatching with the correct permissions for each menu item', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
@@ -74,6 +74,12 @@ export class PortalNavigationService {
       icon: 'gio:box',
       permissions: ['environment-documentation-r', 'environment-documentation-u'],
     },
+    {
+      displayName: 'Subscription Form',
+      routerLink: 'subscription-form',
+      icon: 'gio:list-check',
+      permissions: ['environment-settings-r', 'environment-settings-u'],
+    },
   ];
 
   public getMainMenuItems(): MenuItem[] {

--- a/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
@@ -26,6 +26,7 @@ import { CategoryListComponent } from './catalog/category-list/category-list.com
 import { PortalApiComponent } from './api/portal-api.component';
 import { PortalApiListComponent } from './api/api-list/portal-api-list.component';
 import { HomepageComponent } from './homepage/homepage.component';
+import { SubscriptionFormComponent } from './subscription-form/subscription-form.component';
 
 import { PermissionGuard } from '../shared/components/gio-permission/gio-permission.guard';
 import { HasLicenseGuard } from '../shared/components/gio-license/has-license.guard';
@@ -122,6 +123,15 @@ const portalRoutes: Routes = [
         data: {
           permissions: {
             anyOf: ['environment-documentation-r', 'environment-documentation-u'],
+          },
+        },
+      },
+      {
+        path: 'subscription-form',
+        component: SubscriptionFormComponent,
+        data: {
+          permissions: {
+            anyOf: ['environment-settings-r', 'environment-settings-u'],
           },
         },
       },

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
@@ -1,0 +1,24 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<portal-header
+  subtitle="Define the subscription form that will be displayed to users when subscribing to APIs"
+  [title]="'Subscription Form'"
+  [showActions]="false"
+>
+</portal-header>
+<gmd-form-editor [formControl]="contentControl" />

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
@@ -1,0 +1,24 @@
+@use '../../scss/gio-layout' as gio-layout;
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '@gravitee/gravitee-markdown' as gmd;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+
+  & {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+}
+
+gmd-form-editor {
+  @include gmd.editor-overrides(
+    (
+      container-outline-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20'),
+    )
+  );
+  flex-grow: 1;
+  min-height: 0;
+}

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SubscriptionFormComponent } from './subscription-form.component';
+
+import { GioTestingModule } from '../../shared/testing';
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+
+describe('SubscriptionFormComponent', () => {
+  let fixture: ComponentFixture<SubscriptionFormComponent>;
+  let component: SubscriptionFormComponent;
+
+  const init = async (canUpdate: boolean) => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
+      providers: [
+        {
+          provide: GioPermissionService,
+          useValue: {
+            hasAnyMatching: jest.fn().mockReturnValue(canUpdate),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubscriptionFormComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  };
+
+  it('should create component', async () => {
+    await init(true);
+    expect(component).toBeTruthy();
+  });
+
+  it('should load default boilerplate content', async () => {
+    await init(true);
+
+    const contentValue = component.contentControl.value;
+
+    expect(contentValue).toContain('Subscription Form Builder');
+    expect(contentValue).toContain('Example: Complete Subscription Request Form');
+    expect(contentValue).toContain('Applicant Information');
+    expect(contentValue).toContain('Usage Details');
+    expect(contentValue).toContain('Simplified Quick Access Form');
+  });
+
+  it('should disable editor when user has no update permission', async () => {
+    await init(false);
+
+    expect(component.contentControl.disabled).toBe(true);
+  });
+
+  it('should enable editor when user has update permission', async () => {
+    await init(true);
+
+    expect(component.contentControl.disabled).toBe(false);
+  });
+
+  it('should allow updating content control value', async () => {
+    await init(true);
+
+    component.contentControl.setValue('Custom subscription form content');
+
+    expect(component.contentControl.value).toBe('Custom subscription form content');
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { ConfigureTestingGmdFormEditor, ConfigureTestingGraviteeMarkdownEditor, GmdFormEditorHarness } from '@gravitee/gravitee-markdown';
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -24,8 +29,11 @@ import { GioPermissionService } from '../../shared/components/gio-permission/gio
 describe('SubscriptionFormComponent', () => {
   let fixture: ComponentFixture<SubscriptionFormComponent>;
   let component: SubscriptionFormComponent;
+  let loader: HarnessLoader;
+  let editorHarness: GmdFormEditorHarness;
 
   const init = async (canUpdate: boolean) => {
+    ConfigureTestingGmdFormEditor();
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
       providers: [
@@ -38,10 +46,14 @@ describe('SubscriptionFormComponent', () => {
       ],
     }).compileComponents();
 
+    ConfigureTestingGraviteeMarkdownEditor();
+
     fixture = TestBed.createComponent(SubscriptionFormComponent);
     component = fixture.componentInstance;
 
     fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    editorHarness = await loader.getHarness(GmdFormEditorHarness);
   };
 
   it('should create component', async () => {
@@ -52,7 +64,7 @@ describe('SubscriptionFormComponent', () => {
   it('should load default boilerplate content', async () => {
     await init(true);
 
-    const contentValue = component.contentControl.value;
+    const contentValue = await editorHarness.getEditorValue();
 
     expect(contentValue).toContain('Subscription Form Builder');
     expect(contentValue).toContain('Example: Complete Subscription Request Form');
@@ -64,13 +76,13 @@ describe('SubscriptionFormComponent', () => {
   it('should disable editor when user has no update permission', async () => {
     await init(false);
 
-    expect(component.contentControl.disabled).toBe(true);
+    expect(await editorHarness.isEditorReadOnly()).toBe(true);
   });
 
   it('should enable editor when user has update permission', async () => {
     await init(true);
 
-    expect(component.contentControl.disabled).toBe(false);
+    expect(await editorHarness.isEditorReadOnly()).toBe(false);
   });
 
   it('should allow updating content control value', async () => {

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GmdFormEditorComponent } from '@gravitee/gravitee-markdown';
+
+import { Component, effect, inject, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+
+import { PortalHeaderComponent } from '../components/header/portal-header.component';
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+
+@Component({
+  selector: 'subscription-form',
+  imports: [PortalHeaderComponent, ReactiveFormsModule, GmdFormEditorComponent],
+  templateUrl: './subscription-form.component.html',
+  styleUrl: './subscription-form.component.scss',
+})
+export class SubscriptionFormComponent {
+  contentControl = new FormControl({
+    value: '',
+    disabled: true,
+  });
+
+  private readonly gioPermissionService = inject(GioPermissionService);
+  private readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-settings-u']));
+
+  constructor() {
+    effect(() => {
+      this.contentControl.reset(this.getDefaultBoilerplate());
+    });
+
+    effect(() => {
+      this.canUpdate() ? this.contentControl.enable() : this.contentControl.disable();
+    });
+  }
+
+  private getDefaultBoilerplate(): string {
+    return `<gmd-grid columns="1" class="hero-grid">
+  <gmd-card class="boilerplate-hero">
+    <gmd-card-title>🎨 Subscription Form Builder</gmd-card-title>
+    <gmd-md>
+      Welcome to your subscription form workspace! This is where you can design and customize the form that API consumers will see when subscribing to your APIs.
+
+      **How to use this space:**
+
+      - **✏️ Edit freely** - Modify the examples below or start from scratch
+      - **👀 Live preview** - See your changes instantly on the right side
+      - **🧪 Test validation** - Try filling out the form to test required fields and validation rules
+      - **💾 Save & publish** - When ready, save your form and publish it to make it available in the portal
+
+      ---
+
+      **💡 Pro tip:** Start by editing the example form below, then delete what you don't need and build your own!
+    </gmd-md>
+  </gmd-card>
+</gmd-grid>
+
+<style>
+  .hero-grid {
+    margin-bottom: 2rem;
+  }
+
+  .boilerplate-hero {
+    --gmd-card-container-color: #dbeafe;
+    --gmd-card-text-color: #1e3a8a;
+    --gmd-card-outline-color: #60a5fa;
+    --gmd-card-outline-width: 2px;
+    --gmd-card-container-shape: 12px;
+  }
+</style>
+
+---
+
+## 📋 Example: Complete Subscription Request Form
+
+Below is a full example showing all available form components. Feel free to customize it or use it as inspiration!
+
+<gmd-grid columns="2" class="subscription-form-grid form-demo">
+  <gmd-card>
+    <gmd-card-title>👤 Applicant Information</gmd-card-title>
+    <gmd-md>Tell us about yourself and your organization.</gmd-md>
+
+    <gmd-input name="fullName" label="Full name" fieldKey="full_name" required="true"></gmd-input>
+    <gmd-input name="email" label="Email address" fieldKey="email" type="email" required="true" placeholder="you@company.com"></gmd-input>
+    <gmd-input name="company" label="Company" fieldKey="company" required="true" minLength="2" maxLength="100"></gmd-input>
+    <gmd-input name="website" label="Company website" fieldKey="company_website" type="url" placeholder="https://example.com"></gmd-input>
+    <gmd-select name="country" label="Country" fieldKey="country" required="true" options="United States,Canada,United Kingdom,Germany,France,Poland,Spain,Italy,Netherlands,Other"></gmd-select>
+  </gmd-card>
+
+  <gmd-card>
+    <gmd-card-title>🎯 Usage Details</gmd-card-title>
+    <gmd-md>Help us understand your API usage needs.</gmd-md>
+
+    <gmd-select name="plan" label="Requested plan" fieldKey="requested_plan" required="true" options="Free Tier,Starter,Professional,Enterprise"></gmd-select>
+    <gmd-radio name="env" label="Target environment" fieldKey="target_environment" required="true" options="Production,Staging,Development,Testing"></gmd-radio>
+    <gmd-input name="monthlyCalls" label="Expected monthly API calls" fieldKey="expected_monthly_calls" type="number" placeholder="e.g. 100000"></gmd-input>
+    <gmd-textarea
+      name="useCase"
+      label="Use case description"
+      fieldKey="use_case"
+      required="true"
+      minLength="20"
+      maxLength="500"
+      placeholder="Please describe how you plan to use this API and what problem it will solve for your business..."></gmd-textarea>
+
+    <gmd-checkbox name="terms" label="I confirm that all information provided is accurate" fieldKey="confirm_accuracy" required="true"></gmd-checkbox>
+    <gmd-checkbox name="newsletter" label="Subscribe to API updates and newsletters" fieldKey="subscribe_newsletter"></gmd-checkbox>
+  </gmd-card>
+</gmd-grid>
+
+---
+
+## 🚀 Example: Simplified Quick Access Form
+
+Here's a minimal form variant for faster onboarding:
+
+<gmd-grid columns="1" class="compact-form-grid">
+  <gmd-card class="form-demo form-demo--compact">
+    <gmd-card-title>⚡ Quick Access Request</gmd-card-title>
+    <gmd-md>Get started quickly with just the essentials.</gmd-md>
+
+    <gmd-input name="appName" label="Application name" fieldKey="app_name" required="true" placeholder="My API Integration"></gmd-input>
+    <gmd-select name="team" label="Team or department" fieldKey="team" options="Engineering,Product,Data & Analytics,DevOps,Security,Partner Integration,Other"></gmd-select>
+    <gmd-radio name="priority" label="Request priority" fieldKey="priority" options="Low,Normal,High,Urgent"></gmd-radio>
+    <gmd-textarea name="notes" label="Additional notes" fieldKey="notes" maxLength="300" placeholder="Any additional context or special requirements..."></gmd-textarea>
+    <gmd-checkbox name="terms" label="I accept the terms and conditions" fieldKey="accept_terms" required="true"></gmd-checkbox>
+  </gmd-card>
+</gmd-grid>
+
+<style>
+  .subscription-form-grid {
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .form-demo {
+    --gmd-card-container-color: #f8fafc;
+    --gmd-card-outline-color: #e2e8f0;
+    --gmd-card-outline-width: 1px;
+    --gmd-card-container-shape: 10px;
+    --gmd-card-text-color: #0f172a;
+
+    --gmd-input-label-text-color: #0f172a;
+    --gmd-input-field-text-color: #0f172a;
+    --gmd-input-field-outline-color: #94a3b8;
+    --gmd-input-field-outline-radius: 8px;
+
+    --gmd-textarea-label-text-color: #0f172a;
+    --gmd-textarea-field-text-color: #0f172a;
+    --gmd-textarea-field-outline-color: #94a3b8;
+    --gmd-textarea-field-outline-radius: 8px;
+
+    --gmd-select-label-text-color: #0f172a;
+    --gmd-select-field-text-color: #0f172a;
+    --gmd-select-field-outline-color: #94a3b8;
+    --gmd-select-field-outline-radius: 8px;
+
+    --gmd-checkbox-label-text-color: #0f172a;
+
+    --gmd-radio-label-text-color: #0f172a;
+    --gmd-radio-option-text-color: #0f172a;
+  }
+
+  .form-demo--compact {
+    max-width: 600px;
+    margin: 0 auto;
+  }
+</style>
+`;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
@@ -152,25 +152,24 @@ Here's a minimal form variant for faster onboarding:
     --gmd-card-container-shape: 10px;
     --gmd-card-text-color: #0f172a;
 
-    --gmd-input-label-text-color: #0f172a;
-    --gmd-input-field-text-color: #0f172a;
-    --gmd-input-field-outline-color: #94a3b8;
-    --gmd-input-field-outline-radius: 8px;
+    --gmd-input-outlined-label-text-color: #0f172a;
+    --gmd-input-outlined-input-text-color: #0f172a;
+    --gmd-input-outlined-outline-color: #94a3b8;
+    --gmd-input-outlined-container-shape: 8px;
 
-    --gmd-textarea-label-text-color: #0f172a;
-    --gmd-textarea-field-text-color: #0f172a;
-    --gmd-textarea-field-outline-color: #94a3b8;
-    --gmd-textarea-field-outline-radius: 8px;
+    --gmd-textarea-outlined-label-text-color: #0f172a;
+    --gmd-textarea-outlined-input-text-color: #0f172a;
+    --gmd-textarea-outlined-outline-color: #94a3b8;
+    --gmd-textarea-outlined-container-shape: 8px;
 
-    --gmd-select-label-text-color: #0f172a;
-    --gmd-select-field-text-color: #0f172a;
-    --gmd-select-field-outline-color: #94a3b8;
-    --gmd-select-field-outline-radius: 8px;
+    --gmd-select-outlined-label-text-color: #0f172a;
+    --gmd-select-outlined-input-text-color: #0f172a;
+    --gmd-select-outlined-outline-color: #94a3b8;
+    --gmd-select-outlined-container-shape: 8px;
 
-    --gmd-checkbox-label-text-color: #0f172a;
+    --gmd-checkbox-outlined-label-text-color: #0f172a;
 
-    --gmd-radio-label-text-color: #0f172a;
-    --gmd-radio-option-text-color: #0f172a;
+    --gmd-radio-outlined-label-text-color: #0f172a;
   }
 
   .form-demo--compact {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/README.md
@@ -1,0 +1,65 @@
+# Checkbox Component
+
+Single checkbox input with label, validation, and error display. It is designed for GMD forms and can emit field state when `fieldKey` is provided.
+
+## Usage
+
+### Basic
+
+```html
+<gmd-checkbox name="terms" label="Accept terms"></gmd-checkbox>
+```
+
+### Required
+
+```html
+<gmd-checkbox name="terms" label="Accept terms" required="true"></gmd-checkbox>
+```
+
+### Readonly
+
+```html
+<gmd-checkbox name="terms" label="Accept terms" value="true" readonly="true"></gmd-checkbox>
+```
+
+### Field key for form state
+
+```html
+<gmd-checkbox name="terms" label="Accept terms" fieldKey="terms" required="true"></gmd-checkbox>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fieldKey` | `string \| undefined` | `undefined` | Key used to emit form state events. |
+| `name` | `string` | `''` | Checkbox name and id. |
+| `label` | `string \| undefined` | `undefined` | Label shown next to the checkbox. |
+| `value` | `string \| undefined` | `undefined` | Initial value (`"true"` or `"false"`). |
+| `required` | `boolean` | `false` | Marks the field as required. |
+| `readonly` | `boolean` | `false` | Makes the checkbox read-only (focusable, value submitted). |
+| `disabled` | `boolean` | `false` | Disables the checkbox. |
+
+## Theming
+
+The checkbox component can be customized using SCSS overrides. Use the mixin to override available tokens:
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+.my-scope {
+  @include gmd.checkbox-overrides((
+    // Label styling
+    label-text-color: #111827,
+    label-text-size: 0.875rem,
+    label-text-weight: 500,
+
+    // Required indicator
+    required-text-color: #dc2626,
+
+    // Error messages
+    error-text-color: #dc2626,
+    error-text-size: 0.8125rem,
+  ));
+}
+```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/README.md
@@ -50,16 +50,13 @@ The checkbox component can be customized using SCSS overrides. Use the mixin to 
 .my-scope {
   @include gmd.checkbox-overrides((
     // Label styling
-    label-text-color: #111827,
-    label-text-size: 0.875rem,
-    label-text-weight: 500,
+    outlined-label-text-color: #111827,
+    outlined-label-text-size: 0.875rem,
+    outlined-label-text-weight: 500,
 
-    // Required indicator
-    required-text-color: #dc2626,
-
-    // Error messages
+    // Error messages (also used for required indicator)
     error-text-color: #dc2626,
-    error-text-size: 0.8125rem,
+    subscript-text-size: 0.8125rem,
   ));
 }
 ```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/_overrides.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use './token-utils' as token-utils;
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
 
 @function tokens() {
   @return (
-    (
-      namespace: sys,
-      tokens: (
-        container-shape: 4px,
-        primary-color: #275cf6,
-        on-primary-color: #ffffff,
-        outline-color: #cdd7e1,
-        hover-state-layer-opacity: 90%,
-        focus-state-layer-opacity: 80%,
-        text-color: #1d192b,
-        error-color: #d32f2f,
-      )
+    namespace: checkbox,
+    tokens: (
+      label-text-size: 0.875rem,
+      label-text-weight: 500,
+      label-text-color: inherit,
+      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/_overrides.scss
@@ -22,12 +22,11 @@ $theme-tokens: theme.tokens();
   @return (
     namespace: checkbox,
     tokens: (
-      label-text-size: 0.875rem,
-      label-text-weight: 500,
-      label-text-color: inherit,
-      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
       error-text-color: token-utils.slot(error-color, $theme-tokens),
-      error-text-size: 0.8125rem,
+      subscript-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.harness.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdCheckboxComponentHarness extends ComponentHarness {
+  static hostSelector = 'gmd-checkbox';
+
+  async isChecked(): Promise<boolean> {
+    const checkbox = await this.getCheckbox();
+    return (await checkbox.getProperty('checked')) as boolean;
+  }
+
+  async setChecked(checked: boolean): Promise<void> {
+    const checkbox = await this.getCheckbox();
+    const isCurrentlyChecked = await this.isChecked();
+    if (isCurrentlyChecked !== checked) {
+      await checkbox.click();
+    }
+  }
+
+  async click(): Promise<void> {
+    const checkbox = await this.getCheckbox();
+    await checkbox.click();
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const checkbox = await this.getCheckbox();
+    return (await checkbox.getProperty('disabled')) as boolean;
+  }
+
+  async isRequired(): Promise<boolean> {
+    const checkbox = await this.getCheckbox();
+    return (await checkbox.getProperty('required')) as boolean;
+  }
+
+  async isReadonly(): Promise<boolean> {
+    const checkbox = await this.getCheckbox();
+    return (await checkbox.getProperty('readOnly')) as boolean;
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-checkbox__label-text')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-checkbox__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-checkbox__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async hasErrors(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async blur(): Promise<void> {
+    const checkbox = await this.getCheckbox();
+    await checkbox.blur();
+  }
+
+  private async getCheckbox(): Promise<TestElement> {
+    return this.locatorFor('input[type="checkbox"]')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<label class="gmd-checkbox__label">
+  <input
+    class="gmd-checkbox__field"
+    type="checkbox"
+    [id]="name()"
+    [name]="name()"
+    [checked]="internalValue()"
+    [required]="required()"
+    [readonly]="readonly()"
+    [disabled]="disabled()"
+    (change)="onChange($event)"
+    (blur)="onBlur()" />
+  @if (label()) {
+    <span class="gmd-checkbox__label-text">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-checkbox__required">*</span>
+      }
+    </span>
+  }
+</label>
+
+@if (touched() && errorMessages().length) {
+  <div class="gmd-checkbox__errors" role="alert">
+    @for (msg of errorMessages(); track msg) {
+      <div class="gmd-checkbox__error">{{ msg }}</div>
+    }
+  </div>
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.scss
@@ -44,13 +44,13 @@ $token-mapping: overrides.tokens();
   }
 
   &__label-text {
-    color: token-utils.slot(label-text-color, $token-mapping);
-    font-size: token-utils.slot(label-text-size, $token-mapping);
-    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
   }
 
   &__required {
-    color: token-utils.slot(required-text-color, $token-mapping);
+    color: token-utils.slot(error-text-color, $token-mapping);
   }
 
   &__errors {
@@ -61,6 +61,6 @@ $token-mapping: overrides.tokens();
 
   &__error {
     color: token-utils.slot(error-text-color, $token-mapping);
-    font-size: token-utils.slot(error-text-size, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.scss
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+:host {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.gmd-checkbox {
+  &__label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    gap: 0.5rem;
+  }
+
+  &__field {
+    width: 1.25rem;
+    height: 1.25rem;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+
+  &__label-text {
+    color: token-utils.slot(label-text-color, $token-mapping);
+    font-size: token-utils.slot(label-text-size, $token-mapping);
+    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+  }
+
+  &__required {
+    color: token-utils.slot(required-text-color, $token-mapping);
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(error-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdCheckboxComponent } from './gmd-checkbox.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+
+export default {
+  title: 'Gravitee Markdown/Components/Checkbox',
+  component: GmdCheckboxComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdCheckboxComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' }))],
+    }),
+  ],
+} as Meta<GmdCheckboxComponent>;
+
+export const Basic: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox name="basic" label="Basic Checkbox"></gmd-checkbox>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox name="required" label="I agree to the terms and conditions" required="true"></gmd-checkbox>
+      </div>
+    `,
+  }),
+};
+
+export const PreChecked: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-checkbox name="unchecked" label="Unchecked by default"></gmd-checkbox>
+        <gmd-checkbox name="checked" label="Checked by default" value="true"></gmd-checkbox>
+      </div>
+    `,
+  }),
+};
+
+export const ReadonlyAndDisabled: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-checkbox name="normal" label="Normal Checkbox" value="true"></gmd-checkbox>
+        <gmd-checkbox name="readonly" label="Readonly Checkbox" value="true" readonly="true"></gmd-checkbox>
+        <gmd-checkbox name="disabled" label="Disabled Checkbox" value="true" disabled="true"></gmd-checkbox>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Comparison of normal, readonly, and disabled states. Readonly fields are focusable and their values are submitted, while disabled fields are not focusable and values are not submitted.',
+      },
+    },
+  },
+};
+
+export const CommonUseCases: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-checkbox name="terms" label="I agree to the Terms and Conditions" required="true"></gmd-checkbox>
+        <gmd-checkbox name="privacy" label="I agree to the Privacy Policy" required="true"></gmd-checkbox>
+        <gmd-checkbox name="newsletter" label="Subscribe to newsletter"></gmd-checkbox>
+        <gmd-checkbox name="marketing" label="Receive marketing communications"></gmd-checkbox>
+      </div>
+    `,
+  }),
+};
+
+export const WithFieldKey: StoryObj<GmdCheckboxComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-checkbox
+          name="terms"
+          label="I agree to the Terms and Conditions"
+          fieldKey="termsAccepted"
+          required="true">
+        </gmd-checkbox>
+        <gmd-checkbox
+          name="newsletter"
+          label="Subscribe to newsletter"
+          fieldKey="newsletterSubscription">
+        </gmd-checkbox>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Checkbox fields configured with field keys. These fields emit validation events for form state aggregation. Values are saved as "true"/"false" strings.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Checkbox Component with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# Subscription Form
+
+Please review and accept the following terms:
+
+<gmd-checkbox name="terms" label="I agree to the Terms and Conditions" fieldKey="termsAccepted" required="true"></gmd-checkbox>
+
+<gmd-checkbox name="privacy" label="I agree to the Privacy Policy" fieldKey="privacyAccepted" required="true"></gmd-checkbox>
+
+<gmd-checkbox name="newsletter" label="Subscribe to newsletter" fieldKey="newsletterSubscription"></gmd-checkbox>
+
+<gmd-checkbox name="marketing" label="Receive marketing communications" fieldKey="marketingConsent"></gmd-checkbox>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form editor with live validation tracking. Shows how the gmd-form-editor component tracks field states and displays validation status in real-time.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Checkbox Examples
+
+<gmd-checkbox name="terms" label="I agree to the Terms and Conditions" required="true"></gmd-checkbox>
+
+<gmd-checkbox name="privacy" label="I agree to the Privacy Policy" required="true"></gmd-checkbox>
+
+<gmd-checkbox name="newsletter" label="Subscribe to newsletter"></gmd-checkbox>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Checkbox components rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, ElementRef, computed, effect, inject, input, signal, untracked } from '@angular/core';
+
+import { GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+
+@Component({
+  selector: 'gmd-checkbox',
+  imports: [],
+  templateUrl: './gmd-checkbox.component.html',
+  styleUrl: './gmd-checkbox.component.scss',
+  standalone: true,
+})
+export class GmdCheckboxComponent {
+  // metadata key
+  fieldKey = input<string | undefined>();
+
+  // UI
+  name = input<string>('');
+  label = input<string | undefined>();
+
+  // initial value (optional)
+  value = input<boolean>(false);
+
+  // validation
+  required = input<boolean>(false);
+  readonly = input<boolean>(false);
+  disabled = input<boolean>(false);
+
+  private readonly el = inject(ElementRef<HTMLElement>);
+
+  protected readonly internalValue = signal<boolean>(false);
+  protected readonly touched = signal<boolean>(false);
+
+  errors = computed<GmdFieldErrorCode[]>(() => {
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && !this.internalValue()) errs.push('required');
+
+    return errs;
+  });
+
+  valid = computed(() => this.errors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.errors();
+    const msgs: string[] = [];
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  constructor() {
+    // init/sync from provided value
+    effect(() => {
+      const v = this.value();
+      this.internalValue.set(v);
+    });
+
+    // whenever something relevant changes, notify host (only if fieldKey is set)
+    effect(() => {
+      const key = (this.fieldKey() ?? '').trim();
+      if (!key) return; // Early return if no fieldKey
+
+      // Read all reactive values to track changes
+      this.internalValue();
+      this.required();
+      this.disabled();
+
+      // Emit state only if fieldKey is present
+      this.emitState();
+    });
+  }
+
+  onChange(event: Event) {
+    const checked = (event.target as HTMLInputElement | null)?.checked ?? false;
+    this.internalValue.set(checked);
+  }
+
+  onBlur() {
+    this.touched.set(true);
+    this.emitState();
+  }
+
+  private emitState() {
+    const key = (this.fieldKey() ?? '').trim();
+    if (!key) return;
+
+    // Don't emit state for disabled fields (mimics HTML form behavior where disabled fields are not submitted)
+    if (this.disabled()) return;
+
+    // Use untracked to avoid tracking computed values during event dispatch
+    const detail: GmdFieldState = untracked(() => ({
+      key,
+      value: this.internalValue() ? 'true' : 'false',
+      valid: this.valid(),
+      required: this.required(),
+      touched: this.touched(),
+      errors: this.errors(),
+    }));
+
+    // Dispatch event asynchronously to avoid blocking the event loop
+    setTimeout(() => {
+      this.el.nativeElement.dispatchEvent(
+        new CustomEvent<GmdFieldState>('gmdFieldStateChange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, 0);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.suggestions.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.suggestions.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicCheckbox: ComponentSuggestion = {
+  label: 'Checkbox - Basic',
+  insertText: `<gmd-checkbox name="$1" label="$2"></gmd-checkbox>`,
+  detail: 'Basic checkbox field',
+};
+
+const requiredCheckbox: ComponentSuggestion = {
+  label: 'Checkbox - Required',
+  insertText: `<gmd-checkbox name="$1" label="$2" required="true"></gmd-checkbox>`,
+  detail: 'Required checkbox (must be checked)',
+};
+
+const checkedCheckbox: ComponentSuggestion = {
+  label: 'Checkbox - Pre-checked',
+  insertText: `<gmd-checkbox name="$1" label="$2" value="true"></gmd-checkbox>`,
+  detail: 'Checkbox that is checked by default',
+};
+
+const formCheckbox: ComponentSuggestion = {
+  label: 'Checkbox - Form Field',
+  insertText: `<gmd-checkbox name="$1" label="$2" fieldKey="$3" required="true"></gmd-checkbox>`,
+  detail: 'Checkbox with a field key for validation/data collection',
+};
+
+export const checkboxConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicCheckbox, requiredCheckbox, checkedCheckbox, formCheckbox],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name/id for label association',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the checkbox',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the checkbox required (must be checked)',
+    },
+    {
+      label: 'value="true"',
+      insertText: 'value="true"',
+      detail: 'Initial checked state (true/false)',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'disabled="true"',
+      insertText: 'disabled="true"',
+      detail: 'Disables the checkbox',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Checkbox',
+    description:
+      'A single checkbox component that can be checked or unchecked. When required, the checkbox must be checked for the form to be valid.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name/id attribute for label association and accessibility',
+    label: 'Display label shown next to the checkbox',
+    required: 'Whether the checkbox must be checked (true/false)',
+    value: 'Initial checked state: "true" for checked, "false" or omitted for unchecked',
+    fieldKey: 'Field key used for validation and data collection (saves as "true"/"false" string)',
+    disabled: 'Whether the checkbox is disabled (true/false)',
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/checkbox/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as checkbox-* show checkbox-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
@@ -17,7 +17,12 @@ import { reflectComponentType, Type } from '@angular/core';
 
 import { GmdButtonComponent } from './button/gmd-button.component';
 import { GmdCardComponent } from './card/gmd-card.component';
+import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
 import { GridComponent } from './grid/grid.component';
+import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdRadioComponent } from './radio/gmd-radio.component';
+import { GmdSelectComponent } from './select/gmd-select.component';
+import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
 
 interface InputMetadata {
   propName: string;
@@ -41,4 +46,9 @@ export const componentAttributeNames = [
   ...getComponentInputNames(GmdCardComponent),
   ...getComponentInputNames(GridComponent),
   ...getComponentInputNames(GmdButtonComponent),
+  ...getComponentInputNames(GmdInputComponent),
+  ...getComponentInputNames(GmdTextareaComponent),
+  ...getComponentInputNames(GmdSelectComponent),
+  ...getComponentInputNames(GmdCheckboxComponent),
+  ...getComponentInputNames(GmdRadioComponent),
 ];

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/component-name-selectors.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/component-name-selectors.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { reflectComponentType, Type } from '@angular/core';
+
+import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
+import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdRadioComponent } from './radio/gmd-radio.component';
+import { GmdSelectComponent } from './select/gmd-select.component';
+import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
+
+/**
+ * Extract the component selector from an Angular component type.
+ * @param componentType The Angular component class
+ * @returns The selector string (e.g., 'gmd-input') or null if not found
+ */
+function getComponentSelector(componentType: Type<unknown>): string | null {
+  const mirror = reflectComponentType(componentType);
+  return mirror?.selector ?? null;
+}
+
+/**
+ * Extract the component name without 'gmd-' prefix from an Angular component type.
+ * @param componentType The Angular component class
+ * @returns The component name without prefix (e.g., 'input') or empty string if not found
+ */
+function getComponentName(componentType: Type<unknown>): string {
+  const selector = getComponentSelector(componentType);
+  return selector ? selector.replace('gmd-', '') : '';
+}
+
+/**
+ * List of component names (without 'gmd-' prefix) that should be normalized from self-closing tags.
+ * Dynamically extracted from component selectors using Angular reflection.
+ * Used for normalizing self-closing tags in the markdown renderer (e.g., <gmd-input /> -> <gmd-input></gmd-input>).
+ */
+export const selfClosingComponentNames = [
+  getComponentName(GmdInputComponent),
+  getComponentName(GmdTextareaComponent),
+  getComponentName(GmdSelectComponent),
+  getComponentName(GmdCheckboxComponent),
+  getComponentName(GmdRadioComponent),
+];

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/README.md
@@ -55,25 +55,22 @@ The input component can be customized using SCSS overrides. Use the mixin to ove
 .my-scope {
   @include gmd.input-overrides((
     // Label styling
-    label-text-color: #111827,
-    label-text-size: 0.875rem,
-    label-text-weight: 500,
-
-    // Required indicator
-    required-text-color: #dc2626,
+    outlined-label-text-color: #111827,
+    outlined-label-text-size: 0.875rem,
+    outlined-label-text-weight: 500,
 
     // Field styling
-    field-text-size: 1rem,
-    field-text-color: #111827,
-    field-outline-width: 1px,
-    field-outline-color: #94a3b8,
-    field-outline-radius: 4px,
-    field-background-color: #ffffff,
-    field-focus-outline-color: #2563eb,
+    container-text-size: 1rem,
+    outlined-input-text-color: #111827,
+    outlined-outline-width: 1px,
+    outlined-outline-color: #94a3b8,
+    outlined-container-shape: 4px,
+    outlined-container-color: #ffffff,
+    outlined-focus-outline-color: #2563eb,
 
-    // Error messages
+    // Error messages (also used for required indicator)
     error-text-color: #dc2626,
-    error-text-size: 0.8125rem,
+    subscript-text-size: 0.8125rem,
   ));
 }
 ```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/README.md
@@ -1,0 +1,79 @@
+# Input Component
+
+Single-line text input with label, validation, and error display. It is designed for GMD forms and can emit field state when `fieldKey` is provided.
+
+## Usage
+
+### Basic
+
+```html
+<gmd-input name="email" label="Email" placeholder="you@example.com"></gmd-input>
+```
+
+### Required with validation
+
+```html
+<gmd-input name="company" label="Company" required="true" minLength="2" maxLength="50"></gmd-input>
+```
+
+### Field key for form state
+
+```html
+<gmd-input name="email" label="Email" fieldKey="email" required="true"></gmd-input>
+```
+
+### Readonly and disabled states
+
+```html
+<gmd-input name="readonly" label="Readonly" value="Cannot edit" readonly="true"></gmd-input>
+<gmd-input name="disabled" label="Disabled" value="Disabled" disabled="true"></gmd-input>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fieldKey` | `string \| undefined` | `undefined` | Key used to emit form state events. |
+| `name` | `string` | `''` | Input name and id. |
+| `label` | `string \| undefined` | `undefined` | Label shown above the input. |
+| `placeholder` | `string \| undefined` | `undefined` | Placeholder text. |
+| `value` | `string \| undefined` | `undefined` | Initial value. |
+| `required` | `boolean` | `false` | Marks the field as required. |
+| `minLength` | `number \| string \| null` | `null` | Minimum length constraint. |
+| `maxLength` | `number \| string \| null` | `null` | Maximum length constraint. |
+| `pattern` | `string \| undefined` | `undefined` | RegExp pattern constraint. |
+| `readonly` | `boolean` | `false` | Makes the input read-only (focusable, value submitted). |
+| `disabled` | `boolean` | `false` | Disables the input (not focusable, value not submitted). |
+
+## Theming
+
+The input component can be customized using SCSS overrides. Use the mixin to override available tokens:
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+.my-scope {
+  @include gmd.input-overrides((
+    // Label styling
+    label-text-color: #111827,
+    label-text-size: 0.875rem,
+    label-text-weight: 500,
+
+    // Required indicator
+    required-text-color: #dc2626,
+
+    // Field styling
+    field-text-size: 1rem,
+    field-text-color: #111827,
+    field-outline-width: 1px,
+    field-outline-color: #94a3b8,
+    field-outline-radius: 4px,
+    field-background-color: #ffffff,
+    field-focus-outline-color: #2563eb,
+
+    // Error messages
+    error-text-color: #dc2626,
+    error-text-size: 0.8125rem,
+  ));
+}
+```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/_overrides.scss
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
+
+@function tokens() {
+  @return (
+    namespace: input,
+    tokens: (
+      label-text-size: 0.875rem,
+      label-text-weight: 500,
+      label-text-color: inherit,
+      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      field-text-size: 1rem,
+      field-text-color: inherit,
+      field-outline-width: 1px,
+      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
+      field-background-color: #ffffff,
+      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-size: 0.8125rem,
+    )
+  );
+}
+
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/_overrides.scss
@@ -22,19 +22,18 @@ $theme-tokens: theme.tokens();
   @return (
     namespace: input,
     tokens: (
-      label-text-size: 0.875rem,
-      label-text-weight: 500,
-      label-text-color: inherit,
-      required-text-color: token-utils.slot(error-color, $theme-tokens),
-      field-text-size: 1rem,
-      field-text-color: inherit,
-      field-outline-width: 1px,
-      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
-      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
-      field-background-color: #ffffff,
-      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
+      container-text-size: 1rem,
+      outlined-input-text-color: inherit,
+      outlined-outline-width: 1px,
+      outlined-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      outlined-container-shape: token-utils.slot(container-shape, $theme-tokens),
+      outlined-container-color: token-utils.slot(surface-color, $theme-tokens),
+      outlined-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
       error-text-color: token-utils.slot(error-color, $theme-tokens),
-      error-text-size: 0.8125rem,
+      subscript-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.harness.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdInputComponentHarness extends ComponentHarness {
+  static hostSelector = 'gmd-input';
+
+  async getValue(): Promise<string> {
+    const input = await this.getInput();
+    return (await input.getProperty('value')) as string;
+  }
+
+  async setValue(value: string): Promise<void> {
+    const input = await this.getInput();
+    await input.clear();
+    await input.sendKeys(value);
+  }
+
+  async getPlaceholder(): Promise<string | null> {
+    const input = await this.getInput();
+    return await input.getAttribute('placeholder');
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const input = await this.getInput();
+    return (await input.getProperty('disabled')) as boolean;
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-input__label')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-input__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getMinLength(): Promise<string | null> {
+    const input = await this.getInput();
+    return await input.getAttribute('minlength');
+  }
+
+  async getMaxLength(): Promise<string | null> {
+    const input = await this.getInput();
+    return await input.getAttribute('maxlength');
+  }
+
+  async getPattern(): Promise<string | null> {
+    const input = await this.getInput();
+    return await input.getAttribute('pattern');
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-input__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async hasErrors(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async blur(): Promise<void> {
+    const input = await this.getInput();
+    await input.blur();
+  }
+
+  async focus(): Promise<void> {
+    const input = await this.getInput();
+    await input.focus();
+  }
+
+  async isReadonly(): Promise<boolean> {
+    const input = await this.getInput();
+    return (await input.getProperty('readOnly')) as boolean;
+  }
+
+  private async getInput(): Promise<TestElement> {
+    return this.locatorFor('input')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.html
@@ -1,0 +1,50 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gmd-input">
+  @if (label()) {
+    <label class="gmd-input__label" [for]="name()">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-input__required">*</span>
+      }
+    </label>
+  }
+
+  <input
+    class="gmd-input__field"
+    [id]="name()"
+    [name]="name()"
+    type="text"
+    [placeholder]="placeholder() ?? ''"
+    [value]="internalValue()"
+    [attr.minlength]="minLength()"
+    [attr.maxlength]="maxLength()"
+    [attr.pattern]="pattern() ?? null"
+    [readonly]="readonly()"
+    [disabled]="disabled()"
+    (input)="onInput($event)"
+    (blur)="onBlur()" />
+
+  @if (touched() && errorMessages().length) {
+    <div class="gmd-input__errors" role="alert">
+      @for (msg of errorMessages(); track msg) {
+        <div class="gmd-input__error">{{ msg }}</div>
+      }
+    </div>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.scss
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+.gmd-input {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+
+  &__label {
+    color: token-utils.slot(label-text-color, $token-mapping);
+    font-size: token-utils.slot(label-text-size, $token-mapping);
+    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+  }
+
+  &__required {
+    color: token-utils.slot(required-text-color, $token-mapping);
+  }
+
+  &__field {
+    padding: 0.5rem;
+    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
+    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
+    background-color: token-utils.slot(field-background-color, $token-mapping);
+    color: token-utils.slot(field-text-color, $token-mapping);
+    font-size: token-utils.slot(field-text-size, $token-mapping);
+
+    &:focus {
+      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      outline: none;
+    }
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(error-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.scss
@@ -25,25 +25,25 @@ $token-mapping: overrides.tokens();
   gap: 0.5rem;
 
   &__label {
-    color: token-utils.slot(label-text-color, $token-mapping);
-    font-size: token-utils.slot(label-text-size, $token-mapping);
-    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
   }
 
   &__required {
-    color: token-utils.slot(required-text-color, $token-mapping);
+    color: token-utils.slot(error-text-color, $token-mapping);
   }
 
   &__field {
     padding: 0.5rem;
-    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
-    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
-    background-color: token-utils.slot(field-background-color, $token-mapping);
-    color: token-utils.slot(field-text-color, $token-mapping);
-    font-size: token-utils.slot(field-text-size, $token-mapping);
+    border: token-utils.slot(outlined-outline-width, $token-mapping) solid token-utils.slot(outlined-outline-color, $token-mapping);
+    border-radius: token-utils.slot(outlined-container-shape, $token-mapping);
+    background-color: token-utils.slot(outlined-container-color, $token-mapping);
+    color: token-utils.slot(outlined-input-text-color, $token-mapping);
+    font-size: token-utils.slot(container-text-size, $token-mapping);
 
     &:focus {
-      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      border-color: token-utils.slot(outlined-focus-outline-color, $token-mapping);
       outline: none;
     }
   }
@@ -56,6 +56,6 @@ $token-mapping: overrides.tokens();
 
   &__error {
     color: token-utils.slot(error-text-color, $token-mapping);
-    font-size: token-utils.slot(error-text-size, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdInputComponent } from './gmd-input.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+
+export default {
+  title: 'Gravitee Markdown/Components/Input',
+  component: GmdInputComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdInputComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' }))],
+    }),
+  ],
+} as Meta<GmdInputComponent>;
+
+export const Basic: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-input name="basic" label="Basic Input" placeholder="Enter text..."></gmd-input>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-input name="required" label="Required Input" required="true" placeholder="This field is required"></gmd-input>
+      </div>
+    `,
+  }),
+};
+
+export const ReadonlyAndDisabled: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-input name="normal" label="Normal Input" value="Editable text" placeholder="You can edit this"></gmd-input>
+        <gmd-input name="readonly" label="Readonly Input" value="Read-only text" readonly="true" placeholder="Cannot edit"></gmd-input>
+        <gmd-input name="disabled" label="Disabled Input" value="Disabled text" disabled="true" placeholder="Disabled"></gmd-input>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Comparison of normal, readonly, and disabled states. Readonly fields are focusable and their values are submitted, while disabled fields are not focusable and values are not submitted.',
+      },
+    },
+  },
+};
+
+export const WithValidation: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-input
+          name="minmax"
+          label="Min/Max Length"
+          minLength="3"
+          maxLength="10"
+          placeholder="3-10 characters">
+        </gmd-input>
+        <gmd-input
+          name="pattern"
+          label="Pattern Validation (letters only)"
+          pattern="[A-Za-z]+"
+          placeholder="Letters only">
+        </gmd-input>
+        <gmd-input
+          name="email"
+          label="Email (with pattern validation)"
+          pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+          required="true"
+          placeholder="user@example.com">
+        </gmd-input>
+      </div>
+    `,
+  }),
+};
+
+export const PatternExamples: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-input
+          name="email"
+          label="Email"
+          pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+          placeholder="email@example.com">
+        </gmd-input>
+        <gmd-input
+          name="number"
+          label="Numbers only"
+          pattern="[0-9]+"
+          placeholder="123">
+        </gmd-input>
+        <gmd-input
+          name="url"
+          label="URL"
+          pattern="https?://.*"
+          placeholder="https://example.com">
+        </gmd-input>
+        <gmd-input
+          name="tel"
+          label="Phone"
+          pattern="\\+?[0-9\\s-]+"
+          placeholder="+1 234 567 8900">
+        </gmd-input>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Examples of using pattern validation for different input types. All inputs are type="text" with regex patterns for validation.',
+      },
+    },
+  },
+};
+
+export const WithFieldKey: StoryObj<GmdInputComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-input
+          name="email"
+          label="Email"
+          fieldKey="email"
+          required="true"
+          pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+          placeholder="user@example.com">
+        </gmd-input>
+        <gmd-input
+          name="company"
+          label="Company Name"
+          fieldKey="company"
+          required="true"
+          minLength="2"
+          maxLength="50"
+          placeholder="Your company name">
+        </gmd-input>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Input fields configured with field keys. These fields emit validation events for form state aggregation.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Input Component with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# Registration Form
+
+Please fill in your details:
+
+<gmd-input name="username" label="Username" fieldKey="username" required="true" minLength="3" maxLength="20" placeholder="Choose a username"></gmd-input>
+
+<gmd-input name="email" label="Email Address" fieldKey="email" pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}" required="true" placeholder="your.email@example.com"></gmd-input>
+
+<gmd-input name="website" label="Website" fieldKey="website" pattern="https?://.*" placeholder="https://example.com"></gmd-input>
+
+<gmd-input name="company" label="Company Name" fieldKey="company" required="true" minLength="2" maxLength="100" placeholder="Your company"></gmd-input>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form editor with live validation tracking. Shows how the gmd-form-editor component tracks field states and displays validation status in real-time.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Form Input Examples
+
+<gmd-input name="username" label="Username" required="true" minLength="3" maxLength="20"></gmd-input>
+
+<gmd-input name="email" label="Email Address" pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}" required="true"></gmd-input>
+
+<gmd-input name="website" label="Website" pattern="https?://.*" placeholder="https://example.com"></gmd-input>
+
+<gmd-input name="phone" label="Phone Number" pattern="\\+?[0-9\\s-]+" placeholder="+1 234 567 8900"></gmd-input>
+
+<gmd-input name="company" label="Company Name" required="true" minLength="2" maxLength="100"></gmd-input>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Input components rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.component.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, computed, effect, inject, input, signal, untracked } from '@angular/core';
+
+import { GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+
+@Component({
+  selector: 'gmd-input',
+  imports: [CommonModule],
+  templateUrl: './gmd-input.component.html',
+  styleUrl: './gmd-input.component.scss',
+  standalone: true,
+})
+export class GmdInputComponent {
+  // metadata key
+  fieldKey = input<string | undefined>();
+
+  // UI
+  name = input<string>('');
+  label = input<string | undefined>();
+  placeholder = input<string | undefined>();
+
+  // initial value (optional)
+  value = input<string | undefined>();
+
+  // validation
+  required = input<boolean>(false);
+  minLength = input<number | string | null | undefined>();
+  maxLength = input<number | string | null | undefined>();
+  pattern = input<string | undefined>();
+
+  readonly = input<boolean>(false);
+  disabled = input<boolean>(false);
+
+  errors = computed<GmdFieldErrorCode[]>(() => {
+    const v = this.internalValue();
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && v.trim().length === 0) errs.push('required');
+
+    const minL = this.parseNumberLike(this.minLength());
+    if (minL !== null && v.length < minL) errs.push('minLength');
+
+    const maxL = this.parseNumberLike(this.maxLength());
+    if (maxL !== null && v.length > maxL) errs.push('maxLength');
+
+    const p = this.pattern();
+    if (p) {
+      try {
+        const re = new RegExp(p);
+        if (v.length > 0 && !re.test(v)) errs.push('pattern');
+      } catch (e) {
+        //TODO We need to figure out how to handle invalid regex patterns
+      }
+    }
+
+    return errs;
+  });
+
+  valid = computed(() => this.errors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.errors();
+    const msgs: string[] = [];
+    const minL = this.parseNumberLike(this.minLength());
+    const maxL = this.parseNumberLike(this.maxLength());
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+        case 'minLength':
+          msgs.push(`Minimum length is ${minL}.`);
+          break;
+        case 'maxLength':
+          msgs.push(`Maximum length is ${maxL}.`);
+          break;
+        case 'pattern':
+          msgs.push('Value does not match the required format.');
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  protected readonly HTMLInputElement = HTMLInputElement;
+
+  private readonly el = inject(ElementRef<HTMLElement>);
+
+  protected readonly internalValue = signal<string>('');
+  protected readonly touched = signal<boolean>(false);
+
+  constructor() {
+    // init/sync from provided value
+    effect(() => {
+      const v = this.value();
+      if (v !== undefined) {
+        this.internalValue.set(String(v));
+      }
+    });
+
+    // whenever something relevant changes, notify host (only if fieldKey is set)
+    effect(() => {
+      const key = (this.fieldKey() ?? '').trim();
+      if (!key) return; // Early return if no fieldKey
+
+      // Read all reactive values to track changes
+      this.internalValue();
+      this.required();
+      this.minLength();
+      this.maxLength();
+      this.pattern();
+      this.disabled();
+
+      // Emit state only if fieldKey is present
+      this.emitState();
+    });
+  }
+
+  onInput(event: Event) {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.internalValue.set(value);
+  }
+
+  onBlur() {
+    this.touched.set(true);
+    this.emitState();
+  }
+
+  private parseNumberLike(v: number | string | null | undefined): number | null {
+    if (v === undefined || v === null) return null;
+    const n = typeof v === 'number' ? v : Number(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private emitState() {
+    const key = (this.fieldKey() ?? '').trim();
+    if (!key) return;
+
+    // Don't emit state for disabled fields (mimics HTML form behavior where disabled fields are not submitted)
+    if (this.disabled()) return;
+
+    // Use untracked to avoid tracking computed values during event dispatch
+    const detail: GmdFieldState = untracked(() => ({
+      key,
+      value: this.internalValue(),
+      valid: this.valid(),
+      required: !!this.required(),
+      touched: this.touched(),
+      errors: this.errors(),
+    }));
+
+    // Dispatch event asynchronously to avoid blocking the event loop
+    setTimeout(() => {
+      this.el.nativeElement.dispatchEvent(
+        new CustomEvent<GmdFieldState>('gmdFieldStateChange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, 0);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.suggestions.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/gmd-input.suggestions.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicInput: ComponentSuggestion = {
+  label: 'Input - Basic',
+  insertText: `<gmd-input name="$1" label="$2" placeholder="$3"></gmd-input>`,
+  detail: 'Basic text input field',
+};
+
+const requiredInput: ComponentSuggestion = {
+  label: 'Input - Required',
+  insertText: `<gmd-input name="$1" label="$2" required="true"></gmd-input>`,
+  detail: 'Required text input field',
+};
+
+const emailInput: ComponentSuggestion = {
+  label: 'Input - Email',
+  insertText: `<gmd-input name="email" label="Email" required="true"></gmd-input>`,
+  detail: 'Email input field with required validation',
+};
+
+const inputWithValidation: ComponentSuggestion = {
+  label: 'Input - With Validation',
+  insertText: `<gmd-input name="$1" label="$2" required="true" minLength="3" maxLength="50"></gmd-input>`,
+  detail: 'Input field with min/max length validation',
+};
+
+const formInput: ComponentSuggestion = {
+  label: 'Input - Form Field',
+  insertText: `<gmd-input name="$1" label="$2" fieldKey="$3" required="true"></gmd-input>`,
+  detail: 'Input field with a field key for validation/data collection',
+};
+
+export const inputConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicInput, requiredInput, emailInput, inputWithValidation, formInput],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name/id for label association',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the input field',
+    },
+    {
+      label: 'placeholder="Placeholder"',
+      insertText: 'placeholder="$1"',
+      detail: 'Placeholder text shown when field is empty',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the field required',
+    },
+    {
+      label: 'minLength="3"',
+      insertText: 'minLength="$1"',
+      detail: 'Minimum character length',
+    },
+    {
+      label: 'maxLength="100"',
+      insertText: 'maxLength="$1"',
+      detail: 'Maximum character length',
+    },
+    {
+      label: 'pattern="[A-Za-z]+"',
+      insertText: 'pattern="$1"',
+      detail: 'Regular expression pattern for validation',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'value="default"',
+      insertText: 'value="$1"',
+      detail: 'Default/initial value for the field',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Input',
+    description: 'A text input component with validation options including required, minLength, maxLength, and pattern matching.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name/id attribute for label association and accessibility',
+    label: 'Display label shown above the input field',
+    placeholder: 'Hint text displayed when the field is empty',
+    required: 'Whether the field is required (true/false)',
+    minLength: 'Minimum number of characters allowed',
+    maxLength: 'Maximum number of characters allowed',
+    pattern: 'Regular expression pattern for value validation',
+    fieldKey: 'Field key used for validation and data collection',
+    value: 'Initial/default value for the field',
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/input/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as input-* show input-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
@@ -23,6 +23,11 @@ import { GmdButtonComponent } from './button/gmd-button.component';
 import { GmdCardSubtitleComponent } from './card/components/card-subtitle/gmd-card-subtitle.component';
 import { GmdCardTitleComponent } from './card/components/card-title/gmd-card-title.component';
 import { GmdCardComponent } from './card/gmd-card.component';
+import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
+import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdRadioComponent } from './radio/gmd-radio.component';
+import { GmdSelectComponent } from './select/gmd-select.component';
+import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
 
 export const prefixStripperParser: HookParserEntry[] = [
   {
@@ -52,5 +57,25 @@ export const prefixStripperParser: HookParserEntry[] = [
   {
     component: GmdButtonComponent,
     selector: ComponentSelector.BUTTON,
+  },
+  {
+    component: GmdInputComponent,
+    selector: ComponentSelector.INPUT,
+  },
+  {
+    component: GmdTextareaComponent,
+    selector: ComponentSelector.TEXTAREA,
+  },
+  {
+    component: GmdSelectComponent,
+    selector: ComponentSelector.SELECT,
+  },
+  {
+    component: GmdCheckboxComponent,
+    selector: ComponentSelector.CHECKBOX,
+  },
+  {
+    component: GmdRadioComponent,
+    selector: ComponentSelector.RADIO,
   },
 ];

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/README.md
@@ -54,20 +54,13 @@ Radio group input with label, options, validation, and error display. It is desi
 .my-scope {
   @include gmd.radio-overrides((
     // Label styling
-    label-text-color: #111827,
-    label-text-size: 0.875rem,
-    label-text-weight: 500,
+    outlined-label-text-color: #111827,
+    outlined-label-text-size: 0.875rem,
+    outlined-label-text-weight: 500,
 
-    // Radio option styling
-    option-text-color: #111827,
-    option-text-size: 0.875rem,
-
-    // Required indicator
-    required-text-color: #dc2626,
-
-    // Error messages
+    // Error messages (also used for required indicator)
     error-text-color: #dc2626,
-    error-text-size: 0.8125rem,
+    subscript-text-size: 0.8125rem,
   ));
 }
 ```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/README.md
@@ -1,0 +1,73 @@
+# Radio Component
+
+Radio group input with label, options, validation, and error display. It is designed for GMD forms and can emit field state when `fieldKey` is provided.
+
+## Usage
+
+### Basic
+
+```html
+<gmd-radio name="plan" label="Plan" options="Basic,Pro,Enterprise"></gmd-radio>
+```
+
+### Required
+
+```html
+<gmd-radio name="plan" label="Plan" required="true" options="Basic,Pro,Enterprise"></gmd-radio>
+```
+
+### Readonly
+
+```html
+<gmd-radio name="plan" label="Plan" value="Pro" readonly="true" options="Basic,Pro,Enterprise"></gmd-radio>
+```
+
+### Field key for form state
+
+```html
+<gmd-radio name="plan" label="Plan" fieldKey="plan" required="true" options="Basic,Pro,Enterprise"></gmd-radio>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fieldKey` | `string \| undefined` | `undefined` | Key used to emit form state events. |
+| `name` | `string` | `''` | Radio name and id. |
+| `label` | `string \| undefined` | `undefined` | Label shown above the group. |
+| `value` | `string \| undefined` | `undefined` | Initial value. |
+| `required` | `boolean` | `false` | Marks the field as required. |
+| `options` | `string` | `''` | Comma-separated values or JSON array string. |
+| `readonly` | `boolean` | `false` | Makes the radio group read-only (focusable, value submitted). |
+| `disabled` | `boolean` | `false` | Disables the group. |
+
+## Options format
+
+- Comma-separated: `"Basic,Pro,Enterprise"`
+- JSON array: `'["Basic","Pro","Enterprise"]'`
+
+## Theming
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+.my-scope {
+  @include gmd.radio-overrides((
+    // Label styling
+    label-text-color: #111827,
+    label-text-size: 0.875rem,
+    label-text-weight: 500,
+
+    // Radio option styling
+    option-text-color: #111827,
+    option-text-size: 0.875rem,
+
+    // Required indicator
+    required-text-color: #dc2626,
+
+    // Error messages
+    error-text-color: #dc2626,
+    error-text-size: 0.8125rem,
+  ));
+}
+```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/_overrides.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use './token-utils' as token-utils;
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
 
 @function tokens() {
   @return (
-    (
-      namespace: sys,
-      tokens: (
-        container-shape: 4px,
-        primary-color: #275cf6,
-        on-primary-color: #ffffff,
-        outline-color: #cdd7e1,
-        hover-state-layer-opacity: 90%,
-        focus-state-layer-opacity: 80%,
-        text-color: #1d192b,
-        error-color: #d32f2f,
-      )
+    namespace: radio,
+    tokens: (
+      label-text-size: 0.875rem,
+      label-text-weight: 500,
+      label-text-color: inherit,
+      option-text-size: 0.875rem,
+      option-text-color: inherit,
+      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/_overrides.scss
@@ -22,14 +22,11 @@ $theme-tokens: theme.tokens();
   @return (
     namespace: radio,
     tokens: (
-      label-text-size: 0.875rem,
-      label-text-weight: 500,
-      label-text-color: inherit,
-      option-text-size: 0.875rem,
-      option-text-color: inherit,
-      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
       error-text-color: token-utils.slot(error-color, $theme-tokens),
-      error-text-size: 0.8125rem,
+      subscript-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.harness.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdRadioComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'gmd-radio';
+
+  async getSelectedValue(): Promise<string | null> {
+    const inputs = await this.getRadioInputs();
+    for (const input of inputs) {
+      const checked = await input.getProperty('checked');
+      if (checked) {
+        return await input.getProperty('value');
+      }
+    }
+    return null;
+  }
+
+  async selectOption(value: string): Promise<void> {
+    const input = await this.getRadioInputByValue(value);
+    if (input) {
+      await input.click();
+    } else {
+      throw new Error(`Radio option with value "${value}" not found`);
+    }
+  }
+
+  async getOptionCount(): Promise<number> {
+    const inputs = await this.getRadioInputs();
+    return inputs.length;
+  }
+
+  async getOptionLabels(): Promise<string[]> {
+    const labels = await this.locatorForAll('.gmd-radio__option-label')();
+    const labelTexts: string[] = [];
+    for (const label of labels) {
+      labelTexts.push(await label.text());
+    }
+    return labelTexts;
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const inputs = await this.getRadioInputs();
+    if (inputs.length === 0) {
+      return false;
+    }
+    return await inputs[0].getProperty('disabled');
+  }
+
+  async isRequired(): Promise<boolean> {
+    const inputs = await this.getRadioInputs();
+    if (inputs.length === 0) {
+      return false;
+    }
+    return await inputs[0].getProperty('required');
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-radio__group-label')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-radio__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-radio__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async hasErrors(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async blur(): Promise<void> {
+    const inputs = await this.getRadioInputs();
+    if (inputs.length > 0) {
+      await inputs[0].blur();
+    }
+  }
+
+  private async getRadioInputs(): Promise<TestElement[]> {
+    return this.locatorForAll('input[type="radio"]')();
+  }
+
+  private async getRadioInputByValue(value: string): Promise<TestElement | null> {
+    try {
+      const inputs = await this.getRadioInputs();
+      for (const input of inputs) {
+        const inputValue = await input.getProperty('value');
+        if (inputValue === value) {
+          return input;
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.html
@@ -1,0 +1,52 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gmd-radio">
+  @if (label()) {
+    <div class="gmd-radio__group-label">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-radio__required">*</span>
+      }
+    </div>
+  }
+  <div class="gmd-radio__options">
+    @for (option of optionsVM(); track option) {
+      <label class="gmd-radio__option">
+        <input
+          type="radio"
+          [name]="name()"
+          [value]="option"
+          [checked]="internalValue() === option"
+          [required]="required()"
+          [readonly]="readonly()"
+          [disabled]="disabled()"
+          (change)="onChange($event)"
+          (blur)="onBlur()" />
+        <span class="gmd-radio__option-label">{{ option }}</span>
+      </label>
+    }
+  </div>
+
+  @if (touched() && errorMessages().length) {
+    <div class="gmd-radio__errors" role="alert">
+      @for (msg of errorMessages(); track msg) {
+        <div class="gmd-radio__error">{{ msg }}</div>
+      }
+    </div>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.scss
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+.gmd-radio {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+
+  &__group-label {
+    color: token-utils.slot(label-text-color, $token-mapping);
+    font-size: token-utils.slot(label-text-size, $token-mapping);
+    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+  }
+
+  &__required {
+    color: token-utils.slot(required-text-color, $token-mapping);
+  }
+
+  &__options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    gap: 0.5rem;
+  }
+
+  &__option-label {
+    color: token-utils.slot(option-text-color, $token-mapping);
+    font-size: token-utils.slot(option-text-size, $token-mapping);
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(error-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.scss
@@ -25,13 +25,13 @@ $token-mapping: overrides.tokens();
   gap: 0.5rem;
 
   &__group-label {
-    color: token-utils.slot(label-text-color, $token-mapping);
-    font-size: token-utils.slot(label-text-size, $token-mapping);
-    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
   }
 
   &__required {
-    color: token-utils.slot(required-text-color, $token-mapping);
+    color: token-utils.slot(error-text-color, $token-mapping);
   }
 
   &__options {
@@ -48,8 +48,8 @@ $token-mapping: overrides.tokens();
   }
 
   &__option-label {
-    color: token-utils.slot(option-text-color, $token-mapping);
-    font-size: token-utils.slot(option-text-size, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
   }
 
   &__errors {
@@ -60,6 +60,6 @@ $token-mapping: overrides.tokens();
 
   &__error {
     color: token-utils.slot(error-text-color, $token-mapping);
-    font-size: token-utils.slot(error-text-size, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdRadioComponent } from './gmd-radio.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+
+export default {
+  title: 'Gravitee Markdown/Components/Radio',
+  component: GmdRadioComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdRadioComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' }))],
+    }),
+  ],
+} as Meta<GmdRadioComponent>;
+
+export const Basic: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-radio name="basic" label="Basic Radio Group" options="Option 1,Option 2,Option 3"></gmd-radio>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-radio name="required" label="Required Radio Group" required="true" options="Option 1,Option 2,Option 3"></gmd-radio>
+      </div>
+    `,
+  }),
+};
+
+export const WithJsonOptions: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-radio name="json" label="Radio with JSON Options" options='["Small","Medium","Large","Extra Large"]'></gmd-radio>
+      </div>
+    `,
+  }),
+};
+
+export const ReadonlyAndDisabled: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 24px;">
+        <gmd-radio name="normal" label="Normal Radio" value="Option 2" options="Option 1,Option 2,Option 3"></gmd-radio>
+        <gmd-radio name="readonly" label="Readonly Radio" value="Option 2" readonly="true" options="Option 1,Option 2,Option 3"></gmd-radio>
+        <gmd-radio name="disabled" label="Disabled Radio" value="Option 2" disabled="true" options="Option 1,Option 2,Option 3"></gmd-radio>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Comparison of normal, readonly, and disabled states. Readonly fields are focusable and their values are submitted, while disabled fields are not focusable and values are not submitted.',
+      },
+    },
+  },
+};
+
+export const CommonUseCases: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 24px;">
+        <gmd-radio name="plan" label="Plan" required="true" options="Basic,Professional,Enterprise"></gmd-radio>
+        <gmd-radio name="size" label="Size" required="true" options='["Small","Medium","Large"]'></gmd-radio>
+        <gmd-radio name="frequency" label="Billing Frequency" required="true" options="Monthly,Quarterly,Yearly"></gmd-radio>
+      </div>
+    `,
+  }),
+};
+
+export const WithFieldKey: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 24px;">
+        <gmd-radio
+          name="plan"
+          label="Plan"
+          fieldKey="plan"
+          required="true"
+          options="Basic,Professional,Enterprise">
+        </gmd-radio>
+        <gmd-radio
+          name="frequency"
+          label="Billing Frequency"
+          fieldKey="billingFrequency"
+          required="true"
+          options='["Monthly","Quarterly","Yearly"]'>
+        </gmd-radio>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Radio button groups configured with field keys. These fields emit validation events for form state aggregation.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Radio with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# API Subscription Plan
+
+Choose the subscription plan that best fits your needs.
+
+## Select Your Plan
+
+<gmd-radio
+  name="plan"
+  label="Subscription Plan"
+  fieldKey="plan"
+  required="true"
+  options="Free (10 requests/day),Starter ($9.99/month - 1000 requests/day),Professional ($49.99/month - 10000 requests/day),Enterprise ($199.99/month - Unlimited requests)">
+</gmd-radio>
+
+## Billing Frequency
+
+<gmd-radio
+  name="frequency"
+  label="Billing Frequency"
+  fieldKey="billingFrequency"
+  required="true"
+  options="Monthly (No discount),Quarterly (Save 10%),Yearly (Save 20%)">
+</gmd-radio>
+
+## Support Level
+
+<gmd-radio
+  name="support"
+  label="Support Level"
+  fieldKey="support"
+  required="true"
+  options="Community Support,Email Support (24h response),Priority Support (4h response),Dedicated Support (1h response)">
+</gmd-radio>
+
+## Auto-renewal
+
+<gmd-radio
+  name="renewal"
+  label="Auto-renewal Preference"
+  fieldKey="autoRenewal"
+  options="Enable auto-renewal,Disable auto-renewal">
+</gmd-radio>`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form editor with live validation tracking. Shows how the gmd-form-editor component tracks field states and displays validation status in real-time.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Radio Examples
+
+<gmd-radio name="plan" label="Plan" required="true" options="Basic,Professional,Enterprise"></gmd-radio>
+
+<gmd-radio name="size" label="Size" options='["Small","Medium","Large"]'></gmd-radio>
+
+<gmd-radio name="frequency" label="Billing Frequency" required="true" options="Monthly,Quarterly,Yearly"></gmd-radio>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Radio button groups rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, computed, effect, inject, input, signal, untracked } from '@angular/core';
+
+import { GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+
+@Component({
+  selector: 'gmd-radio',
+  imports: [CommonModule],
+  templateUrl: './gmd-radio.component.html',
+  styleUrl: './gmd-radio.component.scss',
+  standalone: true,
+})
+export class GmdRadioComponent {
+  // metadata key
+  fieldKey = input<string | undefined>();
+
+  // UI
+  name = input<string>('');
+  label = input<string | undefined>();
+
+  // initial value (optional)
+  value = input<string | undefined>();
+
+  // validation
+  required = input<boolean>(false);
+
+  options = input<string>(''); // Comma-separated or JSON array string
+  readonly = input<boolean>(false);
+  disabled = input<boolean>(false);
+
+  errors = computed<GmdFieldErrorCode[]>(() => {
+    const v = this.internalValue();
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && v.trim().length === 0) errs.push('required');
+
+    return errs;
+  });
+
+  valid = computed(() => this.errors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.errors();
+    const msgs: string[] = [];
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  private readonly el = inject(ElementRef<HTMLElement>);
+
+  protected readonly internalValue = signal<string>('');
+  protected readonly touched = signal<boolean>(false);
+
+  constructor() {
+    // init/sync from provided value
+    effect(() => {
+      const v = this.value();
+      if (v !== undefined) {
+        this.internalValue.set(String(v));
+      }
+    });
+
+    // whenever something relevant changes, notify host (only if fieldKey is set)
+    effect(() => {
+      const key = (this.fieldKey() ?? '').trim();
+      if (!key) return; // Early return if no fieldKey
+
+      // Read all reactive values to track changes
+      this.internalValue();
+      this.required();
+      this.disabled();
+
+      // Emit state only if fieldKey is present
+      this.emitState();
+    });
+  }
+
+  onChange(event: Event) {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    this.internalValue.set(value);
+  }
+
+  optionsVM = () => {
+    const opts = this.options();
+    if (!opts) return [];
+
+    // Try to parse as JSON array first
+    try {
+      const parsed = JSON.parse(opts);
+      if (Array.isArray(parsed)) {
+        return parsed.map(opt => (typeof opt === 'string' ? opt : String(opt)));
+      }
+    } catch {
+      // Not JSON, try comma-separated
+    }
+
+    // Parse as comma-separated values
+    return opts
+      .split(',')
+      .map(opt => opt.trim())
+      .filter(opt => opt.length > 0);
+  };
+
+  onBlur() {
+    this.touched.set(true);
+    this.emitState();
+  }
+
+  private emitState() {
+    const key = (this.fieldKey() ?? '').trim();
+    if (!key) return;
+
+    // Don't emit state for disabled fields (mimics HTML form behavior where disabled fields are not submitted)
+    if (this.disabled()) return;
+
+    // Use untracked to avoid tracking computed values during event dispatch
+    const detail: GmdFieldState = untracked(() => ({
+      key,
+      value: this.internalValue(),
+      valid: this.valid(),
+      required: !!this.required(),
+      touched: this.touched(),
+      errors: this.errors(),
+    }));
+
+    // Dispatch event asynchronously to avoid blocking the event loop
+    setTimeout(() => {
+      this.el.nativeElement.dispatchEvent(
+        new CustomEvent<GmdFieldState>('gmdFieldStateChange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, 0);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
@@ -68,6 +68,27 @@ export class GmdRadioComponent {
     return msgs;
   });
 
+  optionsVM = computed(() => {
+    const opts = this.options();
+    if (!opts) return [];
+
+    // Try to parse as JSON array first
+    try {
+      const parsed = JSON.parse(opts);
+      if (Array.isArray(parsed)) {
+        return parsed.map(opt => (typeof opt === 'string' ? opt : String(opt)));
+      }
+    } catch {
+      // Not JSON, try comma-separated
+    }
+
+    // Parse as comma-separated values
+    return opts
+      .split(',')
+      .map(opt => opt.trim())
+      .filter(opt => opt.length > 0);
+  });
+
   private readonly el = inject(ElementRef<HTMLElement>);
 
   protected readonly internalValue = signal<string>('');
@@ -101,28 +122,6 @@ export class GmdRadioComponent {
     const value = (event.target as HTMLInputElement | null)?.value ?? '';
     this.internalValue.set(value);
   }
-
-  optionsVM = () => {
-    const opts = this.options();
-    if (!opts) return [];
-
-    // Try to parse as JSON array first
-    try {
-      const parsed = JSON.parse(opts);
-      if (Array.isArray(parsed)) {
-        return parsed.map(opt => (typeof opt === 'string' ? opt : String(opt)));
-      }
-    } catch {
-      // Not JSON, try comma-separated
-    }
-
-    // Parse as comma-separated values
-    return opts
-      .split(',')
-      .map(opt => opt.trim())
-      .filter(opt => opt.length > 0);
-  };
-
   onBlur() {
     this.touched.set(true);
     this.emitState();

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.suggestions.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/gmd-radio.suggestions.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicRadio: ComponentSuggestion = {
+  label: 'Radio - Basic',
+  insertText: `<gmd-radio name="$1" label="$2" options="Option 1,Option 2,Option 3"></gmd-radio>`,
+  detail: 'Basic radio button group',
+};
+
+const requiredRadio: ComponentSuggestion = {
+  label: 'Radio - Required',
+  insertText: `<gmd-radio name="$1" label="$2" required="true" options="Option 1,Option 2,Option 3"></gmd-radio>`,
+  detail: 'Required radio button group',
+};
+
+const radioWithJson: ComponentSuggestion = {
+  label: 'Radio - JSON Options',
+  insertText: `<gmd-radio name="$1" label="$2" options='["Option 1","Option 2","Option 3"]'></gmd-radio>`,
+  detail: 'Radio group with options defined as JSON array',
+};
+
+const formRadio: ComponentSuggestion = {
+  label: 'Radio - Form Field',
+  insertText: `<gmd-radio name="$1" label="$2" fieldKey="$3" required="true" options="Option 1,Option 2"></gmd-radio>`,
+  detail: 'Radio group with a field key for validation/data collection',
+};
+
+export const radioConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicRadio, requiredRadio, radioWithJson, formRadio],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name/id for label association (same name groups radio buttons)',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the radio button group',
+    },
+    {
+      label: 'options="Option 1,Option 2,Option 3"',
+      insertText: 'options="$1"',
+      detail: 'Comma-separated list of options or JSON array string',
+    },
+    {
+      label: 'options=\'["Option 1","Option 2"]\'',
+      insertText: 'options=\'["$1"]\'',
+      detail: 'JSON array string format for options',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the field required (one option must be selected)',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'value="selectedOption"',
+      insertText: 'value="$1"',
+      detail: 'Default/initial selected value',
+    },
+    {
+      label: 'disabled="true"',
+      insertText: 'disabled="true"',
+      detail: 'Disables all radio buttons in the group',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Radio',
+    description:
+      'A radio button group component that allows users to select a single option from a list. All radio buttons with the same name are grouped together. Options can be provided as a comma-separated string or JSON array.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name/id attribute for label association and grouping radio buttons',
+    label: 'Display label shown above the radio button group',
+    options:
+      'List of options as comma-separated string (e.g., "Option 1,Option 2") or JSON array string (e.g., \'["Option 1","Option 2"]\')',
+    required: 'Whether one option must be selected (true/false)',
+    fieldKey: 'Field key used for validation and data collection',
+    value: 'Initial/default selected value',
+    disabled: 'Whether all radio buttons in the group are disabled (true/false)',
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/radio/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as radio-* show radio-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/README.md
@@ -47,26 +47,23 @@ Dropdown select input with label, validation, and error display. It is designed 
 .my-scope {
   @include gmd.select-overrides((
     // Label styling
-    label-text-color: #111827,
-    label-text-size: 0.875rem,
-    label-text-weight: 500,
-
-    // Required indicator
-    required-text-color: #dc2626,
+    outlined-label-text-color: #111827,
+    outlined-label-text-size: 0.875rem,
+    outlined-label-text-weight: 500,
 
     // Field styling
-    field-text-color: #111827,
-    field-text-size: 1rem,
-    field-outline-width: 1px,
-    field-outline-color: #94a3b8,
-    field-outline-radius: 0.375rem,
-    field-background-color: #ffffff,
-    field-focus-outline-color: #2563eb,
-    field-disabled-background-color: #f5f5f5,
+    outlined-input-text-color: #111827,
+    container-text-size: 1rem,
+    outlined-outline-width: 1px,
+    outlined-outline-color: #94a3b8,
+    outlined-container-shape: 0.375rem,
+    outlined-container-color: #ffffff,
+    outlined-focus-outline-color: #2563eb,
+    outlined-disabled-container-color: #f5f5f5,
 
-    // Error messages
+    // Error messages (also used for required indicator)
     error-text-color: #dc2626,
-    error-text-size: 0.8125rem,
+    subscript-text-size: 0.8125rem,
   ));
 }
 ```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/README.md
@@ -1,0 +1,72 @@
+# Select Component
+
+Dropdown select input with label, validation, and error display. It is designed for GMD forms and can emit field state when `fieldKey` is provided.
+
+## Usage
+
+### Basic
+
+```html
+<gmd-select name="plan" label="Plan" options="Basic,Pro,Enterprise"></gmd-select>
+```
+
+### Required
+
+```html
+<gmd-select name="country" label="Country" required="true" options="US,CA,UK"></gmd-select>
+```
+
+### Field key for form state
+
+```html
+<gmd-select name="plan" label="Plan" fieldKey="plan" required="true" options="Basic,Pro,Enterprise"></gmd-select>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fieldKey` | `string \| undefined` | `undefined` | Key used to emit form state events. |
+| `name` | `string` | `''` | Select name and id. |
+| `label` | `string \| undefined` | `undefined` | Label shown above the select. |
+| `value` | `string \| undefined` | `undefined` | Initial value. |
+| `required` | `boolean` | `false` | Marks the field as required. |
+| `options` | `string` | `''` | Comma-separated values or JSON array string. |
+| `disabled` | `boolean` | `false` | Disables the select. |
+
+## Options format
+
+- Comma-separated: `"Basic,Pro,Enterprise"`
+- JSON array: `'["Basic","Pro","Enterprise"]'`
+
+## Theming
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+.my-scope {
+  @include gmd.select-overrides((
+    // Label styling
+    label-text-color: #111827,
+    label-text-size: 0.875rem,
+    label-text-weight: 500,
+
+    // Required indicator
+    required-text-color: #dc2626,
+
+    // Field styling
+    field-text-color: #111827,
+    field-text-size: 1rem,
+    field-outline-width: 1px,
+    field-outline-color: #94a3b8,
+    field-outline-radius: 0.375rem,
+    field-background-color: #ffffff,
+    field-focus-outline-color: #2563eb,
+    field-disabled-background-color: #f5f5f5,
+
+    // Error messages
+    error-text-color: #dc2626,
+    error-text-size: 0.8125rem,
+  ));
+}
+```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/_overrides.scss
@@ -22,20 +22,19 @@ $theme-tokens: theme.tokens();
   @return (
     namespace: select,
     tokens: (
-      label-text-size: 0.875rem,
-      label-text-weight: 500,
-      label-text-color: inherit,
-      required-text-color: token-utils.slot(error-color, $theme-tokens),
-      field-text-size: 1rem,
-      field-text-color: inherit,
-      field-outline-width: 1px,
-      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
-      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
-      field-background-color: #ffffff,
-      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
-      field-disabled-background-color: #f5f5f5,
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
+      container-text-size: 1rem,
+      outlined-input-text-color: inherit,
+      outlined-outline-width: 1px,
+      outlined-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      outlined-container-shape: token-utils.slot(container-shape, $theme-tokens),
+      outlined-container-color: token-utils.slot(surface-color, $theme-tokens),
+      outlined-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      outlined-disabled-container-color: #f5f5f5,
       error-text-color: token-utils.slot(error-color, $theme-tokens),
-      error-text-size: 0.8125rem,
+      subscript-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/_overrides.scss
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
+
+@function tokens() {
+  @return (
+    namespace: select,
+    tokens: (
+      label-text-size: 0.875rem,
+      label-text-weight: 500,
+      label-text-color: inherit,
+      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      field-text-size: 1rem,
+      field-text-color: inherit,
+      field-outline-width: 1px,
+      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
+      field-background-color: #ffffff,
+      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      field-disabled-background-color: #f5f5f5,
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-size: 0.8125rem,
+    )
+  );
+}
+
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdSelectComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'gmd-select';
+
+  async getValue(): Promise<string> {
+    const select = await this.getSelect();
+    return await select.getProperty('value');
+  }
+
+  async setValue(value: string): Promise<void> {
+    const select = await this.getSelect();
+    await select.sendKeys(value);
+  }
+
+  async getOptionValues(): Promise<string[]> {
+    const options = await this.getOptions();
+    const values: string[] = [];
+    for (const option of options) {
+      const value = await option.getAttribute('value');
+      if (value) {
+        values.push(value);
+      }
+    }
+    return values;
+  }
+
+  async getOptionLabels(): Promise<string[]> {
+    const options = await this.getOptions();
+    const texts: string[] = [];
+    for (const option of options) {
+      texts.push(await option.text());
+    }
+    return texts;
+  }
+
+  async selectOptionByValue(value: string): Promise<void> {
+    const select = await this.getSelect();
+    await select.sendKeys(value);
+  }
+
+  async getOptionCount(): Promise<number> {
+    const options = await this.getOptions();
+    return options.length;
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const select = await this.getSelect();
+    return await select.getProperty('disabled');
+  }
+
+  async isRequired(): Promise<boolean> {
+    const select = await this.getSelect();
+    return await select.getProperty('required');
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-select__label')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-select__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-select__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async hasErrors(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async blur(): Promise<void> {
+    const select = await this.getSelect();
+    await select.blur();
+  }
+
+  async focus(): Promise<void> {
+    const select = await this.getSelect();
+    await select.focus();
+  }
+
+  private async getSelect(): Promise<TestElement> {
+    return this.locatorFor('select')();
+  }
+
+  private async getOptions(): Promise<TestElement[]> {
+    return this.locatorForAll('option')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
@@ -24,8 +24,7 @@ export class GmdSelectComponentHarness extends ComponentHarness {
   }
 
   async setValue(value: string): Promise<void> {
-    const select = await this.getSelect();
-    await select.sendKeys(value);
+    await this.selectOptionByValue(value);
   }
 
   async getOptionValues(): Promise<string[]> {
@@ -51,7 +50,20 @@ export class GmdSelectComponentHarness extends ComponentHarness {
 
   async selectOptionByValue(value: string): Promise<void> {
     const select = await this.getSelect();
-    await select.sendKeys(value);
+    const options = await this.getOptions();
+    let optionIndex = -1;
+    for (let i = 0; i < options.length; i++) {
+      const optionValue = await options[i].getAttribute('value');
+      if (optionValue === value) {
+        optionIndex = i;
+        break;
+      }
+    }
+    if (optionIndex === -1) {
+      throw new Error(`Select option with value "${value}" not found`);
+    }
+    await select.selectOptions(optionIndex);
+    await select.dispatchEvent('change');
   }
 
   async getOptionCount(): Promise<number> {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.html
@@ -1,0 +1,49 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gmd-select">
+  @if (label()) {
+    <label class="gmd-select__label" [for]="name()">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-select__required">*</span>
+      }
+    </label>
+  }
+  <select
+    class="gmd-select__field"
+    [id]="name()"
+    [name]="name()"
+    [value]="internalValue()"
+    [required]="required()"
+    [disabled]="disabled()"
+    (change)="onChange($event)"
+    (blur)="onBlur()">
+    <option value="">-- Select --</option>
+    @for (option of optionsVM(); track option) {
+      <option [value]="option">{{ option }}</option>
+    }
+  </select>
+
+  @if (touched() && errorMessages().length) {
+    <div class="gmd-select__errors" role="alert">
+      @for (msg of errorMessages(); track msg) {
+        <div class="gmd-select__error">{{ msg }}</div>
+      }
+    </div>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.scss
@@ -25,30 +25,30 @@ $token-mapping: overrides.tokens();
   gap: 0.5rem;
 
   &__label {
-    color: token-utils.slot(label-text-color, $token-mapping);
-    font-size: token-utils.slot(label-text-size, $token-mapping);
-    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
   }
 
   &__required {
-    color: token-utils.slot(required-text-color, $token-mapping);
+    color: token-utils.slot(error-text-color, $token-mapping);
   }
 
   &__field {
     padding: 0.5rem;
-    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
-    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
-    background-color: token-utils.slot(field-background-color, $token-mapping);
-    color: token-utils.slot(field-text-color, $token-mapping);
-    font-size: token-utils.slot(field-text-size, $token-mapping);
+    border: token-utils.slot(outlined-outline-width, $token-mapping) solid token-utils.slot(outlined-outline-color, $token-mapping);
+    border-radius: token-utils.slot(outlined-container-shape, $token-mapping);
+    background-color: token-utils.slot(outlined-container-color, $token-mapping);
+    color: token-utils.slot(outlined-input-text-color, $token-mapping);
+    font-size: token-utils.slot(container-text-size, $token-mapping);
 
     &:focus {
-      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      border-color: token-utils.slot(outlined-focus-outline-color, $token-mapping);
       outline: none;
     }
 
     &:disabled {
-      background-color: token-utils.slot(field-disabled-background-color, $token-mapping);
+      background-color: token-utils.slot(outlined-disabled-container-color, $token-mapping);
       cursor: not-allowed;
     }
   }
@@ -61,6 +61,6 @@ $token-mapping: overrides.tokens();
 
   &__error {
     color: token-utils.slot(error-text-color, $token-mapping);
-    font-size: token-utils.slot(error-text-size, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.scss
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+.gmd-select {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+
+  &__label {
+    color: token-utils.slot(label-text-color, $token-mapping);
+    font-size: token-utils.slot(label-text-size, $token-mapping);
+    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+  }
+
+  &__required {
+    color: token-utils.slot(required-text-color, $token-mapping);
+  }
+
+  &__field {
+    padding: 0.5rem;
+    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
+    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
+    background-color: token-utils.slot(field-background-color, $token-mapping);
+    color: token-utils.slot(field-text-color, $token-mapping);
+    font-size: token-utils.slot(field-text-size, $token-mapping);
+
+    &:focus {
+      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      outline: none;
+    }
+
+    &:disabled {
+      background-color: token-utils.slot(field-disabled-background-color, $token-mapping);
+      cursor: not-allowed;
+    }
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(error-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GmdSelectComponent } from './gmd-select.component';
+import { GmdFieldState } from '../../models/formField';
+
+@Component({
+  template: `
+    <gmd-select
+      [fieldKey]="fieldKey()"
+      [name]="name()"
+      [label]="label()"
+      [value]="value()"
+      [required]="required()"
+      [options]="options()"
+      [disabled]="disabled()" />
+  `,
+  standalone: true,
+  imports: [GmdSelectComponent],
+})
+class TestHostComponent {
+  fieldKey = input<string | undefined>();
+  name = input<string>('test-select');
+  label = input<string | undefined>();
+  value = input<string | undefined>();
+  required = input<boolean>(false);
+  options = input<string>('');
+  disabled = input<boolean>(false);
+}
+
+describe('GmdSelectComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let selectComponent: GmdSelectComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    selectComponent = fixture.debugElement.query(p => p.name === 'gmd-select')?.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(selectComponent).toBeTruthy();
+  });
+
+  it('should initialize with default values', () => {
+    expect(selectComponent.value()).toBeUndefined();
+    expect(selectComponent.required()).toBe(false);
+    expect(selectComponent.disabled()).toBe(false);
+  });
+
+  it('should display label when provided', () => {
+    fixture.componentRef.setInput('label', 'Test Select');
+    fixture.detectChanges();
+
+    const labelElement = fixture.nativeElement.querySelector('.gmd-select__label');
+    expect(labelElement).toBeTruthy();
+    expect(labelElement.textContent.trim()).toContain('Test Select');
+  });
+
+  it('should show required indicator when required is true', () => {
+    fixture.componentRef.setInput('label', 'Test Select');
+    fixture.componentRef.setInput('required', true);
+    fixture.detectChanges();
+
+    const requiredIndicator = fixture.nativeElement.querySelector('.gmd-select__required');
+    expect(requiredIndicator).toBeTruthy();
+    expect(requiredIndicator.textContent.trim()).toBe('*');
+  });
+
+  describe('Options parsing', () => {
+    it('should parse comma-separated options', () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual(['option1', 'option2', 'option3']);
+    });
+
+    it('should parse JSON array options', () => {
+      fixture.componentRef.setInput('options', '["option1","option2","option3"]');
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual(['option1', 'option2', 'option3']);
+    });
+
+    it('should decode HTML entities in options', () => {
+      // Test with HTML entities in comma-separated format (as they would appear after DOMParser encoding)
+      fixture.componentRef.setInput('options', 'option &quot;one&quot;,option &#39;two&#39;');
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual(['option "one"', "option 'two'"]);
+    });
+
+    it('should handle empty options', () => {
+      fixture.componentRef.setInput('options', '');
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual([]);
+    });
+
+    it('should trim whitespace from comma-separated options', () => {
+      fixture.componentRef.setInput('options', 'option1 , option2 , option3');
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual(['option1', 'option2', 'option3']);
+    });
+
+    it('should render options in template', () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      const optionElements = select.querySelectorAll('option');
+      // +1 for the default "-- Select --" option
+      expect(optionElements.length).toBe(3);
+    });
+  });
+
+  it('should update value when option is selected', () => {
+    fixture.componentRef.setInput('options', 'option1,option2');
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    select.value = 'option1';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(select.value).toBe('option1');
+  });
+
+  it('should be disabled when disabled input is true', () => {
+    fixture.componentRef.setInput('options', 'option1,option2');
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+  });
+
+  describe('Validation', () => {
+    it('should be valid when not required and empty', () => {
+      fixture.componentRef.setInput('required', false);
+      fixture.detectChanges();
+
+      expect(selectComponent.valid()).toBe(true);
+      expect(selectComponent.errors().length).toBe(0);
+    });
+
+    it('should be invalid when required and no option selected', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      expect(selectComponent.valid()).toBe(false);
+      expect(selectComponent.errors()).toContain('required');
+    });
+
+    it('should be valid when required and option selected', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('value', 'option1');
+      fixture.detectChanges();
+
+      expect(selectComponent.valid()).toBe(true);
+      expect(selectComponent.errors().length).toBe(0);
+    });
+
+    it('should show error messages when touched and invalid', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      select.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      const errorElement = fixture.nativeElement.querySelector('.gmd-select__error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent.trim()).toBe('This field is required.');
+    });
+  });
+
+  describe('Event emission', () => {
+    it('should emit gmdFieldStateChange event when fieldKey is set and value changes', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const eventPromise = new Promise<CustomEvent<GmdFieldState>>(resolve => {
+        const selectElement = fixture.nativeElement.querySelector('gmd-select');
+        selectElement.addEventListener(
+          'gmdFieldStateChange',
+          (event: Event) => {
+            resolve(event as CustomEvent<GmdFieldState>);
+          },
+          { once: true },
+        );
+      });
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      select.value = 'option1';
+      select.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Wait for effect() to trigger and setTimeout in emitState to complete
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const customEvent = await eventPromise;
+      expect(customEvent.detail.key).toBe('test-key');
+      expect(customEvent.detail.value).toBe('option1');
+      expect(customEvent.detail.valid).toBe(true);
+    });
+
+    it('should not emit event when fieldKey is not set', async () => {
+      fixture.componentRef.setInput('fieldKey', undefined);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      let eventEmitted = false;
+      const selectElement = fixture.nativeElement.querySelector('gmd-select');
+      selectElement.addEventListener('gmdFieldStateChange', () => {
+        eventEmitted = true;
+      });
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      select.value = 'option1';
+      select.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Wait to ensure no event is emitted
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(eventEmitted).toBe(false);
+    });
+
+    it('should emit event with validation errors when invalid', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      const eventPromise = new Promise<CustomEvent<GmdFieldState>>(resolve => {
+        const selectElement = fixture.nativeElement.querySelector('gmd-select');
+        selectElement.addEventListener('gmdFieldStateChange', (event: Event) => {
+          resolve(event as CustomEvent<GmdFieldState>);
+        });
+      });
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      select.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const customEvent = await eventPromise;
+      expect(customEvent.detail.key).toBe('test-key');
+      expect(customEvent.detail.valid).toBe(false);
+      expect(customEvent.detail.errors).toContain('required');
+    });
+  });
+
+  describe('Initial value synchronization', () => {
+    it('should sync and update value from input', () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('value', 'option1');
+      fixture.detectChanges();
+
+      let select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('option1');
+
+      fixture.componentRef.setInput('value', 'option2');
+      fixture.detectChanges();
+
+      select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('option2');
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdSelectComponent } from './gmd-select.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+
+export default {
+  title: 'Gravitee Markdown/Components/Select',
+  component: GmdSelectComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdSelectComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' }))],
+    }),
+  ],
+} as Meta<GmdSelectComponent>;
+
+export const Basic: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-select name="basic" label="Basic Select" options="Option 1,Option 2,Option 3"></gmd-select>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-select name="required" label="Required Select" required="true" options="Option 1,Option 2,Option 3"></gmd-select>
+      </div>
+    `,
+  }),
+};
+
+export const WithJsonOptions: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-select name="json" label="Select with JSON Options" options='["United States","Canada","Mexico","United Kingdom"]'></gmd-select>
+      </div>
+    `,
+  }),
+};
+
+export const CommonUseCases: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-select name="country" label="Country" required="true" options="United States,Canada,Mexico,United Kingdom,Germany,France"></gmd-select>
+        <gmd-select name="plan" label="Plan" required="true" options="Basic,Professional,Enterprise"></gmd-select>
+        <gmd-select name="region" label="Region" options="North America,Europe,Asia Pacific,South America"></gmd-select>
+      </div>
+    `,
+  }),
+};
+
+export const WithFieldKey: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-select
+          name="country"
+          label="Country"
+          fieldKey="country"
+          required="true"
+          options="United States,Canada,Mexico,United Kingdom">
+        </gmd-select>
+        <gmd-select
+          name="plan"
+          label="Plan"
+          fieldKey="plan"
+          required="true"
+          options='["Basic","Professional","Enterprise"]'>
+        </gmd-select>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Select fields configured with field keys. These fields emit validation events for form state aggregation.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Select with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# User Preferences
+
+Configure your account preferences below.
+
+## Language & Region
+
+<gmd-select
+  name="language"
+  label="Preferred Language"
+  fieldKey="language"
+  required="true"
+  options="English,Spanish,French,German,Italian,Portuguese,Japanese,Chinese">
+</gmd-select>
+
+<gmd-select
+  name="timezone"
+  label="Timezone"
+  fieldKey="timezone"
+  required="true"
+  options="UTC-8 (PST),UTC-5 (EST),UTC+0 (GMT),UTC+1 (CET),UTC+9 (JST)">
+</gmd-select>
+
+## Notification Settings
+
+<gmd-select
+  name="frequency"
+  label="Email Frequency"
+  fieldKey="frequency"
+  required="true"
+  options="Immediately,Daily Digest,Weekly Digest,Monthly Digest">
+</gmd-select>
+
+<gmd-select
+  name="format"
+  label="Email Format"
+  fieldKey="format"
+  options="Plain Text,HTML,Rich Text">
+</gmd-select>`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form editor with live validation tracking. Shows how the gmd-form-editor component tracks field states and displays validation status in real-time.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Select Examples
+
+<gmd-select name="country" label="Country" required="true" options="United States,Canada,Mexico"></gmd-select>
+
+<gmd-select name="plan" label="Plan" options='["Basic","Professional","Enterprise"]'></gmd-select>
+
+<gmd-select name="region" label="Region" options="North America,Europe,Asia"></gmd-select>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Select components rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, computed, effect, inject, input, signal, untracked } from '@angular/core';
+
+import { GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+
+@Component({
+  selector: 'gmd-select',
+  imports: [CommonModule],
+  templateUrl: './gmd-select.component.html',
+  styleUrl: './gmd-select.component.scss',
+  standalone: true,
+})
+export class GmdSelectComponent {
+  // metadata key
+  fieldKey = input<string | undefined>();
+
+  // UI
+  name = input<string>('');
+  label = input<string | undefined>();
+
+  // initial value (optional)
+  value = input<string | undefined>();
+
+  // validation
+  required = input<boolean>(false);
+
+  options = input<string>(''); // Comma-separated or JSON array string
+  disabled = input<boolean>(false);
+
+  errors = computed<GmdFieldErrorCode[]>(() => {
+    const v = this.internalValue();
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && v.trim().length === 0) errs.push('required');
+
+    return errs;
+  });
+
+  valid = computed(() => this.errors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.errors();
+    const msgs: string[] = [];
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  private readonly el = inject(ElementRef<HTMLElement>);
+
+  protected readonly internalValue = signal<string>('');
+  protected readonly touched = signal<boolean>(false);
+
+  constructor() {
+    // init/sync from provided value
+    effect(() => {
+      const v = this.value();
+      if (v !== undefined) {
+        this.internalValue.set(String(v));
+      }
+    });
+
+    // whenever something relevant changes, notify host (only if fieldKey is set)
+    effect(() => {
+      const key = (this.fieldKey() ?? '').trim();
+      if (!key) return; // Early return if no fieldKey
+
+      // Read all reactive values to track changes
+      this.internalValue();
+      this.required();
+      this.disabled();
+
+      // Emit state only if fieldKey is present
+      this.emitState();
+    });
+  }
+
+  onChange(event: Event) {
+    const value = (event.target as HTMLSelectElement | null)?.value ?? '';
+    this.internalValue.set(value);
+  }
+
+  optionsVM = () => {
+    const opts = this.options();
+    if (!opts) return [];
+
+    // Decode HTML entities (Angular should do this automatically, but be safe)
+    // The renderer service encodes quotes in options attribute to prevent DOMParser truncation
+    const decodedOpts = opts
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
+
+    // Try to parse as JSON array first
+    try {
+      const parsed = JSON.parse(decodedOpts);
+      if (Array.isArray(parsed)) {
+        return parsed.map(opt => (typeof opt === 'string' ? opt : String(opt)));
+      }
+    } catch {
+      // Not JSON, try comma-separated
+    }
+
+    // Parse as comma-separated values
+    return decodedOpts
+      .split(',')
+      .map(opt => opt.trim())
+      .filter(opt => opt.length > 0);
+  };
+
+  onBlur() {
+    this.touched.set(true);
+    this.emitState();
+  }
+
+  private emitState() {
+    const key = (this.fieldKey() ?? '').trim();
+    if (!key) return;
+
+    // Don't emit state for disabled fields (mimics HTML form behavior where disabled fields are not submitted)
+    if (this.disabled()) return;
+
+    // Use untracked to avoid tracking computed values during event dispatch
+    const detail: GmdFieldState = untracked(() => ({
+      key,
+      value: this.internalValue(),
+      valid: this.valid(),
+      required: !!this.required(),
+      touched: this.touched(),
+      errors: this.errors(),
+    }));
+
+    // Dispatch event asynchronously to avoid blocking the event loop
+    setTimeout(() => {
+      this.el.nativeElement.dispatchEvent(
+        new CustomEvent<GmdFieldState>('gmdFieldStateChange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, 0);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.suggestions.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/gmd-select.suggestions.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicSelect: ComponentSuggestion = {
+  label: 'Select - Basic',
+  insertText: `<gmd-select name="$1" label="$2" options="Option 1,Option 2,Option 3"></gmd-select>`,
+  detail: 'Basic dropdown select field',
+};
+
+const requiredSelect: ComponentSuggestion = {
+  label: 'Select - Required',
+  insertText: `<gmd-select name="$1" label="$2" required="true" options="Option 1,Option 2,Option 3"></gmd-select>`,
+  detail: 'Required dropdown select field',
+};
+
+const selectWithJson: ComponentSuggestion = {
+  label: 'Select - JSON Options',
+  insertText: `<gmd-select name="$1" label="$2" options='["Option 1","Option 2","Option 3"]'></gmd-select>`,
+  detail: 'Select with options defined as JSON array',
+};
+
+const formSelect: ComponentSuggestion = {
+  label: 'Select - Form Field',
+  insertText: `<gmd-select name="$1" label="$2" fieldKey="$3" required="true" options="Option 1,Option 2"></gmd-select>`,
+  detail: 'Select field with a field key for validation/data collection',
+};
+
+export const selectConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicSelect, requiredSelect, selectWithJson, formSelect],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name/id for label association',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the select field',
+    },
+    {
+      label: 'options="Option 1,Option 2,Option 3"',
+      insertText: 'options="$1"',
+      detail: 'Comma-separated list of options or JSON array string',
+    },
+    {
+      label: 'options=\'["Option 1","Option 2"]\'',
+      insertText: 'options=\'["$1"]\'',
+      detail: 'JSON array string format for options',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the field required',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'value="Initial selected value"',
+      insertText: 'value="$1"',
+      detail: 'Initial selected value',
+    },
+    {
+      label: 'disabled="true"',
+      insertText: 'disabled="true"',
+      detail: 'Disables the field',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Select',
+    description:
+      'A dropdown select component that allows users to choose from a list of options. Options can be provided as a comma-separated string or JSON array.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name/id attribute for label association and accessibility',
+    label: 'Display label shown above the select field',
+    options:
+      'List of options as comma-separated string (e.g., "Option 1,Option 2") or JSON array string (e.g., \'["Option 1","Option 2"]\')',
+    required: 'Whether the field is required (true/false)',
+    fieldKey: 'Field key used for validation and data collection',
+    value: 'Initial selected value',
+    disabled: 'Whether the field is disabled (true/false)',
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/select/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as select-* show select-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/suggestions.index.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/suggestions.index.ts
@@ -21,7 +21,12 @@ import { mdBlockConfiguration } from './block/gmd-md.suggestions';
 import { buttonConfiguration } from './button/gmd-button.suggestions';
 import { cardTitleConfiguration } from './card/components/card-title/gmd-card-title.suggestions';
 import { cardConfiguration } from './card/gmd-card.suggestions';
+import { checkboxConfiguration } from './checkbox/gmd-checkbox.suggestions';
 import { cellConfiguration } from './grid/cell/cell.suggestions';
+import { inputConfiguration } from './input/gmd-input.suggestions';
+import { radioConfiguration } from './radio/gmd-radio.suggestions';
+import { selectConfiguration } from './select/gmd-select.suggestions';
+import { textareaConfiguration } from './textarea/gmd-textarea.suggestions';
 
 type ComponentSuggestionMap = {
   [Key in ComponentSelector]: ComponentSuggestionConfiguration;
@@ -35,4 +40,9 @@ export const componentSuggestionMap: ComponentSuggestionMap = {
   [ComponentSelector.CARD_SUBTITLE]: cardSubtitleConfiguration,
   [ComponentSelector.MD_BLOCK]: mdBlockConfiguration,
   [ComponentSelector.BUTTON]: buttonConfiguration,
+  [ComponentSelector.INPUT]: inputConfiguration,
+  [ComponentSelector.TEXTAREA]: textareaConfiguration,
+  [ComponentSelector.SELECT]: selectConfiguration,
+  [ComponentSelector.CHECKBOX]: checkboxConfiguration,
+  [ComponentSelector.RADIO]: radioConfiguration,
 };

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/README.md
@@ -56,26 +56,23 @@ The textarea component can be customized using SCSS overrides. Use the mixin to 
 .my-scope {
   @include gmd.textarea-overrides((
     // Label styling
-    label-text-color: #111827,
-    label-text-size: 0.875rem,
-    label-text-weight: 500,
-
-    // Required indicator
-    required-text-color: #dc2626,
+    outlined-label-text-color: #111827,
+    outlined-label-text-size: 0.875rem,
+    outlined-label-text-weight: 500,
 
     // Field styling
-    field-text-size: 1rem,
-    field-text-color: #111827,
-    field-outline-width: 1px,
-    field-outline-color: #94a3b8,
-    field-outline-radius: 4px,
-    field-background-color: #ffffff,
-    field-focus-outline-color: #2563eb,
-    field-disabled-background-color: #f5f5f5,
+    container-text-size: 1rem,
+    outlined-input-text-color: #111827,
+    outlined-outline-width: 1px,
+    outlined-outline-color: #94a3b8,
+    outlined-container-shape: 4px,
+    outlined-container-color: #ffffff,
+    outlined-focus-outline-color: #2563eb,
+    outlined-disabled-container-color: #f5f5f5,
 
-    // Error messages
+    // Error messages (also used for required indicator)
     error-text-color: #dc2626,
-    error-text-size: 0.8125rem,
+    subscript-text-size: 0.8125rem,
   ));
 }
 ```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/README.md
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/README.md
@@ -1,0 +1,81 @@
+# Textarea Component
+
+Multi-line text input with label, validation, and error display. It is designed for GMD forms and can emit field state when `fieldKey` is provided.
+
+## Usage
+
+### Basic
+
+```html
+<gmd-textarea name="message" label="Message" placeholder="Type your message..."></gmd-textarea>
+```
+
+### Required with validation
+
+```html
+<gmd-textarea name="description" label="Description" required="true" minLength="10" maxLength="500"></gmd-textarea>
+```
+
+### Field key for form state
+
+```html
+<gmd-textarea name="notes" label="Notes" fieldKey="notes"></gmd-textarea>
+```
+
+### Readonly and disabled states
+
+```html
+<gmd-textarea name="readonly" label="Readonly" value="Cannot edit" readonly="true"></gmd-textarea>
+<gmd-textarea name="disabled" label="Disabled" value="Disabled" disabled="true"></gmd-textarea>
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `fieldKey` | `string \| undefined` | `undefined` | Key used to emit form state events. |
+| `name` | `string` | `''` | Textarea name and id. |
+| `label` | `string \| undefined` | `undefined` | Label shown above the textarea. |
+| `placeholder` | `string \| undefined` | `undefined` | Placeholder text. |
+| `value` | `string \| undefined` | `undefined` | Initial value. |
+| `required` | `boolean` | `false` | Marks the field as required. |
+| `minLength` | `number \| string \| null` | `null` | Minimum length constraint. |
+| `maxLength` | `number \| string \| null` | `null` | Maximum length constraint. |
+| `rows` | `number` | `4` | Visible number of rows. |
+| `readonly` | `boolean` | `false` | Makes the textarea read-only (focusable, value submitted). |
+| `disabled` | `boolean` | `false` | Disables the textarea (not focusable, value not submitted). |
+
+
+## Theming
+
+The textarea component can be customized using SCSS overrides. Use the mixin to override available tokens:
+
+```scss
+@use '@gravitee/gravitee-markdown' as gmd;
+
+.my-scope {
+  @include gmd.textarea-overrides((
+    // Label styling
+    label-text-color: #111827,
+    label-text-size: 0.875rem,
+    label-text-weight: 500,
+
+    // Required indicator
+    required-text-color: #dc2626,
+
+    // Field styling
+    field-text-size: 1rem,
+    field-text-color: #111827,
+    field-outline-width: 1px,
+    field-outline-color: #94a3b8,
+    field-outline-radius: 4px,
+    field-background-color: #ffffff,
+    field-focus-outline-color: #2563eb,
+    field-disabled-background-color: #f5f5f5,
+
+    // Error messages
+    error-text-color: #dc2626,
+    error-text-size: 0.8125rem,
+  ));
+}
+```

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/_overrides.scss
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
+
+@function tokens() {
+  @return (
+    namespace: textarea,
+    tokens: (
+      label-text-size: 0.875rem,
+      label-text-weight: 500,
+      label-text-color: inherit,
+      required-text-color: token-utils.slot(error-color, $theme-tokens),
+      field-text-size: 1rem,
+      field-text-color: inherit,
+      field-outline-width: 1px,
+      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
+      field-background-color: #ffffff,
+      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      field-disabled-background-color: #f5f5f5,
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      error-text-size: 0.8125rem,
+    )
+  );
+}
+
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/_overrides.scss
@@ -22,20 +22,19 @@ $theme-tokens: theme.tokens();
   @return (
     namespace: textarea,
     tokens: (
-      label-text-size: 0.875rem,
-      label-text-weight: 500,
-      label-text-color: inherit,
-      required-text-color: token-utils.slot(error-color, $theme-tokens),
-      field-text-size: 1rem,
-      field-text-color: inherit,
-      field-outline-width: 1px,
-      field-outline-color: token-utils.slot(outline-color, $theme-tokens),
-      field-outline-radius: token-utils.slot(container-shape, $theme-tokens),
-      field-background-color: #ffffff,
-      field-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
-      field-disabled-background-color: #f5f5f5,
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
+      container-text-size: 1rem,
+      outlined-input-text-color: inherit,
+      outlined-outline-width: 1px,
+      outlined-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      outlined-container-shape: token-utils.slot(container-shape, $theme-tokens),
+      outlined-container-color: token-utils.slot(surface-color, $theme-tokens),
+      outlined-focus-outline-color: token-utils.slot(primary-color, $theme-tokens),
+      outlined-disabled-container-color: #f5f5f5,
       error-text-color: token-utils.slot(error-color, $theme-tokens),
-      error-text-size: 0.8125rem,
+      subscript-text-size: 0.8125rem,
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.harness.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdTextareaComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'gmd-textarea';
+
+  async getValue(): Promise<string> {
+    const textarea = await this.getTextarea();
+    return await textarea.getProperty('value');
+  }
+
+  async setValue(value: string): Promise<void> {
+    const textarea = await this.getTextarea();
+    await textarea.clear();
+    await textarea.sendKeys(value);
+  }
+
+  async getPlaceholder(): Promise<string | null> {
+    const textarea = await this.getTextarea();
+    return await textarea.getAttribute('placeholder');
+  }
+
+  async getRows(): Promise<number> {
+    const textarea = await this.getTextarea();
+    const rows = await textarea.getAttribute('rows');
+    return rows ? parseInt(rows, 10) : 0;
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const textarea = await this.getTextarea();
+    return await textarea.getProperty('disabled');
+  }
+
+  async isReadonly(): Promise<boolean> {
+    const textarea = await this.getTextarea();
+    return await textarea.getProperty('readOnly');
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-textarea__label')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-textarea__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getMinLength(): Promise<string | null> {
+    const textarea = await this.getTextarea();
+    return await textarea.getAttribute('minlength');
+  }
+
+  async getMaxLength(): Promise<string | null> {
+    const textarea = await this.getTextarea();
+    return await textarea.getAttribute('maxlength');
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-textarea__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async hasErrors(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async blur(): Promise<void> {
+    const textarea = await this.getTextarea();
+    await textarea.blur();
+  }
+
+  async focus(): Promise<void> {
+    const textarea = await this.getTextarea();
+    await textarea.focus();
+  }
+
+  private async getTextarea(): Promise<TestElement> {
+    return this.locatorFor('textarea')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gmd-textarea">
+  @if (label()) {
+    <label class="gmd-textarea__label" [for]="name()">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-textarea__required">*</span>
+      }
+    </label>
+  }
+  <textarea
+    class="gmd-textarea__field"
+    [id]="name()"
+    [name]="name()"
+    [placeholder]="placeholder()"
+    [attr.minlength]="minLength()"
+    [attr.maxlength]="maxLength()"
+    [rows]="rows()"
+    [readonly]="readonly()"
+    [disabled]="disabled()"
+    [value]="internalValue()"
+    (input)="onInput($event)"
+    (blur)="onBlur()"></textarea>
+
+  @if (touched() && errorMessages().length) {
+    <div class="gmd-textarea__errors" role="alert">
+      @for (msg of errorMessages(); track msg) {
+        <div class="gmd-textarea__error">{{ msg }}</div>
+      }
+    </div>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.scss
@@ -25,32 +25,32 @@ $token-mapping: overrides.tokens();
   gap: 0.5rem;
 
   &__label {
-    color: token-utils.slot(label-text-color, $token-mapping);
-    font-size: token-utils.slot(label-text-size, $token-mapping);
-    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
   }
 
   &__required {
-    color: token-utils.slot(required-text-color, $token-mapping);
+    color: token-utils.slot(error-text-color, $token-mapping);
   }
 
   &__field {
     padding: 0.5rem;
-    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
-    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
-    background-color: token-utils.slot(field-background-color, $token-mapping);
-    color: token-utils.slot(field-text-color, $token-mapping);
+    border: token-utils.slot(outlined-outline-width, $token-mapping) solid token-utils.slot(outlined-outline-color, $token-mapping);
+    border-radius: token-utils.slot(outlined-container-shape, $token-mapping);
+    background-color: token-utils.slot(outlined-container-color, $token-mapping);
+    color: token-utils.slot(outlined-input-text-color, $token-mapping);
     font-family: inherit;
-    font-size: token-utils.slot(field-text-size, $token-mapping);
+    font-size: token-utils.slot(container-text-size, $token-mapping);
     resize: vertical;
 
     &:focus {
-      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      border-color: token-utils.slot(outlined-focus-outline-color, $token-mapping);
       outline: none;
     }
 
     &:disabled {
-      background-color: token-utils.slot(field-disabled-background-color, $token-mapping);
+      background-color: token-utils.slot(outlined-disabled-container-color, $token-mapping);
       cursor: not-allowed;
     }
   }
@@ -63,6 +63,6 @@ $token-mapping: overrides.tokens();
 
   &__error {
     color: token-utils.slot(error-text-color, $token-mapping);
-    font-size: token-utils.slot(error-text-size, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
   }
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.scss
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+.gmd-textarea {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+
+  &__label {
+    color: token-utils.slot(label-text-color, $token-mapping);
+    font-size: token-utils.slot(label-text-size, $token-mapping);
+    font-weight: token-utils.slot(label-text-weight, $token-mapping);
+  }
+
+  &__required {
+    color: token-utils.slot(required-text-color, $token-mapping);
+  }
+
+  &__field {
+    padding: 0.5rem;
+    border: token-utils.slot(field-outline-width, $token-mapping) solid token-utils.slot(field-outline-color, $token-mapping);
+    border-radius: token-utils.slot(field-outline-radius, $token-mapping);
+    background-color: token-utils.slot(field-background-color, $token-mapping);
+    color: token-utils.slot(field-text-color, $token-mapping);
+    font-family: inherit;
+    font-size: token-utils.slot(field-text-size, $token-mapping);
+    resize: vertical;
+
+    &:focus {
+      border-color: token-utils.slot(field-focus-outline-color, $token-mapping);
+      outline: none;
+    }
+
+    &:disabled {
+      background-color: token-utils.slot(field-disabled-background-color, $token-mapping);
+      cursor: not-allowed;
+    }
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(error-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GmdTextareaComponent } from './gmd-textarea.component';
+import { GmdFieldState } from '../../models/formField';
+
+@Component({
+  template: `
+    <gmd-textarea
+      [fieldKey]="fieldKey()"
+      [name]="name()"
+      [label]="label()"
+      [placeholder]="placeholder()"
+      [value]="value()"
+      [required]="required()"
+      [minLength]="minLength()"
+      [maxLength]="maxLength()"
+      [rows]="rows()"
+      [readonly]="readonly()"
+      [disabled]="disabled()" />
+  `,
+  standalone: true,
+  imports: [GmdTextareaComponent],
+})
+class TestHostComponent {
+  fieldKey = input<string | undefined>();
+  name = input<string>('test-textarea');
+  label = input<string | undefined>();
+  placeholder = input<string | undefined>();
+  value = input<string | undefined>();
+  required = input<boolean>(false);
+  minLength = input<number | string | null>(null);
+  maxLength = input<number | string | null>(null);
+  rows = input<number>(4);
+  readonly = input<boolean>(false);
+  disabled = input<boolean>(false);
+}
+
+describe('GmdTextareaComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let textareaComponent: GmdTextareaComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    textareaComponent = fixture.debugElement.query(p => p.name === 'gmd-textarea')?.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(textareaComponent).toBeTruthy();
+  });
+
+  it('should initialize with default values', () => {
+    expect(textareaComponent.value()).toBeUndefined();
+    expect(textareaComponent.required()).toBe(false);
+    expect(textareaComponent.disabled()).toBe(false);
+    expect(textareaComponent.readonly()).toBe(false);
+    expect(textareaComponent.rows()).toBe(4);
+  });
+
+  it('should display label when provided', () => {
+    fixture.componentRef.setInput('label', 'Test Textarea');
+    fixture.detectChanges();
+
+    const labelElement = fixture.nativeElement.querySelector('.gmd-textarea__label');
+    expect(labelElement).toBeTruthy();
+    expect(labelElement.textContent.trim()).toContain('Test Textarea');
+  });
+
+  it('should show placeholder when provided', () => {
+    fixture.componentRef.setInput('placeholder', 'Enter text here');
+    fixture.detectChanges();
+
+    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.placeholder).toBe('Enter text here');
+  });
+
+  it('should show required indicator when required is true', () => {
+    fixture.componentRef.setInput('label', 'Test Textarea');
+    fixture.componentRef.setInput('required', true);
+    fixture.detectChanges();
+
+    const requiredIndicator = fixture.nativeElement.querySelector('.gmd-textarea__required');
+    expect(requiredIndicator).toBeTruthy();
+    expect(requiredIndicator.textContent.trim()).toBe('*');
+  });
+
+  it('should update value when textarea input changes', () => {
+    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = 'test value';
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(textarea.value).toBe('test value');
+  });
+
+  it('should set rows attribute', () => {
+    fixture.componentRef.setInput('rows', 10);
+    fixture.detectChanges();
+
+    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.rows).toBe(10);
+  });
+
+  it('should be readonly when readonly input is true', () => {
+    fixture.componentRef.setInput('readonly', true);
+    fixture.detectChanges();
+
+    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.readOnly).toBe(true);
+  });
+
+  it('should be disabled when disabled input is true', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(true);
+  });
+
+  describe('Validation', () => {
+    it('should be valid when not required and empty', () => {
+      fixture.componentRef.setInput('required', false);
+      fixture.detectChanges();
+
+      expect(textareaComponent.valid()).toBe(true);
+      expect(textareaComponent.errors().length).toBe(0);
+    });
+
+    it('should be invalid when required and empty', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.detectChanges();
+
+      expect(textareaComponent.valid()).toBe(false);
+      expect(textareaComponent.errors()).toContain('required');
+    });
+
+    it('should be valid when required and has value', () => {
+      fixture.componentRef.setInput('required', true);
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.value = 'test';
+      textarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(textareaComponent.valid()).toBe(true);
+      expect(textareaComponent.errors().length).toBe(0);
+    });
+
+    it('should validate minLength', () => {
+      fixture.componentRef.setInput('minLength', 5);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.value = 'test';
+      textarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(textareaComponent.valid()).toBe(false);
+      expect(textareaComponent.errors()).toContain('minLength');
+    });
+
+    it('should validate maxLength', () => {
+      fixture.componentRef.setInput('maxLength', 5);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.value = 'too long value';
+      textarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(textareaComponent.valid()).toBe(false);
+      expect(textareaComponent.errors()).toContain('maxLength');
+    });
+
+    it('should show error messages when touched and invalid', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      const errorElement = fixture.nativeElement.querySelector('.gmd-textarea__error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent.trim()).toBe('This field is required.');
+    });
+  });
+
+  describe('Event emission', () => {
+    it('should emit gmdFieldStateChange event when fieldKey is set and value changes', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const eventPromise = new Promise<CustomEvent<GmdFieldState>>(resolve => {
+        const textareaElement = fixture.nativeElement.querySelector('gmd-textarea');
+        textareaElement.addEventListener(
+          'gmdFieldStateChange',
+          (event: Event) => {
+            resolve(event as CustomEvent<GmdFieldState>);
+          },
+          { once: true },
+        );
+      });
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.value = 'test value';
+      textarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Wait for effect() to trigger and setTimeout in emitState to complete
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const customEvent = await eventPromise;
+      expect(customEvent.detail.key).toBe('test-key');
+      expect(customEvent.detail.value).toBe('test value');
+      expect(customEvent.detail.valid).toBe(true);
+    });
+
+    it('should not emit event when fieldKey is not set', async () => {
+      fixture.componentRef.setInput('fieldKey', undefined);
+      fixture.detectChanges();
+
+      let eventEmitted = false;
+      const textareaElement = fixture.nativeElement.querySelector('gmd-textarea');
+      textareaElement.addEventListener('gmdFieldStateChange', () => {
+        eventEmitted = true;
+      });
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.value = 'test';
+      textarea.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Wait to ensure no event is emitted
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(eventEmitted).toBe(false);
+    });
+
+    it('should emit event with validation errors when invalid', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('required', true);
+      fixture.detectChanges();
+
+      const eventPromise = new Promise<CustomEvent<GmdFieldState>>(resolve => {
+        const textareaElement = fixture.nativeElement.querySelector('gmd-textarea');
+        textareaElement.addEventListener('gmdFieldStateChange', (event: Event) => {
+          resolve(event as CustomEvent<GmdFieldState>);
+        });
+      });
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const customEvent = await eventPromise;
+      expect(customEvent.detail.key).toBe('test-key');
+      expect(customEvent.detail.valid).toBe(false);
+      expect(customEvent.detail.errors).toContain('required');
+    });
+  });
+
+  describe('Initial value synchronization', () => {
+    it('should sync and update value from input', () => {
+      fixture.componentRef.setInput('value', 'first value');
+      fixture.detectChanges();
+
+      let textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('first value');
+
+      fixture.componentRef.setInput('value', 'second value');
+      fixture.detectChanges();
+
+      textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('second value');
+    });
+
+    it('should handle undefined value', () => {
+      fixture.componentRef.setInput('value', undefined);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('');
+    });
+  });
+
+  describe('Number-like validation inputs', () => {
+    it.each([
+      { input: 5, expected: '5', type: 'numeric' },
+      { input: '10', expected: '10', type: 'string' },
+    ])('should accept $type minLength', ({ input, expected }) => {
+      fixture.componentRef.setInput('minLength', input);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.getAttribute('minlength')).toBe(expected);
+    });
+
+    it.each([
+      { input: 20, expected: '20', type: 'numeric' },
+      { input: '30', expected: '30', type: 'string' },
+    ])('should accept $type maxLength', ({ input, expected }) => {
+      fixture.componentRef.setInput('maxLength', input);
+      fixture.detectChanges();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.getAttribute('maxlength')).toBe(expected);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GmdTextareaComponent } from './gmd-textarea.component';
+import { GmdTextareaComponentHarness } from './gmd-textarea.component.harness';
 import { GmdFieldState } from '../../models/formField';
 
 @Component({
@@ -55,6 +58,8 @@ describe('GmdTextareaComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let component: TestHostComponent;
   let textareaComponent: GmdTextareaComponent;
+  let loader: HarnessLoader;
+  let harness: GmdTextareaComponentHarness;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -64,6 +69,8 @@ describe('GmdTextareaComponent', () => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     textareaComponent = fixture.debugElement.query(p => p.name === 'gmd-textarea')?.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await loader.getHarness(GmdTextareaComponentHarness);
     fixture.detectChanges();
   });
 
@@ -80,64 +87,61 @@ describe('GmdTextareaComponent', () => {
     expect(textareaComponent.rows()).toBe(4);
   });
 
-  it('should display label when provided', () => {
+  it('should display label when provided', async () => {
     fixture.componentRef.setInput('label', 'Test Textarea');
     fixture.detectChanges();
 
-    const labelElement = fixture.nativeElement.querySelector('.gmd-textarea__label');
-    expect(labelElement).toBeTruthy();
-    expect(labelElement.textContent.trim()).toContain('Test Textarea');
+    const label = await harness.getLabel();
+    expect(label).toContain('Test Textarea');
   });
 
-  it('should show placeholder when provided', () => {
+  it('should show placeholder when provided', async () => {
     fixture.componentRef.setInput('placeholder', 'Enter text here');
     fixture.detectChanges();
 
-    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-    expect(textarea.placeholder).toBe('Enter text here');
+    const placeholder = await harness.getPlaceholder();
+    expect(placeholder).toBe('Enter text here');
   });
 
-  it('should show required indicator when required is true', () => {
+  it('should show required indicator when required is true', async () => {
     fixture.componentRef.setInput('label', 'Test Textarea');
     fixture.componentRef.setInput('required', true);
     fixture.detectChanges();
 
-    const requiredIndicator = fixture.nativeElement.querySelector('.gmd-textarea__required');
-    expect(requiredIndicator).toBeTruthy();
-    expect(requiredIndicator.textContent.trim()).toBe('*');
+    const hasIndicator = await harness.hasRequiredIndicator();
+    expect(hasIndicator).toBe(true);
   });
 
-  it('should update value when textarea input changes', () => {
-    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-    textarea.value = 'test value';
-    textarea.dispatchEvent(new Event('input'));
+  it('should update value when textarea input changes', async () => {
+    await harness.setValue('test value');
     fixture.detectChanges();
 
-    expect(textarea.value).toBe('test value');
+    const value = await harness.getValue();
+    expect(value).toBe('test value');
   });
 
-  it('should set rows attribute', () => {
+  it('should set rows attribute', async () => {
     fixture.componentRef.setInput('rows', 10);
     fixture.detectChanges();
 
-    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-    expect(textarea.rows).toBe(10);
+    const rows = await harness.getRows();
+    expect(rows).toBe(10);
   });
 
-  it('should be readonly when readonly input is true', () => {
+  it('should be readonly when readonly input is true', async () => {
     fixture.componentRef.setInput('readonly', true);
     fixture.detectChanges();
 
-    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-    expect(textarea.readOnly).toBe(true);
+    const isReadonly = await harness.isReadonly();
+    expect(isReadonly).toBe(true);
   });
 
-  it('should be disabled when disabled input is true', () => {
+  it('should be disabled when disabled input is true', async () => {
     fixture.componentRef.setInput('disabled', true);
     fixture.detectChanges();
 
-    const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-    expect(textarea.disabled).toBe(true);
+    const isDisabled = await harness.isDisabled();
+    expect(isDisabled).toBe(true);
   });
 
   describe('Validation', () => {
@@ -194,17 +198,16 @@ describe('GmdTextareaComponent', () => {
       expect(textareaComponent.errors()).toContain('maxLength');
     });
 
-    it('should show error messages when touched and invalid', () => {
+    it('should show error messages when touched and invalid', async () => {
       fixture.componentRef.setInput('required', true);
       fixture.detectChanges();
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      textarea.dispatchEvent(new Event('blur'));
+      await harness.blur();
       fixture.detectChanges();
 
-      const errorElement = fixture.nativeElement.querySelector('.gmd-textarea__error');
-      expect(errorElement).toBeTruthy();
-      expect(errorElement.textContent.trim()).toBe('This field is required.');
+      const errorMessages = await harness.getErrorMessages();
+      expect(errorMessages.length).toBeGreaterThan(0);
+      expect(errorMessages[0]).toBe('This field is required.');
     });
   });
 
@@ -225,9 +228,7 @@ describe('GmdTextareaComponent', () => {
         );
       });
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      textarea.value = 'test value';
-      textarea.dispatchEvent(new Event('input'));
+      await harness.setValue('test value');
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -250,9 +251,7 @@ describe('GmdTextareaComponent', () => {
         eventEmitted = true;
       });
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      textarea.value = 'test';
-      textarea.dispatchEvent(new Event('input'));
+      await harness.setValue('test');
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -273,8 +272,7 @@ describe('GmdTextareaComponent', () => {
         });
       });
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      textarea.dispatchEvent(new Event('blur'));
+      await harness.blur();
       fixture.detectChanges();
 
       await new Promise(resolve => setTimeout(resolve, 10));
@@ -287,26 +285,23 @@ describe('GmdTextareaComponent', () => {
   });
 
   describe('Initial value synchronization', () => {
-    it('should sync and update value from input', () => {
+    it('should sync and update value from input', async () => {
       fixture.componentRef.setInput('value', 'first value');
       fixture.detectChanges();
 
-      let textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.value).toBe('first value');
+      expect(await harness.getValue()).toBe('first value');
 
       fixture.componentRef.setInput('value', 'second value');
       fixture.detectChanges();
 
-      textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.value).toBe('second value');
+      expect(await harness.getValue()).toBe('second value');
     });
 
-    it('should handle undefined value', () => {
+    it('should handle undefined value', async () => {
       fixture.componentRef.setInput('value', undefined);
       fixture.detectChanges();
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.value).toBe('');
+      expect(await harness.getValue()).toBe('');
     });
   });
 
@@ -314,23 +309,23 @@ describe('GmdTextareaComponent', () => {
     it.each([
       { input: 5, expected: '5', type: 'numeric' },
       { input: '10', expected: '10', type: 'string' },
-    ])('should accept $type minLength', ({ input, expected }) => {
+    ])('should accept $type minLength', async ({ input, expected }) => {
       fixture.componentRef.setInput('minLength', input);
       fixture.detectChanges();
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.getAttribute('minlength')).toBe(expected);
+      const minLength = await harness.getMinLength();
+      expect(minLength).toBe(expected);
     });
 
     it.each([
       { input: 20, expected: '20', type: 'numeric' },
       { input: '30', expected: '30', type: 'string' },
-    ])('should accept $type maxLength', ({ input, expected }) => {
+    ])('should accept $type maxLength', async ({ input, expected }) => {
       fixture.componentRef.setInput('maxLength', input);
       fixture.detectChanges();
 
-      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.getAttribute('maxlength')).toBe(expected);
+      const maxLength = await harness.getMaxLength();
+      expect(maxLength).toBe(expected);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdTextareaComponent } from './gmd-textarea.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+
+export default {
+  title: 'Gravitee Markdown/Components/Textarea',
+  component: GmdTextareaComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdTextareaComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' }))],
+    }),
+  ],
+} as Meta<GmdTextareaComponent>;
+
+export const Basic: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-textarea name="basic" label="Basic Textarea" placeholder="Enter your message..."></gmd-textarea>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-textarea name="required" label="Required Textarea" required="true" placeholder="This field is required"></gmd-textarea>
+      </div>
+    `,
+  }),
+};
+
+export const CustomRows: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-textarea name="small" label="Small (2 rows)" rows="2" placeholder="2 rows"></gmd-textarea>
+        <gmd-textarea name="default" label="Default (4 rows)" rows="4" placeholder="4 rows (default)"></gmd-textarea>
+        <gmd-textarea name="large" label="Large (8 rows)" rows="8" placeholder="8 rows"></gmd-textarea>
+      </div>
+    `,
+  }),
+};
+
+export const ReadonlyAndDisabled: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-textarea name="normal" label="Normal Textarea" value="This is editable text" placeholder="You can edit this"></gmd-textarea>
+        <gmd-textarea name="readonly" label="Readonly Textarea" value="This is read-only text that cannot be modified" readonly="true" placeholder="Cannot edit"></gmd-textarea>
+        <gmd-textarea name="disabled" label="Disabled Textarea" value="This is disabled text" disabled="true" placeholder="Disabled"></gmd-textarea>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Comparison of normal, readonly, and disabled states. Readonly fields are focusable and their values are submitted, while disabled fields are not focusable and values are not submitted.',
+      },
+    },
+  },
+};
+
+export const WithValidation: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-textarea
+          name="minmax"
+          label="Min/Max Length"
+          minLength="10"
+          maxLength="200"
+          placeholder="10-200 characters">
+        </gmd-textarea>
+        <gmd-textarea
+          name="required"
+          label="Required with Validation"
+          required="true"
+          minLength="20"
+          maxLength="500"
+          placeholder="Required, 20-500 characters">
+        </gmd-textarea>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Textarea with length validation. Note: pattern attribute is not supported for textarea as per HTML specification.',
+      },
+    },
+  },
+};
+
+export const WithFieldKey: StoryObj<GmdTextareaComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+        <gmd-textarea
+          name="description"
+          label="Description"
+          fieldKey="description"
+          required="true"
+          minLength="10"
+          maxLength="500"
+          placeholder="Describe your use case...">
+        </gmd-textarea>
+        <gmd-textarea
+          name="notes"
+          label="Additional Notes"
+          fieldKey="notes"
+          rows="6"
+          placeholder="Any additional information...">
+        </gmd-textarea>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Textarea fields configured with field keys. These fields emit validation events for form state aggregation.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Textarea with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# Feedback Form
+
+Please share your feedback with us to help improve our services.
+
+## Your Feedback
+
+<gmd-textarea
+  name="feedback"
+  label="Feedback"
+  fieldKey="feedback"
+  required="true"
+  minLength="20"
+  maxLength="1000"
+  rows="6"
+  placeholder="Please provide detailed feedback about your experience...">
+</gmd-textarea>
+
+## Additional Comments
+
+<gmd-textarea
+  name="comments"
+  label="Additional Comments"
+  fieldKey="comments"
+  rows="4"
+  placeholder="Any other comments or suggestions...">
+</gmd-textarea>
+
+## Would you like us to follow up?
+
+<gmd-textarea
+  name="contact"
+  label="Contact Information"
+  fieldKey="contact"
+  rows="3"
+  placeholder="Email or phone number (optional)">
+</gmd-textarea>`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form editor with live validation tracking. Shows how the gmd-form-editor component tracks field states and displays validation status in real-time.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Textarea Examples
+
+<gmd-textarea name="message" label="Message" required="true" minLength="10" maxLength="500"></gmd-textarea>
+
+<gmd-textarea name="description" label="Description" rows="6" placeholder="Enter a detailed description..."></gmd-textarea>
+
+<gmd-textarea name="comments" label="Comments" rows="3" placeholder="Any additional comments..."></gmd-textarea>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Textarea components rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, computed, effect, inject, input, signal, untracked } from '@angular/core';
+
+import { GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+
+@Component({
+  selector: 'gmd-textarea',
+  imports: [CommonModule],
+  templateUrl: './gmd-textarea.component.html',
+  styleUrl: './gmd-textarea.component.scss',
+  standalone: true,
+})
+export class GmdTextareaComponent {
+  // metadata key
+  fieldKey = input<string | undefined>();
+
+  // UI
+  name = input<string>('');
+  label = input<string | undefined>();
+  placeholder = input<string | undefined>();
+
+  // initial value (optional)
+  value = input<string | undefined>();
+
+  // validation
+  required = input<boolean>(false);
+  minLength = input<number | string | null>(null);
+  maxLength = input<number | string | null>(null);
+
+  rows = input<number>(4);
+  readonly = input<boolean>(false);
+  disabled = input<boolean>(false);
+
+  errors = computed<GmdFieldErrorCode[]>(() => {
+    const v = this.internalValue();
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && v.trim().length === 0) errs.push('required');
+
+    const minL = this.parseNumberLike(this.minLength());
+    if (minL !== null && v.length < minL) errs.push('minLength');
+
+    const maxL = this.parseNumberLike(this.maxLength());
+    if (maxL !== null && v.length > maxL) errs.push('maxLength');
+
+    return errs;
+  });
+
+  valid = computed(() => this.errors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.errors();
+    const msgs: string[] = [];
+    const minL = this.parseNumberLike(this.minLength());
+    const maxL = this.parseNumberLike(this.maxLength());
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+        case 'minLength':
+          msgs.push(`Minimum length is ${minL}.`);
+          break;
+        case 'maxLength':
+          msgs.push(`Maximum length is ${maxL}.`);
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  private readonly el = inject(ElementRef<HTMLElement>);
+
+  protected readonly internalValue = signal<string>('');
+  protected readonly touched = signal<boolean>(false);
+
+  constructor() {
+    // init/sync from provided value
+    effect(() => {
+      const v = this.value();
+      if (v !== undefined) {
+        this.internalValue.set(String(v));
+      }
+    });
+
+    // whenever something relevant changes, notify host (only if fieldKey is set)
+    effect(() => {
+      const key = (this.fieldKey() ?? '').trim();
+      if (!key) return; // Early return if no fieldKey
+
+      // Read all reactive values to track changes
+      this.internalValue();
+      this.required();
+      this.minLength();
+      this.maxLength();
+      this.disabled();
+
+      // Emit state only if fieldKey is present
+      this.emitState();
+    });
+  }
+
+  onInput(event: Event) {
+    const value = (event.target as HTMLTextAreaElement | null)?.value ?? '';
+    this.internalValue.set(value);
+  }
+
+  onBlur() {
+    this.touched.set(true);
+    this.emitState();
+  }
+
+  private parseNumberLike(v: number | string | null | undefined): number | null {
+    if (v === undefined || v === null) return null;
+    const n = typeof v === 'number' ? v : Number(String(v).trim());
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private emitState() {
+    const key = (this.fieldKey() ?? '').trim();
+    if (!key) return;
+
+    // Don't emit state for disabled fields (mimics HTML form behavior where disabled fields are not submitted)
+    if (this.disabled()) return;
+
+    // Use untracked to avoid tracking computed values during event dispatch
+    const detail: GmdFieldState = untracked(() => ({
+      key,
+      value: this.internalValue(),
+      valid: this.valid(),
+      required: this.required(),
+      touched: this.touched(),
+      errors: this.errors(),
+    }));
+
+    // Dispatch event asynchronously to avoid blocking the event loop
+    setTimeout(() => {
+      this.el.nativeElement.dispatchEvent(
+        new CustomEvent<GmdFieldState>('gmdFieldStateChange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, 0);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.suggestions.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/gmd-textarea.suggestions.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicTextarea: ComponentSuggestion = {
+  label: 'Textarea - Basic',
+  insertText: `<gmd-textarea name="$1" label="$2" placeholder="$3"></gmd-textarea>`,
+  detail: 'Basic multi-line text input field',
+};
+
+const requiredTextarea: ComponentSuggestion = {
+  label: 'Textarea - Required',
+  insertText: `<gmd-textarea name="$1" label="$2" required="true"></gmd-textarea>`,
+  detail: 'Required multi-line text input field',
+};
+
+const textareaWithRows: ComponentSuggestion = {
+  label: 'Textarea - Custom Rows',
+  insertText: `<gmd-textarea name="$1" label="$2" rows="6"></gmd-textarea>`,
+  detail: 'Textarea with custom number of visible rows',
+};
+
+const textareaWithValidation: ComponentSuggestion = {
+  label: 'Textarea - With Validation',
+  insertText: `<gmd-textarea name="$1" label="$2" required="true" minLength="10" maxLength="500"></gmd-textarea>`,
+  detail: 'Textarea with min/max length validation',
+};
+
+const formTextarea: ComponentSuggestion = {
+  label: 'Textarea - Form Field',
+  insertText: `<gmd-textarea name="$1" label="$2" fieldKey="$3" required="true"></gmd-textarea>`,
+  detail: 'Textarea field with a field key for validation/data collection',
+};
+
+export const textareaConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicTextarea, requiredTextarea, textareaWithRows, textareaWithValidation, formTextarea],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name/id for label association',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the textarea field',
+    },
+    {
+      label: 'placeholder="Placeholder"',
+      insertText: 'placeholder="$1"',
+      detail: 'Placeholder text shown when field is empty',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the field required',
+    },
+    {
+      label: 'rows="4"',
+      insertText: 'rows="$1"',
+      detail: 'Number of visible text rows (default: 4)',
+    },
+    {
+      label: 'minLength="10"',
+      insertText: 'minLength="$1"',
+      detail: 'Minimum character length',
+    },
+    {
+      label: 'maxLength="500"',
+      insertText: 'maxLength="$1"',
+      detail: 'Maximum character length',
+    },
+    {
+      label: 'pattern="[A-Za-z]+"',
+      insertText: 'pattern="$1"',
+      detail: 'Regular expression pattern for validation',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'value="default"',
+      insertText: 'value="$1"',
+      detail: 'Default/initial value for the field',
+    },
+    {
+      label: 'readonly="true"',
+      insertText: 'readonly="true"',
+      detail: 'Makes the field read-only',
+    },
+    {
+      label: 'disabled="true"',
+      insertText: 'disabled="true"',
+      detail: 'Disables the field',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Textarea',
+    description:
+      'A multi-line text input component for longer text entries. Supports validation options including required, minLength, maxLength, and pattern matching.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name/id attribute for label association and accessibility',
+    label: 'Display label shown above the textarea field',
+    placeholder: 'Hint text displayed when the field is empty',
+    required: 'Whether the field is required (true/false)',
+    rows: 'Number of visible text rows (default: 4)',
+    minLength: 'Minimum number of characters allowed',
+    maxLength: 'Maximum number of characters allowed',
+    pattern: 'Regular expression pattern for value validation',
+    fieldKey: 'Field key used for validation and data collection',
+    value: 'Initial/default value for the field',
+    readonly: 'Whether the field is read-only (true/false)',
+    disabled: 'Whether the field is disabled (true/false)',
+  },
+};

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/components/textarea/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as textarea-* show textarea-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
@@ -20,6 +20,7 @@ export * from './gravitee-markdown-editor.module';
 // Components
 export * from './gravitee-markdown-editor.component';
 export * from './components/monaco-editor/monaco-editor.component';
+export * from '../gravitee-markdown-form-editor/gmd-form-editor.component';
 
 // Models and Types
 export * from './models/monaco-editor-config';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
@@ -20,7 +20,6 @@ export * from './gravitee-markdown-editor.module';
 // Components
 export * from './gravitee-markdown-editor.component';
 export * from './components/monaco-editor/monaco-editor.component';
-export * from '../gravitee-markdown-form-editor/gmd-form-editor.component';
 
 // Models and Types
 export * from './models/monaco-editor-config';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/_overrides.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/_overrides.scss
@@ -13,26 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use './token-utils' as token-utils;
+@use '../scss/token-utils' as token-utils;
+@use '../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
 
 @function tokens() {
   @return (
-    (
-      namespace: sys,
-      tokens: (
-        container-shape: 4px,
-        primary-color: #275cf6,
-        on-primary-color: #ffffff,
-        outline-color: #cdd7e1,
-        hover-state-layer-opacity: 90%,
-        focus-state-layer-opacity: 80%,
-        text-color: #1d192b,
-        error-color: #d32f2f,
-      )
+    namespace: form-editor,
+    tokens: (
+      card-background-color: #fff,
+      outline-color: token-utils.slot(outline-color, $theme-tokens),
+      primary-color: token-utils.slot(primary-color, $theme-tokens),
+      error-color: token-utils.slot(error-color, $theme-tokens),
+      contrast-text-color: token-utils.slot(on-primary-color, $theme-tokens),
+      text-primary-color: token-utils.slot(text-color, $theme-tokens),
     )
   );
 }
 
+// Component-level override mixin
 @mixin overrides($overrides: ()) {
   @include token-utils.apply-token-overrides(tokens(), $overrides);
 }

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.harness.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { GmdFormEditorComponent } from './gmd-form-editor.component';
+import { MockMonacoEditorStandaloneComponent } from './gmd-form-editor.test.component';
+import { GraviteeMarkdownEditorModule } from '../gravitee-markdown-editor/gravitee-markdown-editor.module';
+
+export const ConfigureTestingGmdFormEditor = () => {
+  try {
+    TestBed.overrideComponent(GmdFormEditorComponent, {
+      remove: {
+        imports: [GraviteeMarkdownEditorModule],
+      },
+      add: {
+        imports: [MockMonacoEditorStandaloneComponent],
+      },
+    });
+  } catch (e) {
+    // Do nothing
+  }
+};
+
+ConfigureTestingGmdFormEditor();
+
+export class GmdFormEditorHarness extends ComponentHarness {
+  static readonly hostSelector = 'gmd-form-editor';
+
+  private readonly getEditorInput = this.locatorFor('gmd-monaco-editor input');
+
+  async getEditorValue(): Promise<string> {
+    const input = await this.getEditorInput();
+    return input.getProperty('value');
+  }
+
+  async isEditorReadOnly(): Promise<boolean> {
+    const input = await this.getEditorInput();
+    const disabled = await input.getAttribute('disabled');
+    return disabled !== null;
+  }
+
+  async getStatusLabelText(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.form-status__label')();
+      return (await label.text()).trim();
+    } catch {
+      return null;
+    }
+  }
+
+  async getStatusBadgeText(): Promise<string | null> {
+    try {
+      const badge = await this.locatorFor('.form-status__badge')();
+      return (await badge.text()).trim();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.html
@@ -1,0 +1,72 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="container">
+  <div class="container__editor-preview">
+    <gmd-monaco-editor
+      class="container__inner-border"
+      [value]="value"
+      [readOnly]="isDisabled"
+      (valueChange)="onValueChange($event)"
+      (touched)="onTouched()" />
+    <hr class="hr" />
+    <div class="container__inner-border">
+      <gmd-viewer [content]="value" />
+    </div>
+  </div>
+  <div class="container__form-status">
+    <div class="form-status">
+      <div class="form-status__header">
+        <span class="form-status__label">Form status:</span>
+        @if (formValid()) {
+          <span class="form-status__badge form-status__badge--valid">Valid</span>
+        } @else {
+          <span class="form-status__badge form-status__badge--invalid">Invalid</span>
+        }
+      </div>
+      @if (requiredFieldsCount() > 0) {
+        <div class="form-status__count">Valid ({{ validRequiredFieldsCount() }}/{{ requiredFieldsCount() }} required fields filled)</div>
+      }
+      @if (invalidFields().length > 0) {
+        <div class="form-status__errors">
+          <div class="form-status__errors-title">Invalid fields:</div>
+          <ul class="form-status__errors-list">
+            @for (field of invalidFields(); track field.key) {
+              <li class="form-status__error-item">
+                <span class="form-status__error-key">{{ field.key }}:</span>
+                <span class="form-status__error-codes">{{ field.errors.join(', ') }}</span>
+              </li>
+            }
+          </ul>
+        </div>
+      }
+      @if (fieldValues().length > 0) {
+        <details class="form-status__values">
+          <summary class="form-status__values-summary">Field values ({{ fieldValues().length }})</summary>
+          <ul class="form-status__values-list">
+            @for (field of fieldValues(); track field.key) {
+              <li class="form-status__value-item">
+                <span class="form-status__value-key">{{ field.key }}:</span>
+                <span class="form-status__value-text">{{ formatValue(field.value) }}</span>
+              </li>
+            }
+          </ul>
+        </details>
+      }
+    </div>
+  </div>
+</div>

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.scss
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use './overrides' as overrides;
+@use '../scss/token-utils' as token-utils;
+
+$token-mapping: overrides.tokens();
+
+// Color tokens
+$card-background: token-utils.slot(card-background-color, $token-mapping);
+$surface-variant: color-mix(in srgb, token-utils.slot(outline-color, $token-mapping) 5%, $card-background);
+$primary-color: token-utils.slot(primary-color, $token-mapping);
+$error-color: token-utils.slot(error-color, $token-mapping);
+$contrast-text: token-utils.slot(contrast-text-color, $token-mapping);
+$text-primary: token-utils.slot(text-primary-color, $token-mapping);
+$text-secondary: color-mix(in srgb, $text-primary 60%, transparent);
+$outline-color: token-utils.slot(outline-color, $token-mapping);
+
+.container {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  padding: 16px;
+  background-color: $card-background;
+  gap: 16px;
+
+  &__editor-preview {
+    display: flex;
+    height: clamp(320px, 55vh, 720px);
+    min-height: 0;
+    flex: 0 0 auto;
+  }
+
+  &__inner-border {
+    position: relative;
+    overflow: auto;
+    width: calc(50% - 6.5px);
+    padding: 16px;
+    border: 1px solid $outline-color;
+    border-radius: 4px;
+    contain: layout style;
+  }
+
+  &__form-status {
+    flex: 0 0 auto;
+  }
+
+  .hr {
+    width: 1px;
+    border: none;
+    margin: 0 12px;
+    background-color: $outline-color;
+  }
+}
+
+.form-status {
+  padding: 12px;
+  border: 1px solid $outline-color;
+  border-radius: 4px;
+  background-color: $surface-variant;
+  font-size: 0.875rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+    gap: 8px;
+  }
+
+  &__label {
+    font-weight: 500;
+  }
+
+  &__badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+
+    &--valid {
+      background-color: $primary-color;
+      color: $contrast-text;
+    }
+
+    &--invalid {
+      background-color: $error-color;
+      color: $contrast-text;
+    }
+  }
+
+  &__count {
+    margin-bottom: 8px;
+    color: $text-secondary;
+  }
+
+  &__errors {
+    margin-top: 8px;
+  }
+
+  &__errors-title {
+    margin-bottom: 4px;
+    color: $error-color;
+    font-weight: 500;
+  }
+
+  &__errors-list {
+    padding-left: 20px;
+    margin: 0;
+  }
+
+  &__error-item {
+    margin-bottom: 4px;
+  }
+
+  &__error-key {
+    font-weight: 500;
+  }
+
+  &__error-codes {
+    color: $text-secondary;
+  }
+
+  &__values {
+    padding: 8px 0 0;
+    border-top: 1px solid $outline-color;
+    margin-top: 12px;
+  }
+
+  &__values-summary {
+    color: $text-primary;
+    cursor: pointer;
+    font-weight: 500;
+    list-style: none;
+  }
+
+  &__values-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  &__values-summary::before {
+    content: '> ';
+  }
+
+  &__values[open] > &__values-summary::before {
+    content: 'v ';
+  }
+
+  &__values-list {
+    padding-left: 20px;
+    margin: 8px 0 0;
+  }
+
+  &__value-item {
+    margin-bottom: 4px;
+  }
+
+  &__value-key {
+    font-weight: 500;
+  }
+
+  &__value-text {
+    color: $text-secondary;
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { AfterViewInit, ChangeDetectorRef, Component, computed, ElementRef, forwardRef, inject, OnDestroy, signal } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { isString } from 'lodash';
+
+import { GraviteeMarkdownEditorModule } from '../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GraviteeMarkdownViewerModule } from '../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+import { GmdFieldErrorCode, GmdFieldState } from '../models/formField';
+
+@Component({
+  selector: 'gmd-form-editor',
+  imports: [CommonModule, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule],
+  templateUrl: './gmd-form-editor.component.html',
+  styleUrl: './gmd-form-editor.component.scss',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => GmdFormEditorComponent),
+      multi: true,
+    },
+  ],
+})
+export class GmdFormEditorComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+  value = '';
+  isDisabled = false;
+
+  // Computed form validity: all required fields must be valid
+  formValid = computed(() => {
+    const fields = this.fieldsMap();
+    if (fields.size === 0) return true; // No fields with fieldKey means form is valid
+
+    for (const state of fields.values()) {
+      if (state.required && !state.valid) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Count of required fields
+  requiredFieldsCount = computed(() => {
+    const fields = this.fieldsMap();
+    let count = 0;
+    for (const state of fields.values()) {
+      if (state.required) count++;
+    }
+    return count;
+  });
+
+  // Count of valid required fields
+  validRequiredFieldsCount = computed(() => {
+    const fields = this.fieldsMap();
+    let count = 0;
+    for (const state of fields.values()) {
+      if (state.required && state.valid) count++;
+    }
+    return count;
+  });
+
+  // List of invalid fields with their errors
+  invalidFields = computed(() => {
+    const fields = this.fieldsMap();
+    const invalid: Array<{ key: string; errors: string[] }> = [];
+    for (const [key, state] of fields.entries()) {
+      if (!state.valid && state.errors.length > 0) {
+        invalid.push({ key, errors: state.errors });
+      }
+    }
+    return invalid;
+  });
+
+  // List of field values for preview
+  fieldValues = computed(() => {
+    const fields = this.fieldsMap();
+    const values: Array<{ key: string; value: string }> = [];
+    for (const [key, state] of fields.entries()) {
+      values.push({ key, value: state.value });
+    }
+    return values;
+  });
+
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly hostElement = inject(ElementRef<HTMLElement>);
+
+  // Map of field states keyed by fieldKey
+  private readonly fieldsMap = signal<Map<string, GmdFieldState>>(new Map());
+
+  private eventHandler?: (event: Event) => void;
+
+  ngAfterViewInit(): void {
+    const host = this.hostElement.nativeElement;
+    this.eventHandler = (event: Event) => {
+      const customEvent = event as CustomEvent<GmdFieldState>;
+      if (customEvent.detail) {
+        const state = customEvent.detail;
+        const currentMap = this.fieldsMap();
+
+        const existingState = currentMap.get(state.key);
+        if (
+          !existingState ||
+          existingState.value !== state.value ||
+          existingState.valid !== state.valid ||
+          existingState.required !== state.required ||
+          existingState.touched !== state.touched ||
+          !this.sameErrors(existingState.errors, state.errors)
+        ) {
+          const newMap = new Map(currentMap);
+          newMap.set(state.key, state);
+          this.fieldsMap.set(newMap);
+        }
+      }
+    };
+
+    host.addEventListener('gmdFieldStateChange', this.eventHandler);
+  }
+
+  ngOnDestroy(): void {
+    if (this.eventHandler) {
+      const host = this.hostElement.nativeElement;
+      host.removeEventListener('gmdFieldStateChange', this.eventHandler);
+    }
+  }
+
+  public writeValue(value: string | null): void {
+    if (value !== null && value !== undefined) {
+      this.value = isString(value) ? value : JSON.stringify(value);
+      this.fieldsMap.set(new Map());
+    }
+  }
+
+  public registerOnChange(fn: (_value: string | null) => void): void {
+    this._onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+    this.changeDetectorRef.detectChanges();
+  }
+
+  public onValueChange(value: string): void {
+    this.value = value;
+    // Reset fields map when markdown content changes
+    this.fieldsMap.set(new Map());
+    this._onChange(value);
+  }
+
+  public onTouched(): void {
+    this._onTouched();
+  }
+
+  public formatValue(value: string): string {
+    return value.trim().length === 0 ? '(empty)' : value;
+  }
+
+  protected _onChange: (_value: string | null) => void = () => ({});
+  protected _onTouched: () => void = () => ({});
+
+  private sameErrors(a: GmdFieldErrorCode[], b: GmdFieldErrorCode[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    return a.every((error, index) => error === b[index]);
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.test.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.test.component.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'gmd-monaco-editor',
+  template: '<input type="text" [value]="value()" [disabled]="readOnly()" (input)="onInput($any($event).target?.value)" />',
+  standalone: true,
+})
+export class MockMonacoEditorStandaloneComponent {
+  value = input<string>('');
+  readOnly = input<boolean>(false);
+  valueChange = output<string>();
+  touched = output<void>();
+
+  onInput(value: string | undefined) {
+    this.valueChange.emit(value ?? '');
+  }
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.scss
@@ -13,15 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+@forward './overrides' as form-editor-* show form-editor-overrides;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Public API Surface of gravitee-markdown
- */
 
-export * from './lib/gravitee-markdown.service';
-export * from './lib/gravitee-markdown.component';
-export * from './lib/gravitee-markdown-editor/public-api';
-export * from './lib/gravitee-markdown-form-editor/public-api';
-export * from './lib/gravitee-markdown-viewer/public-api';
-export * from './lib/components/card/public-api';
-export * from './lib/components/button/public-api';
+// Components
+export * from './gmd-form-editor.component';
+
+// Testing
+export * from './gmd-form-editor.component.harness';

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/models/componentSelector.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/models/componentSelector.ts
@@ -21,6 +21,11 @@ export enum ComponentSelector {
   CARD_SUBTITLE = 'gmd-card-subtitle',
   MD_BLOCK = 'gmd-md',
   BUTTON = 'gmd-button',
+  INPUT = 'gmd-input',
+  TEXTAREA = 'gmd-textarea',
+  SELECT = 'gmd-select',
+  CHECKBOX = 'gmd-checkbox',
+  RADIO = 'gmd-radio',
 }
 
 export function getComponentSelector(componentTag: string): ComponentSelector | undefined {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/models/formField.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/models/formField.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Error codes for form field validation
+ */
+export type GmdFieldErrorCode = 'required' | 'minLength' | 'maxLength' | 'pattern';
+
+/**
+ * State of a form field, including its value, validation status, and errors
+ */
+export interface GmdFieldState {
+  /** Field key used to identify the field in the form */
+  key: string;
+  /** Current value of the field (always string for metadata) */
+  value: string;
+  /** Whether the field passes all validation rules */
+  valid: boolean;
+  /** Whether the field is required */
+  required: boolean;
+  /** Whether the field has been touched/focused by the user */
+  touched: boolean;
+  /** Array of validation error codes */
+  errors: GmdFieldErrorCode[];
+}

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/scss/theme.scss
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/scss/theme.scss
@@ -23,6 +23,7 @@
         container-shape: 4px,
         primary-color: #275cf6,
         on-primary-color: #ffffff,
+        surface-color: #ffffff,
         outline-color: #cdd7e1,
         hover-state-layer-opacity: 90%,
         focus-state-layer-opacity: 80%,

--- a/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-markdown/src/lib/services/gravitee-markdown-renderer.service.spec.ts
@@ -334,6 +334,19 @@ This markdown editor demonstrates the **button component** integration.
           '<gmd-card>\n  <gmd-card-title>Parent Card</gmd-card-title>\n  <gmd-card-subtitle>This card contains another card</gmd-card-subtitle>\n  <gmd-card>\n    <gmd-card-title>Child Card</gmd-card-title>\n    <gmd-card-subtitle>Nested inside parent</gmd-card-subtitle>\n    <gmd-button appearance="filled">Child Action</gmd-button>\n  </gmd-card>\n  <gmd-button appearance="outlined">Parent Action</gmd-button>\n</gmd-card>',
       },
       {
+        description: 'should normalize self-closing GMD form components to opening/closing format',
+        input: `<gmd-input name="test" label="Test Input" type="text" required="true" />
+<gmd-select name="test-select" label="Test Select" options='["Option 1", "Option 2"]' />
+<gmd-textarea name="test-textarea" label="Test Textarea" placeholder="Enter text" />
+<gmd-checkbox name="test-checkbox" label="Test Checkbox" required="true" />
+<gmd-radio name="test-radio" label="Test Radio" options="option1,option2" />`,
+        expected: `<gmd-input name="test" label="Test Input" type="text" required="true"></gmd-input>
+<gmd-select name="test-select" label="Test Select" options="[&quot;Option 1&quot;, &quot;Option 2&quot;]"></gmd-select>
+<gmd-textarea name="test-textarea" label="Test Textarea" placeholder="Enter text"></gmd-textarea>
+<gmd-checkbox name="test-checkbox" label="Test Checkbox" required="true"></gmd-checkbox>
+<gmd-radio name="test-radio" label="Test Radio" options="option1,option2"></gmd-radio>`,
+      },
+      {
         description: 'should handle images inside GMD components without parsing errors',
         input: `## Outside
 
@@ -388,6 +401,67 @@ console.log(special);
         const result = service.render(input);
         expect(result).toBe(expected);
       });
+    });
+  });
+
+  describe('Form Components Normalization', () => {
+    it('should normalize all self-closing form components', () => {
+      const input = `<gmd-input name="test" />
+<gmd-textarea name="test2" />
+<gmd-select name="test3" />
+<gmd-checkbox name="test4" />
+<gmd-radio name="test5" />`;
+
+      const result = service.render(input);
+
+      // All self-closing components should be converted to opening/closing format
+      expect(result).toContain('<gmd-input name="test"></gmd-input>');
+      expect(result).toContain('<gmd-textarea name="test2"></gmd-textarea>');
+      expect(result).toContain('<gmd-select name="test3"></gmd-select>');
+      expect(result).toContain('<gmd-checkbox name="test4"></gmd-checkbox>');
+      expect(result).toContain('<gmd-radio name="test5"></gmd-radio>');
+
+      // Should not contain self-closing format
+      expect(result).not.toContain('<gmd-input name="test" />');
+      expect(result).not.toContain('<gmd-textarea name="test2" />');
+      expect(result).not.toContain('<gmd-select name="test3" />');
+      expect(result).not.toContain('<gmd-checkbox name="test4" />');
+      expect(result).not.toContain('<gmd-radio name="test5" />');
+    });
+
+    it('should preserve attributes when normalizing self-closing components', () => {
+      const input = `<gmd-input name="email" label="Email" placeholder="Enter email" required="true" fieldKey="consumer_email" />
+<gmd-select name="env" label="Environment" options='["dev", "prod"]' fieldKey="environment" />`;
+
+      const result = service.render(input);
+
+      // Attributes should be preserved
+      expect(result).toContain('name="email"');
+      expect(result).toContain('label="Email"');
+      expect(result).toContain('placeholder="Enter email"');
+      expect(result).toContain('required="true"');
+      // DOMParser converts attribute names to lowercase
+      expect(result).toContain('fieldkey="consumer_email"');
+      expect(result).toContain('fieldkey="environment"');
+
+      // Components should be normalized
+      expect(result).toContain('</gmd-input>');
+      expect(result).toContain('</gmd-select>');
+    });
+
+    it('should handle self-closing components with various spacing', () => {
+      const input = `<gmd-input name="test1"/>
+<gmd-input name="test2" />
+<gmd-input name="test3"  />
+<gmd-input name="test4"   />`;
+
+      const result = service.render(input);
+
+      // All variations should be normalized
+      expect(result).toContain('<gmd-input name="test1"></gmd-input>');
+      expect(result).toContain('<gmd-input name="test2"></gmd-input>');
+      expect(result).toContain('<gmd-input name="test3"></gmd-input>');
+      expect(result).toContain('<gmd-input name="test4"></gmd-input>');
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
@@ -53,4 +53,59 @@
       text-color: theme.$card-text-color,
     )
   );
+
+  @include gmd.input-overrides(
+    (
+      label-text-color: theme.$default-text-color,
+      field-text-color: theme.$default-text-color,
+      field-outline-color: theme.$border-color,
+      field-outline-radius: theme.$container-shape,
+      field-focus-outline-color: theme.$primary-main-color,
+      error-text-color: theme.$error-main-color,
+      required-text-color: theme.$error-main-color,
+    )
+  );
+
+  @include gmd.textarea-overrides(
+    (
+      label-text-color: theme.$default-text-color,
+      field-text-color: theme.$default-text-color,
+      field-outline-color: theme.$border-color,
+      field-outline-radius: theme.$container-shape,
+      field-focus-outline-color: theme.$primary-main-color,
+      field-disabled-background-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
+      error-text-color: theme.$error-main-color,
+      required-text-color: theme.$error-main-color,
+    )
+  );
+
+  @include gmd.select-overrides(
+    (
+      label-text-color: theme.$default-text-color,
+      field-text-color: theme.$default-text-color,
+      field-outline-color: theme.$border-color,
+      field-outline-radius: theme.$container-shape,
+      field-focus-outline-color: theme.$primary-main-color,
+      field-disabled-background-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
+      error-text-color: theme.$error-main-color,
+      required-text-color: theme.$error-main-color,
+    )
+  );
+
+  @include gmd.checkbox-overrides(
+    (
+      label-text-color: theme.$default-text-color,
+      required-text-color: theme.$error-main-color,
+      error-text-color: theme.$error-main-color,
+    )
+  );
+
+  @include gmd.radio-overrides(
+    (
+      label-text-color: theme.$default-text-color,
+      option-text-color: theme.$default-text-color,
+      required-text-color: theme.$error-main-color,
+      error-text-color: theme.$error-main-color,
+    )
+  );
 }

--- a/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
@@ -56,55 +56,49 @@
 
   @include gmd.input-overrides(
     (
-      label-text-color: theme.$default-text-color,
-      field-text-color: theme.$default-text-color,
-      field-outline-color: theme.$border-color,
-      field-outline-radius: theme.$container-shape,
-      field-focus-outline-color: theme.$primary-main-color,
+      outlined-label-text-color: theme.$default-text-color,
+      outlined-input-text-color: theme.$default-text-color,
+      outlined-outline-color: theme.$border-color,
+      outlined-container-shape: theme.$container-shape,
+      outlined-focus-outline-color: theme.$primary-main-color,
       error-text-color: theme.$error-main-color,
-      required-text-color: theme.$error-main-color,
     )
   );
 
   @include gmd.textarea-overrides(
     (
-      label-text-color: theme.$default-text-color,
-      field-text-color: theme.$default-text-color,
-      field-outline-color: theme.$border-color,
-      field-outline-radius: theme.$container-shape,
-      field-focus-outline-color: theme.$primary-main-color,
-      field-disabled-background-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
+      outlined-label-text-color: theme.$default-text-color,
+      outlined-input-text-color: theme.$default-text-color,
+      outlined-outline-color: theme.$border-color,
+      outlined-container-shape: theme.$container-shape,
+      outlined-focus-outline-color: theme.$primary-main-color,
+      outlined-disabled-container-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
       error-text-color: theme.$error-main-color,
-      required-text-color: theme.$error-main-color,
     )
   );
 
   @include gmd.select-overrides(
     (
-      label-text-color: theme.$default-text-color,
-      field-text-color: theme.$default-text-color,
-      field-outline-color: theme.$border-color,
-      field-outline-radius: theme.$container-shape,
-      field-focus-outline-color: theme.$primary-main-color,
-      field-disabled-background-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
+      outlined-label-text-color: theme.$default-text-color,
+      outlined-input-text-color: theme.$default-text-color,
+      outlined-outline-color: theme.$border-color,
+      outlined-container-shape: theme.$container-shape,
+      outlined-focus-outline-color: theme.$primary-main-color,
+      outlined-disabled-container-color: color-mix(in srgb, theme.$card-background-color 50%, transparent),
       error-text-color: theme.$error-main-color,
-      required-text-color: theme.$error-main-color,
     )
   );
 
   @include gmd.checkbox-overrides(
     (
-      label-text-color: theme.$default-text-color,
-      required-text-color: theme.$error-main-color,
+      outlined-label-text-color: theme.$default-text-color,
       error-text-color: theme.$error-main-color,
     )
   );
 
   @include gmd.radio-overrides(
     (
-      label-text-color: theme.$default-text-color,
-      option-text-color: theme.$default-text-color,
-      required-text-color: theme.$error-main-color,
+      outlined-label-text-color: theme.$default-text-color,
       error-text-color: theme.$error-main-color,
     )
   );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12155

## Description

Adds form components to Gravitee Markdown (GMD) for defining subscription metadata forms. A new "Subscription Form" page is available in Portal Settings where admins can define forms using GMD syntax and preview validation in real time. The renderer normalizes self-closing form component tags to opening/closing format for DOMParser compatibility.

### Components Added
- gmd-input: Text input with validation (required, minLength, maxLength, pattern)
- gmd-textarea: Multi-line text input with validation
- gmd-select: Dropdown select with JSON array or comma-separated options
- gmd-checkbox: Single checkbox with required validation
- gmd-radio: Radio button group with options parsing

All components support standard form attributes (name, label, placeholder, required, etc.) and emit gmdFieldStateChange events for form state management.

## Additional context
The video showcases a boilerplate example rendered using Gravitee Markdown, featuring a functional form. As the form is being filled out, a validation panel is visible, allowing you to track all active validations for individual fields. This panel also displays the overall form status and provides a preview of the field values that will eventually be passed as subscription metadata.

https://github.com/user-attachments/assets/e3434909-9d28-4bc6-b471-9c69eebcc7b0



