### PR TITLE
feat(analytics): add panel component in side-nav and make analytics e…

### DIFF
--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -25,7 +25,7 @@
     "@gravitee/gravitee-markdown": "portal:dist-lib/gravitee-markdown",
     "@gravitee/ui-analytics": "16.4.0",
     "@gravitee/ui-components": "4.4.0",
-    "@gravitee/ui-particles-angular": "17.0.0",
+    "@gravitee/ui-particles-angular": "17.1.0",
     "@gravitee/ui-policy-studio-angular": "16.4.0",
     "@highcharts/map-collection": "1.1.4",
     "@ngx-formly/core": "6.3.12",

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
@@ -31,19 +31,31 @@
     </gio-menu-header>
     <gio-menu-list>
       <ng-container *ngFor="let item of mainMenuItems">
-        <a [routerLink]="item.routerLink">
-          <gio-menu-item
-            tabIndex="1"
-            routerLinkActive
-            #rla="routerLinkActive"
-            [title]="item.displayName"
-            [icon]="item.icon"
-            [active]="rla.isActive"
-            [gioLicense]="item?.licenseOptions"
-            [iconRight]="item?.iconRight$ | async"
-            >{{ item.displayName }}</gio-menu-item
-          >
-        </a>
+        <ng-container *ngIf="!item.items; else menuItemsGroup">
+          <a [routerLink]="item.routerLink">
+            <gio-menu-item
+              tabIndex="1"
+              routerLinkActive
+              #rla="routerLinkActive"
+              [title]="item.displayName"
+              [icon]="item.icon"
+              [active]="rla.isActive"
+              [gioLicense]="item?.licenseOptions"
+              [iconRight]="item?.iconRight$ | async"
+              >{{ item.displayName }}</gio-menu-item
+            >
+          </a>
+        </ng-container>
+
+        <ng-template #menuItemsGroup>
+          <gio-menu-items [title]="item.displayName" [icon]="item.icon" [routerBasePath]="item.routerBasePath">
+            <ng-container *ngFor="let child of item.items">
+              <a [routerLink]="child.routerLink" [tabindex]="1">
+                <gio-menu-item routerLinkActive>{{ child.displayName }}</gio-menu-item>
+              </a>
+            </ng-container>
+          </gio-menu-items>
+        </ng-template>
       </ng-container>
     </gio-menu-list>
 

--- a/gravitee-apim-console-webui/src/management/analytics/analytics-viewer/analytics-viewer.component.html
+++ b/gravitee-apim-console-webui/src/management/analytics/analytics-viewer/analytics-viewer.component.html
@@ -18,7 +18,7 @@
 
 <div class="gv-sub-content">
   <div class="gv-forms gv-forms-fluid" layout="column">
-    <h1>Proxy v4 Dashboard</h1>
+    <h1>Overview</h1>
   </div>
 </div>
 

--- a/gravitee-apim-console-webui/src/management/analytics/env-analytics-layout.component.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-analytics-layout.component.ts
@@ -25,9 +25,6 @@ import { Component } from '@angular/core';
       <a mat-tab-link routerLinkActive #rla2="routerLinkActive" [active]="rla2.isActive" routerLink="logs"
         ><mat-icon class="navigation-tabs__icon" svgIcon="gio:table-rows"></mat-icon> V2 Logs</a
       >
-      <a mat-tab-link routerLinkActive #rla3="routerLinkActive" [active]="rla3.isActive" routerLink="dashboard-v4"
-        ><mat-icon class="navigation-tabs__icon" svgIcon="gio:dashboard-dots"></mat-icon> V4 Dashboard</a
-      >
     </nav>
     <mat-tab-nav-panel #tabPanel>
       <router-outlet></router-outlet>

--- a/gravitee-apim-console-webui/src/management/analytics/env-analytics.module.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-analytics.module.ts
@@ -30,6 +30,15 @@ import { EnvLogsTableComponent } from './env-logs-v4/components/env-logs-table/e
 
 const routes: Routes = [
   {
+    path: 'overview',
+    component: AnalyticsViewerComponent,
+  },
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'overview',
+  },
+  {
     path: '',
     component: EnvAnalyticsLayoutComponent,
     children: [
@@ -68,17 +77,6 @@ const routes: Routes = [
             page: 'management-environment-logs-v4',
           },
         },
-      },
-
-      {
-        path: 'dashboard-v4',
-        component: AnalyticsViewerComponent,
-      },
-
-      {
-        path: '',
-        pathMatch: 'full',
-        redirectTo: 'dashboard',
       },
     ],
   },

--- a/gravitee-apim-console-webui/yarn.lock
+++ b/gravitee-apim-console-webui/yarn.lock
@@ -3755,9 +3755,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/ui-particles-angular@npm:17.0.0":
-  version: 17.0.0
-  resolution: "@gravitee/ui-particles-angular@npm:17.0.0"
+"@gravitee/ui-particles-angular@npm:17.1.0":
+  version: 17.1.0
+  resolution: "@gravitee/ui-particles-angular@npm:17.1.0"
   dependencies:
     "@fontsource/fira-mono": "npm:5.0.14"
     "@fontsource/kanit": "npm:^5.2.6"
@@ -3786,7 +3786,7 @@ __metadata:
       optional: true
     prismjs:
       optional: true
-  checksum: 10c0/6563a161633c436d4a9560c9588bbaf0037d4bbb49f49d22793ab88f07cbe1c7d0f66ce6d8de0a1de4d04a4c959610a2a6999018abb2b7788a8baa59e6ca1be7
+  checksum: 10c0/6a75af246a1751808adc145e85299f4941d83c5d1a07e2cb0f0a0ccc7dd57a7f8005d8cc53cfc1ae7c5cae9b71c9eae302367c16281d3ff3be77ee6baabbf422
   languageName: node
   linkType: hard
 
@@ -13441,7 +13441,7 @@ __metadata:
     "@gravitee/gravitee-markdown": "portal:dist-lib/gravitee-markdown"
     "@gravitee/ui-analytics": "npm:16.4.0"
     "@gravitee/ui-components": "npm:4.4.0"
-    "@gravitee/ui-particles-angular": "npm:17.0.0"
+    "@gravitee/ui-particles-angular": "npm:17.1.0"
     "@gravitee/ui-policy-studio-angular": "npm:16.4.0"
     "@gravitee/ui-schematics": "npm:16.4.0"
     "@highcharts/map-collection": "npm:1.1.4"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1986

## Description

Use a new panel component into sidenav.
Offer multiple entries for the Analytics category such as overview, dashboards, logs, ...).
It is not a breaking change for the previous path (named legacy dashboard/logs).

## Additional context

<img width="1477" height="1139" alt="Screenshot 2026-02-02 at 14 59 02" src="https://github.com/user-attachments/assets/e3fd7a9d-44b5-4034-9775-af4ee722b5e4" />
<img width="1487" height="1117" alt="Screenshot 2026-02-02 at 12 53 56" src="https://github.com/user-attachments/assets/ef46dd0d-8b22-4989-aca4-ee4578d6ccac" />

https://github.com/user-attachments/assets/5e73301a-0bd1-4e91-9124-fee6213acd64



