### PR TITLE
fix(portal-next): regularize user registration routes with classic portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -280,14 +280,23 @@ export const routes: Routes = [
     ],
   },
   {
-    path: 'registration',
-    component: RegistrationComponent,
-    canActivate: [anonymousGuard],
-  },
-  {
-    path: 'registration/confirm/:token',
-    component: RegistrationConfirmationComponent,
-    canActivate: [anonymousGuard],
+    path: 'user',
+    children: [
+      /**
+       * DO NOT CHANGE THESE PATHS!
+       * Registration routes must match Classic Portal paths: /user/registration/...
+       */
+      {
+        path: 'registration',
+        component: RegistrationComponent,
+        canActivate: [anonymousGuard],
+      },
+      {
+        path: 'registration/confirm/:token',
+        component: RegistrationConfirmationComponent,
+        canActivate: [anonymousGuard],
+      },
+    ],
   },
   { path: 'log-out', component: LogOutComponent, canActivate: [redirectGuard] },
   { path: '404', component: NotFoundComponent },

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -75,7 +75,7 @@
       }
       <div class="log-in__registration m3-label-large">
         <span i18n="@@logInSignupPrefix">Don’t have an account? </span>
-        <a class="internal-link" routerLink="/registration" i18n="@@logInSignupLabel">Sign up</a>
+        <a class="internal-link" routerLink="/user/registration" i18n="@@logInSignupLabel">Sign up</a>
       </div>
     </mat-card-content>
   </mat-card>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12613

## Description

When the user was clicking the confirm link in the email, it was sent to the same path for user registration confirmation that exists in the Classic Portal. However, this was creating a 404.

This fix regularizes the routing to the user registration confirmation page.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

