### PR TITLE
CI: update bridge compatibility tests - 4.9.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -329,7 +329,7 @@ workflows:
                 - graviteeio@4.8.0
                 - 4.7.x-latest
                 - graviteeio@4.7.0
-                - 4.6.x-latest
+                - graviteeio@4.6
                 - graviteeio@4.6.0
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -68,7 +68,7 @@ export class BridgeCompatibilityTestsWorkflow {
             'graviteeio@4.8.0',
             '4.7.x-latest',
             'graviteeio@4.7.0',
-            '4.6.x-latest',
+            'graviteeio@4.6',
             'graviteeio@4.6.0',
           ],
         },


### PR DESCRIPTION
## Description
4.6.x is no longer supported