### PR TITLE
CI: update bridge compatibility tests - 4.7.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -325,7 +325,7 @@ workflows:
               apim_client_tag:
                 - 4.7.x-latest
                 - graviteeio@4.7.0
-                - 4.6.x-latest
+                - graviteeio@4.6
                 - graviteeio@4.6.0
                 - graviteeio@4.5
                 - graviteeio@4.5.0

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -64,7 +64,7 @@ export class BridgeCompatibilityTestsWorkflow {
           apim_client_tag: [
             '4.7.x-latest',
             'graviteeio@4.7.0',
-            '4.6.x-latest',
+            'graviteeio@4.6',
             'graviteeio@4.6.0',
             'graviteeio@4.5',
             'graviteeio@4.5.0',


### PR DESCRIPTION
## Description

4.6.x is no longer supported