### PR TITLE
feat: add environment-level roles and permissions for API Products

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/member/role.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/member/role.ts
@@ -19,5 +19,5 @@ export interface Role {
    * Role's name.
    */
   name?: string;
-  scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM' | 'INTEGRATION' | 'CLUSTER';
+  scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM' | 'INTEGRATION' | 'CLUSTER' | 'API_PRODUCT';
 }

--- a/gravitee-apim-console-webui/src/entities/role/role.ts
+++ b/gravitee-apim-console-webui/src/entities/role/role.ts
@@ -13,7 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type RoleScope = 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM' | 'INTEGRATION' | 'CLUSTER';
+export type RoleScope =
+  | 'API'
+  | 'APPLICATION'
+  | 'GROUP'
+  | 'ENVIRONMENT'
+  | 'ORGANIZATION'
+  | 'PLATFORM'
+  | 'INTEGRATION'
+  | 'CLUSTER'
+  | 'API_PRODUCT';
 
 export interface Role {
   id: string;

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.spec.ts
@@ -114,6 +114,14 @@ describe('OrgSettingsRolesComponent', () => {
           scope: 'CLUSTER',
         }),
       ],
+      [
+        fakeRole({
+          id: 'role-8',
+          name: 'Role 8',
+          description: 'Role 8 description',
+          scope: 'API_PRODUCT',
+        }),
+      ],
     );
 
     expect(component.rolesByScope).toStrictEqual([
@@ -223,6 +231,22 @@ describe('OrgSettingsRolesComponent', () => {
           },
         ],
       },
+      {
+        scope: 'API Product',
+        scopeId: 'API_PRODUCT',
+        roles: [
+          {
+            canBeDeleted: false,
+            description: 'Role 8 description',
+            hasUserRoleManagement: false,
+            icon: 'folder',
+            isDefault: true,
+            isReadOnly: false,
+            isSystem: false,
+            name: 'Role 8',
+          },
+        ],
+      },
     ]);
   });
 
@@ -249,6 +273,7 @@ describe('OrgSettingsRolesComponent', () => {
         [],
         [],
         [],
+        [],
       );
 
       fixture.detectChanges();
@@ -266,7 +291,7 @@ describe('OrgSettingsRolesComponent', () => {
         })
         .flush(null);
 
-      respondToGetRolesRequests([], [], [], [], [], []);
+      respondToGetRolesRequests([], [], [], [], [], [], []);
     });
   });
 
@@ -281,6 +306,7 @@ describe('OrgSettingsRolesComponent', () => {
     appRoles: Role[],
     integrationRoles: Role[],
     clusterRoles: Role[],
+    apiProductRoles: Role[],
   ) {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/ORGANIZATION/roles`).flush(orgRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/ENVIRONMENT/roles`).flush(envRoles);
@@ -288,5 +314,6 @@ describe('OrgSettingsRolesComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/APPLICATION/roles`).flush(appRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/INTEGRATION/roles`).flush(integrationRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/CLUSTER/roles`).flush(clusterRoles);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/API_PRODUCT/roles`).flush(apiProductRoles);
   }
 });

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
@@ -68,9 +68,10 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
       this.roleService.list('APPLICATION'),
       this.roleService.list('INTEGRATION'),
       this.roleService.list('CLUSTER'),
+      this.roleService.list('API_PRODUCT'),
     ])
       .pipe(
-        tap(([orgRoles, envRoles, apiRoles, appRoles, integrationRoles, clusterRoles]) => {
+        tap(([orgRoles, envRoles, apiRoles, appRoles, integrationRoles, clusterRoles, apiProductRoles]) => {
           this.rolesByScope = [
             { scope: 'Organization', scopeId: 'ORGANIZATION', roles: this.convertToRoleVMs(orgRoles) },
             { scope: 'Environment', scopeId: 'ENVIRONMENT', roles: this.convertToRoleVMs(envRoles) },
@@ -78,6 +79,7 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
             { scope: 'Application', scopeId: 'APPLICATION', roles: this.convertToRoleVMs(appRoles) },
             { scope: 'Integration', scopeId: 'INTEGRATION', roles: this.convertToRoleVMs(integrationRoles) },
             { scope: 'Cluster', scopeId: 'CLUSTER', roles: this.convertToRoleVMs(clusterRoles) },
+            { scope: 'API Product', scopeId: 'API_PRODUCT', roles: this.convertToRoleVMs(apiProductRoles) },
           ];
           this.loading = false;
         }),
@@ -153,6 +155,8 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
         return 'corporate_fare';
       case 'INTEGRATION':
         return 'list';
+      case 'API_PRODUCT':
+        return 'folder';
       default:
         return '';
     }

--- a/gravitee-apim-console-webui/src/services-ngx/role.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/role.service.ts
@@ -44,13 +44,13 @@ export class RoleService {
 
   getPermissionsByScope(scope: string): Observable<string[]>;
   getPermissionsByScope(
-    scope: Extract<RoleScope, 'API' | 'APPLICATION' | 'ENVIRONMENT' | 'ORGANIZATION' | 'INTEGRATION' | 'CLUSTER'>,
+    scope: Extract<RoleScope, 'API' | 'APPLICATION' | 'ENVIRONMENT' | 'ORGANIZATION' | 'INTEGRATION' | 'CLUSTER' | 'API_PRODUCT'>,
   ): Observable<string[]> {
-    const availableScopes = ['API', 'APPLICATION', 'ENVIRONMENT', 'ORGANIZATION', 'INTEGRATION', 'CLUSTER'];
+    const availableScopes = ['API', 'APPLICATION', 'ENVIRONMENT', 'ORGANIZATION', 'INTEGRATION', 'CLUSTER', 'API_PRODUCT'];
 
     const isAvailableScope = (
       scopeString: string,
-    ): scopeString is 'API' | 'APPLICATION' | 'ENVIRONMENT' | 'ORGANIZATION' | 'INTEGRATION' | 'CLUSTER' => {
+    ): scopeString is 'API' | 'APPLICATION' | 'ENVIRONMENT' | 'ORGANIZATION' | 'INTEGRATION' | 'CLUSTER' | 'API_PRODUCT' => {
       return availableScopes.includes(scope);
     };
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
@@ -28,4 +28,5 @@ public enum RoleScope {
     PLATFORM,
     INTEGRATION,
     CLUSTER,
+    API_PRODUCT,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiProductsResource.java
@@ -41,7 +41,7 @@ public class ApiProductsResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.READ }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.READ }) })
     public Response getApiProductsForApi(@PathParam("apiId") String apiId, @BeanParam @Valid PaginationParam paginationParam) {
         var executionContext = GraviteeContext.getExecutionContext();
         var input = GetApiProductsByApiIdUseCase.Input.of(apiId, executionContext.getOrganizationId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
@@ -58,7 +58,7 @@ public class ApiProductResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.READ }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.READ }) })
     public Response getApiProductById(@PathParam("apiProductId") String apiProductId) {
         var executionContext = GraviteeContext.getExecutionContext();
         var input = GetApiProductsUseCase.Input.of(executionContext.getEnvironmentId(), apiProductId, executionContext.getOrganizationId());
@@ -74,7 +74,7 @@ public class ApiProductResource extends AbstractResource {
     }
 
     @DELETE
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.DELETE }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.DELETE }) })
     public Response deleteApiProductById(@PathParam("apiProductId") String apiProductId) {
         AuditInfo audit = getAuditInfo();
         deleteApiProductUseCase.execute(DeleteApiProductUseCase.Input.of(apiProductId, audit));
@@ -84,7 +84,7 @@ public class ApiProductResource extends AbstractResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
     public Response updateApiProductById(
         @PathParam("apiProductId") String apiProductId,
         @Valid @NotNull UpdateApiProduct updateApiProduct
@@ -99,7 +99,7 @@ public class ApiProductResource extends AbstractResource {
 
     @DELETE
     @Path("/apis")
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
     public Response deleteAllApisFromApiProduct(@PathParam("apiProductId") String apiProductId) {
         log.debug("Delete all APIs from API Product: {}", apiProductId);
         AuditInfo audit = getAuditInfo();
@@ -111,7 +111,7 @@ public class ApiProductResource extends AbstractResource {
 
     @DELETE
     @Path("/apis/{apiId}")
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
     public Response deleteApiFromApiProduct(@PathParam("apiProductId") String apiProductId, @PathParam("apiId") String apiId) {
         log.debug("Delete API {} from API Product: {}", apiId, apiProductId);
         AuditInfo audit = getAuditInfo();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -76,12 +76,7 @@ public class ApiProductsResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions(
-        {
-            @Permission(
-                value = RolePermission.ENVIRONMENT_API_PRODUCTS,
-                acls = { RolePermissionAction.CREATE, RolePermissionAction.UPDATE }
-            ),
-        }
+        { @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.CREATE, RolePermissionAction.UPDATE }) }
     )
     public Response verifyApiProductName(@Valid @NotNull final VerifyApiProduct verifyApiProduct) {
         var executionContext = GraviteeContext.getExecutionContext();
@@ -112,7 +107,7 @@ public class ApiProductsResource extends AbstractResource {
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.CREATE }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.CREATE }) })
     public Response createApiProduct(@Valid @NotNull final CreateApiProduct createApiProduct) throws TechnicalException {
         AuditInfo audit = getAuditInfo();
         var input = new CreateApiProductUseCase.Input(createApiProduct, audit);
@@ -127,7 +122,7 @@ public class ApiProductsResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCTS, acls = { RolePermissionAction.READ }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.READ }) })
     public Response getApiProducts(@BeanParam @Valid PaginationParam paginationParam) {
         var executionContext = GraviteeContext.getExecutionContext();
         var output = getApiProductsUseCase.execute(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1611,6 +1611,7 @@ components:
         - PLATFORM
         - INTEGRATION
         - CLUSTER
+        - API_PRODUCT
     Member:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
@@ -141,7 +141,9 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.READ, () -> rootTarget().request().get());
+            shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.READ, () ->
+                rootTarget().request().get()
+            );
         }
     }
 
@@ -165,7 +167,7 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.DELETE, () ->
+            shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.DELETE, () ->
                 rootTarget().request().delete()
             );
         }
@@ -240,7 +242,7 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.UPDATE, () ->
+            shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
                 rootTarget().request().put(json(""))
             );
         }
@@ -273,7 +275,7 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.UPDATE, () ->
+            shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
                 rootTarget().path("apis").request().delete()
             );
         }
@@ -330,7 +332,7 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.UPDATE, () ->
+            shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
                 rootTarget().path("apis").path(API_ID).request().delete()
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
@@ -130,7 +130,7 @@ class ApiProductsResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.CREATE, () ->
+            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.CREATE, () ->
                 rootTarget().path("_verify").request().post(json(new VerifyApiProduct()))
             );
         }
@@ -185,7 +185,7 @@ class ApiProductsResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.CREATE, () ->
+            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.CREATE, () ->
                 rootTarget().request().post(json(new CreateApiProduct()))
             );
         }
@@ -248,7 +248,7 @@ class ApiProductsResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCTS, ENV_ID, RolePermissionAction.READ, () -> rootTarget().request().get());
+            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.READ, () -> rootTarget().request().get());
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.RoleScope;
 import io.gravitee.rest.api.management.rest.model.wrapper.RoleScopesLinkedHashMap;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
@@ -78,6 +79,10 @@ public class RoleScopesResource extends AbstractResource {
             stream(IntegrationPermission.values()).map(IntegrationPermission::getName).sorted().collect(toList())
         );
         roles.put(RoleScope.CLUSTER.name(), stream(ClusterPermission.values()).map(ClusterPermission::getName).sorted().collect(toList()));
+        roles.put(
+            RoleScope.API_PRODUCT.name(),
+            stream(ApiProductPermission.values()).map(ApiProductPermission::getName).sorted().collect(toList())
+        );
         return roles;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -52,7 +52,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             "ALERT",
             "API",
             "API_HEADER",
-            "API_PRODUCTS",
+            "API_PRODUCT",
             "APPLICATION",
             "AUDIT",
             "CATEGORY",
@@ -123,7 +123,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
 
         assertAll(
             () -> assertEquals(HttpStatusCode.OK_200, response.getStatus()),
-            () -> assertThat(resultRoleScopes.size()).isEqualTo(6),
+            () -> assertThat(resultRoleScopes.size()).isEqualTo(7),
             () ->
                 assertThat(resultRoleScopes.keySet()).containsExactlyInAnyOrder(
                     "ORGANIZATION",
@@ -131,7 +131,8 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
                     "API",
                     "APPLICATION",
                     "INTEGRATION",
-                    "CLUSTER"
+                    "CLUSTER",
+                    "API_PRODUCT"
                 ),
             () -> assertThat(resultRoleScopes.get("ORGANIZATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ORGANIZATION")),
             () -> assertThat(resultRoleScopes.get("ENVIRONMENT")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ENVIRONMENT")),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public enum MembershipReferenceType {
     APPLICATION(EnumSet.of(RoleScope.APPLICATION)),
     API(EnumSet.of(RoleScope.API)),
+    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT)),
     GROUP(EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION, RoleScope.CLUSTER)),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ApiProductPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ApiProductPermission.java
@@ -13,20 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.member.model;
+package io.gravitee.rest.api.model.permissions;
 
-/**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum RoleScope {
-    API,
-    APPLICATION,
-    GROUP,
-    ENVIRONMENT,
-    ORGANIZATION,
-    PLATFORM,
-    INTEGRATION,
-    CLUSTER,
-    API_PRODUCT,
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
+public enum ApiProductPermission implements Permission {
+    DEFINITION("DEFINITION", 1000),
+    PLAN("PLAN", 1100),
+    SUBSCRIPTION("SUBSCRIPTION", 1200);
+
+    final String name;
+    final int mask;
+
+    ApiProductPermission(String name, int mask) {
+        this.name = name;
+        this.mask = mask;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMask() {
+        return mask;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -50,7 +50,7 @@ public enum EnvironmentPermission implements Permission {
     INTEGRATION("INTEGRATION", 3800),
     SHARED_POLICY_GROUP("SHARED_POLICY_GROUP", 3900),
     CLUSTER("CLUSTER", 4000),
-    API_PRODUCTS("API_PRODUCTS", 4100);
+    API_PRODUCT("API_PRODUCT", 4100);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
@@ -44,6 +44,8 @@ public interface Permission {
                 return IntegrationPermission.values();
             case CLUSTER:
                 return ClusterPermission.values();
+            case API_PRODUCT:
+                return ApiProductPermission.values();
             default:
                 throw new IllegalArgumentException("[" + scope + "] are not a RolePermission");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -88,7 +88,7 @@ public enum RolePermission {
     ENVIRONMENT_INTEGRATION(RoleScope.ENVIRONMENT, EnvironmentPermission.INTEGRATION),
     ENVIRONMENT_SHARED_POLICY_GROUP(RoleScope.ENVIRONMENT, EnvironmentPermission.SHARED_POLICY_GROUP),
     ENVIRONMENT_CLUSTER(RoleScope.ENVIRONMENT, EnvironmentPermission.CLUSTER),
-    ENVIRONMENT_API_PRODUCTS(RoleScope.ENVIRONMENT, EnvironmentPermission.API_PRODUCTS),
+    ENVIRONMENT_API_PRODUCT(RoleScope.ENVIRONMENT, EnvironmentPermission.API_PRODUCT),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),
@@ -113,7 +113,11 @@ public enum RolePermission {
     CLUSTER_ANALYTICS(RoleScope.CLUSTER, ClusterPermission.ANALYTICS),
     CLUSTER_CONFIGURATION(RoleScope.CLUSTER, ClusterPermission.CONFIGURATION),
     CLUSTER_DEFINITION(RoleScope.CLUSTER, ClusterPermission.DEFINITION),
-    CLUSTER_MEMBER(RoleScope.CLUSTER, ClusterPermission.MEMBER);
+    CLUSTER_MEMBER(RoleScope.CLUSTER, ClusterPermission.MEMBER),
+
+    API_PRODUCT_DEFINITION(RoleScope.API_PRODUCT, ApiProductPermission.DEFINITION),
+    API_PRODUCT_PLAN(RoleScope.API_PRODUCT, ApiProductPermission.PLAN),
+    API_PRODUCT_SUBSCRIPTION(RoleScope.API_PRODUCT, ApiProductPermission.SUBSCRIPTION);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
@@ -31,4 +31,5 @@ public enum RoleScope {
     PLATFORM,
     INTEGRATION,
     CLUSTER,
+    API_PRODUCT,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
@@ -52,6 +52,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
     private static final String APPLICATION_ID_PARAM_V1 = "application";
     private static final String INTEGRATION_ID_PARAM = "integrationId";
     private static final String CLUSTER_ID_PARAM = "clusterId";
+    private static final String API_PRODUCT_ID_PARAM = "apiProductId";
 
     @Context
     protected ResourceInfo resourceInfo;
@@ -87,6 +88,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case GROUP -> hasPermission(executionContext, permission, getGroupId(requestContext));
             case INTEGRATION -> hasPermission(executionContext, permission, getId(INTEGRATION_ID_PARAM, requestContext));
             case CLUSTER -> hasPermission(executionContext, permission, getId(CLUSTER_ID_PARAM, requestContext));
+            case API_PRODUCT -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
             case PLATFORM -> false;
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public enum MembershipReferenceType {
     APPLICATION(EnumSet.of(RoleScope.APPLICATION)),
     API(EnumSet.of(RoleScope.API)),
+    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT)),
     GROUP(EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION)),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainService.java
@@ -128,7 +128,7 @@ public class ApiProductPrimaryOwnerDomainService {
     }
 
     private Optional<Role> findPrimaryOwnerRole(String organizationId) {
-        return roleQueryService.findApiRole(
+        return roleQueryService.findApiProductRole(
             SystemRole.PRIMARY_OWNER.name(),
             ReferenceContext.builder().referenceType(ReferenceContext.Type.ORGANIZATION).referenceId(organizationId).build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
@@ -49,5 +49,6 @@ public class Role {
         PLATFORM,
         INTEGRATION,
         CLUSTER,
+        API_PRODUCT,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
@@ -25,6 +25,7 @@ public interface RoleQueryService {
     Optional<Role> findApiRole(String name, ReferenceContext referenceContext);
     Optional<Role> findApplicationRole(String name, ReferenceContext referenceContext);
     Optional<Role> findIntegrationRole(String name, ReferenceContext referenceContext);
+    Optional<Role> findApiProductRole(String name, ReferenceContext referenceContext);
     Optional<Role> findByScopeAndNameAndOrganizationId(Role.Scope scope, String name, String organizationId);
     Set<Role> findByIds(Set<String> ids);
     Optional<Role> findByScopeAndName(Role.Scope scope, String name, String organizationId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/RoleQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/RoleQueryServiceImpl.java
@@ -111,6 +111,22 @@ public class RoleQueryServiceImpl implements RoleQueryService {
     }
 
     @Override
+    public Optional<Role> findApiProductRole(String name, ReferenceContext referenceContext) {
+        try {
+            return roleRepository
+                .findByScopeAndNameAndReferenceIdAndReferenceType(
+                    RoleScope.API_PRODUCT,
+                    name,
+                    referenceContext.getReferenceId(),
+                    RoleReferenceType.valueOf(referenceContext.getReferenceType().name())
+                )
+                .map(RoleAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find api product role", e);
+        }
+    }
+
+    @Override
     public Optional<Role> findByScopeAndNameAndOrganizationId(Role.Scope scope, String name, String organizationId) {
         try {
             return roleRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toMap;
 import io.gravitee.common.util.Maps;
 import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
@@ -53,6 +54,7 @@ public interface DefaultRoleEntityDefinition {
             .put(EnvironmentPermission.API.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(EnvironmentPermission.APPLICATION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(EnvironmentPermission.INTEGRATION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(EnvironmentPermission.API_PRODUCT.getName(), new char[] { READ.getId() })
             .put(
                 EnvironmentPermission.SHARED_POLICY_GROUP.getName(),
                 new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() }
@@ -76,6 +78,7 @@ public interface DefaultRoleEntityDefinition {
             .put(EnvironmentPermission.GROUP.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.DOCUMENTATION.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.INTEGRATION.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.API_PRODUCT.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.SHARED_POLICY_GROUP.getName(), new char[] { READ.getId() })
             .build()
     );
@@ -203,6 +206,30 @@ public interface DefaultRoleEntityDefinition {
         Maps.<String, char[]>builder()
             .put(IntegrationPermission.DEFINITION.getName(), new char[] { READ.getId() })
             .put(IntegrationPermission.MEMBER.getName(), new char[] { READ.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_API_PRODUCT_OWNER = new NewRoleEntity(
+        "OWNER",
+        "API Product Role. Created by Gravitee.io.",
+        API_PRODUCT,
+        false,
+        Maps.<String, char[]>builder()
+            .put(ApiProductPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(ApiProductPermission.PLAN.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(ApiProductPermission.SUBSCRIPTION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_API_PRODUCT_USER = new NewRoleEntity(
+        "USER",
+        "Default API Product Role. Created by Gravitee.io.",
+        API_PRODUCT,
+        true,
+        Maps.<String, char[]>builder()
+            .put(ApiProductPermission.DEFINITION.getName(), new char[] { READ.getId() })
+            .put(ApiProductPermission.PLAN.getName(), new char[] { READ.getId() })
+            .put(ApiProductPermission.SUBSCRIPTION.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -45,6 +45,7 @@ public class PermissionServiceImpl extends AbstractService implements Permission
 
     public static final Map<RoleScope, MembershipReferenceType> ROLE_SCOPE_TO_REFERENCE_TYPE = Map.ofEntries(
         Pair.of(RoleScope.API, MembershipReferenceType.API),
+        Pair.of(RoleScope.API_PRODUCT, MembershipReferenceType.API_PRODUCT),
         Pair.of(RoleScope.APPLICATION, MembershipReferenceType.APPLICATION),
         Pair.of(RoleScope.ORGANIZATION, MembershipReferenceType.ORGANIZATION),
         Pair.of(RoleScope.ENVIRONMENT, MembershipReferenceType.ENVIRONMENT),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -31,6 +31,8 @@ import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DE
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ENVIRONMENT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ORGANIZATION_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_APPLICATION_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
@@ -50,6 +52,7 @@ import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
@@ -113,6 +116,8 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         Map.entry("<APPLICATION> OWNER", ROLE_APPLICATION_OWNER),
         Map.entry("<INTEGRATION> OWNER", ROLE_INTEGRATION_OWNER),
         Map.entry("<INTEGRATION> USER", ROLE_INTEGRATION_USER),
+        Map.entry("<API_PRODUCT> OWNER", ROLE_API_PRODUCT_OWNER),
+        Map.entry("<API_PRODUCT> USER", ROLE_API_PRODUCT_USER),
         Map.entry("<CLUSTER> USER", CLUSTER_ROLE_USER),
         Map.entry("<CLUSTER> OWNER", CLUSTER_ROLE_OWNER)
     );
@@ -590,6 +595,14 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 SystemRole.PRIMARY_OWNER,
                 RoleScope.INTEGRATION,
                 IntegrationPermission.values(),
+                organizationId
+            );
+            //API_PRODUCT - PRIMARY_OWNER
+            createOrUpdateSystemRole(
+                executionContext,
+                SystemRole.PRIMARY_OWNER,
+                RoleScope.API_PRODUCT,
+                ApiProductPermission.values(),
                 organizationId
             );
             //GROUP - ADMINISTRATOR

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/RoleFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/RoleFixtures.java
@@ -51,6 +51,10 @@ public class RoleFixtures {
         return "int-po-id-" + integrationId;
     }
 
+    public static String apiProductPrimaryOwnerRoleId(String organizationId) {
+        return "api-product-po-id-" + organizationId;
+    }
+
     public static Role anOrganizationAdminRole(String organizationId) {
         return systemRoleBuilder()
             .id(organizationAdminRoleId(organizationId))
@@ -108,6 +112,16 @@ public class RoleFixtures {
             .referenceId(organizationId)
             .referenceType(ReferenceType.ORGANIZATION)
             .scope(Role.Scope.INTEGRATION)
+            .build();
+    }
+
+    public static Role anApiProductPrimaryOwnerRole(String organizationId) {
+        return systemRoleBuilder()
+            .id(apiProductPrimaryOwnerRoleId(organizationId))
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .referenceId(organizationId)
+            .referenceType(ReferenceType.ORGANIZATION)
+            .scope(Role.Scope.API_PRODUCT)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/RoleQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/RoleQueryServiceInMemory.java
@@ -71,6 +71,17 @@ public class RoleQueryServiceInMemory implements RoleQueryService, InMemoryAlter
     }
 
     @Override
+    public Optional<Role> findApiProductRole(String name, ReferenceContext referenceContext) {
+        return storage
+            .stream()
+            .filter(role -> role.getScope().equals(Role.Scope.API_PRODUCT))
+            .filter(role -> role.getReferenceType().name().equals(referenceContext.getReferenceType().name()))
+            .filter(role -> role.getReferenceId().equals(referenceContext.getReferenceId()))
+            .filter(role -> role.getName().equals(name))
+            .findFirst();
+    }
+
+    @Override
     public Optional<Role> findByScopeAndNameAndOrganizationId(Role.Scope scope, String name, String organizationId) {
         return storage
             .stream()
@@ -118,6 +129,8 @@ public class RoleQueryServiceInMemory implements RoleQueryService, InMemoryAlter
         this.storage.add(RoleFixtures.aGroupAdminRole(organizationId));
         //Integration Primary Owner
         this.storage.add(RoleFixtures.anIntegrationPrimaryOwnerRole(organizationId));
+        // API Product Primary Owner
+        this.storage.add(RoleFixtures.anApiProductPrimaryOwnerRole(organizationId));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
-import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
+import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -86,7 +86,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
                     .memberType(Membership.Type.USER)
                     .referenceType(Membership.ReferenceType.API_PRODUCT)
                     .referenceId("api-product-id")
-                    .roleId(apiPrimaryOwnerRoleId(ORG_ID))
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
                     .source("system")
                     .build()
             )
@@ -117,7 +117,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
                     .memberType(Membership.Type.USER)
                     .referenceType(Membership.ReferenceType.API_PRODUCT)
                     .referenceId("id1")
-                    .roleId(apiPrimaryOwnerRoleId(ORG_ID))
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
                     .source("system")
                     .build(),
                 Membership.builder()
@@ -126,7 +126,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
                     .memberType(Membership.Type.USER)
                     .referenceType(Membership.ReferenceType.API_PRODUCT)
                     .referenceId("id2")
-                    .roleId(apiPrimaryOwnerRoleId(ORG_ID))
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
                     .source("system")
                     .build()
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainServiceTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.core.membership.domain_service;
 
-import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
+import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -121,7 +121,7 @@ class ApiProductPrimaryOwnerDomainServiceTest {
                         .referenceId(API_PRODUCT_ID)
                         .memberType(Membership.Type.USER)
                         .memberId(MEMBER_ID)
-                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -152,14 +152,14 @@ class ApiProductPrimaryOwnerDomainServiceTest {
                         .referenceId(API_PRODUCT_ID)
                         .memberType(Membership.Type.GROUP)
                         .memberId(GROUP_ID)
-                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build(),
                     Membership.builder()
                         .referenceType(Membership.ReferenceType.GROUP)
                         .referenceId(GROUP_ID)
                         .memberType(Membership.Type.USER)
                         .memberId(MEMBER_ID)
-                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -206,7 +206,7 @@ class ApiProductPrimaryOwnerDomainServiceTest {
                 assertThat(membershipCrudService.storage()).containsExactly(
                     Membership.builder()
                         .id("generated-id")
-                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .memberId(MEMBER_ID)
                         .memberType(Membership.Type.USER)
                         .referenceId(API_PRODUCT_ID)
@@ -257,7 +257,7 @@ class ApiProductPrimaryOwnerDomainServiceTest {
                 assertThat(membershipCrudService.storage()).containsExactly(
                     Membership.builder()
                         .id("generated-id")
-                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .memberId(GROUP_ID)
                         .memberType(Membership.Type.GROUP)
                         .referenceId(API_PRODUCT_ID)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
@@ -72,14 +72,14 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(7)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
             eq(REFERENCE_TYPE)
         );
         verify(mockRoleRepository, never()).update(any());
-        verify(mockRoleRepository, times(7)).create(any());
+        verify(mockRoleRepository, times(8)).create(any());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(7)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
@@ -138,7 +138,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
                     Arrays.stream(envtAdminPermissions).reduce(Math::addExact).orElse(0)
             )
         );
-        verify(mockRoleRepository, times(5)).create(
+        verify(mockRoleRepository, times(6)).create(
             argThat(
                 o ->
                     o.getScope().equals(RoleScope.API) ||
@@ -146,7 +146,8 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
                     o.getScope().equals(RoleScope.ORGANIZATION) ||
                     o.getScope().equals(RoleScope.PLATFORM) ||
                     o.getScope().equals(RoleScope.GROUP) ||
-                    o.getScope().equals(RoleScope.INTEGRATION)
+                    o.getScope().equals(RoleScope.INTEGRATION) ||
+                    o.getScope().equals(RoleScope.API_PRODUCT)
             )
         );
     }
@@ -185,14 +186,14 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(7)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
             eq(REFERENCE_TYPE)
         );
         verify(mockRoleRepository, never()).update(any());
-        verify(mockRoleRepository, times(5)).create(
+        verify(mockRoleRepository, times(6)).create(
             argThat(
                 o ->
                     o.getScope().equals(RoleScope.API) ||
@@ -200,7 +201,8 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
                     o.getScope().equals(RoleScope.ORGANIZATION) ||
                     o.getScope().equals(RoleScope.PLATFORM) ||
                     o.getScope().equals(RoleScope.GROUP) ||
-                    o.getScope().equals(RoleScope.INTEGRATION)
+                    o.getScope().equals(RoleScope.INTEGRATION) ||
+                    o.getScope().equals(RoleScope.API_PRODUCT)
             )
         );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12480

## Description

adding roles and permission for API PRODUCT (owner, primary owner, user) and scope (DEFINITION, PLAN, SUBSCRIPTION).
<img width="3444" height="1724" alt="Screenshot 2026-01-23 at 1 31 13 PM" src="https://github.com/user-attachments/assets/edfe05e5-53fa-4c50-a417-8f7032b3fa3f" />

<img width="3444" height="1724" alt="Screenshot 2026-01-23 at 1 31 06 PM" src="https://github.com/user-attachments/assets/e7979a96-4d25-47a2-969e-6f396c961070" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

