### PR TITLE
fix: default referrer policy  if not explicitly configured

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/config/SecureHeadersConfigurer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/config/SecureHeadersConfigurer.java
@@ -69,8 +69,10 @@ public interface SecureHeadersConfigurer {
     }
 
     static void referrerPolicy(HttpSecurity security, ConfigurableEnvironment environment) throws Exception {
-        String policyString = environment.getProperty("http.secureHeaders.referrerPolicy.policy");
-
+        String policyString = environment.getProperty(
+            "http.secureHeaders.referrerPolicy.policy",
+            ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN.getPolicy()
+        );
         var policy = Arrays.stream(ReferrerPolicyHeaderWriter.ReferrerPolicy.values())
             .filter(p -> p.getPolicy().equalsIgnoreCase(policyString))
             .findFirst()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12476


The application strictly requires the presence of the referrerPolicy configuration. If missing, the Spring security filter chain fails to instantiate, causing the entire Management API to crash with the error: Invalid referrer policy provided: 'null'.



## Description

 - Added fall back for `http.secureHeaders.referrerPolicy.policy` 
 - When the referer policy is not provided, it is set as 'strict-origin-when-cross-origin' 
 
## Additional context

| Scenario                                       |  Action                                                                     | Referer Policy                                  | 
| ------------------------------- | ----------------------------------------------- | --------------------------------- | 
| Valid policy                                  |  System applies config referer policy                    |   As configured                                | 
| Invalid policy value                     |  System rejects invalid config with error               |    NA                                                  | 
| No value chosen                         |  System set the default value for referer policy    |  strict-origin-when-cross-origin. | 
