### PR TITLE
Prevent multiple primary owners through ownership transfer

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+import static io.gravitee.rest.api.model.permissions.SystemRole.*;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -88,6 +89,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
@@ -1065,7 +1067,7 @@ public class ApiResource extends AbstractResource {
     }
 
     private void assertNoPrimaryOwnerReassignment(String poRole) {
-        if ("PRIMARY_OWNER".equals(poRole)) {
+        if (PRIMARY_OWNER.name().equals(poRole)) {
             throw new TransferOwnershipNotAllowedException(poRole);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
@@ -41,6 +42,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -200,6 +202,7 @@ public class ApiMembersResource extends AbstractResource {
         List<RoleEntity> newRoles = new ArrayList<>();
 
         if (transferOwnership.getPoRole() != null) {
+            assertNoPrimaryOwnerReassignment(transferOwnership.getPoRole());
             roleService
                 .findByScopeAndName(RoleScope.API, transferOwnership.getPoRole(), GraviteeContext.getCurrentOrganization())
                 .ifPresent(newRoles::add);
@@ -247,6 +250,12 @@ public class ApiMembersResource extends AbstractResource {
     private void isExistingApi() {
         if (!apiSearchService.exists(api)) {
             throw new ApiNotFoundException(api);
+        }
+    }
+
+    private void assertNoPrimaryOwnerReassignment(String poRole) {
+        if (PRIMARY_OWNER.name().equals(poRole)) {
+            throw new TransferOwnershipNotAllowedException(poRole);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResource.java
@@ -240,7 +240,7 @@ public class ApplicationMembersResource extends AbstractResource {
     }
 
     private void assertNoPrimaryOwnerReassignment(String poRole) {
-        if ("PRIMARY_OWNER".equals(poRole)) {
+        if (PRIMARY_OWNER.name().equals(poRole)) {
             throw new TransferOwnershipNotAllowedException(poRole);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResourceTest.java
@@ -17,16 +17,20 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.rest.model.ApiMembership;
+import io.gravitee.rest.api.management.rest.model.TransferOwnership;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,5 +92,24 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
         assertEquals(API, memberShipRefCaptor.getValue().getId());
         assertEquals("my-api-membership-role", memberShipRoleCaptor.getValue().getName());
         assertEquals(MEMBER_1, memberShipUserCaptor.getValue().getMemberId());
+    }
+
+    @Test
+    public void shouldNotTransferOwnershipToPrimaryOwner() {
+        TransferOwnership transferOwnership = new TransferOwnership();
+        transferOwnership.setId(MEMBER_1);
+        transferOwnership.setReference("USER");
+        transferOwnership.setPoRole("PRIMARY_OWNER");
+
+        Response response = envTarget(API).path("members").path("transfer_ownership").request().post(Entity.json(transferOwnership));
+
+        Map<String, Object> error = response.readEntity(new GenericType<>() {});
+
+        assertAll(
+            () -> assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus()),
+            () -> assertEquals("The [PRIMARY_OWNER] role cannot be transferred to a Primary Owner.", error.get("message")),
+            () -> assertEquals("role.transferNotAllowed", error.get("technicalCode")),
+            () -> assertEquals("PRIMARY_OWNER", ((Map<?, ?>) error.get("parameters")).get("role"))
+        );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12564

## Description

When transfer ownership, we must ensure that the new role of the old PO is not "PRIMARY_OWNER"