### PR TITLE
feat: allow api in api product

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
@@ -108,6 +108,12 @@ export interface GenericApi extends BaseApi {
   properties?: Property[];
   primaryOwner?: PrimaryOwner;
   _links?: { [key: string]: string };
+  /**
+   * Indicates whether this API is allowed to be used in API Products.
+   *
+   * Present for V4 HTTP Proxy APIs; defaults to false when absent.
+   */
+  allowInApiProduct?: boolean;
 }
 
 export type ApiState = 'CLOSED' | 'INITIALIZED' | 'STARTED' | 'STOPPED' | 'STOPPING';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/apiProduct.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrimaryOwner } from '../api/primaryOwner';
+
+/**
+ * API Product entity
+ */
+export interface ApiProduct {
+  /**
+   * The unique technical identifier of the API Product.
+   */
+  id: string;
+
+  /**
+   * The environment ID where this API Product is defined.
+   */
+  environmentId?: string;
+
+  /**
+   * The display name.
+   */
+  name: string;
+
+  /**
+   * A short description of the product.
+   */
+  description?: string;
+
+  /**
+   * The version of the API Product.
+   */
+  version?: string;
+
+  /**
+   * The APIs contained in this product.
+   * Useful to verify the current API is indeed in the list.
+   */
+  apiIds?: string[];
+
+  /**
+   * Creation timestamp (ISO 8601).
+   */
+  createdAt?: string;
+
+  /**
+   * Last update timestamp (ISO 8601).
+   */
+  updatedAt?: string;
+
+  /**
+   * Owner information.
+   */
+  primaryOwner?: PrimaryOwner;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/apiProductsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/apiProductsResponse.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProduct } from './apiProduct';
+
+import { Links } from '../links';
+import { Pagination } from '../pagination';
+
+export interface ApiProductsResponse {
+  /**
+   * List of API Products.
+   */
+  data?: ApiProduct[];
+  pagination?: Pagination;
+  links?: Links;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/apiProduct/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './apiProduct';
+export * from './apiProductsResponse';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 export * from './api';
+export * from './apiProduct';
 export * from './application';
 export * from './audit';
 export * from './plugin';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/updateApi/updateBaseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/updateApi/updateBaseApi.ts
@@ -75,4 +75,8 @@ export interface UpdateBaseApi {
    */
   disableMembershipNotifications?: boolean;
   properties?: Property[];
+  /**
+   * @description Whether this API can be used in API Products.
+   */
+  allowInApiProduct?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -80,6 +80,19 @@
                 </mat-select>
               </mat-form-field>
 
+              @if (canDisplayAllowInApiProduct) {
+                <gio-form-slide-toggle class="details-card__header__info-inputs__second-row__allow-in-api-products-field">
+                  Allow in API Products
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    formControlName="allowInApiProduct"
+                    aria-label="Allow in API Products"
+                    name="allowInApiProduct"
+                    [disabled]="isInApiProduct"
+                  />
+                </gio-form-slide-toggle>
+              }
+
               @if (canDisplayV4EmulationEngineToggle) {
                 <gio-form-slide-toggle class="details-card__header__info-inputs__second-row__emulate-v4-engine-field">
                   Emulate v4 engine

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -22,6 +22,7 @@ import { isEqual } from 'lodash';
 import { Constants } from '../entities/Constants';
 import {
   Api,
+  ApiProductsResponse,
   ApiSearchQuery,
   ApiSortByParam,
   ApisResponse,
@@ -251,5 +252,9 @@ export class ApiV2Service {
         params: httpParams,
       },
     );
+  }
+
+  getApiProductsForApi(apiId: string): Observable<ApiProductsResponse> {
+    return this.http.get<ApiProductsResponse>(`${this.constants.env.v2BaseURL}/apis/${apiId}/api-products`);
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Inject, Input, OnDestroy, OnInit, DOCUMENT } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { flatten, sortBy } from 'lodash';
 import { fromEvent, Observable, Subject } from 'rxjs';
 import { debounceTime, filter, map, shareReplay, takeUntil, tap } from 'rxjs/operators';

--- a/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AfterViewInit, Directive, ElementRef, Inject, NgZone, Optional, ViewContainerRef, DOCUMENT } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Inject, NgZone, Optional, ViewContainerRef } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MAT_TOOLTIP_SCROLL_STRATEGY, MatTooltip, MatTooltipDefaultOptions } from '@angular/material/tooltip';
 import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import { Platform } from '@angular/cdk/platform';

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -16,6 +16,7 @@
 package io.gravitee.definition.model.v4;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.ResponseTemplate;
@@ -88,6 +89,28 @@ public class Api extends AbstractApi {
 
     private ApiServices services;
 
+    @JsonIgnore
+    @Builder.Default
+    private boolean allowInApiProduct = false;
+
+    /**
+     * Internal getter for boolean value (used by internal code).
+     * Returns the actual boolean value regardless of API type.
+     */
+    public boolean isAllowInApiProduct() {
+        return allowInApiProduct;
+    }
+
+    /**
+     * Custom getter that returns null for non-Proxy APIs to ensure the key is omitted from JSON.
+     * Jackson's @JsonInclude(NON_NULL) will skip serializing this field when null.
+     */
+    @JsonProperty("allowInApiProduct")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        return ApiType.PROXY.equals(getType()) ? allowInApiProduct : null;
+    }
+
     public Api(Api other) {
         super(other.id, other.name, other.type, other.apiVersion, other.definitionVersion, other.tags, other.properties, other.resources);
         this.listeners = other.listeners;
@@ -99,6 +122,7 @@ public class Api extends AbstractApi {
         this.flows = other.flows;
         this.responseTemplates = other.responseTemplates;
         this.services = other.services;
+        this.allowInApiProduct = other.allowInApiProduct;
     }
 
     public Plan getPlan(final String plan) {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
@@ -46,6 +46,7 @@ public class ApiCriteria {
     private String crossId;
     private List<DefinitionVersion> definitionVersion;
     private String integrationId;
+    private Boolean allowInApiProduct;
 
     ApiCriteria(ApiCriteria.Builder builder) {
         this.ids = builder.ids;
@@ -62,6 +63,7 @@ public class ApiCriteria {
         this.crossId = builder.crossId;
         this.definitionVersion = builder.definitionVersion;
         this.integrationId = builder.integrationId;
+        this.allowInApiProduct = builder.allowInApiProduct;
     }
 
     public Collection<String> getIds() {
@@ -132,6 +134,14 @@ public class ApiCriteria {
         this.integrationId = integrationId;
     }
 
+    public Boolean getAllowInApiProduct() {
+        return allowInApiProduct;
+    }
+
+    public void setAllowInApiProduct(Boolean allowInApiProduct) {
+        this.allowInApiProduct = allowInApiProduct;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -151,7 +161,8 @@ public class ApiCriteria {
             Objects.equals(environments, that.environments) &&
             Objects.equals(crossId, that.crossId) &&
             Objects.equals(definitionVersion, that.definitionVersion) &&
-            Objects.equals(integrationId, that.integrationId)
+            Objects.equals(integrationId, that.integrationId) &&
+            Objects.equals(allowInApiProduct, that.allowInApiProduct)
         );
     }
 
@@ -171,7 +182,8 @@ public class ApiCriteria {
             environments,
             crossId,
             definitionVersion,
-            integrationId
+            integrationId,
+            allowInApiProduct
         );
     }
 
@@ -191,6 +203,7 @@ public class ApiCriteria {
         private String crossId;
         private List<DefinitionVersion> definitionVersion;
         private String integrationId;
+        private Boolean allowInApiProduct;
 
         public ApiCriteria.Builder ids(final String... id) {
             this.ids = Set.of(id);
@@ -269,6 +282,11 @@ public class ApiCriteria {
 
         public ApiCriteria.Builder integrationId(final String integrationId) {
             this.integrationId = integrationId;
+            return this;
+        }
+
+        public ApiCriteria.Builder allowInApiProduct(final Boolean allowInApiProduct) {
+            this.allowInApiProduct = allowInApiProduct;
             return this;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCT;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
@@ -93,6 +94,7 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -327,6 +329,10 @@ public class ApisResource extends AbstractResource {
 
         if (CollectionUtils.isNotEmpty(apiSearchQuery.getVisibilities())) {
             apiQueryBuilder.addFilter(FIELD_VISIBILITY, apiSearchQuery.getVisibilities());
+        }
+
+        if (apiSearchQuery.getAllowInApiProduct() != null) {
+            apiQueryBuilder.addFilter(FIELD_ALLOW_IN_API_PRODUCT, List.of(apiSearchQuery.getAllowInApiProduct().toString()));
         }
 
         var selectedDefinitions = Stream.concat(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3354,6 +3354,10 @@ components:
                               $ref: "#/components/schemas/FlowV4"
                       services:
                           $ref: "#/components/schemas/ApiServices"
+                      allowInApiProduct:
+                          type: boolean
+                          description: Indicates whether the API can be included in API Products (V4 HTTP Proxy only).
+                          default: false
 
         ApiFederated:
             type: object
@@ -3785,6 +3789,10 @@ components:
                         - awesome
                     items:
                         type: string
+                allowInApiProduct:
+                    type: boolean
+                    description: Indicates whether the API can be included in API Products (V4 HTTP Proxy only).
+                    default: false
                 lifecycleState:
                     $ref: "#/components/schemas/ApiLifecycleState"
                 disableMembershipNotifications:
@@ -4008,6 +4016,9 @@ components:
                   type: array
                   items:
                     type: string
+                allowInApiProduct:
+                  type: boolean
+                  description: Filters APIs that can be added to API Products. Applies to V4 Proxy APIs only.
         ApiType:
             type: string
             description: API's type.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.api;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.gravitee.common.component.Lifecycle;
@@ -236,6 +237,19 @@ public class ApiEntity implements GenericApiEntity {
 
     @JsonProperty("disable_membership_notifications")
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        // V2 ApiEntity: always return null since allowInApiProduct is only for V4 Proxy APIs
+        // V4 APIs use io.gravitee.rest.api.model.v4.api.ApiEntity which has its own getter
+        return null;
+    }
 
     private List<ApiEntrypointEntity> entrypoints;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model.v4.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
@@ -201,6 +202,20 @@ public class ApiEntity implements GenericApiEntity {
     private WorkflowState workflowState;
 
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        if (this.definitionVersion == DefinitionVersion.V4 && this.type == ApiType.PROXY) {
+            return allowInApiProduct;
+        }
+        return null;
+    }
 
     @Schema(description = "the API background encoded in base64")
     private String background;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model.v4.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
@@ -190,6 +191,20 @@ public class UpdateApiEntity {
     private ApiLifecycleState lifecycleState;
 
     private boolean disableMembershipNotifications;
+
+    @Schema(
+        description = "Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.",
+        example = "false"
+    )
+    private Boolean allowInApiProduct;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllowInApiProduct() {
+        if (this.definitionVersion == DefinitionVersion.V4 && this.type == ApiType.PROXY) {
+            return allowInApiProduct;
+        }
+        return null;
+    }
 
     @Schema(description = "the API background encoded in base64")
     private String background;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/AllowInApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/AllowInApiProductDomainService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+
+/**
+ * Centralizes business rules for the {@code allowInApiProduct} flag so that
+ * imports and updates keep a single source of truth.
+ */
+@DomainService
+public class AllowInApiProductDomainService {
+
+    public Boolean normalizeForImport(Boolean importedFlag, boolean isAlreadyInProduct) {
+        if (importedFlag == null) {
+            return Boolean.TRUE;
+        }
+
+        if (Boolean.FALSE.equals(importedFlag) && isAlreadyInProduct) {
+            return Boolean.TRUE;
+        }
+
+        return importedFlag;
+    }
+
+    public Boolean normalizeForUpdate(Boolean requestedFlag, boolean isAlreadyInProduct) {
+        if (!Boolean.FALSE.equals(requestedFlag)) {
+            return requestedFlag;
+        }
+
+        if (isAlreadyInProduct) {
+            return Boolean.TRUE;
+        }
+
+        return Boolean.FALSE;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
@@ -52,11 +52,11 @@ public class NewHttpApi extends AbstractNewApi {
     private Failover failover;
 
     /**
-     * @return An instance of {@link io.gravitee.definition.model.v4.Api.ApiBuilder} based on the current state of this NewV4Api.
+     * @return An instance of {@link io.gravitee.definition.model.v4.Api.ApiBuilder} based on the current state of this NewHttpApi.
      */
     public io.gravitee.definition.model.v4.Api.ApiBuilder<?, ?> toApiDefinitionBuilder() {
         // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
-        return io.gravitee.definition.model.v4.Api.builder()
+        io.gravitee.definition.model.v4.Api.ApiBuilder<?, ?> builder = io.gravitee.definition.model.v4.Api.builder()
             .name(name)
             .type(type)
             .apiVersion(apiVersion)
@@ -68,5 +68,12 @@ public class NewHttpApi extends AbstractNewApi {
             .flows(flows)
             .flowExecution(flowExecution)
             .failover(failover);
+
+        // Business rule: new V4 HTTP Proxy APIs should be allowed in API Products by default.
+        if (type == io.gravitee.definition.model.v4.ApiType.PROXY) {
+            builder.allowInApiProduct(true);
+        }
+
+        return builder;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
@@ -111,7 +111,8 @@ public sealed interface ApiDescriptor {
         List<Property> properties,
         List<Resource> resources,
         ApiServices services,
-        Failover failover
+        Failover failover,
+        Boolean allowInApiProduct
     ) implements ApiDescriptor {
         @JsonProperty("definitionVersion")
         @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiExport.java
@@ -109,6 +109,7 @@ public class ApiExport {
     private ApiLifecycleState lifecycleState;
     private WorkflowState workflowState;
     private boolean disableMembershipNotifications;
+    private Boolean allowInApiProduct;
     private String background;
     private String backgroundUrl;
 
@@ -140,7 +141,7 @@ public class ApiExport {
         if (ApiType.NATIVE.equals(type)) {
             return null;
         }
-        return io.gravitee.definition.model.v4.Api.builder()
+        var builder = io.gravitee.definition.model.v4.Api.builder()
             .analytics(analytics)
             .apiVersion(apiVersion)
             .definitionVersion(DefinitionVersion.V4)
@@ -156,6 +157,11 @@ public class ApiExport {
             .tags(tags)
             .type(type)
             .services((ApiServices) services);
+        // Only set allowInApiProduct for V4 Proxy APIs
+        if (type == ApiType.PROXY && allowInApiProduct != null) {
+            builder.allowInApiProduct(allowInApiProduct);
+        }
+        return builder;
     }
 
     public io.gravitee.definition.model.v4.nativeapi.NativeApi.NativeApiBuilder<?, ?> toNativeApiDefinitionBuilder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -125,7 +125,8 @@ class ApiMigration {
                     null,
                     null /* flows are managed in another place because is in a different collection */,
                     apiDefinitionV2.getResponseTemplates(),
-                    apiServices
+                    apiServices,
+                    false
                 );
                 api.setId(apiDefinitionV2.getId());
                 api.setName(apiDefinitionV2.getName());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
@@ -24,4 +24,12 @@ public interface ApiProductQueryService {
     Set<ApiProduct> findByEnvironmentId(String environmentId);
     Optional<ApiProduct> findById(String apiProductId);
     Set<ApiProduct> findByApiId(String apiId);
+
+    /**
+     * Check for whether any API Product contains the given API.
+     * Prefer this over {@link #findByApiId(String)} when only existence is needed.
+     */
+    default boolean existsByApiId(String apiId) {
+        return apiId != null && !findByApiId(apiId).isEmpty();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -107,6 +107,10 @@ public interface GraviteeDefinitionAdapter {
         expression = "java(apiEntity.getApiDefinitionHttpV4() != null ? apiEntity.getApiDefinitionHttpV4().getFailover() : null)"
     )
     @Mapping(target = "endpointGroups", source = "apiEntity.apiDefinitionHttpV4.endpointGroups")
+    @Mapping(
+        target = "allowInApiProduct",
+        expression = "java(apiEntity.getType() == io.gravitee.definition.model.v4.ApiType.PROXY && apiEntity.getApiDefinitionHttpV4() != null ? Boolean.valueOf(apiEntity.getApiDefinitionHttpV4().isAllowInApiProduct()) : null)"
+    )
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -114,6 +114,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_ORIGIN,
         FIELD_HAS_HEALTH_CHECK,
         FIELD_DEFINITION_VERSION,
+        ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCT,
     };
 
     public ApiDocumentSearcher(IndexWriter indexWriter) {
@@ -209,6 +210,9 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             );
             buildWildcardQuery(executionContext, query, baseFilterQuery).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
             buildIdsQuery(executionContext, query).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
+            if (isBlank(query.getQuery()) && baseFilterQuery.isPresent() && (query.getIds() == null || query.getIds().isEmpty())) {
+                apiQuery.add(buildApiQuery(executionContext, baseFilterQuery).build(), BooleanClause.Occur.MUST);
+            }
         } catch (ParseException pe) {
             log.error("Invalid query to search for API documents", pe);
             throw new TechnicalException("Invalid query to search for API documents", pe);
@@ -399,7 +403,8 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             !FIELD_TAGS.equals(term.field()) &&
             !FIELD_ORIGIN.equals(term.field()) &&
             !FIELD_HAS_HEALTH_CHECK.equals(term.field()) &&
-            !FIELD_DEFINITION_VERSION.equals(term.field())
+            !FIELD_DEFINITION_VERSION.equals(term.field()) &&
+            !ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCT.equals(term.field())
         ) {
             text = text.toLowerCase();
             field = field.concat("_lowercase");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -110,6 +110,7 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
     public static final String FIELD_PORTAL_STATUS_SORTED = "portal_status_sorted";
     public static final String FIELD_VISIBILITY = "visibility";
     public static final String FIELD_VISIBILITY_SORTED = "visibility_sorted";
+    public static final String FIELD_ALLOW_IN_API_PRODUCT = "allow_in_api_product";
 
     private final ApiService apiService;
     private final Collator collator = Collator.getInstance(Locale.ENGLISH);
@@ -250,6 +251,13 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
         if (api.getOriginContext() != null && api.getOriginContext().name() != null) {
             doc.add(new StringField(FIELD_ORIGIN, api.getOriginContext().name(), NO));
         }
+
+        boolean allowInApiProduct = false;
+        if (api instanceof io.gravitee.rest.api.model.v4.api.ApiEntity v4) {
+            Boolean val = v4.getAllowInApiProduct();
+            allowInApiProduct = Boolean.TRUE.equals(val);
+        }
+        doc.add(new StringField(FIELD_ALLOW_IN_API_PRODUCT, String.valueOf(allowInApiProduct), NO));
 
         return doc;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -158,6 +158,16 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
             doc.add(new StringField(FIELD_ORIGIN, api.getOriginContext().name(), Field.Store.NO));
         }
 
+        boolean allowInApiProduct = false;
+        if (
+            api.getDefinitionVersion() == DefinitionVersion.V4 &&
+            api.getType() == ApiType.PROXY &&
+            api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api v4Def
+        ) {
+            allowInApiProduct = v4Def.isAllowInApiProduct();
+        }
+        doc.add(new StringField(FIELD_ALLOW_IN_API_PRODUCT, String.valueOf(allowInApiProduct), Field.Store.NO));
+
         if (api.getDefinitionVersion() == DefinitionVersion.V4) {
             transformV4Api(doc, indexableApi);
         } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -129,6 +129,14 @@ public class ApiMapper {
                 apiEntity.setFlows(apiDefinition.getFlows());
 
                 apiEntity.setResponseTemplates(apiDefinition.getResponseTemplates());
+                if (
+                    apiDefinition.getType() == ApiType.PROXY &&
+                    apiDefinition.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+                ) {
+                    apiEntity.setAllowInApiProduct(apiDefinition.isAllowInApiProduct());
+                } else {
+                    apiEntity.setAllowInApiProduct(null);
+                }
             } catch (IOException ioe) {
                 log.error(API_DEFINITION_UNEXPECTED_ERROR_MESSAGE, ioe);
             }
@@ -402,6 +410,12 @@ public class ApiMapper {
             apiDefinition.setFailover(newApiEntity.getFailover());
             apiDefinition.setFlowExecution(newApiEntity.getFlowExecution());
             apiDefinition.setFlows(newApiEntity.getFlows());
+            if (
+                newApiEntity.getType() == ApiType.PROXY &&
+                newApiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                apiDefinition.setAllowInApiProduct(true);
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {
@@ -483,6 +497,12 @@ public class ApiMapper {
             apiDefinition.setFlows(updateApiEntity.getFlows());
             apiDefinition.setResponseTemplates(updateApiEntity.getResponseTemplates());
             apiDefinition.setServices(updateApiEntity.getServices());
+            if (
+                updateApiEntity.getType() == ApiType.PROXY &&
+                updateApiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                apiDefinition.setAllowInApiProduct(Boolean.TRUE.equals(updateApiEntity.getAllowInApiProduct()));
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {
@@ -562,6 +582,12 @@ public class ApiMapper {
             apiDefinition.setFlows(apiEntity.getFlows());
             apiDefinition.setResponseTemplates(apiEntity.getResponseTemplates());
             apiDefinition.setServices(apiEntity.getServices());
+            if (
+                apiEntity.getType() == ApiType.PROXY &&
+                apiEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4
+            ) {
+                apiDefinition.setAllowInApiProduct(Boolean.TRUE.equals(apiEntity.getAllowInApiProduct()));
+            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ValidateApiProductServiceTest {
+
+    private ValidateApiProductService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ValidateApiProductService();
+    }
+
+    @Test
+    void should_validate_successfully_when_name_and_version_are_present() {
+        // Given
+        ApiProduct apiProduct = ApiProduct.builder().name("My API Product").version("1.0.0").build();
+
+        // When / Then
+        assertThatCode(() -> cut.validate(apiProduct)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_exception_when_name_is_empty() {
+        // Given
+        var apiProduct = ApiProduct.builder().version("1.0.0").build();
+
+        // When / Then
+        assertThatThrownBy(() -> cut.validate(apiProduct))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("API Product name is required");
+    }
+
+    @Test
+    void should_throw_exception_when_version_is_empty() {
+        // Given
+        var apiProduct = ApiProduct.builder().name("My API Product").build();
+
+        // When / Then
+        assertThatThrownBy(() -> cut.validate(apiProduct))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("API Product version is required");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
@@ -46,6 +47,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     private final ApiProductCrudServiceInMemory apiProductCrudService = new ApiProductCrudServiceInMemory();
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
     private final ValidateApiProductService validateApiProductService = new ValidateApiProductService();
     private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.WorkflowState;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class GraviteeDefinitionAdapterTest {
+
+    private final GraviteeDefinitionAdapter cut = GraviteeDefinitionAdapter.INSTANCE;
+
+    @Test
+    void should_map_allowInApiProduct_true_for_v4_proxy_api() {
+        // Given
+        io.gravitee.definition.model.v4.Api v4Def = io.gravitee.definition.model.v4.Api.builder()
+            .type(ApiType.PROXY)
+            .allowInApiProduct(true)
+            .build();
+
+        Api apiEntity = Api.builder()
+            .id("api-id")
+            .name("My API")
+            .version("1.0.0")
+            .type(ApiType.PROXY)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionHttpV4(v4Def)
+            .build();
+
+        PrimaryOwnerEntity primaryOwner = PrimaryOwnerEntity.builder()
+            .id("user-id")
+            .displayName("User")
+            .email("user@gravitee.io")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+
+        // When
+        ApiDescriptor.ApiDescriptorV4 result = cut.mapV4(
+            apiEntity,
+            primaryOwner,
+            WorkflowState.REVIEW_OK,
+            Set.of("group1"),
+            Collections.emptyList(),
+            null,
+            false
+        );
+
+        // Then
+        assertThat(result.allowInApiProduct()).isTrue();
+    }
+
+    @Test
+    void should_not_set_allowInApiProduct_when_not_proxy_or_definition_missing() {
+        // Given: MESSAGE API without http v4 definition
+        Api apiEntity = Api.builder()
+            .id("api-id")
+            .name("My API")
+            .version("1.0.0")
+            .type(ApiType.MESSAGE)
+            .definitionVersion(DefinitionVersion.V4)
+            .build();
+
+        PrimaryOwnerEntity primaryOwner = PrimaryOwnerEntity.builder()
+            .id("user-id")
+            .displayName("User")
+            .email("user@gravitee.io")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+
+        // When
+        ApiDescriptor.ApiDescriptorV4 result = cut.mapV4(
+            apiEntity,
+            primaryOwner,
+            WorkflowState.REVIEW_OK,
+            Set.of("group1"),
+            Collections.emptyList(),
+            null,
+            false
+        );
+
+        // Then
+        assertThat(result.allowInApiProduct()).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -55,6 +55,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.domain_service.AllowInApiProductDomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.http.HttpMethod;
@@ -305,6 +307,12 @@ public class ApiServiceImplTest {
     @InjectMocks
     private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
 
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private AllowInApiProductDomainService allowInApiProductDomainService;
+
     private ApiService apiService;
     private UpdateApiEntity updateApiEntity;
     private Api api;
@@ -368,7 +376,9 @@ public class ApiServiceImplTest {
             tagsValidationService,
             apiAuthorizationService,
             groupService,
-            apiCategoryService
+            apiCategoryService,
+            apiProductQueryService,
+            allowInApiProductDomainService
         );
         var apiSearchService = new ApiSearchServiceImpl(
             apiRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.domain_service.AllowInApiProductDomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -209,6 +211,12 @@ public class ApiServiceImpl_findAllTest {
     @Mock
     private CategoryMapper categoryMapper;
 
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private AllowInApiProductDomainService allowInApiProductDomainService;
+
     private ApiService apiService;
 
     @AfterClass
@@ -278,7 +286,9 @@ public class ApiServiceImpl_findAllTest {
             tagsValidationService,
             apiAuthorizationService,
             groupService,
-            apiCategoryService
+            apiCategoryService,
+            apiProductQueryService,
+            allowInApiProductDomainService
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12363

## Description

Toggle “Allow API Products” added to V4 HTTP Proxy APIs

Default:

1. OFF for existing APIs
2. ON for new APIs

**Key Items:**
- APIs with toggle OFF cannot be added to products
- Toggle disabled if API already belongs to a product
- API Product search only returns APIs with toggle ON

- Add `allowInApiProduct` field to ApiEntity and V4 definition
- Index new field in Elasticsearch and expose it in API Search criteria
- Add validation to prevent disabling flag if API is used in a Product
- Update Management API import logic to respect product associations
- Add UI toggle in General Info section for V4 Proxy APIs

## Additional context


