### PR TITLE
Fix IsSynchronized with plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1868,7 +1868,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     //  current one.
                     removeIdsFromFlows(api);
                     removeIdsFromFlows(deployedApi);
-
+                    removePlans(api, deployedApi);
                     sync = synchronizationService.checkSynchronization(ApiEntity.class, deployedApi, api);
 
                     // 2_ If API definition is synchronized, check if there is any modification for API's plans
@@ -1898,6 +1898,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private void removeIdsFromFlows(ApiEntity api) {
         api.getFlows().forEach(flow -> flow.setId(null));
         api.getPlans().forEach(plan -> plan.getFlows().forEach(flow -> flow.setId(null)));
+    }
+
+    private static void removePlans(ApiEntity api, ApiEntity deployedApi) {
+        api.setPlans(null);
+        deployedApi.setPlans(null);
     }
 
     private void removeDescriptionFromPolicies(final ApiEntity api) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -546,37 +546,25 @@ public class ApiStateServiceImpl implements ApiStateService {
                     ) {
                         io.gravitee.rest.api.model.api.ApiEntity apiEntity = (io.gravitee.rest.api.model.api.ApiEntity) genericApiEntity;
 
-                        io.gravitee.rest.api.model.api.ApiEntity deployedApiEntity = apiConverter.toApiEntity(
-                            executionContext,
-                            payloadEntity,
-                            null,
-                            false,
-                            false,
-                            false
-                        );
+                        io.gravitee.rest.api.model.api.ApiEntity deployedApiEntity = apiConverter.toApiEntity(payloadEntity, null, false);
 
                         removePathsRuleDescriptionFromApiV1(deployedApiEntity);
                         removePathsRuleDescriptionFromApiV1(apiEntity);
 
+                        removePlans(apiEntity, deployedApiEntity);
                         sync = synchronizationService.checkSynchronization(
                             io.gravitee.rest.api.model.api.ApiEntity.class,
                             deployedApiEntity,
                             apiEntity
                         );
                     } else if (genericApiEntity instanceof ApiEntity httpApiEntity) {
-                        ApiEntity deployedApiEntity = apiMapper.toEntity(executionContext, payloadEntity, false, false, false);
-
+                        ApiEntity deployedApiEntity = apiMapper.toEntity(payloadEntity, null);
+                        removePlans(httpApiEntity, deployedApiEntity);
                         sync = synchronizationService.checkSynchronization(ApiEntity.class, deployedApiEntity, httpApiEntity);
                     } else if (genericApiEntity instanceof NativeApiEntity nativeApiEntity) {
-                        NativeApiEntity deployedApiEntity = apiMapper.toNativeEntity(
-                            executionContext,
-                            payloadEntity,
-                            null,
-                            false,
-                            false,
-                            false
-                        );
+                        NativeApiEntity deployedApiEntity = apiMapper.toNativeEntity(payloadEntity, null);
 
+                        removePlans(nativeApiEntity, deployedApiEntity);
                         sync = synchronizationService.checkSynchronization(NativeApiEntity.class, deployedApiEntity, nativeApiEntity);
                     }
 
@@ -624,5 +612,18 @@ public class ApiStateServiceImpl implements ApiStateService {
 
     private DefinitionVersion getOrV2(Supplier<DefinitionVersion> getDefinitionVersion) {
         return getDefinitionVersion.get() != null ? getDefinitionVersion.get() : DefinitionVersion.V2;
+    }
+
+    private static void removePlans(GenericApiEntity api, GenericApiEntity deployedApi) {
+        if (api instanceof ApiEntity apiEntity) {
+            apiEntity.setPlans(null);
+            ((ApiEntity) deployedApi).setPlans(null);
+        } else if (api instanceof NativeApiEntity nativeApiEntity) {
+            (nativeApiEntity).setPlans(null);
+            ((NativeApiEntity) deployedApi).setPlans(null);
+        } else if (api instanceof io.gravitee.rest.api.model.api.ApiEntity apiV2Entity) {
+            (apiV2Entity).setPlans(null);
+            ((io.gravitee.rest.api.model.api.ApiEntity) deployedApi).setPlans(null);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
@@ -183,6 +183,8 @@ public class ApiServiceImplTest {
 
         boolean result = apiService.isSynchronized(executionContext, "api-id");
 
+        verify(currentApi, times(2)).setPlans(null);
+
         assertTrue(result);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EventLatestRepository;
@@ -244,7 +245,9 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         ).thenReturn(List.of(event));
 
         ApiEntity apiEntity = apiMapper.toEntity(GraviteeContext.getExecutionContext(), api, false, false, false);
+        apiEntity.setPlans(Set.of(PlanEntity.builder().id("This plan should be ignored").build()));
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
         final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
 
         assertThat(isSynchronized).isTrue();
@@ -507,6 +510,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             false
         );
         apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        apiEntity.setPlans(Set.of(io.gravitee.rest.api.model.PlanEntity.builder().id("This plan should be ignored").build()));
         final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
 
         assertThat(isSynchronized).isTrue();


### PR DESCRIPTION
## Issue
n/a

## Description


Previous code: 
Step 1:
We retrieved the current API on apim with its plans. 
Then we retrieved the deployed API in the event table. We also added the apim plans (i.e., not the deployed ones, the one id plans table) (yes, for no reason).

Step 2:
Next, we have a specialized step for the plans that checks whether there has been a change to the plans since the last deployment.

New code :
This completely ignores the plans in step 1 so that only step 2 is responsible for them.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

