### PR TITLE
fix(console): override min-height of svg icons in mat buttons

### DIFF
--- a/gravitee-apim-console-webui/src/scss/gio-global-style.scss
+++ b/gravitee-apim-console-webui/src/scss/gio-global-style.scss
@@ -33,6 +33,21 @@ $snackbar-button: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
 }
 
 /**
+ * Override Material min-height: fit-content applied to svgIcons inside buttons and links
+ */
+button,
+a {
+  &[mat-button],
+  &[mat-stroked-button],
+  &[mat-flat-button],
+  &[mat-raised-button] {
+    .mat-icon[svgicon] {
+      min-height: auto;
+    }
+  }
+}
+
+/**
  * Reset `box-sizing` for all elements
  */
 *,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12448

## Description

With Angular Material 20, svgIcon styling now contains `min-height: fit-content`, which changes the text and icon vertical alignment of a mat-button.

By applying `min-height: auto`, we reproduce the previous behavior in Material.

✏️  Note: icons in buttons such as `<mat-icon>add</mat-icon>` are not affected by the Material upgrade nor this PR's changes.

### Before

<img width="363" height="92" alt="Screenshot 2026-01-29 at 16 04 59" src="https://github.com/user-attachments/assets/84f7815b-bd74-467a-933f-2148115d092c" />

### After

<img width="370" height="107" alt="Screenshot 2026-01-29 at 16 05 08" src="https://github.com/user-attachments/assets/0042770c-5ee8-40af-849f-1b90d043753d" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

