### PR TITLE
fix: when a group is an API PO, we should not be able to remove the group from its PO member

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -1097,10 +1097,44 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         return entity;
     }
 
+    private void verifyUserCanBeDeletedFromGroup(ExecutionContext executionContext, String groupId, String username) {
+        // Check if this group is the primary owner of any API and if the user to remove has the API primary owner role in this group
+        RoleEntity apiPORole = roleService
+            .findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+            .orElseThrow(() -> new TechnicalManagementException("API System Role 'PRIMARY_OWNER' not found."));
+
+        Set<MembershipEntity> groupApiPrimaryOwnerMemberships = membershipService.getMembershipsByMemberAndReferenceAndRole(
+            MembershipMemberType.GROUP,
+            groupId,
+            MembershipReferenceType.API,
+            apiPORole.getId()
+        );
+
+        if (!groupApiPrimaryOwnerMemberships.isEmpty()) {
+            // Check if the user has the API primary owner role in this group
+            Set<RoleEntity> userRolesInGroup = membershipService.getRoles(
+                MembershipReferenceType.GROUP,
+                groupId,
+                MembershipMemberType.USER,
+                username
+            );
+
+            boolean userHasApiPrimaryOwnerRole = userRolesInGroup
+                .stream()
+                .anyMatch(role -> role.getScope() == RoleScope.API && SystemRole.PRIMARY_OWNER.name().equals(role.getName()));
+
+            if (userHasApiPrimaryOwnerRole) {
+                throw new StillPrimaryOwnerException(groupApiPrimaryOwnerMemberships.size(), ApiPrimaryOwnerMode.GROUP);
+            }
+        }
+    }
+
     @Override
     public void deleteUserFromGroup(ExecutionContext executionContext, String groupId, String username) {
         //check if user exist
         this.userService.findById(executionContext, username);
+
+        verifyUserCanBeDeletedFromGroup(executionContext, groupId, username);
 
         eventManager.publishEvent(
             ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
@@ -20,12 +20,15 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 import static io.gravitee.rest.api.service.impl.AbstractService.convert;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.event.EventManager;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.api.search.GroupCriteria;
 import io.gravitee.repository.management.model.Group;
@@ -42,8 +45,10 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -70,6 +75,12 @@ public class GroupServiceImplTest {
 
     @Mock
     private RoleService roleService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private EventManager eventManager;
 
     @Test
     public void search_hasNotPermissionCreateUpdateDelete() {
@@ -162,6 +173,131 @@ public class GroupServiceImplTest {
             () -> assertThat(searchResult.getTotalElements()).isEqualTo(13),
             () -> assertThat(searchResult.getPageNumber()).isEqualTo(pageNumber),
             () -> assertThat(searchResult.getPageElements()).isEqualTo(pageSize)
+        );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldSucceed_whenGroupIsNotApiPrimaryOwner() throws Exception {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+
+        // Group is NOT a primary owner of any API (empty memberships)
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API,
+                apiPORole.getId()
+            )
+        ).thenReturn(Set.of());
+
+        // Mock group lookup for apiPrimaryOwner check at the end
+        when(groupRepository.findById(groupId)).thenReturn(
+            Optional.of(Group.builder().id(groupId).environmentId(executionContext.getEnvironmentId()).build())
+        );
+        when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Set.of());
+
+        service.deleteUserFromGroup(executionContext, groupId, username);
+
+        verify(membershipService).deleteReferenceMember(
+            executionContext,
+            MembershipReferenceType.GROUP,
+            groupId,
+            MembershipMemberType.USER,
+            username
+        );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldSucceed_whenGroupIsApiPrimaryOwner_butUserDoesNotHavePrimaryOwnerRole() throws Exception {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+
+        // Group IS a primary owner of some APIs
+        MembershipEntity groupApiPOMembership = MembershipEntity.builder()
+            .id("membership-1")
+            .referenceId("api-1")
+            .referenceType(MembershipReferenceType.API)
+            .build();
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API,
+                apiPORole.getId()
+            )
+        ).thenReturn(Set.of(groupApiPOMembership));
+
+        // User does NOT have API PRIMARY_OWNER role in this group (has a different role)
+        RoleEntity userApiRole = RoleEntity.builder().id("api-user-role-id").name("USER").scope(RoleScope.API).build();
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username)).thenReturn(
+            Set.of(userApiRole)
+        );
+
+        // Mock group lookup for apiPrimaryOwner check at the end
+        when(groupRepository.findById(groupId)).thenReturn(
+            Optional.of(Group.builder().id(groupId).environmentId(executionContext.getEnvironmentId()).build())
+        );
+
+        service.deleteUserFromGroup(executionContext, groupId, username);
+
+        verify(membershipService).deleteReferenceMember(
+            executionContext,
+            MembershipReferenceType.GROUP,
+            groupId,
+            MembershipMemberType.USER,
+            username
+        );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldThrowException_whenGroupIsApiPrimaryOwner_andUserHasPrimaryOwnerRole() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+
+        // Group IS a primary owner of some APIs
+        MembershipEntity groupApiPOMembership = MembershipEntity.builder()
+            .id("membership-1")
+            .referenceId("api-1")
+            .referenceType(MembershipReferenceType.API)
+            .build();
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API,
+                apiPORole.getId()
+            )
+        ).thenReturn(Set.of(groupApiPOMembership));
+
+        // User HAS API PRIMARY_OWNER role in this group
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username)).thenReturn(
+            Set.of(apiPORole)
+        );
+
+        assertThatThrownBy(() -> service.deleteUserFromGroup(executionContext, groupId, username)).isInstanceOf(
+            StillPrimaryOwnerException.class
         );
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12349

Steps to reproduce:
- create a simple API
- create a group with a member with API PO role
- transfer the ownership of the API to this group
- go to Organization > Users > the group API PO member > groups > Delete
<img width="1040" height="336" alt="image" src="https://github.com/user-attachments/assets/65748ec8-4085-48f1-a87d-865c742b63b1" />

Before you were able to delete the group from this page