### PR TITLE
feat: create v4 env level logs skeleton

### DIFF
--- a/gravitee-apim-console-webui/src/management/analytics/env-analytics.module.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-analytics.module.ts
@@ -16,13 +16,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { MatTabsModule } from '@angular/material/tabs';
-import { GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { EnvAnalyticsLayoutComponent } from './env-analytics-layout.component';
 import { AnalyticsDashboardComponent } from './analytics-dashboard/analytics-dashboard.component';
 import { PlatformLogsComponent } from './logs/platform-logs.component';
 import { PlatformLogComponent } from './logs/platform-log.component';
 import { AnalyticsViewerComponent } from './analytics-viewer/analytics-viewer.component';
+import { EnvRuntimeLogsV4Component } from './env-runtime-logs-v4/env-runtime-logs-v4.component';
 
 const routes: Routes = [
   {
@@ -57,6 +60,16 @@ const routes: Routes = [
         },
       },
       {
+        path: 'logs-v4',
+        component: EnvRuntimeLogsV4Component,
+        data: {
+          docs: {
+            page: 'management-environment-logs-v4',
+          },
+        },
+      },
+
+      {
         path: 'dashboard-v4',
         component: AnalyticsViewerComponent,
       },
@@ -71,8 +84,14 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  declarations: [EnvAnalyticsLayoutComponent, AnalyticsDashboardComponent, PlatformLogsComponent, PlatformLogComponent],
-  imports: [RouterModule.forChild(routes), MatTabsModule, GioIconsModule, MatTabsModule],
+  declarations: [
+    EnvAnalyticsLayoutComponent,
+    AnalyticsDashboardComponent,
+    PlatformLogsComponent,
+    PlatformLogComponent,
+    EnvRuntimeLogsV4Component,
+  ],
+  imports: [RouterModule.forChild(routes), MatTabsModule, MatCardModule, MatIconModule, GioIconsModule, GioBannerModule],
   exports: [RouterModule],
 })
 export class EnvAnalyticsModule {}

--- a/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.html
@@ -1,0 +1,38 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<div class="env-runtime-logs-v4">
+  <div class="env-runtime-logs-v4__header">
+    <h1>Logs</h1>
+  </div>
+
+  <gio-banner-info class="banner-warning">
+    <div class="banner-warning__content">
+      Currently, only HTTP Proxy is supported.
+      <span class="mat-body">Message APIs, SSEs, and webhook support are coming soon.</span>
+    </div>
+  </gio-banner-info>
+
+  <mat-card class="logs-section">
+    <!-- Filters Section -->
+    <div class="filters-section">Filters section coming soon</div>
+
+    <!-- Table Section -->
+    <div class="table-section">Table section coming soon</div>
+  </mat-card>
+</div>

--- a/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.scss
+++ b/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.scss
@@ -1,0 +1,43 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.env-runtime-logs-v4 {
+  padding: 24px;
+
+  &__header {
+    display: flex;
+    margin-bottom: 24px;
+    justify-content: space-between;
+    align-items: center;
+
+    h1 {
+      margin: auto 0;
+      @include mat.m2-typography-level($typography, 'headline-6');
+    }
+  }
+
+  .banner-warning {
+    margin-bottom: 24px;
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .logs-section {
+    border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+  }
+
+  .filters-section {
+    padding: 16px;
+    border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+  }
+
+  .table-section {
+    padding: 16px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatCardModule } from '@angular/material/card';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+
+import { EnvRuntimeLogsV4Component } from './env-runtime-logs-v4.component';
+
+import { GioTestingModule } from '../../../shared/testing';
+
+describe('EnvRuntimeLogsV4Component', () => {
+  let component: EnvRuntimeLogsV4Component;
+  let fixture: ComponentFixture<EnvRuntimeLogsV4Component>;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EnvRuntimeLogsV4Component],
+      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, GioBannerModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EnvRuntimeLogsV4Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the title', () => {
+    const compiled = fixture.nativeElement;
+    const title = compiled.querySelector('h1');
+    expect(title.textContent).toContain('Logs');
+  });
+
+  it('should render the banner warning', () => {
+    const compiled = fixture.nativeElement;
+    const banner = compiled.querySelector('gio-banner-info');
+    expect(banner).toBeTruthy();
+  });
+
+  it('should display filters section', () => {
+    const compiled = fixture.nativeElement;
+    const filtersSection = compiled.querySelector('.filters-section');
+    expect(filtersSection).toBeTruthy();
+  });
+
+  it('should display table section', () => {
+    const compiled = fixture.nativeElement;
+    const tableSection = compiled.querySelector('.table-section');
+    expect(tableSection).toBeTruthy();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-runtime-logs-v4/env-runtime-logs-v4.component.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'env-runtime-logs-v4',
+  templateUrl: './env-runtime-logs-v4.component.html',
+  styleUrls: ['./env-runtime-logs-v4.component.scss'],
+  standalone: false,
+})
+export class EnvRuntimeLogsV4Component {
+  // Placeholder component for environment-level v4 logs
+  // Backend integration and real functionality will be added in future PRs
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2020
## Description

Adds path (/analytics/logs-v4) and barebones placeholder for env level logging component. 
<img width="1492" height="810" alt="Screenshot 2026-01-22 at 11 34 34 AM" src="https://github.com/user-attachments/assets/72d1f163-f789-4822-a768-fc34d6cf461e" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

