### PR TITLE
WIP : Feat/api product gateway changes phase2

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.handlers.api.manager.impl;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.node.api.license.LicenseManager;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class ApiProductManagerImpl implements ApiProductManager {
 
     private final ApiProductRegistry apiProductRegistry;
+    private final LicenseManager licenseManager;
     private final Map<String, ReactableApiProduct> apiProducts = new ConcurrentHashMap<>();
 
     @Override
@@ -82,7 +84,8 @@ public class ApiProductManagerImpl implements ApiProductManager {
     }
 
     private void deploy(ReactableApiProduct apiProduct) {
-        // TODO Phase 2 End: Add license validation (licenseManager.validateFeature)
+        // TODO: When LicenseManager.validateFeature(orgId, "API_PRODUCTS") is available,
+        // add validation here to block deployment when the feature is not allowed by the license.
         log.debug("Deploying API Product [{}]", apiProduct.getId());
 
         apiProducts.put(apiProduct.getId(), apiProduct);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ProductPlanDefinitionCache.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ProductPlanDefinitionCache.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.registry;
+
+import io.gravitee.definition.model.v4.plan.AbstractPlan;
+import java.util.List;
+
+/**
+ * Cache of product plan definitions for APIs that are part of API Products.
+ * Populated when API Products are deployed; used when building the security chain
+ * to iterate product plans before API plans.
+ *
+ * @author GraviteeSource Team
+ */
+public interface ProductPlanDefinitionCache {
+    /**
+     * Register plan definitions for an API Product.
+     *
+     * @param apiProductId the API Product ID
+     * @param plans the plan definitions (from repository, converted to definition model)
+     */
+    void register(String apiProductId, List<? extends AbstractPlan> plans);
+
+    /**
+     * Remove plan definitions for an API Product.
+     *
+     * @param apiProductId the API Product ID
+     */
+    void unregister(String apiProductId);
+
+    /**
+     * Get plan definitions for an API Product.
+     *
+     * @param apiProductId the API Product ID
+     * @return the plan definitions, or empty list if not found
+     */
+    List<? extends AbstractPlan> getByApiProductId(String apiProductId);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ProductPlanDefinitionCacheImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ProductPlanDefinitionCacheImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.registry.impl;
+
+import io.gravitee.definition.model.v4.plan.AbstractPlan;
+import io.gravitee.gateway.handlers.api.registry.ProductPlanDefinitionCache;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.CustomLog;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ProductPlanDefinitionCacheImpl implements ProductPlanDefinitionCache {
+
+    private final ConcurrentHashMap<String, List<? extends AbstractPlan>> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public void register(String apiProductId, List<? extends AbstractPlan> plans) {
+        if (apiProductId != null && plans != null && !plans.isEmpty()) {
+            cache.put(apiProductId, List.copyOf(plans));
+            log.debug("Registered {} plan definitions for API Product [{}]", plans.size(), apiProductId);
+        }
+    }
+
+    @Override
+    public void unregister(String apiProductId) {
+        if (apiProductId != null) {
+            cache.remove(apiProductId);
+            log.debug("Unregistered plan definitions for API Product [{}]", apiProductId);
+        }
+    }
+
+    @Override
+    public List<? extends AbstractPlan> getByApiProductId(String apiProductId) {
+        if (apiProductId == null) {
+            return Collections.emptyList();
+        }
+        List<? extends AbstractPlan> plans = cache.get(apiProductId);
+        return plans != null ? plans : Collections.emptyList();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -20,8 +20,8 @@ import static io.gravitee.repository.management.model.Subscription.Status.ACCEPT
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
-import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
@@ -113,11 +113,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
         ReactableApiProduct apiProduct = apiProductRegistry.get(apiProductId, environmentId);
         if (apiProduct == null || apiProduct.getApiIds() == null || apiProduct.getApiIds().isEmpty()) {
-            log.debug(
-                "API Product [{}] not found or has no APIs for subscription [{}], skipping",
-                apiProductId,
-                subscription.getId()
-            );
+            log.debug("API Product [{}] not found or has no APIs for subscription [{}], skipping", apiProductId, subscription.getId());
             return;
         }
         for (String apiId : apiProduct.getApiIds()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.services;
+
+import io.gravitee.gateway.api.service.Subscription;
+import java.util.Map;
+
+/**
+ * Utility class for subscription-related operations.
+ *
+ * @author GraviteeSource Team
+ */
+public final class SubscriptionUtils {
+
+    private static final String METADATA_REFERENCE_TYPE = "referenceType";
+    private static final String REFERENCE_TYPE_API_PRODUCT = "API_PRODUCT";
+
+    private SubscriptionUtils() {
+        // Utility class - no instantiation
+    }
+
+    /**
+     * Checks if a subscription is an API Product subscription.
+     *
+     * @param subscription the subscription to check
+     * @return true if the subscription is an API Product subscription, false otherwise
+     */
+    public static boolean isApiProductSubscription(Subscription subscription) {
+        if (subscription == null) {
+            return false;
+        }
+        Map<String, String> metadata = subscription.getMetadata();
+        return metadata != null && REFERENCE_TYPE_API_PRODUCT.equals(metadata.get(METADATA_REFERENCE_TYPE));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -234,12 +234,7 @@ public class ApiHandlerConfiguration {
         ApiManager apiManager,
         io.gravitee.gateway.handlers.api.registry.ApiProductRegistry apiProductRegistry
     ) {
-        return new SubscriptionCacheService(
-            apiKeyService,
-            subscriptionTrustStoreLoaderManager,
-            apiManager,
-            apiProductRegistry
-        );
+        return new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager, apiProductRegistry);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -231,9 +231,15 @@ public class ApiHandlerConfiguration {
     public SubscriptionCacheService subscriptionService(
         ApiKeyCacheService apiKeyService,
         SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager,
-        ApiManager apiManager
+        ApiManager apiManager,
+        io.gravitee.gateway.handlers.api.registry.ApiProductRegistry apiProductRegistry
     ) {
-        return new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager);
+        return new SubscriptionCacheService(
+            apiKeyService,
+            subscriptionTrustStoreLoaderManager,
+            apiManager,
+            apiProductRegistry
+        );
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
@@ -18,7 +18,11 @@ package io.gravitee.gateway.handlers.api.spring;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiProductManagerImpl;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ProductPlanDefinitionCache;
 import io.gravitee.gateway.handlers.api.registry.impl.ApiProductRegistryImpl;
+import io.gravitee.gateway.handlers.api.registry.impl.ProductPlanDefinitionCacheImpl;
+import io.gravitee.node.api.license.LicenseManager;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,7 +39,15 @@ public class ApiProductConfiguration {
     }
 
     @Bean
-    public ApiProductManager apiProductManager(ApiProductRegistry apiProductRegistry) {
-        return new ApiProductManagerImpl(apiProductRegistry);
+    public ProductPlanDefinitionCache productPlanDefinitionCache() {
+        return new ProductPlanDefinitionCacheImpl();
+    }
+
+    @Bean
+    public ApiProductManager apiProductManager(
+        ApiProductRegistry apiProductRegistry,
+        @Autowired(required = false) LicenseManager licenseManager
+    ) {
+        return new ApiProductManagerImpl(apiProductRegistry, licenseManager);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
@@ -26,6 +26,7 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionUtils;
 import io.gravitee.gateway.reactive.api.ComponentType;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
@@ -37,7 +38,6 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.annotation.Nonnull;
-import java.util.Map;
 import java.util.Optional;
 import lombok.CustomLog;
 
@@ -165,7 +165,7 @@ public abstract class AbstractSecurityPlan<T extends BaseSecurityPolicy, C exten
             if (subscriptionOpt.isPresent()) {
                 Subscription subscription = subscriptionOpt.get();
                 boolean planMatches = planContext.planId().equals(subscription.getPlan());
-                boolean isApiProductSubscription = isApiProductSubscription(subscription);
+                boolean isApiProductSubscription = SubscriptionUtils.isApiProductSubscription(subscription);
                 if ((planMatches || isApiProductSubscription) && subscription.isTimeValid(ctx.timestamp())) {
                     ctx.setAttribute(ATTR_APPLICATION, subscription.getApplication());
                     ctx.setAttribute(ATTR_SUBSCRIPTION_ID, subscription.getId());
@@ -188,10 +188,5 @@ public abstract class AbstractSecurityPlan<T extends BaseSecurityPolicy, C exten
             ctx.withLogger(log).warn("An error occurred during subscription validation", t);
             return false;
         }
-    }
-
-    private static boolean isApiProductSubscription(Subscription subscription) {
-        Map<String, String> metadata = subscription.getMetadata();
-        return metadata != null && "API_PRODUCT".equals(metadata.get("referenceType"));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -28,6 +28,8 @@ import io.gravitee.gateway.dictionary.DictionaryManager;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ProductPlanDefinitionCache;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.policy.PolicyConfigurationFactory;
@@ -68,6 +70,7 @@ import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.plugin.policy.PolicyClassLoaderFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import java.util.List;
+import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 
 /**
@@ -347,6 +350,15 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         LogGuardService logGuardService,
         ConnectionDrainManager connectionDrainManager
     ) {
+        ApiProductRegistry apiProductRegistry = null;
+        ProductPlanDefinitionCache productPlanDefinitionCache = null;
+        try {
+            apiProductRegistry = applicationContext.getBean(ApiProductRegistry.class);
+            productPlanDefinitionCache = applicationContext.getBean(ProductPlanDefinitionCache.class);
+        } catch (BeansException e) {
+            // API Product support may not be loaded
+        }
+
         return new DefaultApiReactor(
             api,
             deploymentContext,
@@ -368,7 +380,9 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
             eventManager,
             httpAcceptorFactory,
             createTracingContext(api, "API_V4"),
-            logGuardService
+            logGuardService,
+            apiProductRegistry,
+            productPlanDefinitionCache
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiPlanFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiPlanFlowResolver.java
@@ -21,6 +21,7 @@ import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.handlers.api.services.SubscriptionUtils;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
@@ -43,9 +44,6 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("common-java:DuplicatedBlocks") // Needed for v4 definition. Will replace the other one at the end.
 class ApiPlanFlowResolver extends AbstractFlowResolver {
-
-    private static final String METADATA_REFERENCE_TYPE = "referenceType";
-    private static final String REFERENCE_TYPE_API_PRODUCT = "API_PRODUCT";
 
     private final Api api;
 
@@ -73,19 +71,12 @@ class ApiPlanFlowResolver extends AbstractFlowResolver {
             return getFlows(plans, planId);
         }
 
-        if (isApiProductSubscription(ctx)) {
+        Subscription subscription = ctx.getInternalAttribute(ATTR_INTERNAL_SUBSCRIPTION);
+        if (SubscriptionUtils.isApiProductSubscription(subscription)) {
             return getFlowsFromAllPlans(plans);
         }
 
         return Flowable.empty();
-    }
-
-    private boolean isApiProductSubscription(BaseExecutionContext ctx) {
-        Subscription subscription = ctx.getInternalAttribute(ATTR_INTERNAL_SUBSCRIPTION);
-        if (subscription == null || subscription.getMetadata() == null) {
-            return false;
-        }
-        return REFERENCE_TYPE_API_PRODUCT.equals(subscription.getMetadata().get(METADATA_REFERENCE_TYPE));
     }
 
     private Flowable<Flow> getFlows(List<Plan> plans, String planId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
@@ -47,11 +47,14 @@ class ApiProductManagerImplTest {
     @Mock
     private ApiProductRegistry apiProductRegistry;
 
+    @Mock
+    private io.gravitee.node.api.license.LicenseManager licenseManager;
+
     private ApiProductManagerImpl manager;
 
     @BeforeEach
     void setUp() {
-        manager = new ApiProductManagerImpl(apiProductRegistry);
+        manager = new ApiProductManagerImpl(apiProductRegistry, null);
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
@@ -66,6 +67,9 @@ class SubscriptionCacheServiceTest {
     @Mock
     private ApiManager apiManager;
 
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
+
     private SubscriptionCacheService subscriptionService;
     private Map<String, Subscription> cacheByApiClientId;
     private Map<String, Subscription> cacheByApiClientCertificate;
@@ -74,7 +78,8 @@ class SubscriptionCacheServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        subscriptionService = new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager);
+        subscriptionService =
+            new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager, apiProductRegistry);
         cacheByApiClientId = (Map<String, Subscription>) ReflectionTestUtils.getField(subscriptionService, "cacheByApiClientId");
         cacheByApiClientCertificate = (Map<String, Subscription>) ReflectionTestUtils.getField(
             subscriptionService,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -78,8 +78,12 @@ class SubscriptionCacheServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        subscriptionService =
-            new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager, apiProductRegistry);
+        subscriptionService = new SubscriptionCacheService(
+            apiKeyService,
+            subscriptionTrustStoreLoaderManager,
+            apiManager,
+            apiProductRegistry
+        );
         cacheByApiClientId = (Map<String, Subscription>) ReflectionTestUtils.getField(subscriptionService, "cacheByApiClientId");
         cacheByApiClientCertificate = (Map<String, Subscription>) ReflectionTestUtils.getField(
             subscriptionService,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -408,7 +408,9 @@ class DefaultApiReactorTest {
                 eventManager,
                 new HttpAcceptorFactory(false),
                 tracingContext,
-                logGuardService
+                logGuardService,
+                null,
+                null
             );
             ReflectionTestUtils.setField(defaultApiReactor, "entrypointConnectorResolver", entrypointConnectorResolver);
             ReflectionTestUtils.setField(defaultApiReactor, "defaultInvoker", defaultInvoker);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugV4ApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugV4ApiReactor.java
@@ -38,6 +38,7 @@ import io.gravitee.gateway.reactor.handler.Acceptor;
 import io.gravitee.gateway.reactor.handler.DefaultHttpAcceptor;
 import io.gravitee.gateway.reactor.handler.HttpAcceptorFactory;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
@@ -70,7 +71,8 @@ public class DebugV4ApiReactor extends DefaultApiReactor {
         AccessPointManager accessPointManager,
         EventManager eventManager,
         HttpAcceptorFactory httpAcceptorFactory,
-        TracingContext tracingContext
+        TracingContext tracingContext,
+        LogGuardService logGuardService
     ) {
         super(
             api,
@@ -93,6 +95,8 @@ public class DebugV4ApiReactor extends DefaultApiReactor {
             eventManager,
             httpAcceptorFactory,
             tracingContext,
+            logGuardService,
+            null,
             null
         );
         invokerHooks.add(new DebugInvokerHook());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
@@ -143,7 +143,8 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
             accessPointManager,
             eventManager,
             httpAcceptorFactory,
-            TracingContext.noop()
+            TracingContext.noop(),
+            logGuardService
         );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -190,7 +190,8 @@ public class SyncConfiguration {
         AccessPointManager accessPointManager,
         SharedPolicyGroupManager sharedPolicyGroupManager,
         DistributedSyncService distributedSyncService,
-        ApiProductManager apiProductManager
+        ApiProductManager apiProductManager,
+        PlanRepository planRepository
     ) {
         Supplier<SubscriptionDispatcher> subscriptionDispatcherSupplier = provideSubscriptionDispatcher(subscriptionDispatcher);
         return new DeployerFactory(
@@ -211,7 +212,8 @@ public class SyncConfiguration {
             accessPointManager,
             sharedPolicyGroupManager,
             distributedSyncService,
-            apiProductManager
+            apiProductManager,
+            planRepository
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
+import io.gravitee.gateway.handlers.api.registry.ProductPlanDefinitionCache;
 import io.gravitee.gateway.handlers.sharedpolicygroup.manager.SharedPolicyGroupManager;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
@@ -58,6 +59,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -191,7 +193,8 @@ public class SyncConfiguration {
         SharedPolicyGroupManager sharedPolicyGroupManager,
         DistributedSyncService distributedSyncService,
         ApiProductManager apiProductManager,
-        PlanRepository planRepository
+        PlanRepository planRepository,
+        @Autowired(required = false) ProductPlanDefinitionCache productPlanDefinitionCache
     ) {
         Supplier<SubscriptionDispatcher> subscriptionDispatcherSupplier = provideSubscriptionDispatcher(subscriptionDispatcher);
         return new DeployerFactory(
@@ -213,7 +216,8 @@ public class SyncConfiguration {
             sharedPolicyGroupManager,
             distributedSyncService,
             apiProductManager,
-            planRepository
+            planRepository,
+            productPlanDefinitionCache
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
@@ -32,6 +32,7 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.license.LicenseFactory;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.CommandRepository;
+import io.gravitee.repository.management.api.PlanRepository;
 import java.util.function.Supplier;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +70,8 @@ public class DeployerFactory {
     private final DistributedSyncService distributedSyncService;
 
     private final io.gravitee.gateway.handlers.api.manager.ApiProductManager apiProductManager;
+
+    private final PlanRepository planRepository;
 
     public SubscriptionDeployer createSubscriptionDeployer() {
         return new SubscriptionDeployer(
@@ -118,6 +121,6 @@ public class DeployerFactory {
     }
 
     public ApiProductDeployer createApiProductDeployer() {
-        return new ApiProductDeployer(apiProductManager, distributedSyncService);
+        return new ApiProductDeployer(apiProductManager, planRepository, planCache, distributedSyncService);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.dictionary.DictionaryManager;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.registry.ProductPlanDefinitionCache;
 import io.gravitee.gateway.handlers.sharedpolicygroup.manager.SharedPolicyGroupManager;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
@@ -73,6 +74,8 @@ public class DeployerFactory {
 
     private final PlanRepository planRepository;
 
+    private final ProductPlanDefinitionCache productPlanDefinitionCache;
+
     public SubscriptionDeployer createSubscriptionDeployer() {
         return new SubscriptionDeployer(
             subscriptionService,
@@ -121,6 +124,6 @@ public class DeployerFactory {
     }
 
     public ApiProductDeployer createApiProductDeployer() {
-        return new ApiProductDeployer(apiProductManager, planRepository, planCache, distributedSyncService);
+        return new ApiProductDeployer(apiProductManager, planRepository, planCache, distributedSyncService, productPlanDefinitionCache);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/RepositoryPlanToDefinitionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/RepositoryPlanToDefinitionMapper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common.mapper;
+
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Maps repository Plan to definition Plan for use in the gateway security chain.
+ *
+ * @author GraviteeSource Team
+ */
+public final class RepositoryPlanToDefinitionMapper {
+
+    private RepositoryPlanToDefinitionMapper() {}
+
+    public static Plan toDefinition(io.gravitee.repository.management.model.Plan repoPlan) {
+        if (repoPlan == null) {
+            return null;
+        }
+
+        PlanSecurity security = PlanSecurity.builder()
+            .type(repoPlan.getSecurity() != null ? repoPlan.getSecurity().name() : "api-key")
+            .configuration(repoPlan.getSecurityDefinition())
+            .build();
+
+        PlanStatus status = toPlanStatus(repoPlan.getStatus());
+        PlanMode mode = repoPlan.getMode() != null ? PlanMode.valueOf(repoPlan.getMode().name()) : PlanMode.STANDARD;
+
+        return Plan.builder()
+            .id(repoPlan.getId())
+            .name(repoPlan.getName())
+            .security(security)
+            .mode(mode)
+            .selectionRule(repoPlan.getSelectionRule())
+            .tags(repoPlan.getTags() != null ? Set.copyOf(repoPlan.getTags()) : null)
+            .status(status)
+            .flows(List.of())
+            .build();
+    }
+
+    private static PlanStatus toPlanStatus(io.gravitee.repository.management.model.Plan.Status repoStatus) {
+        if (repoStatus == null) {
+            return PlanStatus.PUBLISHED;
+        }
+        return switch (repoStatus) {
+            case PUBLISHED -> PlanStatus.PUBLISHED;
+            case DEPRECATED -> PlanStatus.DEPRECATED;
+            case STAGING -> PlanStatus.STAGING;
+            case CLOSED -> PlanStatus.CLOSED;
+            default -> PlanStatus.PUBLISHED;
+        };
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -63,7 +63,9 @@ public class SubscriptionMapper {
                     objectMapper.readValue(subscriptionModel.getConfiguration(), SubscriptionConfiguration.class)
                 );
             }
-            Map<String, String> metadata = subscriptionModel.getMetadata() != null ? new HashMap<>(subscriptionModel.getMetadata()) : new HashMap<>();
+            Map<String, String> metadata = subscriptionModel.getMetadata() != null
+                ? new HashMap<>(subscriptionModel.getMetadata())
+                : new HashMap<>();
             if (subscriptionModel.getReferenceId() != null) {
                 metadata.put(METADATA_REFERENCE_ID, subscriptionModel.getReferenceId());
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SubscriptionSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SubscriptionSynchronizer.java
@@ -134,15 +134,14 @@ public class SubscriptionSynchronizer implements RepositorySynchronizer {
 
     private boolean isPlanDeployed(Subscription subscription) {
         String referenceId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
-        PlanReferenceType referenceType =
-            subscription.getReferenceType() != null ? toPlanReferenceType(subscription.getReferenceType()) : PlanReferenceType.API;
+        PlanReferenceType referenceType = subscription.getReferenceType() != null
+            ? toPlanReferenceType(subscription.getReferenceType())
+            : PlanReferenceType.API;
         return planCache.isDeployed(referenceId, subscription.getPlan(), referenceType);
     }
 
     private static PlanReferenceType toPlanReferenceType(SubscriptionReferenceType subscriptionReferenceType) {
-        return subscriptionReferenceType == SubscriptionReferenceType.API_PRODUCT
-            ? PlanReferenceType.API_PRODUCT
-            : PlanReferenceType.API;
+        return subscriptionReferenceType == SubscriptionReferenceType.API_PRODUCT ? PlanReferenceType.API_PRODUCT : PlanReferenceType.API;
     }
 
     @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12491

## Description

Implements **Phase 2: API Product Gateway Runtime Integration** - enabling API Products to be fully functional at the gateway runtime level. This PR adds plan synchronization, subscription management, and product-first security chain validation for API Products.

### Key Changes

- **Plan Sync**: API Product plans are synchronized from Management API to Gateway and cached via `PlanService` and `ProductPlanDefinitionCache`
- **Subscription Management**: API Product subscriptions are registered per API in `SubscriptionCacheService`, enabling efficient product subscription lookup
- **Product-First Security Chain**: `HttpSecurityChain` validates product subscriptions before API subscriptions, ensuring a single subscription governs multiple APIs
- **Security Plan Relaxation**: `AbstractSecurityPlan` accepts product subscriptions even when plan ID doesn't exactly match, enabling product plans to work across APIs

### Technical Flow

```
Plan: MAPI Event → ApiProductDeployer → PlanService → ProductPlanDefinitionCache
Subscription: MAPI Event → SubscriptionSynchronizer → SubscriptionCacheService
Security: Request → HttpSecurityChain (Product Plans First) → AbstractSecurityPlan → SubscriptionCacheService
```

## Additional context

- **Gateway-only changes**: This PR focuses on runtime integration; Management API changes are in separate PRs
- **V4 Only**: API Products apply only to V4 Proxy APIs
- **Backward Compatible**: Existing API subscriptions continue to work alongside product subscriptions
- **Related PRs**: Requires Plan Model PR (referenceId/referenceType) and Subscription Model PR (product fields)

### Known Limitations

**Security Chain Staleness**: When an API Product is deployed or updated, APIs that belong to that product keep their existing security chain until the gateway is restarted or those APIs are redeployed.

- **Issue**: `HttpSecurityChain.buildSecurityPlans()` is called once during gateway startup or API deployment/update, but is not triggered by API Product deploy or update
- **Effect**: New or updated product plans are not reflected in the security chain until an affected API is redeployed or the gateway restarts
- **Mitigation Options** (requires architecture confirmation):
  - Event-driven chain refresh when a product changes
  - Trigger redeploy of affected APIs on product change
  
  Possible suggested solution : 
  
  
<img width="1264" height="423" alt="image" src="https://github.com/user-attachments/assets/acdcf9fd-d0f9-4562-ba01-2c36aca5d834" />

