### PR TITLE
fix: Added gateway instance details to api metrics detail

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture.ts
@@ -39,6 +39,8 @@ export const fakeApiMetricResponse = (modifier?: Partial<ApiMetricsDetailRespons
       apiKeyMode: 'UNSPECIFIED',
     },
     gateway: 'b504bb7b-8b6e-426f-84bb-7b8b6e626f3f',
+    gatewayHostname: 'hostname.example.com',
+    gatewayIp: 'ip.example',
     uri: '/v4/echo',
     status: 202,
     requestContentLength: 0,

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/apiMetricsDetailResponse.ts
@@ -33,6 +33,8 @@ export interface ApiMetricsDetailResponse {
   plan: BasePlan;
   application: BaseApplication;
   gateway: string;
+  gatewayHostname?: string;
+  gatewayIp?: string;
   uri: string;
   status: number;
   requestContentLength: number;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
@@ -18,6 +18,6 @@
 <a mat-flat-button routerLink=".." aria-label="Back to logs"><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a>
 <div class="mat-h2">Log</div>
 <div class="card__container">
-  <api-proxy-request-metric-overview [metric]="apiMetricsDetail()" [instance]="gatewayInstanceDetail()" [apiType]="apiType()" />
+  <api-proxy-request-metric-overview [metric]="apiMetricsDetail()" [apiType]="apiType()" />
   <api-proxy-request-log-overview class="log-details" [log]="connectionLog()" />
 </div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
@@ -31,13 +31,15 @@ import {
   fakeConnectionLogDetailResponse,
 } from '../../../../../../entities/management-api-v2';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../../shared/testing';
-import { ApiMetricsDetailResponse, BaseInstance } from '../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
+import { ApiMetricsDetailResponse } from '../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
 import { fakeApiMetricResponse } from '../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture';
 
 describe('ApiRuntimeLogsProxyComponent', () => {
   const API_ID = 'an-api-id';
   const INSTANCE_ID = 'instance-id';
   const REQUEST_ID = 'a-request-id';
+  const HOST_NAME = 'hostname.example.com';
+  const GATEWAY_IP = 'ip.example';
 
   let fixture: ComponentFixture<ApiRuntimeLogsProxyComponent>;
   let httpTestingController: HttpTestingController;
@@ -86,7 +88,15 @@ describe('ApiRuntimeLogsProxyComponent', () => {
   it('should display the component with all metrics and logs detail', async () => {
     await initComponent();
 
-    expectApiMetric(fakeApiMetricResponse({ apiId: API_ID, requestId: REQUEST_ID, gateway: INSTANCE_ID }));
+    expectApiMetric(
+      fakeApiMetricResponse({
+        apiId: API_ID,
+        requestId: REQUEST_ID,
+        gateway: INSTANCE_ID,
+        gatewayHostname: HOST_NAME,
+        gatewayIp: GATEWAY_IP,
+      }),
+    );
     expectApiWithConnectionLog(
       fakeConnectionLogDetail({
         apiId: API_ID,
@@ -97,7 +107,6 @@ describe('ApiRuntimeLogsProxyComponent', () => {
         endpointResponse: fakeConnectionLogDetailResponse({ body: 'endpointResponseBody', headers: {} }),
       }),
     );
-    expectGatewayDetails({ id: INSTANCE_ID, hostname: 'hostname.example.com', ip: 'ip.example' });
 
     const metricsHarness = await loader.getHarness(ApiProxyRequestMetricOverviewHarness);
     expect(await metricsHarness.getAllKeyValues()).toEqual([
@@ -147,9 +156,16 @@ describe('ApiRuntimeLogsProxyComponent', () => {
   it('should display nothing when connection log is not found', async () => {
     await initComponent();
 
-    expectApiMetric(fakeApiMetricResponse({ apiId: API_ID, requestId: REQUEST_ID, gateway: INSTANCE_ID }));
+    expectApiMetric(
+      fakeApiMetricResponse({
+        apiId: API_ID,
+        requestId: REQUEST_ID,
+        gateway: INSTANCE_ID,
+        gatewayHostname: HOST_NAME,
+        gatewayIp: GATEWAY_IP,
+      }),
+    );
     expectApiConnectionLogNotFound();
-    expectGatewayDetails({ id: INSTANCE_ID, hostname: 'hostname.example.com', ip: 'ip.example' });
 
     const logHarness = await loader.getHarness(ApiProxyRequestLogOverviewHarness);
     expect(await logHarness.getAllKeyValues()).toEqual([]);
@@ -159,16 +175,6 @@ describe('ApiRuntimeLogsProxyComponent', () => {
     httpTestingController
       .expectOne({
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/analytics/${REQUEST_ID}`,
-        method: 'GET',
-      })
-      .flush(data);
-    fixture.detectChanges();
-  }
-
-  function expectGatewayDetails(data: BaseInstance) {
-    httpTestingController
-      .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/instances/${INSTANCE_ID}`,
         method: 'GET',
       })
       .flush(data);

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import { Component, DestroyRef, inject, input, InputSignal } from '@angular/core';
-import { catchError, share, switchMap } from 'rxjs/operators';
+import { catchError, share } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -31,7 +30,6 @@ import { ApiProxyRequestMetricOverviewComponent } from './components/api-proxy-r
 import { ApiRuntimeLogsConnectionLogDetailsModule, ApiRuntimeLogsDetailsEmptyStateModule } from '../components';
 import { ApiLogsV2Service } from '../../../../../../services-ngx/api-logs-v2.service';
 import { ApiAnalyticsV2Service } from '../../../../../../services-ngx/api-analytics-v2.service';
-import { InstanceService } from '../../../../../../services-ngx/instance.service';
 import { ApiType } from '../../../../../../entities/management-api-v2';
 
 @Component({
@@ -55,8 +53,6 @@ export class ApiRuntimeLogsProxyComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly apiLogsService = inject(ApiLogsV2Service);
   private readonly apiAnalyticsService = inject(ApiAnalyticsV2Service);
-  private readonly matSnackBar = inject(MatSnackBar);
-  private readonly instanceService = inject(InstanceService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly apiId = this.activatedRoute.snapshot.params.apiId;
   private readonly requestId = this.activatedRoute.snapshot.params.requestId;
@@ -67,12 +63,6 @@ export class ApiRuntimeLogsProxyComponent {
     .pipe(share(), takeUntilDestroyed(this.destroyRef));
 
   public apiMetricsDetail = toSignal(this.metric$);
-  public gatewayInstanceDetail = toSignal(
-    this.metric$.pipe(
-      switchMap((metric) => this.instanceService.getByGatewayId(metric.gateway)),
-      takeUntilDestroyed(this.destroyRef),
-    ),
-  );
 
   public connectionLog = toSignal(
     this.apiLogsService.searchConnectionLogDetail(this.apiId, this.requestId).pipe(

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.html
@@ -108,10 +108,10 @@
         <dd class="gio-caption-2">{{ metricValue?.endpoint }}</dd>
 
         <dt class="mat-caption">Gateway Host</dt>
-        <dd class="gio-caption-2">{{ instance()?.hostname }}</dd>
+        <dd class="gio-caption-2">{{ metricValue?.gatewayHostname }}</dd>
 
         <dt class="mat-caption">Gateway IP</dt>
-        <dd class="gio-caption-2">{{ instance()?.ip }}</dd>
+        <dd class="gio-caption-2">{{ metricValue?.gatewayIp }}</dd>
       </dl>
     </mat-expansion-panel>
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-metric-overview/api-proxy-request-metric-overview.component.ts
@@ -18,10 +18,7 @@ import { DatePipe } from '@angular/common';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
 
-import {
-  ApiMetricsDetailResponse,
-  BaseInstance,
-} from '../../../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
+import { ApiMetricsDetailResponse } from '../../../../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
 import { ApiUtils } from '../../../../../../../../util/api.util';
 import { ApiType } from '../../../../../../../../entities/management-api-v2';
 
@@ -33,7 +30,6 @@ import { ApiType } from '../../../../../../../../entities/management-api-v2';
 })
 export class ApiProxyRequestMetricOverviewComponent {
   metric: InputSignal<ApiMetricsDetailResponse> = input.required<ApiMetricsDetailResponse>();
-  instance: InputSignal<BaseInstance> = input<BaseInstance>();
   apiType: InputSignal<ApiType> = input.required<ApiType>();
 
   getMcpErrorLabel(error: string) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -9223,6 +9223,14 @@ components:
                     type: string
                     description: The id of the gateway.
                     example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                  gatewayHostname:
+                    type: string
+                    description: The hostname of the gateway instance.
+                    example: gateway-1.example.com
+                  gatewayIp:
+                    type: string
+                    description: The IP address of the gateway instance.
+                    example: 192.168.1.100
                   uri:
                     type: string
                     description: URI of the request.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResourceTest.java
@@ -24,6 +24,7 @@ import assertions.MAPIAssertions;
 import fakes.FakeAnalyticsQueryService;
 import fixtures.core.model.ApiFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.InstanceQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.apim.core.analytics.model.HistogramAnalytics;
 import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
@@ -54,6 +55,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -85,6 +87,9 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
 
     @Inject
     private PlanCrudServiceInMemory planCrudServiceInMemory;
+
+    @Inject
+    private InstanceQueryServiceInMemory instanceQueryServiceInMemory;
 
     @Override
     protected String contextPath() {
@@ -982,6 +987,19 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
             );
 
             var instanceId = "instance-id";
+            var gatewayHostname = "gateway.example.com";
+            var gatewayIp = "192.168.1.100";
+            instanceQueryServiceInMemory.initWith(
+                List.of(
+                    io.gravitee.apim.core.gateway.model.Instance.builder()
+                        .id(instanceId)
+                        .hostname(gatewayHostname)
+                        .ip(gatewayIp)
+                        .environments(Set.of(ENVIRONMENT))
+                        .build()
+                )
+            );
+
             var timestamp = "2025-08-01T17:29:20.385+02:00";
             var transactionId = "transaction-id";
             var host = "request.host.example.com";
@@ -1037,6 +1055,8 @@ class ApiAnalyticsResourceTest extends ApiResourceTest {
                     assertThat(apiMetricsDetail.getEndpointResponseTime()).isEqualTo(endpointResponseTime);
                     assertThat(apiMetricsDetail.getEndpoint()).isEqualTo(endpoint);
                     assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
+                    assertThat(apiMetricsDetail.getGatewayHostname()).isEqualTo(gatewayHostname);
+                    assertThat(apiMetricsDetail.getGatewayIp()).isEqualTo(gatewayIp);
 
                     assertThat(apiMetricsDetail.getApplication())
                         .extracting(BaseApplication::getId, BaseApplication::getName)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/model/ApiMetricsDetail.java
@@ -36,6 +36,8 @@ public class ApiMetricsDetail {
     BaseApplicationEntity application;
     GenericPlanEntity plan;
     String gateway;
+    String gatewayHostname;
+    String gatewayIp;
     String uri;
     int status;
     long requestContentLength;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCase.java
@@ -19,12 +19,14 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics.model.ApiMetricsDetail;
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Optional;
@@ -38,6 +40,7 @@ public class FindApiMetricsDetailUseCase {
     private final AnalyticsQueryService analyticsQueryService;
     private final ApplicationCrudService applicationCrudService;
     private final PlanCrudService planCrudService;
+    private final InstanceQueryService instanceQueryService;
 
     public FindApiMetricsDetailUseCase.Output execute(ExecutionContext executionContext, FindApiMetricsDetailUseCase.Input input) {
         return analyticsQueryService
@@ -62,7 +65,7 @@ public class FindApiMetricsDetailUseCase {
         ExecutionContext executionContext,
         io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail apiMetricsDetail
     ) {
-        var result = ApiMetricsDetail.builder()
+        var builder = ApiMetricsDetail.builder()
             .timestamp(apiMetricsDetail.getTimestamp())
             .apiId(apiMetricsDetail.getApiId())
             .requestId(apiMetricsDetail.getRequestId())
@@ -86,10 +89,20 @@ public class FindApiMetricsDetailUseCase {
             .errorComponentName(apiMetricsDetail.getErrorComponentName())
             .errorComponentType(apiMetricsDetail.getErrorComponentType())
             .warnings(apiMetricsDetail.getWarnings())
-            .additionalMetrics(apiMetricsDetail.getAdditionalMetrics())
-            .build();
+            .additionalMetrics(apiMetricsDetail.getAdditionalMetrics());
 
-        return new Output(result);
+        // Fetch gateway instance details if gateway ID is available
+        if (apiMetricsDetail.getGateway() != null) {
+            try {
+                var instance = instanceQueryService.findById(executionContext, apiMetricsDetail.getGateway());
+                builder.gatewayHostname(instance.getHostname());
+                builder.gatewayIp(instance.getIp());
+            } catch (InstanceNotFoundException e) {
+                // If instance not found, leave hostname and ip as null
+            }
+        }
+
+        return new Output(builder.build());
     }
 
     private BaseApplicationEntity getApplication(String environmentId, String applicationId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
@@ -19,7 +19,7 @@ import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import jakarta.ws.rs.NotFoundException;
+import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class InstanceQueryServiceInMemory implements InstanceQueryService, InMem
             )
             .findFirst()
             .map(instance -> BaseInstance.builder().ip(instance.getIp()).id(instance.getId()).hostname(instance.getHostname()).build())
-            .orElseThrow(NotFoundException::new);
+            .orElseThrow(() -> new InstanceNotFoundException(instanceId));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/FindApiMetricsDetailUseCaseTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fakes.FakeAnalyticsQueryService;
 import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.InstanceQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -28,6 +30,7 @@ import io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,12 +45,18 @@ class FindApiMetricsDetailUseCaseTest {
     FakeAnalyticsQueryService fakeAnalyticsQueryService = new FakeAnalyticsQueryService();
     ApplicationCrudServiceInMemory applicationCrudServiceInMemory = new ApplicationCrudServiceInMemory();
     PlanCrudServiceInMemory planCrudServiceInMemory = new PlanCrudServiceInMemory();
+    InstanceQueryServiceInMemory instanceQueryServiceInMemory = new InstanceQueryServiceInMemory();
 
     FindApiMetricsDetailUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new FindApiMetricsDetailUseCase(fakeAnalyticsQueryService, applicationCrudServiceInMemory, planCrudServiceInMemory);
+        useCase = new FindApiMetricsDetailUseCase(
+            fakeAnalyticsQueryService,
+            applicationCrudServiceInMemory,
+            planCrudServiceInMemory,
+            instanceQueryServiceInMemory
+        );
     }
 
     @AfterEach
@@ -97,7 +106,6 @@ class FindApiMetricsDetailUseCaseTest {
             List.of(Plan.builder().id(PLAN_ID).definitionVersion(DefinitionVersion.V4).name(planName).build())
         );
 
-        var instanceId = "instance-id";
         var transactionId = "transaction-id";
         var host = "request.host.example.com";
         var uri = "/example/api";
@@ -122,7 +130,7 @@ class FindApiMetricsDetailUseCaseTest {
             .responseContentLength(responseContentLength)
             .gatewayLatency(gatewayLatency)
             .gatewayResponseTime(gatewayResponseTime)
-            .gateway(instanceId)
+            .gateway(null)
             .remoteAddress(remoteAddress)
             .method(HttpMethod.GET)
             .endpointResponseTime(endpointResponseTime)
@@ -147,7 +155,9 @@ class FindApiMetricsDetailUseCaseTest {
             assertThat(apiMetricsDetail.getMethod()).isEqualTo(HttpMethod.GET);
             assertThat(apiMetricsDetail.getEndpointResponseTime()).isEqualTo(endpointResponseTime);
             assertThat(apiMetricsDetail.getEndpoint()).isEqualTo(endpoint);
-            assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
+            assertThat(apiMetricsDetail.getGateway()).isNull();
+            assertThat(apiMetricsDetail.getGatewayHostname()).isNull();
+            assertThat(apiMetricsDetail.getGatewayIp()).isNull();
 
             assertThat(apiMetricsDetail.getApplication())
                 .extracting(BaseApplicationEntity::getId, BaseApplicationEntity::getName)
@@ -156,6 +166,77 @@ class FindApiMetricsDetailUseCaseTest {
             assertThat(apiMetricsDetail.getPlan())
                 .extracting(GenericPlanEntity::getId, GenericPlanEntity::getName)
                 .containsExactly(PLAN_ID, planName);
+        });
+    }
+
+    @Test
+    void should_return_api_analytic_with_gateway_hostname_and_ip() {
+        var appName = "app-name";
+        applicationCrudServiceInMemory.initWith(List.of(BaseApplicationEntity.builder().id(APP_ID).name(appName).build()));
+
+        var planName = "plan-name";
+        planCrudServiceInMemory.initWith(
+            List.of(Plan.builder().id(PLAN_ID).definitionVersion(DefinitionVersion.V4).name(planName).build())
+        );
+
+        var instanceId = "instance-id";
+        var gatewayHostname = "gateway.example.com";
+        var gatewayIp = "192.168.1.100";
+        instanceQueryServiceInMemory.initWith(
+            List.of(
+                Instance.builder()
+                    .id(instanceId)
+                    .hostname(gatewayHostname)
+                    .ip(gatewayIp)
+                    .environments(Set.of(GraviteeContext.getCurrentEnvironment()))
+                    .build()
+            )
+        );
+
+        fakeAnalyticsQueryService.apiMetricsDetail = ApiMetricsDetail.builder()
+            .apiId(API_ID)
+            .requestId(REQUEST_ID)
+            .applicationId(APP_ID)
+            .planId(PLAN_ID)
+            .gateway(instanceId)
+            .build();
+
+        var result = useCase.execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(API_ID, REQUEST_ID));
+
+        assertThat(result).isNotNull();
+        assertThat(result.apiMetricsDetail()).hasValueSatisfying(apiMetricsDetail -> {
+            assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
+            assertThat(apiMetricsDetail.getGatewayHostname()).isEqualTo(gatewayHostname);
+            assertThat(apiMetricsDetail.getGatewayIp()).isEqualTo(gatewayIp);
+        });
+    }
+
+    @Test
+    void should_return_api_analytic_without_gateway_fields_when_instance_not_found() {
+        var appName = "app-name";
+        applicationCrudServiceInMemory.initWith(List.of(BaseApplicationEntity.builder().id(APP_ID).name(appName).build()));
+
+        var planName = "plan-name";
+        planCrudServiceInMemory.initWith(
+            List.of(Plan.builder().id(PLAN_ID).definitionVersion(DefinitionVersion.V4).name(planName).build())
+        );
+
+        var instanceId = "non-existent-instance-id";
+        fakeAnalyticsQueryService.apiMetricsDetail = ApiMetricsDetail.builder()
+            .apiId(API_ID)
+            .requestId(REQUEST_ID)
+            .applicationId(APP_ID)
+            .planId(PLAN_ID)
+            .gateway(instanceId)
+            .build();
+
+        var result = useCase.execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(API_ID, REQUEST_ID));
+
+        assertThat(result).isNotNull();
+        assertThat(result.apiMetricsDetail()).hasValueSatisfying(apiMetricsDetail -> {
+            assertThat(apiMetricsDetail.getGateway()).isEqualTo(instanceId);
+            assertThat(apiMetricsDetail.getGatewayHostname()).isNull();
+            assertThat(apiMetricsDetail.getGatewayIp()).isNull();
         });
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12400

## Description
Added gateway instance details to api metrics detail instead making another getInstanceById API call which explicitly requires INSTANCE_READ permission

Result: API owners can now access API logs along with instance details without any error
After Fix: 

https://github.com/user-attachments/assets/8c622334-74bd-4b0b-9aa7-a2fb05456402

Before Fix: 

https://github.com/user-attachments/assets/21931f48-ba51-48b4-a2a2-1e91ecd1aabb

