### PR TITLE
feat(console): add API Product creation flow in Console UI

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -141,6 +141,12 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
         category: 'Apis',
       },
       {
+        icon: 'gio:folder',
+        routerLink: './api-products',
+        displayName: 'API Products',
+        category: 'API Products',
+      },
+      {
         icon: 'gio:box',
         routerLink: './integrations',
         displayName: 'Integrations',

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrimaryOwner } from '../api';
+
+export interface ApiProduct {
+  /**
+   * API Product's unique identifier.
+   */
+  id: string;
+  /**
+   * The environment's uuid.
+   */
+  environmentId?: string;
+  /**
+   * API Product's name.
+   */
+  name: string;
+  /**
+   * API Product's version.
+   */
+  version: string;
+  /**
+   * API Product's description.
+   */
+  description?: string;
+  /**
+   * List of API IDs included in the product.
+   */
+  apiIds?: string[];
+  /**
+   * The date (as timestamp) when the API Product was created.
+   */
+  createdAt?: Date;
+  /**
+   * The last date (as timestamp) when the API Product was updated.
+   */
+  updatedAt?: Date;
+  /**
+   * The primary owner of the API Product.
+   */
+  primaryOwner?: PrimaryOwner;
+  _links?: { [key: string]: string };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductsResponse.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProduct } from './apiProduct';
+
+import { Links } from '../links';
+import { Pagination } from '../pagination';
+
+export interface ApiProductsResponse {
+  /**
+   * List of API Products.
+   */
+  data?: ApiProduct[];
+  pagination?: Pagination;
+  links?: Links;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/createApiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/createApiProduct.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface CreateApiProduct {
+  /**
+   * API Product's name. Must be unique within the environment.
+   */
+  name: string;
+  /**
+   * API Product's version.
+   */
+  version: string;
+  /**
+   * API Product's description.
+   */
+  description?: string;
+  /**
+   * List of API IDs included in the product.
+   */
+  apiIds?: string[];
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './apiProduct';
+export * from './createApiProduct';
+export * from './updateApiProduct';
+export * from './apiProductsResponse';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface UpdateApiProduct {
+  /**
+   * API Product's name. Must be unique within the environment.
+   */
+  name: string;
+  /**
+   * API Product's version.
+   */
+  version: string;
+  /**
+   * API Product's description.
+   */
+  description?: string;
+  /**
+   * List of API IDs included in the product.
+   */
+  apiIds?: string[];
+}

--- a/gravitee-apim-console-webui/src/management/api-products/api-product.utils.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-product.utils.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActivatedRoute } from '@angular/router';
+
+/**
+ * Resolves the apiProductId from the current route or any parent route.
+ * Useful when the component is rendered in a child route that does not have the param.
+ */
+export function getApiProductId(route: ActivatedRoute): string | null {
+  if (route.snapshot.params['apiProductId']) {
+    return route.snapshot.params['apiProductId'];
+  }
+  if (route.parent) {
+    return getApiProductId(route.parent);
+  }
+  return null;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/api-products-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products-routing.module.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ApiProductListComponent } from './list/api-product-list.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: ApiProductListComponent,
+    data: {
+      docs: {
+        page: 'management-api-products',
+      },
+    },
+  },
+  {
+    path: 'new',
+    loadChildren: () => import('./create/api-product-create.module').then((m) => m.ApiProductCreateModule),
+    data: {
+      permissions: {
+        anyOf: ['environment-api-c'],
+      },
+    },
+  },
+  {
+    path: ':apiProductId',
+    loadChildren: () => import('./detail/api-product-detail.module').then((m) => m.ApiProductDetailModule),
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ApiProductsRoutingModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.module.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ApiProductsRoutingModule } from './api-products-routing.module';
+import { ApiProductListModule } from './list/api-product-list.module';
+
+@NgModule({
+  imports: [CommonModule, ApiProductsRoutingModule, ApiProductListModule],
+})
+export class ApiProductsModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis-routing.module.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ApiProductApisComponent } from './api-product-apis.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ApiProductApisComponent,
+    data: {
+      docs: {
+        page: 'management-api-products-apis',
+      },
+    },
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ApiProductApisRoutingModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -1,0 +1,144 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+<div class="api-product-apis">
+  <div class="api-product-apis__header">
+    <div>
+      <h1>APIs</h1>
+      <p class="subtitle">Manage APIs grouped together in your API Product.</p>
+    </div>
+    <button
+      (click)="onAddApi()"
+      mat-raised-button
+      color="primary"
+      class="add-api-button"
+      aria-label="add-api"
+      data-testid="api_product_apis_add_api_button"
+      *gioPermission="{ anyOf: ['environment-api_products-c'] }"
+    >
+      Add API
+    </button>
+  </div>
+
+  <!-- Table View -->
+  <gio-table-wrapper
+    [searchLabel]="searchLabel"
+    [length]="apisTableDSUnpaginatedLength"
+    [filters]="filters"
+    (filtersChange)="onFiltersChanged($event)"
+    [paginationPageSizeOptions]="[10, 25, 50, 100]"
+  >
+    <table mat-table matSort [dataSource]="apisTableDS" id="apiProductApisTable" aria-label="APIs table">
+      <!-- Picture Column -->
+      <ng-container matColumnDef="picture">
+        <th mat-header-cell *matHeaderCellDef id="picture"></th>
+        <td mat-cell *matCellDef="let element">
+          <gio-avatar
+            class="api-product-apis__avatar"
+            [name]="element.name + ' ' + element.version"
+            [size]="32"
+            [roundedBorder]="true"
+          ></gio-avatar>
+        </td>
+      </ng-container>
+
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
+        <td mat-cell *matCellDef="let element" title="{{ element.name }}">
+          {{ element.name }}
+        </td>
+      </ng-container>
+
+      <!-- Context Path Column -->
+      <ng-container matColumnDef="contextPath">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="contextPath">Context Path</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.contextPath }}
+        </td>
+      </ng-container>
+
+      <!-- Definition Column -->
+      <ng-container matColumnDef="definition">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="definition">Definition</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.definition }}
+        </td>
+      </ng-container>
+
+      <!-- Version Column -->
+      <ng-container matColumnDef="version">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="version">Version</th>
+        <td mat-cell *matCellDef="let element">
+          <span class="version__badge gio-badge-neutral">v{{ element.version }}</span>
+          <span *ngIf="element.lifecycleState === 'DEPRECATED'" class="deprecated__badge gio-badge-warning">Deprecated</span>
+        </td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="actions__delete">
+            <button
+              (click)="onDeleteApi(element)"
+              mat-icon-button
+              aria-label="Button to remove API from API Product"
+              matTooltip="Remove API from API Product"
+              data-testid="api_product_apis_delete_button"
+              *gioPermission="{ anyOf: ['environment-api_products-u'] }"
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns" data-testid="api_product_apis_table_header"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="api_product_apis_table_row"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td
+          *ngIf="!isLoadingData && apisTableDS.length === 0"
+          class="mat-mdc-cell mdc-data-table__cell"
+          [attr.colspan]="displayedColumns.length"
+        >
+          There are no APIs in this API Product (yet).
+        </td>
+        <td *ngIf="isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
@@ -1,0 +1,131 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-product-apis {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 32px;
+
+    h1 {
+      margin: 0;
+      font-size: 32px;
+      font-weight: 600;
+    }
+
+    .subtitle {
+      margin-top: 8px;
+      margin-bottom: 0;
+      color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+      font-size: 14px;
+    }
+  }
+
+  .add-api-button {
+    flex-shrink: 0;
+  }
+
+  &__content-card {
+    flex: 1;
+    min-height: 400px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  &__avatar {
+    height: 32px;
+    width: 32px;
+  }
+}
+
+.api-product-apis-empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  padding: 48px 24px;
+}
+
+.empty-state-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  max-width: 500px;
+
+  h3 {
+    margin: 24px 0 8px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #424242;
+  }
+
+  p {
+    margin: 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    font-size: 14px;
+  }
+}
+
+.empty-state-icon {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: #fff3e0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  border: 1px solid #ffb74d;
+
+  &__svg {
+    width: 40px;
+    height: 40px;
+    color: #e64a19;
+  }
+}
+
+// Table styles
+.mat-column-picture,
+.mat-column-version,
+.mat-column-actions {
+  padding: 0 8px;
+}
+
+.mat-column-name,
+.mat-column-contextPath,
+.mat-column-definition {
+  padding: 0 8px;
+  width: auto;
+}
+
+.mat-column-version {
+  .version__badge {
+    cursor: default;
+    margin-right: 8px;
+  }
+
+  .deprecated__badge {
+    cursor: default;
+  }
+}
+
+.actions__delete {
+  display: flex;
+  justify-content: center;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+
+import { ApiProductApisComponent } from './api-product-apis.component';
+import { ApiProductApisModule } from './api-product-apis.module';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Api, fakeApiV2, fakeApiV4 } from '../../../entities/management-api-v2';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+
+describe('ApiProductApisComponent', () => {
+  let fixture: ComponentFixture<ApiProductApisComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let _router: Router;
+  let matDialog: MatDialog;
+  const API_PRODUCT_ID = 'api-product-id';
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductApisModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-api_products-c', 'environment-api_products-u'] },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { apiProductId: API_PRODUCT_ID }, queryParams: {} },
+            parent: {
+              snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductApisComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    _router = TestBed.inject(Router);
+    matDialog = TestBed.inject(MatDialog);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should display empty state when no APIs', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    await initComponent(apiProduct, []);
+
+    expect(fixture.nativeElement.textContent).toContain('There are no APIs in this API Product (yet).');
+  }));
+
+  it('should display APIs in table', fakeAsync(async () => {
+    const api1 = fakeApiV2({ id: 'api-1', name: 'API 1', apiVersion: '1.0', contextPath: '/api1' });
+    const api2 = fakeApiV2({ id: 'api-2', name: 'API 2', apiVersion: '2.0', contextPath: '/api2' });
+
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: ['api-1', 'api-2'],
+    };
+
+    await initComponent(apiProduct, [api1, api2]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductApisTable' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(2);
+
+    const row1Cells = await rows[0].getCellTextByIndex();
+    expect(row1Cells[1]).toContain('API 1');
+    expect(row1Cells[2]).toContain('/api1');
+    expect(row1Cells[3]).toContain('HTTP Proxy Gravitee');
+    expect(row1Cells[4]).toContain('1.0');
+  }));
+
+  it('should handle error when loading API product', fakeAsync(() => {
+    fixture.detectChanges();
+    tick(200);
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    tick();
+    fixture.detectChanges();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  }));
+
+  it('should handle error when loading individual APIs', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: ['api-1', 'api-2'],
+    };
+
+    fixture.detectChanges();
+    tick(200);
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush(apiProduct);
+    tick();
+
+    const api1Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`);
+    api1Req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+
+    const api2Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`);
+    api2Req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+
+    tick();
+    fixture.detectChanges();
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductApisTable' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(0);
+  }));
+
+  it('should do nothing when Add API button is clicked (placeholder for future work)', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    await initComponent(apiProduct, []);
+
+    const dialogOpenSpy = jest.spyOn(matDialog, 'open');
+
+    const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_apis_add_api_button"]' }));
+    await addButton.click();
+    tick();
+
+    // No dialog should open; Add API is a placeholder for future work
+    expect(dialogOpenSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should delete API from product', fakeAsync(async () => {
+    const api = fakeApiV2({ id: 'api-1', name: 'API 1' });
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: ['api-1'],
+    };
+
+    await initComponent(apiProduct, [api]);
+
+    const dialogRef = {
+      afterClosed: () => of(true),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_apis_delete_button"]' }));
+    await deleteButton.click();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis/api-1`);
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(null);
+    tick();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('API "API 1" has been removed from the API Product');
+  }));
+
+  it('should display V4 API correctly', fakeAsync(async () => {
+    const api = fakeApiV4({ id: 'api-1', name: 'V4 API', apiVersion: '1.0' });
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: ['api-1'],
+    };
+
+    await initComponent(apiProduct, [api]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductApisTable' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(1);
+
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[1]).toContain('V4 API');
+  }));
+
+  async function initComponent(apiProduct: ApiProduct, apis: Api[]) {
+    fixture.detectChanges();
+    tick(200);
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush(apiProduct);
+    tick();
+
+    if (apiProduct.apiIds && apiProduct.apiIds.length > 0) {
+      apiProduct.apiIds.forEach((apiId) => {
+        const api = apis.find((a) => a.id === apiId);
+        if (api) {
+          const apiReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}`);
+          apiReq.flush(api);
+        }
+      });
+    }
+
+    tick();
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, Subject, forkJoin, of, EMPTY } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { isEqual } from 'lodash';
+import { MatDialog } from '@angular/material/dialog';
+import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { getApiProductId } from '../api-product.utils';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { Api, ApiV2, ApiV4, Listener, ListenerType } from '../../../entities/management-api-v2';
+import { Constants } from '../../../entities/Constants';
+
+export type ApiProductApiTableDS = {
+  id: string;
+  name: string;
+  contextPath: string;
+  definition: string;
+  version: string;
+  lifecycleState?: string;
+}[];
+
+interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {
+  // Add any additional filters here if needed
+}
+
+@Component({
+  selector: 'api-product-apis',
+  templateUrl: './api-product-apis.component.html',
+  styleUrls: ['./api-product-apis.component.scss'],
+  standalone: false,
+})
+export class ApiProductApisComponent implements OnInit, OnDestroy {
+  displayedColumns = ['picture', 'name', 'contextPath', 'definition', 'version', 'actions'];
+  apisTableDS: ApiProductApiTableDS = [];
+  apisTableDSUnpaginatedLength = 0;
+  filters: ApiProductApisTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+  searchLabel = 'Search';
+  isLoadingData = true;
+  apiProductId: string;
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  private filters$ = new BehaviorSubject<ApiProductApisTableWrapperFilters>(this.filters);
+
+  constructor(
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly router: Router,
+    @Inject(Constants) private readonly constants: Constants,
+    private readonly apiProductV2Service: ApiProductV2Service,
+    private readonly apiV2Service: ApiV2Service,
+    private readonly snackBarService: SnackBarService,
+    private readonly matDialog: MatDialog,
+  ) {}
+
+  ngOnInit(): void {
+    this.apiProductId = getApiProductId(this.activatedRoute) || '';
+    this.initFilters();
+
+    this.filters$
+      .pipe(
+        debounceTime(100),
+        distinctUntilChanged(isEqual),
+        tap((filters: ApiProductApisTableWrapperFilters) => {
+          // Update URL params
+          this.router.navigate([], {
+            relativeTo: this.activatedRoute,
+            queryParams: {
+              q: filters.searchTerm,
+              page: filters.pagination.index,
+              size: filters.pagination.size,
+            },
+            queryParamsHandling: 'merge',
+          });
+        }),
+        switchMap((_filters: ApiProductApisTableWrapperFilters) => {
+          // Call GET /api-products/{apiProductId} to reload the table
+          this.isLoadingData = true;
+          return this.apiProductV2Service.get(this.apiProductId).pipe(
+            catchError((error) => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+              return of(null);
+            }),
+          );
+        }),
+        switchMap((apiProduct) => {
+          if (!apiProduct || !apiProduct.apiIds || apiProduct.apiIds.length === 0) {
+            this.apisTableDS = [];
+            this.apisTableDSUnpaginatedLength = 0;
+            this.isLoadingData = false;
+            return of([]);
+          }
+
+          // Fetch all APIs for the API Product
+          const apiObservables = apiProduct.apiIds.map((apiId) => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
+
+          return forkJoin(apiObservables).pipe(
+            catchError((error) => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading APIs');
+              return of([]);
+            }),
+          );
+        }),
+        tap((apis: (Api | null)[]) => {
+          // Filter out null values and apply search filter
+          let filteredApis = apis.filter((api): api is Api => api !== null);
+          const searchTerm = this.filters.searchTerm?.toLowerCase() || '';
+
+          if (searchTerm) {
+            filteredApis = filteredApis.filter(
+              (api) =>
+                api.name?.toLowerCase().includes(searchTerm) ||
+                this.getContextPath(api)?.toLowerCase().includes(searchTerm) ||
+                api.apiVersion?.toLowerCase().includes(searchTerm),
+            );
+          }
+
+          // Apply pagination
+          const page = this.filters.pagination?.index || 1;
+          const perPage = this.filters.pagination?.size || 10;
+          const startIndex = (page - 1) * perPage;
+          const endIndex = startIndex + perPage;
+          const paginatedApis = filteredApis.slice(startIndex, endIndex);
+
+          this.apisTableDS = this.toApisTableDS(paginatedApis);
+          this.apisTableDSUnpaginatedLength = filteredApis.length;
+          this.isLoadingData = false;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.complete();
+  }
+
+  private initFilters(): void {
+    const initialSearchValue = this.activatedRoute.snapshot.queryParams.q ?? this.filters.searchTerm;
+    const initialPageNumber = this.activatedRoute.snapshot.queryParams.page
+      ? Number(this.activatedRoute.snapshot.queryParams.page)
+      : this.filters.pagination.index;
+    const initialPageSize = this.activatedRoute.snapshot.queryParams.size
+      ? Number(this.activatedRoute.snapshot.queryParams.size)
+      : this.filters.pagination.size;
+
+    this.filters = {
+      searchTerm: initialSearchValue,
+      pagination: {
+        index: initialPageNumber,
+        size: initialPageSize,
+      },
+    };
+    this.filters$.next(this.filters);
+  }
+
+  private toApisTableDS(data: Api[]): ApiProductApiTableDS {
+    return data.map((api) => ({
+      id: api.id,
+      name: api.name,
+      contextPath: this.getContextPath(api) || '-',
+      definition: this.getApiDefinition(api),
+      version: api.apiVersion || '-',
+      lifecycleState: api.lifecycleState,
+    }));
+  }
+
+  private getContextPath(api: Api): string | undefined {
+    if (api.definitionVersion === 'V2') {
+      return (api as ApiV2).contextPath;
+    } else if (api.definitionVersion === 'V4') {
+      const apiV4 = api as ApiV4;
+      // For V4 APIs, get context path from HTTP listeners
+      const httpListener = apiV4.listeners?.find((listener) => listener.type === 'HTTP');
+      if (httpListener && 'paths' in httpListener) {
+        const paths = (httpListener as any).paths;
+        if (paths && paths.length > 0) {
+          return paths[0];
+        }
+      }
+      return undefined;
+    }
+    return undefined;
+  }
+
+  private getApiDefinition(api: Api): string {
+    if (!api.definitionVersion) {
+      return 'HTTP Proxy Gravitee';
+    }
+
+    switch (api.definitionVersion) {
+      case 'V2':
+        return 'HTTP Proxy Gravitee';
+      case 'V4':
+        return this.getLabelType(api as ApiV4);
+      case 'FEDERATED':
+        return 'Federated API';
+      case 'FEDERATED_AGENT':
+        return 'Federated A2A Agent';
+      default:
+        return 'HTTP Proxy Gravitee';
+    }
+  }
+
+  private getLabelType(api: ApiV4): string {
+    if (api.type === 'MESSAGE') {
+      return 'Message';
+    }
+    if (api.type === 'NATIVE') {
+      return api.listeners?.map((listener: Listener): ListenerType => listener.type).includes('KAFKA') ? 'Kafka Native' : 'Native';
+    }
+    if (api.type === 'MCP_PROXY') {
+      return 'MCP Proxy';
+    }
+    if (api.type === 'LLM_PROXY') {
+      return 'LLM Proxy';
+    }
+
+    return api.listeners?.map((listener: Listener): ListenerType => listener.type).includes('TCP') ? 'TCP Proxy' : 'HTTP Proxy Gravitee';
+  }
+
+  onFiltersChanged(filters: ApiProductApisTableWrapperFilters): void {
+    this.filters = { ...this.filters, ...filters };
+    this.filters$.next(this.filters);
+  }
+
+  /**
+   * Reload the table by calling GET /api-products/{apiProductId}
+   * This method directly triggers the GET request to refresh the API list
+   */
+  private reloadTable(): void {
+    // Directly call GET /api-products/{apiProductId} to reload the table
+    // This bypasses distinctUntilChanged to ensure the GET call is always made
+    this.isLoadingData = true;
+    this.apiProductV2Service
+      .get(this.apiProductId)
+      .pipe(
+        catchError((error) => {
+          this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+          this.isLoadingData = false;
+          return of(null);
+        }),
+        switchMap((apiProduct) => {
+          if (!apiProduct || !apiProduct.apiIds || apiProduct.apiIds.length === 0) {
+            this.apisTableDS = [];
+            this.apisTableDSUnpaginatedLength = 0;
+            this.isLoadingData = false;
+            return of([]);
+          }
+
+          // Fetch all APIs for the API Product
+          const apiObservables = apiProduct.apiIds.map((apiId) => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
+
+          return forkJoin(apiObservables).pipe(
+            catchError((error) => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading APIs');
+              return of([]);
+            }),
+          );
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe((apis: (Api | null)[]) => {
+        // Filter out null values and apply search filter
+        let filteredApis = apis.filter((api): api is Api => api !== null);
+        const searchTerm = this.filters.searchTerm?.toLowerCase() || '';
+
+        if (searchTerm) {
+          filteredApis = filteredApis.filter(
+            (api) =>
+              api.name?.toLowerCase().includes(searchTerm) ||
+              this.getContextPath(api)?.toLowerCase().includes(searchTerm) ||
+              api.apiVersion?.toLowerCase().includes(searchTerm),
+          );
+        }
+
+        // Apply pagination
+        const page = this.filters.pagination?.index || 1;
+        const perPage = this.filters.pagination?.size || 10;
+        const startIndex = (page - 1) * perPage;
+        const endIndex = startIndex + perPage;
+        const paginatedApis = filteredApis.slice(startIndex, endIndex);
+
+        this.apisTableDS = this.toApisTableDS(paginatedApis);
+        this.apisTableDSUnpaginatedLength = filteredApis.length;
+        this.isLoadingData = false;
+      });
+  }
+
+  /**
+   * Add API to this API Product.
+   * Placeholder for future work: no-op for current scope. Button remains visible for UX.
+   */
+  onAddApi(): void {
+    // Functionality to be implemented in a future iteration.
+  }
+
+  onDeleteApi(api: ApiProductApiTableDS[0]): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Remove API',
+          content: 'Please note that once your API is removed from this API Product, consumers will lose access to this API.',
+          confirmButton: 'Remove',
+        },
+        role: 'alertdialog',
+        id: 'removeApiDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((result) => {
+          if (!result) return EMPTY;
+          return this.apiProductV2Service.deleteApiFromApiProduct(this.apiProductId, api.id).pipe(
+            catchError((error) => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while removing the API');
+              return of(null);
+            }),
+            tap(() => {
+              this.snackBarService.success(`API "${api.name}" has been removed from the API Product`);
+              this.filters$.next(this.filters);
+            }),
+          );
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  get hasApis(): boolean {
+    return this.apisTableDS.length > 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.module.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialogModule } from '@angular/material/dialog';
+import { GioIconsModule, GioAvatarModule, GioConfirmDialogModule } from '@gravitee/ui-particles-angular';
+import { RouterModule } from '@angular/router';
+
+import { ApiProductApisComponent } from './api-product-apis.component';
+import { ApiProductApisRoutingModule } from './api-product-apis-routing.module';
+
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+
+@NgModule({
+  declarations: [ApiProductApisComponent],
+  exports: [ApiProductApisComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatTableModule,
+    MatSortModule,
+    MatTooltipModule,
+    MatDialogModule,
+    GioIconsModule,
+    GioAvatarModule,
+    GioConfirmDialogModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    RouterModule,
+    ApiProductApisRoutingModule,
+  ],
+})
+export class ApiProductApisModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration-routing.module.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ApiProductConfigurationComponent } from './api-product-configuration.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ApiProductConfigurationComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ApiProductConfigurationRoutingModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -1,0 +1,76 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+<form *ngIf="form" [formGroup]="form" autocomplete="off" gioFormFocusInvalid>
+  <div class="configuration-section">
+    <h1 class="configuration-section__title">Configuration</h1>
+    <p class="configuration-section__subtitle">Manage general settings and user permissions.</p>
+
+    <mat-card class="configuration-card">
+      <mat-card-content>
+        <div class="configuration-card__fields">
+          <mat-form-field class="configuration-card__fields__name">
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" required />
+            <mat-error *ngIf="form.controls.name.hasError('required')">Name is required.</mat-error>
+            <mat-error *ngIf="form.controls.name.hasError('unique')">API Product name must be unique</mat-error>
+          </mat-form-field>
+
+          <mat-form-field class="configuration-card__fields__version">
+            <mat-label>Version</mat-label>
+            <input matInput formControlName="version" required />
+            <mat-error *ngIf="form.controls.version.hasError('required')">Version is required.</mat-error>
+          </mat-form-field>
+
+          <mat-form-field class="configuration-card__fields__description">
+            <mat-label>Description</mat-label>
+            <textarea matInput formControlName="description" [maxlength]="descriptionMaxLength"></textarea>
+            <!--Check if we really need to show the number of characters allowed-->
+            <!-- <mat-hint align="end">{{ getDescriptionLength() }}/{{ descriptionMaxLength }}</mat-hint> -->
+          </mat-form-field>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <api-product-danger-zone [apiProduct]="apiProduct" (reloadDetails)="ngOnInit()"></api-product-danger-zone>
+
+    <gio-save-bar
+      [form]="form"
+      data-testid="api_product_configuration_savebar"
+      [formInitialValues]="initialFormValue"
+      (resetClicked)="onReset()"
+      (submitted)="onSubmit()"
+    />
+  </div>
+</form>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.configuration-section {
+  &__title {
+    font-size: 24px;
+    font-weight: 500;
+    margin: 0 0 8px 0;
+  }
+
+  &__subtitle {
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+    margin: 0 0 24px 0;
+  }
+}
+
+.configuration-card {
+  margin-bottom: 24px;
+
+  &__fields {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    &__name,
+    &__version {
+      width: 100%;
+    }
+
+    &__description {
+      width: 100%;
+
+      textarea {
+        min-height: 100px;
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+
+import { ApiProductConfigurationComponent } from './api-product-configuration.component';
+import { ApiProductConfigurationModule } from './api-product-configuration.module';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductConfigurationComponent', () => {
+  let fixture: ComponentFixture<ApiProductConfigurationComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  const API_PRODUCT_ID = 'api-product-id';
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductConfigurationModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: {
+              snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductConfigurationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      description: '',
+      apiIds: [],
+    });
+    tick();
+
+    expect(fixture.componentInstance).toBeTruthy();
+  }));
+
+  it('should load API product and initialize form', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: ['api-1'],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.apiProduct).toEqual(apiProduct);
+    expect(fixture.componentInstance.form.get('name')?.value).toBe('Test Product');
+    expect(fixture.componentInstance.form.get('version')?.value).toBe('1.0');
+    expect(fixture.componentInstance.form.get('description')?.value).toBe('Test description');
+  }));
+
+  it('should update API product successfully', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: ['api-1'],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const getReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    getReq.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Updated Product');
+    await nameInput.blur();
+    tick(300);
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    tick();
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(updateReq.request.body).toEqual({
+      name: 'Updated Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: ['api-1'],
+    });
+
+    const updatedProduct: ApiProduct = {
+      ...apiProduct,
+      name: 'Updated Product',
+    };
+    updateReq.flush(updatedProduct);
+    tick();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
+  }));
+
+  it('should handle error when loading API product', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    tick();
+    fixture.detectChanges();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+    expect(fixture.componentInstance.form).toBeTruthy();
+  }));
+
+  it('should handle error when updating API product', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const getReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    getReq.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    updateReq.flush({ message: 'Update failed' }, { status: 400, statusText: 'Bad Request' });
+    tick();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  }));
+
+  it('should reset form to initial values', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: [],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const getReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    getReq.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Modified Product');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onReset();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('name')?.value).toBe('Test Product');
+    expect(fixture.componentInstance.form.pristine).toBe(true);
+  }));
+
+  it('should validate name uniqueness excluding current product', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const getReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    getReq.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Test Product');
+    await nameInput.blur();
+    tick(300);
+
+    // Should not call verify if name hasn't changed
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+  }));
+});

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { AsyncValidatorFn, FormControl, UntypedFormBuilder, UntypedFormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { EMPTY, Observable, of, Subject, timer } from 'rxjs';
+import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+
+import { Constants } from '../../../entities/Constants';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { getApiProductId } from '../api-product.utils';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { ApiProduct, UpdateApiProduct } from '../../../entities/management-api-v2/api-product';
+
+@Component({
+  selector: 'api-product-configuration',
+  templateUrl: './api-product-configuration.component.html',
+  styleUrls: ['./api-product-configuration.component.scss'],
+  standalone: false,
+})
+export class ApiProductConfigurationComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+
+  public form: UntypedFormGroup;
+  public initialFormValue: unknown;
+  public descriptionMaxLength = 250;
+  public apiProductId: string;
+  public apiProduct: ApiProduct | null = null;
+  public isLoading = false;
+
+  constructor(
+    @Inject(Constants) private readonly constants: Constants,
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly formBuilder: UntypedFormBuilder,
+    private readonly apiProductV2Service: ApiProductV2Service,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnInit(): void {
+    this.apiProductId = getApiProductId(this.activatedRoute) || '';
+
+    if (this.apiProductId) {
+      this.isLoading = true;
+      this.apiProductV2Service
+        .get(this.apiProductId)
+        .pipe(
+          tap((apiProduct) => {
+            this.apiProduct = apiProduct;
+            this.isLoading = false;
+            this.initializeForm();
+          }),
+          catchError((error) => {
+            this.isLoading = false;
+            this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+            // Initialize form with empty values on error
+            this.initializeForm();
+            return of(null);
+          }),
+          takeUntil(this.unsubscribe$),
+        )
+        .subscribe();
+    } else {
+      // Initialize form with empty values if no API Product ID
+      this.initializeForm();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  onSubmit(): void {
+    if (this.form.valid && this.apiProductId) {
+      const formValue = this.form.getRawValue();
+      const updateApiProduct: UpdateApiProduct = {
+        name: formValue.name,
+        version: formValue.version,
+        description: formValue.description || undefined,
+        // Preserve existing apiIds if they exist
+        apiIds: this.apiProduct?.apiIds,
+      };
+
+      this.apiProductV2Service
+        .update(this.apiProductId, updateApiProduct)
+        .pipe(
+          tap((updatedApiProduct) => {
+            this.apiProduct = updatedApiProduct;
+            this.initialFormValue = this.form.getRawValue();
+            this.snackBarService.success('Configuration successfully saved!');
+          }),
+          catchError((error) => {
+            this.snackBarService.error(error.error?.message || error.message || 'An error occurred while updating the API Product');
+            return EMPTY;
+          }),
+          takeUntil(this.unsubscribe$),
+        )
+        .subscribe();
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+
+  onReset(): void {
+    this.form.reset(this.initialFormValue);
+    this.form.markAsPristine();
+    this.form.markAsUntouched();
+  }
+
+  getDescriptionLength(): number {
+    return this.form.get('description')?.value?.length || 0;
+  }
+
+  private initializeForm(): void {
+    this.form = this.formBuilder.group({
+      name: this.formBuilder.control(this.apiProduct?.name || '', {
+        validators: [Validators.required],
+        asyncValidators: [this.nameUniquenessValidator()],
+        updateOn: 'blur', // Only validate on blur, not on every keystroke
+      }),
+      version: this.formBuilder.control(this.apiProduct?.version || '', [Validators.required]),
+      description: this.formBuilder.control(this.apiProduct?.description || '', [Validators.maxLength(this.descriptionMaxLength)]),
+    });
+    this.initialFormValue = this.form.getRawValue();
+  }
+
+  private nameUniquenessValidator(): AsyncValidatorFn {
+    return (formControl: FormControl): Observable<ValidationErrors | null> => {
+      if (!formControl || !formControl.value || formControl.value.trim() === '') {
+        return of(null);
+      }
+      const trimmedName = formControl.value.trim();
+      // Skip validation if the name hasn't changed from the original
+      if (this.apiProduct && trimmedName === this.apiProduct.name) {
+        return of(null);
+      }
+      // Debounce API call to avoid too many requests
+      return timer(250).pipe(
+        switchMap(() => this.apiProductV2Service.verify(trimmedName)),
+        map((res) => (res.ok ? null : { unique: true })),
+      );
+    };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.module.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { GioFormFocusInvalidModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { ApiProductConfigurationComponent } from './api-product-configuration.component';
+import { ApiProductConfigurationRoutingModule } from './api-product-configuration-routing.module';
+import { ApiProductDangerZoneComponent } from './danger-zone/api-product-danger-zone.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    GioFormFocusInvalidModule,
+    GioSaveBarModule,
+    ApiProductConfigurationRoutingModule,
+  ],
+  declarations: [ApiProductConfigurationComponent, ApiProductDangerZoneComponent],
+  exports: [ApiProductConfigurationComponent],
+})
+export class ApiProductConfigurationModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -1,0 +1,52 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+<mat-card class="danger-card">
+  <mat-card-content>
+    <h3 class="danger-card__title">Danger Zone</h3>
+    <div class="danger-card__actions">
+      <div class="danger-card__actions__action">
+        <span>Remove all the APIs of this API Product.</span>
+        <button mat-button color="warn" [disabled]="isReadOnly" (click)="removeApis()">Remove APIs</button>
+      </div>
+
+      <div class="danger-card__actions__action">
+        <span>Delete this API Product. This won't delete APIs associated to it.</span>
+        <button mat-button color="warn" [disabled]="isReadOnly" data-testid="api_product_dangerzone_delete" (click)="deleteApiProduct()">
+          Delete API Product
+        </button>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
@@ -1,0 +1,28 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  display: block;
+}
+
+.danger-card {
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+
+  &__title {
+    color: mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+
+    &__action {
+      display: flex;
+      align-items: center;
+      flex-direction: row;
+      justify-content: space-between;
+      height: 48px;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+
+import { ApiProductDangerZoneComponent } from './api-product-danger-zone.component';
+
+import { ApiProductConfigurationModule } from '../api-product-configuration.module';
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+describe('ApiProductDangerZoneComponent', () => {
+  let fixture: ComponentFixture<ApiProductDangerZoneComponent>;
+  let loader: HarnessLoader;
+  let _rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
+  let matDialog: MatDialog;
+  const API_PRODUCT_ID = 'api-product-id';
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  const apiProduct: ApiProduct = {
+    id: API_PRODUCT_ID,
+    name: 'Test Product',
+    version: '1.0',
+    apiIds: ['api-1', 'api-2'],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductConfigurationModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: {
+              snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductDangerZoneComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    _rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    const router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
+    matDialog = TestBed.inject(MatDialog);
+    fixture.componentInstance.apiProduct = apiProduct;
+    jest.spyOn(fixture.componentInstance.reloadDetails, 'emit');
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should remove all APIs from API product', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(true),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const removeButton = await loader.getHarness(MatButtonHarness.with({ text: /Remove APIs/i }));
+    await removeButton.click();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(null);
+    tick();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('All APIs have been removed from the API Product.');
+    expect(fixture.componentInstance.reloadDetails.emit).toHaveBeenCalled();
+  }));
+
+  it('should not remove APIs if dialog is cancelled', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(false),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const removeButton = await loader.getHarness(MatButtonHarness.with({ text: /Remove APIs/i }));
+    await removeButton.click();
+    tick();
+
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
+  }));
+
+  it('should handle error when removing APIs', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(true),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const removeButton = await loader.getHarness(MatButtonHarness.with({ text: /Remove APIs/i }));
+    await removeButton.click();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
+    req.flush({ message: 'Error removing APIs' }, { status: 500, statusText: 'Internal Server Error' });
+    tick();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  }));
+
+  it('should delete API product', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(true),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    await deleteButton.click();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(null);
+    tick();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('The API Product has been deleted.');
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], expect.anything());
+  }));
+
+  it('should not delete API product if dialog is cancelled', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(false),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    await deleteButton.click();
+    tick();
+
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+  }));
+
+  it('should handle error when deleting API product', fakeAsync(async () => {
+    const dialogRef = {
+      afterClosed: () => of(true),
+    };
+    jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    await deleteButton.click();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Error deleting product' }, { status: 500, statusText: 'Internal Server Error' });
+    tick();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  }));
+});

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -43,7 +43,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
-import {ApiProduct} from "../../../../entities/management-api-v2/api-product";
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
 
 @Component({
   selector: 'api-product-danger-zone',
@@ -70,8 +70,7 @@ export class ApiProductDangerZoneComponent implements OnInit, OnDestroy {
     private readonly apiProductV2Service: ApiProductV2Service,
   ) {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  GioConfirmAndValidateDialogComponent,
+  GioConfirmAndValidateDialogData,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+} from '@gravitee/ui-particles-angular';
+import { EMPTY, Subject } from 'rxjs';
+import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
+
+@Component({
+  selector: 'api-product-danger-zone',
+  templateUrl: './api-product-danger-zone.component.html',
+  styleUrls: ['./api-product-danger-zone.component.scss'],
+  standalone: false,
+})
+export class ApiProductDangerZoneComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  @Input()
+  public apiProduct: any; // TODO: Replace with proper ApiProduct type
+
+  @Output()
+  public reloadDetails = new EventEmitter<void>();
+
+  public isReadOnly = false;
+
+  constructor(
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly matDialog: MatDialog,
+    private readonly snackBarService: SnackBarService,
+    private readonly apiProductV2Service: ApiProductV2Service,
+  ) {}
+
+  ngOnInit(): void {
+    // TODO: Check permissions for read-only
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  removeApis(): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Remove all APIs',
+          content: 'Are you sure you want to remove all the APIs from this API Product?',
+          confirmButton: 'Yes, remove them',
+          // warning: 'This operation is irreversible.',
+        },
+        role: 'alertdialog',
+        id: 'removeApisDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm) => confirm === true),
+        switchMap(() => this.apiProductV2Service.deleteAllApisFromApiProduct(this.apiProduct.id)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message || 'An error occurred while removing APIs.');
+          return EMPTY;
+        }),
+        map(() => this.snackBarService.success('All APIs have been removed from the API Product.')),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this.reloadDetails.emit();
+      });
+  }
+
+  deleteApiProduct(): void {
+    this.matDialog
+      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Delete API Product',
+          content: 'Are you sure you want to delete this API Product?',
+          confirmButton: 'Yes, delete it',
+          validationMessage: `Please, type in the name of the API Product <code>${this.apiProduct.name}</code> to confirm.`,
+          validationValue: this.apiProduct.name,
+          warning: 'This operation is irreversible.',
+        },
+        role: 'alertdialog',
+        id: 'deleteApiProductDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm) => confirm === true),
+        switchMap(() => this.apiProductV2Service.delete(this.apiProduct.id)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message || 'An error occurred while deleting the API Product.');
+          return EMPTY;
+        }),
+        map(() => this.snackBarService.success('The API Product has been deleted.')),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+      });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -43,6 +43,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
+import {ApiProduct} from "../../../../entities/management-api-v2/api-product";
 
 @Component({
   selector: 'api-product-danger-zone',
@@ -54,7 +55,7 @@ export class ApiProductDangerZoneComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
   @Input()
-  public apiProduct: any; // TODO: Replace with proper ApiProduct type
+  public apiProduct: ApiProduct;
 
   @Output()
   public reloadDetails = new EventEmitter<void>();
@@ -70,12 +71,11 @@ export class ApiProductDangerZoneComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // TODO: Check permissions for read-only
   }
 
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);
-    this.unsubscribe$.unsubscribe();
+    this.unsubscribe$.complete();
   }
 
   removeApis(): void {
@@ -86,7 +86,6 @@ export class ApiProductDangerZoneComponent implements OnInit, OnDestroy {
           title: 'Remove all APIs',
           content: 'Are you sure you want to remove all the APIs from this API Product?',
           confirmButton: 'Yes, remove them',
-          // warning: 'This operation is irreversible.',
         },
         role: 'alertdialog',
         id: 'removeApisDialog',

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create-routing.module.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ApiProductCreateComponent } from './api-product-create.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ApiProductCreateComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ApiProductCreateRoutingModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
@@ -1,0 +1,97 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+
+<div class="api-product-create">
+  <div class="api-product-create__header">
+    <a class="back-link" (click)="onBack()">
+      <mat-icon>arrow_back</mat-icon>
+      <span>Go back to API Products</span>
+    </a>
+  </div>
+
+  <mat-card class="api-product-create__form-card">
+    <mat-card-content>
+      <h1 class="api-product-create__title">Create API Product</h1>
+      <p class="api-product-create__instructions">Fill in the details and select the APIs to include in this product.</p>
+
+      <div class="form-section">
+        <h2 class="form-section__title">Product Details</h2>
+
+        <form [formGroup]="form">
+          <div class="form-row form-row--inline">
+            <mat-form-field appearance="outline" class="form-field--name">
+              <mat-label>Name </mat-label>
+              <input matInput formControlName="name" required [maxlength]="nameMaxLength" />
+              <mat-error *ngIf="form.get('name')?.hasError('required')">Name is required</mat-error>
+              <mat-error *ngIf="form.get('name')?.hasError('maxlength')">Name must be at most {{ nameMaxLength }} characters</mat-error>
+              <mat-error *ngIf="form.get('name')?.hasError('minlength')">Name must be at least 1 character</mat-error>
+              <mat-error *ngIf="form.get('name')?.hasError('unique')">API Product name must be unique</mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="form-field--version">
+              <mat-label>Version </mat-label>
+              <input matInput formControlName="version" required [maxlength]="versionMaxLength" />
+              <mat-error *ngIf="form.get('version')?.hasError('required')">Version is required</mat-error>
+              <mat-error *ngIf="form.get('version')?.hasError('maxlength')"
+                >Version must be at most {{ versionMaxLength }} characters</mat-error
+              >
+              <mat-error *ngIf="form.get('version')?.hasError('minlength')">Version must be at least 1 character</mat-error>
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Description</mat-label>
+              <textarea matInput formControlName="description" rows="4" [maxlength]="descriptionMaxLength"></textarea>
+              <!-- <mat-hint align="end">{{ getDescriptionLength() }}/{{ descriptionMaxLength }}</mat-hint> -->
+              <mat-error *ngIf="form.get('description')?.hasError('maxlength')"
+                >Description must be at most {{ descriptionMaxLength }} characters</mat-error
+              >
+            </mat-form-field>
+          </div>
+        </form>
+      </div>
+    </mat-card-content>
+    <mat-card-footer>
+      <div class="api-product-create__footer">
+        <button mat-stroked-button class="cancel-button" (click)="onBack()" [disabled]="isCreating">Cancel</button>
+        <button mat-raised-button class="create-button" color="primary" (click)="onCreate()" [disabled]="form.invalid || isCreating">
+          <span *ngIf="!isCreating">Create API Product</span>
+          <span *ngIf="isCreating">Creating...</span>
+        </button>
+      </div>
+    </mat-card-footer>
+  </mat-card>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
@@ -1,0 +1,127 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-product-create {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__header {
+    margin-bottom: 24px;
+  }
+
+  &__title {
+    margin: 0 0 8px 0;
+    font-size: 24px;
+    font-weight: 600;
+    color: #424242;
+  }
+
+  &__instructions {
+    margin: 0 0 24px 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    font-size: 14px;
+  }
+
+  &__form-card {
+    flex: 1;
+    margin-bottom: 24px;
+    padding: 24px;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    padding: 16px 0;
+    gap: 16px;
+  }
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'default');
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 14px;
+  margin-bottom: 16px;
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+  }
+
+  &:hover {
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'darker');
+    text-decoration: underline;
+  }
+}
+
+.form-section {
+  &__title {
+    margin: 0 0 24px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #424242;
+  }
+}
+
+.form-row {
+  margin-bottom: 16px;
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  &--inline {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+
+    .form-field--name {
+      flex: 1;
+    }
+
+    .form-field--version {
+      flex: 0 0 200px;
+    }
+  }
+}
+
+.cancel-button {
+  color: #424242;
+  border-color: #e0e0e0;
+  background-color: white;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+}
+
+.create-button {
+  background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
+  color: white;
+  font-weight: 500;
+  min-width: 180px;
+
+  &:hover:not(:disabled) {
+    background: linear-gradient(135deg, #e55a2b 0%, #e0841a 100%);
+  }
+
+  &:disabled {
+    background: #e0e0e0;
+    color: #9e9e9e;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ApiProductCreateComponent } from './api-product-create.component';
+import { ApiProductCreateModule } from './api-product-create.module';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductCreateComponent', () => {
+  let fixture: ComponentFixture<ApiProductCreateComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
+  let matDialog: MatDialog;
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductCreateModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductCreateComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    const router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
+    matDialog = TestBed.inject(MatDialog);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should validate required fields', async () => {
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('name')?.hasError('required')).toBe(true);
+    expect(fixture.componentInstance.form.get('version')?.hasError('required')).toBe(true);
+  });
+
+  it('should validate name uniqueness', fakeAsync(async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Existing Product');
+    await nameInput.blur();
+    tick(300);
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    expect(verifyReq.request.body).toEqual({ name: 'Existing Product' });
+    verifyReq.flush({ ok: false });
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('name')?.hasError('unique')).toBe(true);
+  }));
+
+  it('should create API product successfully', fakeAsync(async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+
+    await nameInput.setValue('New Product');
+    await nameInput.blur();
+    tick(300);
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    tick();
+
+    await versionInput.setValue('1.0');
+    await descriptionInput.setValue('Test description');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    expect(createReq.request.body).toEqual({
+      name: 'New Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: [],
+    });
+
+    const createdProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'New Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: [],
+    };
+    createReq.flush(createdProduct);
+    tick();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('API Product product-1 successfully created');
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['..', 'product-1', 'configuration'], expect.anything());
+  }));
+
+  it('should trim whitespace from form values', fakeAsync(async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+
+    await nameInput.setValue('  Trimmed Product  ');
+    await nameInput.blur();
+    tick(300);
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    tick();
+
+    await versionInput.setValue('  1.0  ');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    expect(createReq.request.body.name).toBe('Trimmed Product');
+    expect(createReq.request.body.version).toBe('1.0');
+  }));
+
+  it('should handle creation error', fakeAsync(async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+
+    await nameInput.setValue('New Product');
+    await nameInput.blur();
+    tick(300);
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    tick();
+
+    await versionInput.setValue('1.0');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    createReq.flush({ message: 'Creation failed' }, { status: 400, statusText: 'Bad Request' });
+    tick();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalledWith('Creation failed');
+  }));
+
+  it('should show exit confirmation dialog when form is dirty', fakeAsync(async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Test Product');
+    fixture.componentInstance.form.markAsDirty();
+    fixture.detectChanges();
+
+    const dialogOpenSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+      afterClosed: () => ({ pipe: () => ({ subscribe: jest.fn() }) }),
+    } as any);
+
+    fixture.componentInstance.onExit();
+    fixture.detectChanges();
+
+    expect(dialogOpenSpy).toHaveBeenCalled();
+  }));
+
+  it('should navigate back without dialog when form is not dirty', () => {
+    fixture.detectChanges();
+    fixture.componentInstance.onExit();
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], expect.anything());
+  });
+
+  it('should validate max length for name', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('a'.repeat(256));
+    await nameInput.blur();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('name')?.hasError('maxlength')).toBe(true);
+  });
+
+  it('should validate max length for version', async () => {
+    fixture.detectChanges();
+
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    await versionInput.setValue('a'.repeat(256));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('version')?.hasError('maxlength')).toBe(true);
+  });
+
+  it('should validate max length for description', async () => {
+    fixture.detectChanges();
+
+    const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+    await descriptionInput.setValue('a'.repeat(251));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('description')?.hasError('maxlength')).toBe(true);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { AsyncValidatorFn, FormControl, UntypedFormBuilder, UntypedFormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of, Subject, timer } from 'rxjs';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
+import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+
+import { Constants } from '../../../entities/Constants';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { CreateApiProduct } from '../../../entities/management-api-v2/api-product';
+
+@Component({
+  selector: 'api-product-create',
+  templateUrl: './api-product-create.component.html',
+  styleUrls: ['./api-product-create.component.scss'],
+  standalone: false,
+})
+export class ApiProductCreateComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+
+  public form: UntypedFormGroup;
+  public descriptionMaxLength = 250;
+  public nameMaxLength = 255;
+  public versionMaxLength = 255;
+  public isCreating = false;
+
+  constructor(
+    @Inject(Constants) private readonly constants: Constants,
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly formBuilder: UntypedFormBuilder,
+    private readonly matDialog: MatDialog,
+    private readonly apiProductV2Service: ApiProductV2Service,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.formBuilder.group({
+      name: this.formBuilder.control('', {
+        validators: [Validators.required, Validators.maxLength(this.nameMaxLength), Validators.minLength(1)],
+        asyncValidators: [this.nameUniquenessValidator()],
+        updateOn: 'blur', // Only validate on blur, not on every keystroke
+      }),
+      version: this.formBuilder.control('', [Validators.required, Validators.maxLength(this.versionMaxLength), Validators.minLength(1)]),
+      description: this.formBuilder.control('', [Validators.maxLength(this.descriptionMaxLength)]),
+    });
+  }
+
+  private nameUniquenessValidator(): AsyncValidatorFn {
+    return (formControl: FormControl): Observable<ValidationErrors | null> => {
+      if (!formControl || !formControl.value || formControl.value.trim() === '') {
+        return of(null);
+      }
+      const trimmedName = formControl.value.trim();
+      // Debounce API call to avoid too many requests
+      return timer(250).pipe(
+        switchMap(() => this.apiProductV2Service.verify(trimmedName)),
+        map((res) => (res.ok ? null : { unique: true })),
+      );
+    };
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  onExit(): void {
+    if (this.form.dirty) {
+      this.matDialog
+        .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+          data: {
+            title: 'Exit without saving?',
+            content: 'You have unsaved changes. Are you sure you want to exit without saving?',
+            confirmButton: 'Exit without saving',
+            cancelButton: 'Cancel',
+          },
+        })
+        .afterClosed()
+        .pipe(takeUntil(this.unsubscribe$))
+        .subscribe((confirmed) => {
+          if (confirmed) {
+            this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+          }
+        });
+      return;
+    }
+    this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+  }
+
+  onBack(): void {
+    this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+  }
+
+  onCreate(): void {
+    if (this.form.valid && !this.isCreating) {
+      this.isCreating = true;
+      const formValue = this.form.getRawValue();
+
+      // Sanitize input: trim whitespace and validate non-empty after trim
+      const trimmedName = formValue.name?.trim() || '';
+      const trimmedVersion = formValue.version?.trim() || '';
+      const trimmedDescription = formValue.description?.trim() || '';
+
+      // Validate that trimmed values are not empty
+      if (!trimmedName || !trimmedVersion) {
+        this.snackBarService.error('Name and version are required and cannot be empty');
+        this.isCreating = false;
+        this.form.markAllAsTouched();
+        return;
+      }
+
+      const createApiProduct: CreateApiProduct = {
+        name: trimmedName,
+        version: trimmedVersion,
+        description: trimmedDescription || undefined,
+        apiIds: [], // TODO: Add API selection functionality
+      };
+
+      this.apiProductV2Service
+        .create(createApiProduct)
+        .pipe(takeUntil(this.unsubscribe$))
+        .subscribe({
+          next: (apiProduct) => {
+            this.isCreating = false;
+            this.snackBarService.success(`API Product ${apiProduct.id} successfully created`);
+            this.router.navigate(['..', apiProduct.id, 'configuration'], { relativeTo: this.activatedRoute });
+          },
+          error: (error) => {
+            this.isCreating = false;
+            const errorMessage =
+              error.error?.message || error.error?.errors?.[0]?.message || 'An error occurred while creating the API Product';
+            this.snackBarService.error(errorMessage);
+          },
+        });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+
+  getDescriptionLength(): number {
+    const description = this.form.get('description')?.value;
+    return description ? description.length : 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.module.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
+import { GioConfirmDialogModule } from '@gravitee/ui-particles-angular';
+
+import { ApiProductCreateComponent } from './api-product-create.component';
+import { ApiProductCreateRoutingModule } from './api-product-create-routing.module';
+
+@NgModule({
+  declarations: [ApiProductCreateComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatDialogModule,
+    ApiProductCreateRoutingModule,
+    GioConfirmDialogModule,
+  ],
+})
+export class ApiProductCreateModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/detail/api-product-detail-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/detail/api-product-detail-routing.module.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ApiProductNavigationComponent } from '../navigation/api-product-navigation.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ApiProductNavigationComponent,
+    children: [
+      {
+        path: '',
+        redirectTo: 'configuration',
+        pathMatch: 'full',
+      },
+      {
+        path: 'configuration',
+        loadChildren: () => import('../configuration/api-product-configuration.module').then((m) => m.ApiProductConfigurationModule),
+      },
+      {
+        path: 'apis',
+        loadChildren: () => import('../apis/api-product-apis.module').then((m) => m.ApiProductApisModule),
+      },
+      // TODO: Add route for 'consumers' when component is created
+    ],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ApiProductDetailRoutingModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/detail/api-product-detail.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/detail/api-product-detail.module.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ApiProductDetailRoutingModule } from './api-product-detail-routing.module';
+
+import { ApiProductNavigationModule } from '../navigation/api-product-navigation.module';
+
+@NgModule({
+  imports: [CommonModule, ApiProductDetailRoutingModule, ApiProductNavigationModule],
+})
+export class ApiProductDetailModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -1,0 +1,167 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+
+<div class="api-product-list">
+  <div class="api-product-list__header">
+    <div>
+      <h1>API Products</h1>
+      <p class="subtitle">Group together multiple APIs for consumers</p>
+    </div>
+    <button
+      [routerLink]="'./new'"
+      mat-raised-button
+      color="primary"
+      class="create-api-product-button"
+      aria-label="create-api-product"
+      *gioPermission="{ anyOf: ['environment-api_products-c'] }"
+      data-testid="api_product_list_create_button"
+    >
+      Create API Product
+    </button>
+  </div>
+
+  <!-- Empty State -->
+  <mat-card class="api-product-list__content-card" *ngIf="!hasApiProducts && !isLoadingData">
+    <mat-card-content>
+      <div class="api-product-list__card-header">
+        <h2>API Products</h2>
+      </div>
+      <mat-card class="api-product-list__content-card">
+        <mat-card-content>
+          <div class="api-products-empty-state">
+            <div class="empty-state-card">
+              <div class="empty-state-icon">
+                <mat-icon class="empty-state-icon__svg">search</mat-icon>
+              </div>
+              <h3>No API Product created yet</h3>
+              <p>Create API Products to group together your APIs.</p>
+            </div>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Table View -->
+  <gio-table-wrapper
+    *ngIf="hasApiProducts"
+    [searchLabel]="searchLabel"
+    [length]="apiProductsTableDSUnpaginatedLength"
+    [filters]="filters"
+    (filtersChange)="onFiltersChanged($event)"
+    [paginationPageSizeOptions]="[10, 25, 50, 100]"
+  >
+    <table mat-table matSort [dataSource]="apiProductsTableDS" id="apiProductsTable" aria-label="API Products table">
+      <!-- Picture Column -->
+      <ng-container matColumnDef="picture">
+        <th mat-header-cell *matHeaderCellDef id="picture"></th>
+        <td mat-cell *matCellDef="let element">
+          <gio-avatar
+            class="api-products__avatar"
+            [src]="element.picture"
+            [name]="element.name + ' ' + element.version"
+            [size]="32"
+            [roundedBorder]="true"
+          ></gio-avatar>
+        </td>
+      </ng-container>
+
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
+        <td mat-cell *matCellDef="let element" title="{{ element.name }}">
+          <a [routerLink]="'./' + element.id">{{ element.name }}</a>
+        </td>
+      </ng-container>
+
+      <!-- APIs Column -->
+      <ng-container matColumnDef="apis">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="apis">APIs</th>
+        <td mat-cell *matCellDef="let element">
+          <span class="apis__badge gio-badge-neutral">{{ element.numberOfApis }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Version Column -->
+      <ng-container matColumnDef="version">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="version">Version</th>
+        <td mat-cell *matCellDef="let element">
+          <span class="version__badge gio-badge-neutral">v{{ element.version }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Owner Column -->
+      <ng-container matColumnDef="owner">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="owner">Owner</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.owner }}
+        </td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="actions__edit">
+            <button
+              [routerLink]="'./' + element.id"
+              mat-icon-button
+              aria-label="Button to edit an API Product"
+              matTooltip="Edit API Product"
+              data-testid="api_product_list_edit_button"
+            >
+              <mat-icon>edit</mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns" data-testid="api_product_list_table_header"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="api_product_list_table_row"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td
+          *ngIf="!isLoadingData && apiProductsTableDS.length === 0"
+          class="mat-mdc-cell mdc-data-table__cell"
+          [attr.colspan]="displayedColumns.length"
+        >
+          There is no API Product (yet).
+        </td>
+        <td *ngIf="isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
@@ -1,0 +1,150 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-product-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 32px;
+
+    h1 {
+      margin: 0;
+      font-size: 32px;
+      font-weight: 600;
+    }
+
+    .subtitle {
+      margin-top: 8px;
+      margin-bottom: 0;
+      color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+      font-size: 14px;
+    }
+  }
+
+  &__content-card {
+    flex: 1;
+    min-height: 400px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  &__card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e0e0e0;
+
+    h2 {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 600;
+      color: #424242;
+    }
+  }
+}
+
+.api-products-empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  padding: 48px 24px;
+}
+
+.empty-state-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  max-width: 500px;
+
+  h3 {
+    margin: 24px 0 8px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #424242;
+  }
+
+  p {
+    margin: 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    font-size: 14px;
+  }
+}
+
+.empty-state-icon {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: #fff3e0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  border: 1px solid #ffb74d;
+
+  &__svg {
+    width: 40px;
+    height: 40px;
+    color: #e64a19;
+  }
+}
+
+// Table styles
+.mat-column-picture {
+  padding: 0 8px;
+  width: 48px;
+  min-width: 48px;
+}
+
+.mat-column-apis,
+.mat-column-version,
+.mat-column-owner,
+.mat-column-actions {
+  padding: 0 8px;
+}
+
+.mat-column-name {
+  cursor: pointer;
+  padding: 0 8px;
+  width: auto;
+}
+
+.mat-column-apis {
+  .apis__badge {
+    cursor: default;
+  }
+}
+
+.mat-column-version {
+  .version__badge {
+    cursor: default;
+  }
+}
+
+.actions__edit {
+  display: flex;
+  justify-content: center;
+}
+
+.api-products__avatar {
+  height: 32px;
+  width: 32px;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ApiProductListComponent } from './api-product-list.component';
+import { ApiProductListModule } from './api-product-list.module';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
+describe('ApiProductListComponent', () => {
+  let fixture: ComponentFixture<ApiProductListComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let _router: Router;
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductListModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-api_products-c'] },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParams: {} },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductListComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    _router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should display an empty state when no API products', fakeAsync(async () => {
+    await initComponent([]);
+
+    expect(fixture.nativeElement.textContent).toContain('No API Product created yet');
+    expect(fixture.nativeElement.textContent).toContain('Create API Products to group together your APIs.');
+  }));
+
+  it('should display a table with one row', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Payments API Product',
+      version: '1.0',
+      apiIds: ['api-1', 'api-2'],
+      primaryOwner: { displayName: 'Jane Doe' } as any,
+    };
+
+    await initComponent([apiProduct]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(1);
+
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[1]).toContain('Payments API Product');
+    expect(rowCells[2]).toContain('2');
+    expect(rowCells[3]).toContain('1.0');
+    expect(rowCells[4]).toContain('Jane Doe');
+  }));
+
+  it('should display multiple API products', fakeAsync(async () => {
+    const apiProducts: ApiProduct[] = [
+      {
+        id: 'product-1',
+        name: 'Payments API Product',
+        version: '1.0',
+        apiIds: ['api-1'],
+        primaryOwner: { displayName: 'Jane Doe' } as any,
+      },
+      {
+        id: 'product-2',
+        name: 'Orders API Product',
+        version: '2.0',
+        apiIds: ['api-2', 'api-3'],
+        primaryOwner: { displayName: 'John Smith' } as any,
+      },
+    ];
+
+    await initComponent(apiProducts);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(2);
+  }));
+
+  it('should handle error when loading products', fakeAsync(async () => {
+    fixture.detectChanges();
+    tick(200);
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+    req.flush({ message: 'Error loading products' }, { status: 500, statusText: 'Internal Server Error' });
+    tick();
+    fixture.detectChanges();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  }));
+
+  it('should update filters and reload data', fakeAsync(async () => {
+    await initComponent([]);
+
+    const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
+    await tableWrapper.setSearchValue('test');
+    tick(200);
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+    req.flush({ data: [], pagination: { totalCount: 0 } });
+    tick();
+  }));
+
+  it('should display owner as N/A when no primary owner', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    await initComponent([apiProduct]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
+    const rows = await table.getRows();
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[4]).toContain('N/A');
+  }));
+
+  it('should display zero APIs count when apiIds is empty', fakeAsync(async () => {
+    const apiProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+      primaryOwner: { displayName: 'Jane Doe' } as any,
+    };
+
+    await initComponent([apiProduct]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
+    const rows = await table.getRows();
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[2]).toContain('0');
+  }));
+
+  async function initComponent(apiProducts: ApiProduct[]) {
+    fixture.detectChanges();
+    tick(200);
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+    expect(req.request.method).toEqual('GET');
+    req.flush({ data: apiProducts, pagination: { totalCount: apiProducts.length } });
+    tick();
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -157,11 +157,18 @@ describe('ApiProductListComponent', () => {
   }));
 
   it('should update filters and reload data', fakeAsync(async () => {
-    await initComponent([]);
+    const apiProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+      primaryOwner: { displayName: 'Jane Doe' } as any,
+    };
+    await initComponent([apiProduct]);
 
     const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
     await tableWrapper.setSearchValue('test');
-    tick(200);
+    tick(500);
 
     const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
     req.flush({ data: [], pagination: { totalCount: 0 } });

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, Subject, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { isEqual } from 'lodash';
+
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { toSort, toOrder } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../entities/Constants';
+import { ApiProduct, ApiProductsResponse } from '../../../entities/management-api-v2/api-product';
+
+export type ApiProductTableDS = {
+  id: string;
+  name: string;
+  version: string;
+  numberOfApis: number;
+  owner: string;
+  picture?: string;
+}[];
+
+interface ApiProductListTableWrapperFilters extends GioTableWrapperFilters {
+  // Add any additional filters here if needed
+}
+
+@Component({
+  selector: 'api-product-list',
+  templateUrl: './api-product-list.component.html',
+  styleUrls: ['./api-product-list.component.scss'],
+  standalone: false,
+})
+export class ApiProductListComponent implements OnInit, OnDestroy {
+  displayedColumns = ['picture', 'name', 'apis', 'version', 'owner', 'actions'];
+  apiProductsTableDS: ApiProductTableDS = [];
+  apiProductsTableDSUnpaginatedLength = 0;
+  filters: ApiProductListTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+  searchLabel = 'Search';
+  isLoadingData = true;
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  private filters$ = new BehaviorSubject<ApiProductListTableWrapperFilters>(this.filters);
+
+  constructor(
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly router: Router,
+    @Inject(Constants) private readonly constants: Constants,
+    private readonly apiProductV2Service: ApiProductV2Service,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnInit(): void {
+    this.initFilters();
+
+    this.filters$
+      .pipe(
+        debounceTime(100),
+        distinctUntilChanged(isEqual),
+        tap((filters: ApiProductListTableWrapperFilters) => {
+          // Update URL params
+          this.router.navigate([], {
+            relativeTo: this.activatedRoute,
+            queryParams: {
+              q: filters.searchTerm,
+              page: filters.pagination.index,
+              size: filters.pagination.size,
+              ...(filters.sort ? { order: toOrder(filters.sort) } : {}),
+            },
+            queryParamsHandling: 'merge',
+          });
+        }),
+        tap(() => {
+          this.isLoadingData = true;
+        }),
+        switchMap((filters: ApiProductListTableWrapperFilters) => {
+          const page = filters.pagination?.index || 1;
+          const perPage = filters.pagination?.size || 10;
+          return this.apiProductV2Service.list(page, perPage).pipe(
+            catchError((error) => {
+              this.isLoadingData = false;
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading API Products');
+              return of({ data: [], pagination: { totalCount: 0 } } as ApiProductsResponse);
+            }),
+          );
+        }),
+        tap((response: ApiProductsResponse) => {
+          this.apiProductsTableDS = this.toApiProductsTableDS(response.data || []);
+          this.apiProductsTableDSUnpaginatedLength = response.pagination?.totalCount || 0;
+          this.isLoadingData = false;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  private initFilters(): void {
+    const initialSearchValue = this.activatedRoute.snapshot.queryParams.q ?? this.filters.searchTerm;
+    const initialPageNumber = this.activatedRoute.snapshot.queryParams.page
+      ? Number(this.activatedRoute.snapshot.queryParams.page)
+      : this.filters.pagination.index;
+    const initialPageSize = this.activatedRoute.snapshot.queryParams.size
+      ? Number(this.activatedRoute.snapshot.queryParams.size)
+      : this.filters.pagination.size;
+    const initialSort = toSort(this.activatedRoute.snapshot.queryParams.order, this.filters.sort);
+
+    this.filters = {
+      searchTerm: initialSearchValue,
+      sort: initialSort,
+      pagination: {
+        index: initialPageNumber,
+        size: initialPageSize,
+      },
+    };
+    this.filters$.next(this.filters);
+  }
+
+  private toApiProductsTableDS(data: ApiProduct[]): ApiProductTableDS {
+    if (!data || data.length === 0) {
+      return [];
+    }
+    return data.map((product: ApiProduct) => ({
+      id: product.id,
+      name: product.name,
+      version: product.version,
+      numberOfApis: product.apiIds?.length || 0,
+      owner: product.primaryOwner?.displayName || 'N/A',
+      picture: product._links?.pictureUrl,
+    }));
+  }
+
+  onFiltersChanged(filters: ApiProductListTableWrapperFilters): void {
+    this.filters = { ...this.filters, ...filters };
+    this.filters$.next(this.filters);
+  }
+
+  get hasApiProducts(): boolean {
+    return this.apiProductsTableDS.length > 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.module.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { GioIconsModule, GioAvatarModule } from '@gravitee/ui-particles-angular';
+import { RouterModule } from '@angular/router';
+
+import { ApiProductListComponent } from './api-product-list.component';
+
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+
+@NgModule({
+  declarations: [ApiProductListComponent],
+  exports: [ApiProductListComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatTableModule,
+    MatSortModule,
+    MatTooltipModule,
+    GioIconsModule,
+    GioAvatarModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    RouterModule,
+  ],
+})
+export class ApiProductListModule {}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -1,0 +1,68 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+ *
+ *    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *            http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+-->
+<div *ngIf="currentApiProduct" class="api-product-navigation">
+  <div class="api-product-navigation__menu">
+    <gio-submenu class="api-product-navigation__submenu">
+      <div gioSubmenuTitle class="api-product-navigation__submenu__title">
+        <h2 class="api-product-navigation__submenu__title__name">{{ currentApiProduct.name }}</h2>
+      </div>
+      <ng-container *ngFor="let menuItem of subMenuItems">
+        <a [routerLink]="menuItem.routerLink">
+          <gio-submenu-item tabIndex="1" [active]="isActive(menuItem)">
+            <div class="api-product-navigation__submenu__item">
+              <mat-icon
+                *ngIf="menuItem.icon"
+                class="api-product-navigation__submenu__item__icon"
+                [matTooltip]="menuItem.displayName"
+                [svgIcon]="'gio:' + menuItem.icon"
+              >
+              </mat-icon>
+              {{ menuItem.displayName }}
+            </div>
+          </gio-submenu-item>
+        </a>
+      </ng-container>
+    </gio-submenu>
+  </div>
+  <div class="api-product-navigation__content">
+    <gio-breadcrumb *ngIf="hasBreadcrumb" class="api-product-navigation__breadcrumb">
+      <span *gioBreadcrumbItem class="api-product-navigation__breadcrumb__item">API Products</span>
+      <span *gioBreadcrumbItem class="api-product-navigation__breadcrumb__item">{{ currentApiProduct.name }}</span>
+    </gio-breadcrumb>
+    <div class="api-product-navigation__content__view">
+      <router-outlet></router-outlet>
+    </div>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$textColor: map.get(gio.$mat-dove-palette, default);
+
+.api-product-navigation {
+  height: 100%;
+  display: grid;
+  grid-template-columns: min-content auto;
+  grid-template-areas: 'menu content';
+
+  a {
+    text-decoration: none;
+  }
+
+  &__menu {
+    grid-area: menu;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__submenu {
+    z-index: 70;
+    height: 100%;
+    color: $textColor;
+
+    &__title {
+      border-bottom: 1px solid #8a8383;
+      &__name {
+        margin: 0;
+        padding: 16px 20px;
+        font-size: 16px;
+        font-weight: 500;
+      }
+    }
+
+    &__item {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      &__icon {
+        margin-right: 8px;
+        color: $textColor;
+        width: 20px;
+        height: 20px;
+      }
+    }
+  }
+
+  &__breadcrumb {
+    padding: 16px 32px 0 32px;
+
+    &__item {
+      display: contents;
+    }
+  }
+
+  &__content {
+    grid-area: content;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+
+    &__view {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      height: 100%;
+      margin: 12px 24px 0 24px;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { GioMenuService } from '@gravitee/ui-particles-angular';
+
+import { ApiProductNavigationComponent } from './api-product-navigation.component';
+import { ApiProductNavigationModule } from './api-product-navigation.module';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductNavigationComponent', () => {
+  let fixture: ComponentFixture<ApiProductNavigationComponent>;
+  let _loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let router: Router;
+  const API_PRODUCT_ID = 'api-product-id';
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductNavigationModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: {
+              snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            },
+            params: new Subject(),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductNavigationComponent);
+    _loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should load API product on init', fakeAsync(() => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.currentApiProduct).toEqual(apiProduct);
+    expect(fixture.componentInstance.isLoading).toBe(false);
+  }));
+
+  it('should handle error when loading API product', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    tick();
+    fixture.detectChanges();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+    expect(fixture.componentInstance.isLoading).toBe(false);
+  }));
+
+  it('should reload API product on route params change', fakeAsync(() => {
+    const apiProduct: ApiProduct = {
+      id: API_PRODUCT_ID,
+      name: 'Test Product',
+      version: '1.0',
+      apiIds: [],
+    };
+
+    fixture.detectChanges();
+    tick();
+
+    const req1 = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req1.flush(apiProduct);
+    tick();
+    fixture.detectChanges();
+
+    // Component should have loaded the API product
+    expect(fixture.componentInstance.currentApiProduct).toEqual(apiProduct);
+  }));
+
+  it('should check if menu item is active', () => {
+    fixture.detectChanges();
+
+    const menuItem = {
+      displayName: 'Configuration',
+      routerLink: 'configuration',
+      icon: 'gio:settings',
+    };
+
+    jest.spyOn(router, 'isActive').mockReturnValue(true);
+    const isActive = fixture.componentInstance.isActive(menuItem);
+    expect(isActive).toBe(true);
+  });
+
+  it('should have correct submenu items', () => {
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.subMenuItems).toEqual([
+      {
+        displayName: 'Configuration',
+        routerLink: 'configuration',
+        icon: 'gio:settings',
+      },
+      {
+        displayName: 'APIs',
+        routerLink: 'apis',
+        icon: 'gio:cloud',
+      },
+      {
+        displayName: 'Consumers',
+        routerLink: 'consumers',
+        icon: 'gio:users',
+      },
+    ]);
+  });
+
+  it('should update breadcrumb visibility based on menu service', () => {
+    const gioMenuService = TestBed.inject(GioMenuService);
+    fixture.detectChanges();
+
+    gioMenuService.reduced$.next(true);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.hasBreadcrumb).toBe(true);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Subject, of } from 'rxjs';
+import { catchError, filter, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { GioMenuService } from '@gravitee/ui-particles-angular';
+
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { getApiProductId } from '../api-product.utils';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+interface MenuItem {
+  displayName: string;
+  routerLink: string;
+  icon?: string;
+}
+
+@Component({
+  selector: 'api-product-navigation',
+  templateUrl: './api-product-navigation.component.html',
+  styleUrls: ['./api-product-navigation.component.scss'],
+  standalone: false,
+})
+export class ApiProductNavigationComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+
+  public currentApiProduct: ApiProduct | null = null;
+  public apiProductId: string;
+  public isLoading = false;
+  public subMenuItems: MenuItem[] = [
+    {
+      displayName: 'Configuration',
+      routerLink: 'configuration',
+      icon: 'gio:settings',
+    },
+    {
+      displayName: 'APIs',
+      routerLink: 'apis',
+      icon: 'gio:cloud',
+    },
+    {
+      displayName: 'Consumers',
+      routerLink: 'consumers',
+      icon: 'gio:users',
+    },
+  ];
+  public hasBreadcrumb = false;
+
+  constructor(
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly gioMenuService: GioMenuService,
+    private readonly apiProductV2Service: ApiProductV2Service,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnInit(): void {
+    this.gioMenuService.reduced$.pipe(takeUntil(this.unsubscribe$)).subscribe((reduced) => {
+      this.hasBreadcrumb = reduced;
+    });
+
+    this.activatedRoute.params
+      .pipe(
+        tap(() => {
+          const apiProductId = getApiProductId(this.activatedRoute);
+          if (apiProductId) {
+            this.apiProductId = apiProductId;
+            this.isLoading = true;
+            this.currentApiProduct = null;
+          }
+        }),
+        switchMap(() => {
+          const apiProductId = getApiProductId(this.activatedRoute);
+          if (apiProductId) {
+            return this.apiProductV2Service.get(apiProductId).pipe(
+              catchError((error) => {
+                this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+                return of(null);
+              }),
+            );
+          }
+          return of(null);
+        }),
+        tap((apiProduct) => {
+          this.currentApiProduct = apiProduct;
+          this.isLoading = false;
+        }),
+        switchMap(() => this.router.events),
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  isActive(item: MenuItem): boolean {
+    if (!item.routerLink) {
+      return false;
+    }
+    return this.router.isActive(this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }), {
+      paths: 'subset',
+      queryParams: 'subset',
+      fragment: 'ignored',
+      matrixParams: 'ignored',
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.module.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { GioBreadcrumbModule, GioIconsModule, GioMenuModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { ApiProductNavigationComponent } from './api-product-navigation.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    GioSubmenuModule,
+    GioIconsModule,
+    GioBreadcrumbModule,
+    GioMenuModule,
+    MatIconModule,
+    MatTooltipModule,
+  ],
+  declarations: [ApiProductNavigationComponent],
+  exports: [ApiProductNavigationComponent],
+})
+export class ApiProductNavigationModule {}

--- a/gravitee-apim-console-webui/src/management/management-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/management-routing.module.ts
@@ -49,6 +49,10 @@ const managementRoutes: Routes = [
         loadChildren: () => import('./api/apis.module').then((m) => m.ApisModule),
       },
       {
+        path: 'api-products',
+        loadChildren: () => import('./api-products/api-products.module').then((m) => m.ApiProductsModule),
+      },
+      {
         path: 'integrations',
         loadChildren: () => import('./integrations/integrations.module').then((m) => m.IntegrationsModule),
         data: {

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { ApiProduct, ApiProductsResponse, CreateApiProduct, UpdateApiProduct } from '../entities/management-api-v2/api-product';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiProductV2Service {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  /**
+   * Create a new API Product
+   * Calls POST /environments/{envId}/api-products
+   * @param newApiProduct - The API Product data to create (name, version, description, apiIds)
+   * @returns Observable of the created API Product
+   */
+  create(newApiProduct: CreateApiProduct): Observable<ApiProduct> {
+    return this.http.post<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products`, newApiProduct);
+  }
+
+  /**
+   * Get list of API Products
+   * Calls GET /environments/{envId}/api-products
+   * @param page - Page number (starting from 1)
+   * @param perPage - Number of items per page (1-100)
+   * @returns Observable of ApiProductsResponse with paginated data
+   */
+  list(page = 1, perPage = 10): Observable<ApiProductsResponse> {
+    const params = new HttpParams().set('page', page.toString()).set('perPage', perPage.toString());
+    return this.http.get<ApiProductsResponse>(`${this.constants.env.v2BaseURL}/api-products`, { params });
+  }
+
+  /**
+   * Get a single API Product by ID
+   * Calls GET /environments/{envId}/api-products/{apiProductId}
+   * @param apiProductId - The API Product ID
+   * @returns Observable of the API Product
+   */
+  get(apiProductId: string): Observable<ApiProduct> {
+    return this.http.get<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`);
+  }
+
+  /**
+   * Delete an API from an API Product
+   * Calls DELETE /environments/{envId}/api-products/{apiProductId}/apis/{apiId}
+   * @param apiProductId - The API Product ID
+   * @param apiId - The API ID to remove
+   * @returns Observable of void
+   */
+  deleteApiFromApiProduct(apiProductId: string, apiId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/apis/${apiId}`);
+  }
+
+  /**
+   * Delete all APIs from an API Product
+   * Calls DELETE /environments/{envId}/api-products/{apiProductId}/apis
+   * @param apiProductId - The API Product ID
+   * @returns Observable of void
+   */
+  deleteAllApisFromApiProduct(apiProductId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/apis`);
+  }
+
+  /**
+   * Update an API Product
+   * Calls PUT /environments/{envId}/api-products/{apiProductId}
+   * @param apiProductId - The API Product ID
+   * @param updateApiProduct - The API Product data to update (name, version, description, apiIds)
+   * @returns Observable of the updated API Product
+   */
+  update(apiProductId: string, updateApiProduct: UpdateApiProduct): Observable<ApiProduct> {
+    return this.http.put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, updateApiProduct);
+  }
+
+  /**
+   * Update API Product's APIs list
+   * Calls PUT /environments/{envId}/api-products/{apiProductId}
+   * @param apiProductId - The API Product ID
+   * @param apiIds - The new list of API IDs
+   * @returns Observable of the updated API Product
+   */
+  updateApiProductApis(apiProductId: string, apiIds: string[]): Observable<ApiProduct> {
+    return this.http.put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, {
+      apiIds,
+    });
+  }
+
+  /**
+   * Delete an API Product
+   * Calls DELETE /environments/{envId}/api-products/{apiProductId}
+   * @param apiProductId - The API Product ID
+   * @returns Observable of void
+   */
+  delete(apiProductId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`);
+  }
+
+  /**
+   * Verify if an API Product name is unique
+   * Calls POST /environments/{envId}/api-products/_verify
+   * @param name - The API Product name to verify
+   * @returns Observable with ok boolean and optional reason
+   */
+  verify(name: string): Observable<{ ok: boolean; reason?: string }> {
+    return this.http.post<{ ok: boolean; reason?: string }>(`${this.constants.env.v2BaseURL}/api-products/_verify`, {
+      name,
+    });
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12357

## Description
Implement complete API Product creation workflow with the following features:

- Add API Products list page with empty state when no products exist
- Implement create API Product form with name, version, and description fields
- Add name uniqueness validation per environment with error display
- Configure routing to redirect to configuration page after successful creation
- Add API Products menu item in sidebar navigation
- Create API Product service (api-product-v2.service) for CRUD operations
- Add entity type definitions for API Product models
- Implement configuration page with danger zone for product management


