### PR TITLE
CI: update bridge compatibility tests - 4.8.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -327,7 +327,7 @@ workflows:
                 - graviteeio@4.8.0
                 - 4.7.x-latest
                 - graviteeio@4.7.0
-                - 4.6.x-latest
+                - graviteeio@4.6
                 - graviteeio@4.6.0
                 - graviteeio@4.5
                 - graviteeio@4.5.0

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -66,7 +66,7 @@ export class BridgeCompatibilityTestsWorkflow {
             'graviteeio@4.8.0',
             '4.7.x-latest',
             'graviteeio@4.7.0',
-            '4.6.x-latest',
+            'graviteeio@4.6',
             'graviteeio@4.6.0',
             'graviteeio@4.5',
             'graviteeio@4.5.0',


### PR DESCRIPTION
## Description
4.6.x is no longer supported