### PR TITLE
CI: do a git diff based on common commit

### DIFF
--- a/.circleci/ci/src/index.ts
+++ b/.circleci/ci/src/index.ts
@@ -28,6 +28,7 @@ const CI_DRY_RUN: string | undefined = process.env.CI_DRY_RUN;
 const CI_GRAVITEEIO_VERSION: string = process.env.CI_GRAVITEEIO_VERSION ?? '';
 const CI_DOCKER_TAG_AS_LATEST: string | undefined = process.env.CI_DOCKER_TAG_AS_LATEST;
 const GIT_BASE_BRANCH: string = process.env.GIT_BASE_BRANCH ?? 'master';
+const GIT_COMMON_COMMIT_HASH: string = process.env.GIT_COMMON_COMMIT_HASH ?? '';
 const APIM_VERSION_PATH: string | undefined = process.env.APIM_VERSION_PATH;
 
 if (isBlank(CIRCLE_SHA1)) {
@@ -40,7 +41,7 @@ if (isBlank(CIRCLE_SHA1)) {
  *     - if the branch is supported ( CIRCLE_BRANCH is master or a support branch )
  *     - if we are working on a branch with changes committed on the base branch
  */
-const changed = isSupportBranchOrMaster(CIRCLE_BRANCH) ? Promise.resolve([]) : changedFiles(GIT_BASE_BRANCH);
+const changed = isSupportBranchOrMaster(CIRCLE_BRANCH) ? Promise.resolve([]) : changedFiles(GIT_COMMON_COMMIT_HASH ?? GIT_BASE_BRANCH);
 
 changed
   .then(

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
                                     # If the branch name is not empty, then the matching branch has been found
                                     if [ -n "$branch" ]; then
                                       BASE_REF=$branch
-                                      echo "Base branch is $branch (common ancestor is commit: $hash)"
+                                      COMMON_COMMIT=$hash
                                       break
                                     fi
                                   done
@@ -105,7 +105,10 @@ jobs:
                                 # else use the pull request info
                                 else
                                   PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
-                                  BASE_REF=origin/$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL} | jq -r '.base.ref // "master"')
+                                  PULL_REQUEST_RESPONSE_CONTENT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL})
+
+                                  BASE_REF=origin/$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.ref // "master"')
+                                  COMMON_COMMIT=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.sha // ""')
                                 fi;
 
                                 # if BASE_REF is empty just stop
@@ -116,6 +119,9 @@ jobs:
 
                                 echo "export GIT_BASE_BRANCH=${BASE_REF}" >> $BASH_ENV
                                 echo "The base branch is ${BASE_REF}"
+
+                                echo "export GIT_COMMON_COMMIT_HASH=${COMMON_COMMIT}" >> $BASH_ENV
+                                echo "The common commit hash is ${COMMON_COMMIT}"
 
             - node/install-packages:
                   app-dir: .circleci/ci


### PR DESCRIPTION
## Description

instead of comparing the HEAD of the current branch with the HEAD of the target branch, we try to compare the HEAD of the current branch with the commit in common between current and target branches.

This way, the git diff contains only the modified files on the current branch.

⚠️ Once merged, we will have to force all PRs to be up to date with target branch so they can be merged.