### PR TITLE
fix: backend to backend application creation in next gen portal.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -319,9 +319,9 @@ export class CreateApplicationComponent {
 
           return {
             oauth: {
-              application_type: selectedType.id || selectedType.name || undefined,
-              grant_types: grantTypes.length > 0 ? grantTypes : undefined,
-              redirect_uris: redirectUris.length > 0 ? redirectUris : undefined,
+              application_type: selectedType.id || selectedType.name,
+              grant_types: grantTypes,
+              redirect_uris: redirectUris,
               additional_client_metadata: metadata && Object.keys(metadata).length > 0 ? metadata : undefined,
             },
           };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12479

## Description

FIx default values of oauth fields to make them the same as when an application is created from the Console.

- `application_type`: selectedType id or name
- `grant_types`: grantTypes or empty array
- `redirect_uris`: redirectUris or empty array