### PR TITLE
fix flaky test with dynamic properties

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceTest.java
@@ -866,9 +866,11 @@ class HttpDynamicPropertiesServiceTest {
      * @param configuration the configuration needed to build the {@link CronTrigger}
      */
     private void advanceTimeBy(final int delay, HttpDynamicPropertiesService cut, HttpDynamicPropertiesServiceConfiguration configuration) {
-        testScheduler.advanceTimeBy(delay, TimeUnit.MILLISECONDS);
-        TimeProvider.overrideClock(Clock.fixed(Instant.ofEpochMilli(testScheduler.now(TimeUnit.MILLISECONDS)), ZoneId.systemDefault()));
+        TimeProvider.overrideClock(
+            Clock.fixed(Instant.ofEpochMilli(testScheduler.now(TimeUnit.MILLISECONDS) + delay), ZoneId.systemDefault())
+        );
         cut.cronTrigger = new CronTrigger(configuration.getSchedule());
+        testScheduler.advanceTimeBy(delay, TimeUnit.MILLISECONDS);
     }
 
     private HttpDynamicPropertiesService buildServiceFor(AbstractApi api) {


### PR DESCRIPTION
## Description

The test instability was caused by updating the system clock after advancing the TestScheduler, leading to incorrect timer delays.
The fix involved updating the system clock and resetting the CronTrigger before advancing the TestScheduler in the advanceTimeBy method.

(made with Junie)
