### PR TITLE
feat(portal): Added subscription table and filters

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
@@ -17,10 +17,13 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, provideRouter, Router, Routes } from '@angular/router';
+import { of } from 'rxjs/internal/observable/of';
 
 import { routes } from '../app.routes';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardComponentHarness } from './dashboard.component.harness';
+import { ApplicationService } from '../../services/application.service';
+import { SubscriptionService } from '../../services/subscription.service';
 
 describe('DashboardComponent', () => {
   let fixture: ComponentFixture<DashboardComponent>;
@@ -40,6 +43,25 @@ describe('DashboardComponent', () => {
             children: dashboardRoute?.children ?? [],
           },
         ]),
+
+        {
+          provide: SubscriptionService,
+          useValue: {
+            list: () =>
+              of({
+                rows: [],
+                totalElements: 0,
+              }),
+          },
+        },
+
+        {
+          provide: ApplicationService,
+          useValue: {
+            list: () => of([]),
+          },
+        },
+
         {
           provide: ActivatedRoute,
           useValue: {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
 
 import { DivHarness } from '../../../testing/div.harness';
 
@@ -21,8 +23,73 @@ export class SubscriptionsComponentHarness extends ComponentHarness {
   public static hostSelector = 'app-subscriptions';
 
   private getEmptyState = this.locatorForOptional(DivHarness.with({ selector: '.subscriptions__empty-state' }));
+  private getEmptyFiltered = this.locatorForOptional(DivHarness.with({ selector: '.subscriptions__empty-filtered' }));
+  private getTable = this.locatorForOptional(MatTableHarness);
+  private getApiFilter = this.locatorForOptional(MatSelectHarness.with({ selector: '#subscriptions-api-filter' }));
+  private getApplicationFilter = this.locatorForOptional(MatSelectHarness.with({ selector: '#subscriptions-application-filter' }));
+  private getStatusFilter = this.locatorForOptional(MatSelectHarness.with({ selector: '#subscriptions-status-filter' }));
 
   public async isEmptyStateDisplayed(): Promise<boolean> {
     return !!(await this.getEmptyState());
+  }
+
+  public async isEmptyFilteredStateDisplayed(): Promise<boolean> {
+    return !!(await this.getEmptyFiltered());
+  }
+
+  public async isTableDisplayed(): Promise<boolean> {
+    return !!(await this.getTable());
+  }
+
+  public async getTableRowCount(): Promise<number> {
+    const table = await this.getTable();
+    if (!table) return 0;
+    const rows = await table.getRows();
+    return rows.length;
+  }
+
+  public async getTableHeaderCells(): Promise<string[]> {
+    const table = await this.getTable();
+    if (!table) return [];
+    const headerRows = await table.getHeaderRows();
+    if (headerRows.length === 0) return [];
+    const cells = await headerRows[0].getCells();
+    return Promise.all(cells.map(cell => cell.getText()));
+  }
+
+  public async selectApiFilter(index: number): Promise<void> {
+    const filter = await this.getApiFilter();
+    if (filter) {
+      await filter.open();
+      const options = await filter.getOptions();
+      if (options[index]) {
+        await options[index].click();
+      }
+    }
+  }
+
+  public async selectApplicationFilter(index: number): Promise<void> {
+    const filter = await this.getApplicationFilter();
+    if (filter) {
+      await filter.open();
+      const options = await filter.getOptions();
+      if (options[index]) {
+        await options[index].click();
+      }
+    }
+  }
+
+  public async selectStatusFilter(values: string[]): Promise<void> {
+    const filter = await this.getStatusFilter();
+    if (filter) {
+      await filter.open();
+      const options = await filter.getOptions();
+      for (const option of options) {
+        const text = await option.getText();
+        if (values.includes(text)) {
+          await option.click();
+        }
+      }
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,8 +15,65 @@
     limitations under the License.
 
 -->
-<div class="subscriptions__empty-state">
-  <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">search</span>
-  <h2 class="m3-title-large" i18n="@@subscriptionsEmptyStateTitle">No API subscriptions yet</h2>
-  <p i18n="@@subscriptionsEmptyStateDescription">Browse the catalog to discover available APIs and subscribe with an application.</p>
+<div class="subscriptions">
+  @if (hasSubscriptions()) {
+    <!-- Filters -->
+    <div class="subscriptions__filters">
+      <mat-form-field appearance="outline" class="subscriptions__filter" subscriptSizing="dynamic">
+        <mat-label i18n="@@subscriptionFilterApi">API</mat-label>
+        <mat-select [formControl]="apiFilter" id="subscriptions-api-filter">
+          <mat-option [value]="null" i18n="@@allApis">All APIs</mat-option>
+          @for (api of availableApis(); track api.id) {
+            <mat-option [value]="api.id">{{ api.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="subscriptions__filter" subscriptSizing="dynamic">
+        <mat-label i18n="@@subscriptionFilterApplication">Application</mat-label>
+        <mat-select [formControl]="applicationFilter" id="subscriptions-application-filter">
+          <mat-option [value]="null" i18n="@@allApplications">All Applications</mat-option>
+          @for (app of availableApplications() ?? []; track app.id) {
+            <mat-option [value]="app.id">{{ app.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="subscriptions__filter" subscriptSizing="dynamic">
+        <mat-label i18n="@@subscriptionFilterStatus">Status</mat-label>
+        <mat-select [formControl]="statusFilter" multiple id="subscriptions-status-filter">
+          @for (status of subscriptionStatusesList; track status) {
+            <mat-option [value]="status">{{ status | capitalizeFirst }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    @if (subscriptionsResource.isLoading()) {
+      <app-loader />
+    } @else if (rows().length === 0) {
+      <div class="subscriptions__empty-filtered">
+        <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">filter_list_off</span>
+        <h2 class="m3-title-large" i18n="@@subscriptionsNoResultsTitle">No subscriptions found</h2>
+        <p i18n="@@subscriptionsNoResultsDescription">Try adjusting your filters to find subscriptions.</p>
+        <button mat-button (click)="clearFilters()" i18n="@@clearFilters">Clear filters</button>
+      </div>
+    } @else {
+      <app-paginated-table
+        [columns]="tableColumns"
+        [rows]="rows()"
+        [totalElements]="totalElements()"
+        [currentPage]="currentSelectedPage"
+        [pageSize]="pageSize()"
+        (pageChange)="onPageChange($event)"
+        (pageSizeChange)="onPageSizeChange($event)" />
+    }
+  } @else {
+    <!-- Empty State -->
+    <div class="subscriptions__empty-state">
+      <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">search</span>
+      <h2 class="m3-title-large" i18n="@@subscriptionsEmptyStateTitle">No API subscriptions yet</h2>
+      <p i18n="@@subscriptionsEmptyStateDescription">Browse the catalog to discover available APIs and subscribe with an application.</p>
+    </div>
+  }
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,40 @@
 @use '../../../scss/helper';
 
 :host {
+  display: block;
   height: 100%;
 }
 
 .subscriptions {
-  &__empty-state {
+  padding: 24px;
+
+  &__filters {
+    display: flex;
+    max-width: fit-content;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+    gap: 16px;
+  }
+
+  &__filter {
+    flex: 1 1 200px;
+  }
+
+  &__empty-state,
+  &__empty-filtered {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding-top: 100px;
+    justify-content: center;
+    text-align: center;
 
     h2 {
-      margin-bottom: 0;
+      margin-bottom: 8px;
     }
 
     p {
-      text-align: center;
+      margin-bottom: 16px;
+      color: app-theme.$paragraph-color;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
@@ -14,30 +14,115 @@
  * limitations under the License.
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 
 import SubscriptionsComponent from './subscriptions.component';
 import { SubscriptionsComponentHarness } from './subscriptions.component.harness';
+import { ApplicationsResponse } from '../../../entities/application/application';
+import { SubscriptionConsumerStatusEnum } from '../../../entities/subscription';
+import { fakeSubscriptionResponse } from '../../../entities/subscription/subscription.fixture';
+import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
 
 describe('SubscriptionsComponent', () => {
   let fixture: ComponentFixture<SubscriptionsComponent>;
   let harness: SubscriptionsComponentHarness;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SubscriptionsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideNoopAnimations(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubscriptionsComponent);
-    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionsComponentHarness);
-    fixture.detectChanges();
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  async function initHarness() {
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionsComponentHarness);
+  }
+
   it('should create', async () => {
+    fixture.detectChanges();
+    expectApplicationsList();
+    expectSubscriptionsList({ data: [], links: { self: '' }, metadata: {} });
+    await initHarness();
+
+    expect(fixture.componentInstance).toBeTruthy();
     expect(await harness.host()).toBeTruthy();
   });
 
-  it('should display empty state', async () => {
+  it('should display empty state when no subscriptions', async () => {
+    fixture.detectChanges();
+    expectApplicationsList();
+    expectSubscriptionsList({ data: [], links: { self: '' }, metadata: {} });
+    await fixture.whenStable();
+    await initHarness();
+
     expect(await harness.isEmptyStateDisplayed()).toBeTruthy();
   });
+
+  it('should display table when subscriptions exist', async () => {
+    fixture.detectChanges();
+    expectApplicationsList();
+    expectSubscriptionsList(fakeSubscriptionResponse());
+    await fixture.whenStable();
+    await initHarness();
+
+    expect(await harness.isEmptyStateDisplayed()).toBeFalsy();
+  });
+
+  it('should parse rows correctly from response', async () => {
+    const response: SubscriptionsResponse = {
+      data: [
+        {
+          id: 'sub-1',
+          api: 'api-1',
+          application: 'app-1',
+          plan: 'plan-1',
+          status: 'ACCEPTED',
+          created_at: '2026-02-03T23:00:00Z',
+          consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
+        },
+      ],
+      metadata: {
+        'api-1': { name: 'API One', apiVersion: '1' },
+        'app-1': { name: 'App One' },
+        'plan-1': { name: 'Plan One' },
+      },
+      links: { self: '' },
+    };
+
+    fixture.detectChanges();
+    expectApplicationsList();
+    expectSubscriptionsList(response);
+    await initHarness();
+
+    expect(fixture.componentInstance.rows().length).toBe(1);
+    expect(fixture.componentInstance.rows()[0]).toEqual({
+      id: 'sub-1',
+      api: 'API One',
+      plan: 'Plan One',
+      application: 'App One',
+      created_at: '2026-02-03T23:00:00Z',
+      status: 'Active',
+    });
+  });
+
+  function expectSubscriptionsList(response: SubscriptionsResponse) {
+    httpTestingController.expectOne(req => req.url.includes('/subscriptions')).flush(response);
+  }
+
+  function expectApplicationsList() {
+    const applicationsResponse: ApplicationsResponse = { data: [] };
+    httpTestingController.expectOne(req => req.url.includes('/applications')).flush(applicationsResponse);
+  }
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -13,12 +13,168 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatOption, MatSelect } from '@angular/material/select';
+import { map } from 'rxjs';
+
+import { LoaderComponent } from '../../../components/loader/loader.component';
+import { PaginatedTableComponent, TableColumn } from '../../../components/paginated-table/paginated-table.component';
+import { SubscriptionMetadata, SubscriptionsResponse, SubscriptionStatusEnum } from '../../../entities/subscription';
+import { CapitalizeFirstPipe } from '../../../pipe/capitalize-first.pipe';
+import { ApplicationService } from '../../../services/application.service';
+import { SubscriptionService } from '../../../services/subscription.service';
 
 @Component({
   selector: 'app-subscriptions',
-  imports: [],
+  standalone: true,
+  imports: [
+    MatButton,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    ReactiveFormsModule,
+    LoaderComponent,
+    CapitalizeFirstPipe,
+    PaginatedTableComponent,
+  ],
   templateUrl: './subscriptions.component.html',
   styleUrl: './subscriptions.component.scss',
 })
-export default class SubscriptionsComponent {}
+export default class SubscriptionsComponent {
+  private subscriptionService = inject(SubscriptionService);
+  private applicationService = inject(ApplicationService);
+  subscriptionStatusesList = Object.values(SubscriptionStatusEnum);
+  tableColumns: TableColumn[] = [
+    { id: 'api', label: 'Subscribed API' },
+    { id: 'plan', label: 'Plan' },
+    { id: 'application', label: 'Application' },
+    { id: 'created_at', label: 'Created', type: 'date' },
+    { id: 'status', label: 'Status' },
+  ];
+
+  // Form controls for filters
+  apiFilter = new FormControl<string | null>(null);
+  applicationFilter = new FormControl<string | null>(null);
+  statusFilter = new FormControl<SubscriptionStatusEnum[] | null>([]);
+
+  // Pagination state
+  pageSize = signal<number>(20);
+  currentPage = signal<number>(1);
+
+  // Available options for filters
+  availableApplications = toSignal(this.applicationService.list(1, -1).pipe(map(response => response.data ?? [])));
+
+  // Filter signals
+  private apiFilterSignal = toSignal(this.apiFilter.valueChanges.pipe(map(v => v ?? undefined)), {
+    initialValue: this.apiFilter.value ?? undefined,
+  });
+  private applicationFilterSignal = toSignal(this.applicationFilter.valueChanges.pipe(map(v => v ?? undefined)), {
+    initialValue: this.applicationFilter.value ?? undefined,
+  });
+  private statusFilterSignal = toSignal(this.statusFilter.valueChanges.pipe(map(v => v ?? [])), {
+    initialValue: this.statusFilter.value ?? [],
+  });
+
+  // Subscriptions Resource
+  subscriptionsResource = rxResource({
+    params: () => ({
+      apiId: this.apiFilterSignal(),
+      applicationId: this.applicationFilterSignal(),
+      statuses: this.statusFilterSignal(),
+      size: this.pageSize(),
+      page: this.currentPage(),
+    }),
+    stream: (params: {
+      params: {
+        apiId?: string;
+        applicationId?: string;
+        statuses: SubscriptionStatusEnum[] | null;
+        size?: number;
+        page?: number;
+      };
+    }) => this.subscriptionService.list(params.params),
+  });
+
+  totalElements = computed(() => {
+    const response = this.subscriptionsResource.value() as SubscriptionsResponse | undefined;
+    return response?.metadata?.['paginateMetaData']?.totalElements ?? response?.data?.length ?? 0;
+  });
+
+  rows = computed(() => {
+    const response = this.subscriptionsResource.value() as SubscriptionsResponse | undefined;
+    if (!response?.data) {
+      return [];
+    }
+
+    const statusMap: Record<string, string> = {
+      ACCEPTED: 'Active',
+      PAUSED: 'Suspended',
+      CLOSED: 'Closed',
+      PENDING: 'Pending',
+      REJECTED: 'Rejected',
+    };
+
+    return response.data.map(sub => ({
+      id: sub.id,
+      api: this.retrieveMetadataName(sub.api, response.metadata),
+      plan: this.retrieveMetadataName(sub.plan, response.metadata),
+      application: this.retrieveMetadataName(sub.application, response.metadata),
+      created_at: sub.created_at ?? '',
+      status: statusMap[sub.status] ?? sub.status,
+    }));
+  });
+
+  availableApis = computed(() => {
+    const response = this.subscriptionsResource.value() as SubscriptionsResponse | undefined;
+    const apis: { id: string; name: string }[] = [];
+    if (response?.metadata) {
+      for (const [key, value] of Object.entries(response.metadata)) {
+        // APIs are identified by the presence of 'apiVersion' in their metadata
+        if (typeof value === 'object' && value !== null && 'apiVersion' in value && 'name' in value) {
+          apis.push({ id: key, name: value.name as string });
+        }
+      }
+    }
+    return apis;
+  });
+
+  hasSubscriptions = computed(() => {
+    const response = this.subscriptionsResource.value() as SubscriptionsResponse | undefined;
+    const isFiltered = !!this.apiFilterSignal() || !!this.applicationFilterSignal() || (this.statusFilterSignal()?.length ?? 0) > 0;
+
+    if (!isFiltered) {
+      return (response?.data?.length ?? 0) > 0 || this.totalElements() > 0;
+    }
+    return true;
+  });
+
+  retrieveMetadataName(id: string, metadata: SubscriptionMetadata | undefined): string {
+    return metadata?.[id]?.name ?? id;
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSize.set(size);
+    // Reset to page 1 when page size changes
+    this.currentPage.set(1);
+  }
+
+  clearFilters(): void {
+    this.apiFilter.reset();
+    this.applicationFilter.reset();
+    this.statusFilter.reset();
+    this.currentPage.set(1);
+  }
+
+  get currentSelectedPage(): number {
+    return this.currentPage();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -1,0 +1,69 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="paginated-table__container">
+  <table mat-table [dataSource]="rows()" class="paginated-table">
+    @for (column of columns(); track column.id) {
+      <ng-container [matColumnDef]="column.id">
+        <th mat-header-cell *matHeaderCellDef class="m3-title-medium">{{ column.label }}</th>
+        <td mat-cell *matCellDef="let element">
+          @switch (column.type) {
+            @case ('date') {
+              {{ element[column.id] | date: 'yyyy-MM-dd' }}
+            }
+            @default {
+              {{ element[column.id] }}
+            }
+          }
+        </td>
+      </ng-container>
+    }
+
+    <ng-container matColumnDef="expand">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let element" class="paginated-table__column-expand">
+        <mat-icon>chevron_right</mat-icon>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
+    <tr
+      mat-row
+      class="paginated-table__row"
+      *matRowDef="let row; columns: displayedColumns()"
+      [routerLink]="['/subscriptions', row.id]"></tr>
+  </table>
+</div>
+
+<div class="paginated-table__pagination">
+  <app-pagination
+    [totalResults]="totalElements()"
+    [currentPage]="currentPage()"
+    [pageSize]="pageSize()"
+    (selectPage)="onPageChange($event)" />
+
+  <div class="paginated-table__page-size">
+    <span class="m3-body-medium" i18n="@@showPerPage">Show per page:</span>
+    <mat-form-field appearance="outline" class="paginated-table__page-size-select" subscriptSizing="dynamic">
+      <mat-select [value]="pageSize()" (selectionChange)="onPageSizeChange($event.value)">
+        @for (size of pageSizeOptions(); track size) {
+          <mat-option [value]="size">{{ size }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/theme/index' as app-theme;
+
+.paginated-table {
+  width: 100%;
+
+  th {
+    border-bottom: 1px solid app-theme.$table-border-color;
+    background-color: app-theme.$table-header-background-color;
+    color: app-theme.$table-header-headline-color;
+    font-weight: 600;
+  }
+
+  td {
+    border-bottom: 1px solid app-theme.$table-border-color;
+  }
+
+  &__container {
+    border: 1px solid app-theme.$table-border-color;
+    border-radius: app-theme.$table-border-radius;
+    overflow-x: auto;
+  }
+
+  &__row {
+    cursor: pointer;
+
+    &:last-child td {
+      border-bottom: none;
+    }
+  }
+
+  &__column-expand {
+    width: 48px;
+    text-align: center;
+
+    mat-icon {
+      color: app-theme.$link-icon-color;
+    }
+  }
+
+  &__pagination {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 24px;
+    gap: 16px;
+  }
+
+  &__page-size {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    &-select {
+      width: 80px;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DatePipe } from '@angular/common';
+import { Component, computed, input, output } from '@angular/core';
+import { MatFormField } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatOption, MatSelect } from '@angular/material/select';
+import { MatTableModule } from '@angular/material/table';
+import { RouterLink } from '@angular/router';
+
+import { PaginationComponent } from '../pagination/pagination.component';
+
+export interface TableColumn {
+  id: string;
+  label: string;
+  type?: 'text' | 'date';
+}
+
+@Component({
+  selector: 'app-paginated-table',
+  standalone: true,
+  imports: [DatePipe, MatTableModule, MatIcon, MatFormField, MatSelect, MatOption, RouterLink, PaginationComponent],
+  templateUrl: './paginated-table.component.html',
+  styleUrl: './paginated-table.component.scss',
+})
+export class PaginatedTableComponent<T> {
+  columns = input.required<TableColumn[]>();
+  rows = input.required<T[]>();
+  totalElements = input.required<number>();
+  currentPage = input.required<number>();
+  pageSize = input.required<number>();
+  pageSizeOptions = input<number[]>([5, 10, 20, 50, 100]);
+
+  pageChange = output<number>();
+  pageSizeChange = output<number>();
+
+  displayedColumns = computed(() => [...this.columns().map(c => c.id as string), 'expand']);
+
+  onPageChange(page: number): void {
+    this.pageChange.emit(page);
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSizeChange.emit(size);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -47,7 +47,7 @@ export const SubscriptionStatusEnum = {
   CLOSED: 'CLOSED',
   REJECTED: 'REJECTED',
   PAUSED: 'PAUSED',
-};
+} as const;
 
 export interface SubscriptionDataKeys {
   key?: string;

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscriptions-response.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscriptions-response.ts
@@ -36,6 +36,7 @@ export interface SubscriptionMetadataContent {
   planMode?: PlanMode;
   securityType?: PlanSecurityEnum;
   apiVersion?: string;
+  totalElements?: number;
 }
 
 export interface SubscriptionMetadataEntrypointsTarget {

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -35,12 +35,14 @@ export class SubscriptionService {
     applicationId?: string;
     statuses: SubscriptionStatusEnum[] | null;
     size?: number;
+    page?: number;
   }): Observable<SubscriptionsResponse> {
     const params = {
       ...(queryParams.apiId ? { apiId: queryParams.apiId } : {}),
       ...(queryParams.applicationId ? { applicationId: queryParams.applicationId } : {}),
       ...(queryParams.statuses ? { statuses: queryParams.statuses } : { statuses: [] }),
       ...(queryParams.size ? { size: queryParams.size } : {}),
+      ...(queryParams.page ? { page: queryParams.page } : {}),
     };
     return this.http.get<SubscriptionsResponse>(`${this.configService.baseURL}/subscriptions`, {
       params,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -133,7 +133,8 @@ public class SubscriptionsResource extends AbstractResource {
             }
             SubscriptionEntity createdSubscription = subscriptionService.create(executionContext, newSubscriptionEntity);
 
-            // For consumer convenience, fetch the keys just after the subscription has been created.
+            // For consumer convenience, fetch the keys just after the subscription has been
+            // created.
             List<Key> keys = apiKeyService
                 .findBySubscription(executionContext, createdSubscription.getId())
                 .stream()
@@ -192,7 +193,7 @@ public class SubscriptionsResource extends AbstractResource {
             subscriptions
         )
             .withApis(true)
-            .withApplications(applicationId == null)
+            .withApplications(true)
             .withPlans(true)
             .withSubscribers(true)
             .includeDetails()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12268

## Description

This PR implements a Subscriptions table. It provides users with a centralized view to manage their API subscriptions, featuring a data-rich table, filtering capabilities, and full pagination support.

- Created the SubscriptionsComponent as a standalone Angular component in src/app/dashboard/subscriptions.
- Injected SubscriptionService for data retrieval and ApplicationService to populate filter options.
- Implemented rxResource to reactively fetch subscriptions whenever filters or pagination state change.
- Used Angular computed signals to transform raw API responses into display-ready SubscriptionTableRow objects, including mapping IDs to human-readable names using the response metadata.
- Used FormControls for API, Application, and Status filters.
- Added support for filtering by multiple subscription statuses simultaneously (e.g., Accepted, Pending, Rejected).
- Filter changes automatically trigger the rxResource stream, resetting the pagination to the first page.
- Developed tests in subscriptions.component.spec.ts covering:
    -   Initial data load and display.
    -   Filter application and data refresh logic.
    -   Pagination behavior (page change and page size change).
    -   Correct rendering of empty states and loading indicators.

https://github.com/user-attachments/assets/202e112d-7c97-4787-9bf0-f8368f4c4176

updated filter look - fixed wide width

<img width="1490" height="743" alt="image" src="https://github.com/user-attachments/assets/235b5806-33e3-48c9-a52d-7fa668ffe4c9" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

