### PR TITLE
fix(gateway): strip double quotes from Forwarded header host

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessor.java
@@ -93,6 +93,9 @@ public class XForwardProcessor implements Processor {
                 }
                 if (normalizedElement.startsWith("host=")) {
                     String host = element.trim().substring(5);
+                    if (host.indexOf('"') != -1) {
+                        host = host.replace("\"", "");
+                    }
                     int commaIndex = host.indexOf(',');
                     originalHost = commaIndex == -1 ? host : host.substring(0, commaIndex).trim();
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessorTest.java
@@ -190,6 +190,21 @@ public class XForwardProcessorTest extends AbstractProcessorTest {
         arg16Headers.set(HttpHeaderNames.X_FORWARDED_PREFIX, "/app");
         ForwardedTestData arg16Data = ForwardedTestData.builder().headers(arg16Headers).uri("/test").build();
 
+        HttpHeaders arg17Headers = HttpHeaders.create();
+        arg17Headers.set(HttpHeaderNames.FORWARDED, "for=192.0.2.43;proto=http;host=\"client-proxy-instance.com\"");
+        ForwardedTestData arg17Data = ForwardedTestData.builder().headers(arg17Headers).uri("/test").build();
+
+        HttpHeaders arg18Headers = HttpHeaders.create();
+        arg18Headers.set(HttpHeaderNames.FORWARDED, "for=192.0.2.43;proto=http;host=\"client-proxy-instance.com:8080\"");
+        ForwardedTestData arg18Data = ForwardedTestData.builder().headers(arg18Headers).uri("/test").build();
+
+        HttpHeaders arg19Headers = HttpHeaders.create();
+        arg19Headers.set(
+            HttpHeaderNames.FORWARDED,
+            "for=192.0.2.43;proto=http;host=\"client-proxy-instance1.com,client-proxy-instance2.com\""
+        );
+        ForwardedTestData arg19Data = ForwardedTestData.builder().headers(arg19Headers).uri("/test").build();
+
         return Stream.of(
             Arguments.of(arg1Data, "http://client-instance.com/test"),
             Arguments.of(arg2Data, "http://client-proxy-instance.com/test"),
@@ -206,7 +221,10 @@ public class XForwardProcessorTest extends AbstractProcessorTest {
             Arguments.of(arg13Data, "http://client-proxy-instance.com"),
             Arguments.of(arg14Data, "http://client-proxy-instance.com"),
             Arguments.of(arg15Data, "http://client-proxy-instance1.com:8080/app/test"),
-            Arguments.of(arg16Data, "http://client-proxy-instance1.com:8080/app/test")
+            Arguments.of(arg16Data, "http://client-proxy-instance1.com:8080/app/test"),
+            Arguments.of(arg17Data, "http://client-proxy-instance.com/test"),
+            Arguments.of(arg18Data, "http://client-proxy-instance.com:8080/test"),
+            Arguments.of(arg19Data, "http://client-proxy-instance1.com/test")
         );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12533

## Description

This pull request addresses an issue where the gateway was unable to correctly parse the host value from the Forwarded header when it was enclosed in double quotes. The changes ensure that the host is extracted accurately, aligning with RFC 7239 specifications, which improves the reliability of host resolution in proxied environments.

## Additional context

Forwarded Header Parsing Fix: Corrected the parsing logic for the host parameter within the Forwarded HTTP header to properly handle values enclosed in double quotes, as permitted by RFC 7239.
Quote Removal: Implemented a mechanism to remove double quotes from the extracted host string if they are present, ensuring accurate host resolution.
New Test Cases: Added comprehensive test cases to validate the updated Forwarded header parsing, covering scenarios with quoted hosts, hosts with ports, and multiple hosts within the header.

