### PR TITLE
fix(mapi): fetch crossId and name from API definition not from API which is not always available

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResourceTest.java
@@ -149,7 +149,8 @@ class PromotionsResourceTest extends AbstractResourceTest {
             .toBuilder()
             .id(PROMOTION_ID)
             .apiId(API_ID)
-            .apiDefinition("{ \"gravitee\" : \"2.0.0\", \"id\" : \"api-id\" }")
+            .targetEnvCockpitId(TARGET_ENV_COCKPIT_ID)
+            .apiDefinition("{ \"gravitee\" : \"2.0.0\", \"id\" : \"api-id\", \"crossId\" : \"api-cross-id\" }")
             .build();
         promotionCrudServiceInMemory.initWith(List.of(promotion));
         apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).crossId(API_CROSS_ID).environmentId(DEFAULT_ENV_ID).build()));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12625

## Description

When an API is promoted from one environment to another the promotion task is displayed and processed in the target environment. The existing code incorrectly tried to look up the source API by its ID in the target environment's database, where it doesn't exist yet (the promotion hasn't been accepted)
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

