### PR TITLE
fix: Updated unit tests with more accurate test data.

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/forward/XForwardProcessorTest.java
@@ -173,8 +173,8 @@ public class XForwardProcessorTest extends AbstractProcessorTest {
         ForwardedTestData arg13Data = ForwardedTestData.builder().headers(arg13Headers).uri("").build();
 
         HttpHeaders arg14Headers = HttpHeaders.create();
-        arg14Headers.set(HttpHeaderNames.FORWARDED, "for=192.0.2.43 , Proto=http , HOST=client-proxy-instance.com");
-        ForwardedTestData arg14Data = ForwardedTestData.builder().headers(arg13Headers).uri("").build();
+        arg14Headers.set(HttpHeaderNames.FORWARDED, "for=192.0.2.43 , Proto=http , HOST=\"client-proxy-instance.com\"");
+        ForwardedTestData arg14Data = ForwardedTestData.builder().headers(arg14Headers).uri("").build();
 
         HttpHeaders arg15Headers = HttpHeaders.create();
         arg15Headers.set(HttpHeaderNames.X_FORWARDED_FOR, "192.168.1.15");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12522

## Description

- Test Data Correction: Corrected a typo in the `FORWARDED` header value within a unit test, specifically by enclosing the `HOST` value in quotes to ensure proper parsing.

- Logical Error Fix: Updated the test data to use the correct HttpHeaders object

