### PR TITLE
fix: make el secret resolution non-blocking

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
@@ -78,7 +78,8 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
                 " value1='initial value1'" +
                 " value2='initial value2'" +
                 " value3='initial value3'" +
-                " value4='initial value4'"
+                " value4='initial value4'",
+            "kv put secret/test2 value1='initial testValue1'"
         );
 
     @Override
@@ -167,7 +168,7 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
         wiremock.verify(
             1,
             getRequestedFor(urlPathEqualTo("/echo"))
-                .withHeader("X-Secret-URI", equalTo("initial value1"))
+                .withHeader("X-Secret-URI", equalTo("initial value1 initial testValue1"))
                 .withHeader("X-Secret-URI-renewable", equalTo("initial value2"))
                 .withHeader("X-Secret-URI-reloadOnChange", equalTo("initial value3"))
                 .withHeader("X-Secret-Dictionary", equalTo("initial value4"))
@@ -205,7 +206,7 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
                 wiremock.verify(
                     1,
                     getRequestedFor(urlPathEqualTo("/echo"))
-                        .withHeader("X-Secret-URI", equalTo("initial value1"))
+                        .withHeader("X-Secret-URI", equalTo("updated value1 initial testValue1")) // As the full secret is refreshed, all values are updated and benefit to all specs.
                         .withHeader("X-Secret-URI-renewable", equalTo("updated value2"))
                         .withHeader("X-Secret-URI-reloadOnChange", equalTo("updated value3"))
                         .withHeader("X-Secret-Dictionary", equalTo("updated value4"))

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-with-secrets.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-with-secrets.json
@@ -35,7 +35,7 @@
                       "headers": [
                         {
                           "name": "X-Secret-URI",
-                          "value": "{#secrets.get('/vault/secret/test:value1')}"
+                          "value": "{#secrets.get('/vault/secret/test:value1')} {#secrets.get('/vault/secret/test2:value1')}"
                         },
                         {
                           "name": "X-Secret-URI-renewable",

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gravitee-common.version>4.7.3</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.9.1</gravitee-exchange.version>
-        <gravitee-expression-language.version>4.2.0</gravitee-expression-language.version>
+        <gravitee-expression-language.version>4.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>4.0.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
@@ -76,7 +76,7 @@
         <gravitee-resource-oauth2-provider-api.version>1.4.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>
         <gravitee-scoring-api.version>0.7.0</gravitee-scoring-api.version>
-        <gravitee-secret-api.version>2.0.0</gravitee-secret-api.version>
+        <gravitee-secret-api.version>3.0.0</gravitee-secret-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
 
@@ -301,7 +301,7 @@
         <gravitee-apim-repository-bridge.version>7.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
-        <gravitee-service-secrets.version>2.0.2</gravitee-service-secrets.version>
+        <gravitee-service-secrets.version>3.0.0</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
 
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-644

## Description

Switches to the latest gravitee-service-secrets plugin that supports non-blocking secret evaluation using EL.
