### PR TITLE
Refactor and enhance metrics functionality

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.Facet;
 import io.gravitee.repository.analytics.engine.api.result.*;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/BucketNamesPostProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/BucketNamesPostProcessor.java
@@ -17,8 +17,8 @@ package io.gravitee.apim.core.analytics_engine.domain_service;
 
 import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
 import java.util.List;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterPreProcessor.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.core.analytics_engine.domain_service;
 
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
 
 /**
  * @author GraviteeSource Team

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCase.java
@@ -21,10 +21,11 @@ import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProc
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
+import io.gravitee.apim.core.metric.mapper.FilterMapper;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -87,7 +88,7 @@ public class ComputeFacetsUseCase {
         var responses = new ArrayList<FacetsResponse>();
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filters.addAll(metricsContext.filters());
+            filters.addAll(FilterMapper.INSTANCE.toAnalyticsFilters(metricsContext.filters()));
 
             responses.add(queryService.searchFacets(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCase.java
@@ -20,10 +20,11 @@ import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValid
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
+import io.gravitee.apim.core.metric.mapper.FilterMapper;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +80,7 @@ public class ComputeMeasuresUseCase {
 
         queryExecutions.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filters.addAll(metricsContext.filters());
+            filters.addAll(FilterMapper.INSTANCE.toAnalyticsFilters(metricsContext.filters()));
 
             responses.add(queryService.searchMeasures(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCase.java
@@ -19,12 +19,13 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
+import io.gravitee.apim.core.metric.mapper.FilterMapper;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,7 +89,7 @@ public class ComputeTimeSeriesUseCase {
 
         queryContext.forEach((queryService, request) -> {
             var filters = new ArrayList<>(request.filters());
-            filters.addAll(metricsContext.filters());
+            filters.addAll(FilterMapper.INSTANCE.toAnalyticsFilters(metricsContext.filters()));
 
             responses.add(queryService.searchTimeSeries(executionContext, request.withFilters(filters)));
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/domain_service/MetricsContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/domain_service/MetricsContext.java
@@ -13,23 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.analytics_engine.model;
+package io.gravitee.apim.core.metric.domain_service;
 
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.model.Filter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.Getter;
+import lombok.Builder;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
 public record MetricsContext(
-    @Getter AuditInfo auditInfo,
+    AuditInfo auditInfo,
     Optional<Map<String, String>> apiNameById,
     Optional<Map<String, String>> applicationNameById,
-    List<Filter> filters
+    List<io.gravitee.apim.core.metric.model.Filter> filters
 ) {
     public MetricsContext(AuditInfo auditInfo) {
         this(auditInfo, Optional.empty(), Optional.empty(), List.of());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/mapper/FilterMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/mapper/FilterMapper.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.mapper;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.metric.model.ArrayFilter;
+import io.gravitee.apim.core.metric.model.Filter;
+import io.gravitee.apim.core.metric.model.FilterName;
+import io.gravitee.apim.core.metric.model.NumberFilter;
+import io.gravitee.apim.core.metric.model.Operator;
+import io.gravitee.apim.core.metric.model.StringFilter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface FilterMapper {
+    FilterMapper INSTANCE = Mappers.getMapper(FilterMapper.class);
+
+    default Filter toFilter(io.gravitee.apim.core.analytics_engine.model.Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+        var operator = filter.operator();
+        if (operator == null) {
+            return null;
+        }
+        return switch (operator) {
+            case EQ -> new Filter(
+                new StringFilter(mapFilterName(filter.name()), mapOperator(filter.operator()), filter.value().toString())
+            );
+            case IN -> {
+                List<String> values = filter.value() instanceof Collection<?> rawValues
+                    ? rawValues.stream().map(String::valueOf).toList()
+                    : List.of(String.valueOf(filter.value()));
+
+                yield new Filter(new ArrayFilter(mapFilterName(filter.name()), mapOperator(filter.operator()), values));
+            }
+            case GTE, LTE -> new Filter(
+                new NumberFilter(mapFilterName(filter.name()), mapOperator(filter.operator()), (Integer) filter.value())
+            );
+        };
+    }
+
+    default io.gravitee.apim.core.analytics_engine.model.Filter toAnalyticsFilter(Filter filter) {
+        if (filter == null) {
+            return null;
+        }
+        var instance = filter.actualInstance();
+        if (instance == null) {
+            return null;
+        }
+
+        return switch (instance) {
+            case StringFilter s -> new io.gravitee.apim.core.analytics_engine.model.Filter(
+                mapAnalyticsFilterName(s.name()),
+                mapAnalyticsOperator(s.operator()),
+                s.value()
+            );
+            case ArrayFilter a -> new io.gravitee.apim.core.analytics_engine.model.Filter(
+                mapAnalyticsFilterName(a.name()),
+                mapAnalyticsOperator(a.operator()),
+                new LinkedHashSet<>(a.value())
+            );
+            case NumberFilter n -> new io.gravitee.apim.core.analytics_engine.model.Filter(
+                mapAnalyticsFilterName(n.name()),
+                mapAnalyticsOperator(n.operator()),
+                n.value()
+            );
+            default -> throw new ValidationDomainException("unknown filter type");
+        };
+    }
+
+    default List<Filter> toFilters(Collection<io.gravitee.apim.core.analytics_engine.model.Filter> filters) {
+        if (filters == null) {
+            return null;
+        }
+        return filters.stream().map(this::toFilter).collect(Collectors.toList());
+    }
+
+    default List<io.gravitee.apim.core.analytics_engine.model.Filter> toAnalyticsFilters(Collection<Filter> filters) {
+        if (filters == null) {
+            return null;
+        }
+        return filters.stream().map(this::toAnalyticsFilter).collect(Collectors.toList());
+    }
+
+    private List<Filter> filterListToFilterList(List<io.gravitee.apim.core.analytics_engine.model.Filter> list) {
+        if (list == null) {
+            return null;
+        }
+
+        var list1 = new ArrayList<Filter>(list.size());
+        for (io.gravitee.apim.core.analytics_engine.model.Filter filter : list) {
+            list1.add(toFilter(filter));
+        }
+
+        return list1;
+    }
+
+    FilterName mapFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name filterName);
+
+    io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name mapAnalyticsFilterName(FilterName filterName);
+
+    Operator mapOperator(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator operator);
+
+    io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator mapAnalyticsOperator(Operator operator);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/ArrayFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/ArrayFilter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+import java.util.List;
+
+public record ArrayFilter(FilterName name, Operator operator, List<String> value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/Filter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/Filter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record Filter(Object actualInstance) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/FilterName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/FilterName.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+public enum FilterName {
+    API,
+    APPLICATION,
+    PLAN,
+    GATEWAY,
+    TENANT,
+    ZONE,
+    HTTP_METHOD,
+    HTTP_STATUS_CODE_GROUP,
+    HTTP_STATUS,
+    HTTP_PATH,
+    HTTP_PATH_MAPPING,
+    HOST,
+    GEO_IP_COUNTRY,
+    GEO_IP_REGION,
+    GEO_IP_CITY,
+    GEO_IP_CONTINENT,
+    CONSUMER_IP,
+    HTTP_USER_AGENT_OS_NAME,
+    HTTP_USER_AGENT_DEVICE,
+    MESSAGE_CONNECTOR_TYPE,
+    MESSAGE_CONNECTOR_ID,
+    MESSAGE_OPERATION_TYPE,
+    KAFKA_TOPIC,
+    API_STATE,
+    API_LIFECYCLE_STATE,
+    API_VISIBILITY,
+    MESSAGE_SIZE,
+    MESSAGE_COUNT,
+    MESSAGE_ERROR_COUNT,
+    HTTP_ENDPOINT_RESPONSE_TIME,
+    HTTP_GATEWAY_LATENCY,
+    HTTP_GATEWAY_RESPONSE_TIME,
+    HTTP_REQUEST_CONTENT_LENGTH,
+    HTTP_RESPONSE_CONTENT_LENGTH,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/NumberFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/NumberFilter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+public record NumberFilter(FilterName name, Operator operator, Integer value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/Operator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/Operator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+public enum Operator {
+    EQ,
+    LTE,
+    GTE,
+    IN,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/StringFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metric/model/StringFilter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metric.model;
+
+public record StringFilter(FilterName name, Operator operator, String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.model.*;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.service.ApplicationService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessor.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
 
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name.API;
-import static io.gravitee.apim.core.analytics_engine.model.FilterSpec.Operator.IN;
-
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
+import io.gravitee.apim.core.metric.mapper.FilterMapper;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -60,9 +59,9 @@ public class ManagementFilterPreProcessor implements FilterPreProcessor {
 
         var userApisIds = userApis.keySet();
 
-        var permissionsFilter = new Filter(API, IN, userApisIds);
+        var permissionsFilters = List.of(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, userApisIds));
 
-        return context.withFilters(List.of(permissionsFilter)).withApiNamesById(userApis);
+        return context.withFilters(FilterMapper.INSTANCE.toFilters(permissionsFilters)).withApiNamesById(userApis);
     }
 
     private static Map<String, String> mapApiIdsToNames(Collection<Api> apis) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
@@ -20,11 +20,20 @@ import static io.gravitee.apim.core.analytics_engine.model.MetricSpec.Measure.CO
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
-import io.gravitee.apim.core.analytics_engine.model.*;
+import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.application.ApplicationListItem;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ManagementFilterPreProcessorTest.java
@@ -19,9 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
-import io.gravitee.apim.core.analytics_engine.model.MetricsContext;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metric.domain_service.MetricsContext;
+import io.gravitee.apim.core.metric.mapper.FilterMapper;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.model.Api;
@@ -115,7 +116,7 @@ class ManagementFilterPreProcessorTest {
 
         assertThat(contextWithFilters.filters()).size().isEqualTo(1);
 
-        var value = contextWithFilters.filters().getFirst().value();
+        var value = FilterMapper.INSTANCE.toAnalyticsFilter(contextWithFilters.filters().getFirst()).value();
         assertThat(value)
             .isInstanceOf(Set.class)
             .asInstanceOf(InstanceOfAssertFactories.SET)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/gko-2164

## Description

This PR refactors the metrics-related code by relocating the `MetricsContext` to the `domain_service` package and updating all related references in the analytics code. Additionally, new features have been introduced:  
- Added `FilterMapper` for mapping between metric and analytics filter models.  
- Implemented a metrics model to support enhanced functionalities.

This refactoring has been done so the context can be reused in logs packages without having to depend on the analycitc engine code.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->