### PR TITLE
fix(console): Separator shown when create and either update or delete…

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
@@ -18,6 +18,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatMenuItemHarness } from '@angular/material/menu/testing';
 import { MatTreeHarness, MatTreeNodeHarness } from '@angular/material/tree/testing';
 import { MatIconHarness } from '@angular/material/icon/testing';
+import { MatDividerHarness } from '@angular/material/divider/testing';
 
 import { EmptyStateComponentHarness } from '../../../shared/components/empty-state/empty-state.component.harness';
 
@@ -157,5 +158,9 @@ export class FlatTreeComponentHarness extends ComponentHarness {
 
   async getMenuItemByTestId(testId: string): Promise<MatMenuItemHarness | null> {
     return this._documentRootLocator.locatorForOptional(MatMenuItemHarness.with({ selector: `[data-testid="${testId}"]` }))();
+  }
+
+  async hasDivider(): Promise<boolean> {
+    return (await this._documentRootLocator.locatorForOptional(MatDividerHarness)()) !== null;
   }
 }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -139,7 +139,9 @@
             <mat-icon svgIcon="gio:link"></mat-icon>
             Add Link
           </button>
-          <mat-divider></mat-divider>
+          @if (canUpdate || canDelete) {
+            <mat-divider></mat-divider>
+          }
         }
       }
 

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -590,6 +590,44 @@ describe('FlatTreeComponent', () => {
       expect(deleteButton).toBeNull();
     });
 
+    const testCases = [
+      {
+        description: 'should NOT show divider if user has only create permission',
+        permissions: ['environment-documentation-c'],
+        expected: false,
+      },
+      {
+        description: 'should show divider if user has create and update permission',
+        permissions: ['environment-documentation-c', 'environment-documentation-u'],
+        expected: true,
+      },
+      {
+        description: 'should show divider if user has create and delete permission',
+        permissions: ['environment-documentation-c', 'environment-documentation-d'],
+        expected: true,
+      },
+    ];
+
+    testCases.forEach(({ description, permissions, expected }) => {
+      it(description, async () => {
+        setupPermissions(permissions);
+        fixture = TestBed.createComponent(FlatTreeComponent);
+        component = fixture.componentInstance;
+        harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, FlatTreeComponentHarness);
+
+        const links = [makeItem('f2', 'FOLDER', 'Folder 2', 0)];
+        fixture.componentRef.setInput('links', links);
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const moreActionsButton = await harness['getMoreActionsButtonById']('f2')();
+        await moreActionsButton.click();
+
+        expect(await harness.hasDivider()).toBe(expected);
+      });
+    });
+
     it('should show only "Edit" and publishing options if user has only update permission', async () => {
       setupPermissions(['environment-documentation-u']);
       fixture = TestBed.createComponent(FlatTreeComponent);


### PR DESCRIPTION
… permission

## Issue

https://gravitee.atlassian.net/browse/APIM-12393

## Description

separator will be shown only when it has any permissions other than create.

<img width="461" height="397" alt="Screenshot 2026-01-28 at 13 39 12" src="https://github.com/user-attachments/assets/617a9b60-e4d0-496b-9550-ee547751ce97" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

