### PR TITLE
CI: update bridge compatibility tests - 4.10.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -323,7 +323,8 @@ workflows:
               database:
                 - bridge
               apim_client_tag:
-                - master-latest
+                - 4.10.x-latest
+                - graviteeio@4.10.0
                 - 4.9.x-latest
                 - graviteeio@4.9.0
                 - 4.8.x-latest

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -62,7 +62,8 @@ export class BridgeCompatibilityTestsWorkflow {
           execution_mode: ['v3', 'v4-emulation-engine'],
           database: ['bridge'],
           apim_client_tag: [
-            'master-latest',
+            '4.10.x-latest',
+            'graviteeio@4.10.0',
             '4.9.x-latest',
             'graviteeio@4.9.0',
             '4.8.x-latest',


### PR DESCRIPTION
## Description
4.6.x is no longer supported