### PR TITLE
GKO-2163: Enhance Logs Search Endpoint with Additional Filter Support

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -204,6 +204,10 @@ components:
         - PLAN
         - HTTP_METHOD
         - HTTP_STATUS
+        - MCP_METHOD
+        - TRANSACTION_ID
+        - REQUEST_ID
+        - URI
       description: Available filter names for filtering analytics data
 
     Operator:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -193,7 +193,7 @@ components:
           items:
             type: string
           description: Filter value (array for IN operator)
-      example: { name: "HTTP_STATUS_CODE_GROUP", operator: "IN", value: ["2xx", "3xx"] }
+      example: { name: "HTTP_STATUS", operator: "IN", value: ["200", "301"] }
 
     FilterName:
       type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
@@ -30,6 +30,10 @@ public final class FilterContext {
     private Set<HttpMethod> methods;
     private Set<Integer> statuses;
     private Set<String> entrypointIds;
+    private Set<String> mcpMethods;
+    private Set<String> transactionIds;
+    private Set<String> requestIds;
+    private String uri;
 
     public void limitByApiIds(Set<String> apiIds) {
         if (apiIds == null) {
@@ -97,6 +101,46 @@ public final class FilterContext {
         }
     }
 
+    public void limitByMcpMethods(Set<String> mcpMethods) {
+        if (mcpMethods == null) {
+            return;
+        }
+        if (this.mcpMethods == null) {
+            this.mcpMethods = new HashSet<>(mcpMethods);
+        } else {
+            this.mcpMethods.retainAll(mcpMethods);
+        }
+    }
+
+    public void limitByTransactionIds(Set<String> transactionIds) {
+        if (transactionIds == null) {
+            return;
+        }
+        if (this.transactionIds == null) {
+            this.transactionIds = new HashSet<>(transactionIds);
+        } else {
+            this.transactionIds.retainAll(transactionIds);
+        }
+    }
+
+    public void limitByRequestIds(Set<String> requestIds) {
+        if (requestIds == null) {
+            return;
+        }
+        if (this.requestIds == null) {
+            this.requestIds = new HashSet<>(requestIds);
+        } else {
+            this.requestIds.retainAll(requestIds);
+        }
+    }
+
+    public void limitByUri(String uri) {
+        if (uri == null) {
+            return;
+        }
+        this.uri = uri;
+    }
+
     public Optional<Set<String>> apiIds() {
         return Optional.ofNullable(apiIds);
     }
@@ -119,5 +163,21 @@ public final class FilterContext {
 
     public Optional<Set<String>> entrypointIds() {
         return Optional.ofNullable(entrypointIds);
+    }
+
+    public Optional<Set<String>> mcpMethods() {
+        return Optional.ofNullable(mcpMethods);
+    }
+
+    public Optional<Set<String>> transactionIds() {
+        return Optional.ofNullable(transactionIds);
+    }
+
+    public Optional<Set<String>> requestIds() {
+        return Optional.ofNullable(requestIds);
+    }
+
+    public Optional<String> uri() {
+        return Optional.ofNullable(uri);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
@@ -22,4 +22,8 @@ public enum FilterName {
     PLAN,
     HTTP_METHOD,
     HTTP_STATUS,
+    MCP_METHOD,
+    TRANSACTION_ID,
+    REQUEST_ID,
+    URI,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -445,6 +445,165 @@ class SearchEnvironmentLogsUseCaseTest {
                 )
             );
         }
+
+        @ParameterizedTest
+        @MethodSource("mcpMethodFiltersProvider")
+        void should_intersect_mcp_method_filters(List<Filter> filters, String[] expectedMcpMethods) {
+            var request = new SearchLogsRequest(null, filters, 1, 10);
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().mcpMethods()).containsExactlyInAnyOrder(expectedMcpMethods);
+        }
+
+        static Stream<Arguments> mcpMethodFiltersProvider() {
+            return Stream.of(
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.MCP_METHOD, Operator.EQ, "initialize")),
+                        new Filter(new ArrayFilter(FilterName.MCP_METHOD, Operator.IN, List.of("initialize", "tools/list")))
+                    ),
+                    new String[] { "initialize" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new ArrayFilter(FilterName.MCP_METHOD, Operator.IN, List.of("initialize", "tools/list"))),
+                        new Filter(new ArrayFilter(FilterName.MCP_METHOD, Operator.IN, List.of("tools/list", "resources/read")))
+                    ),
+                    new String[] { "tools/list" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.MCP_METHOD, Operator.EQ, "initialize")),
+                        new Filter(new StringFilter(FilterName.MCP_METHOD, Operator.EQ, "ping"))
+                    ),
+                    new String[] {}
+                ),
+                Arguments.of(
+                    List.of(new Filter(new ArrayFilter(FilterName.MCP_METHOD, Operator.IN, List.of("initialize", "ping", "tools/list")))),
+                    new String[] { "initialize", "ping", "tools/list" }
+                )
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("transactionIdFiltersProvider")
+        void should_intersect_transaction_id_filters(List<Filter> filters, String[] expectedTransactionIds) {
+            var request = new SearchLogsRequest(null, filters, 1, 10);
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().transactionIds()).containsExactlyInAnyOrder(expectedTransactionIds);
+        }
+
+        static Stream<Arguments> transactionIdFiltersProvider() {
+            return Stream.of(
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.TRANSACTION_ID, Operator.EQ, "txn-123")),
+                        new Filter(new ArrayFilter(FilterName.TRANSACTION_ID, Operator.IN, List.of("txn-123", "txn-456")))
+                    ),
+                    new String[] { "txn-123" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new ArrayFilter(FilterName.TRANSACTION_ID, Operator.IN, List.of("txn-123", "txn-456"))),
+                        new Filter(new ArrayFilter(FilterName.TRANSACTION_ID, Operator.IN, List.of("txn-456", "txn-789")))
+                    ),
+                    new String[] { "txn-456" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.TRANSACTION_ID, Operator.EQ, "txn-123")),
+                        new Filter(new StringFilter(FilterName.TRANSACTION_ID, Operator.EQ, "txn-456"))
+                    ),
+                    new String[] {}
+                ),
+                Arguments.of(
+                    List.of(new Filter(new ArrayFilter(FilterName.TRANSACTION_ID, Operator.IN, List.of("txn-123", "txn-456", "txn-789")))),
+                    new String[] { "txn-123", "txn-456", "txn-789" }
+                )
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("requestIdFiltersProvider")
+        void should_intersect_request_id_filters(List<Filter> filters, String[] expectedRequestIds) {
+            var request = new SearchLogsRequest(null, filters, 1, 10);
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().requestIds()).containsExactlyInAnyOrder(expectedRequestIds);
+        }
+
+        static Stream<Arguments> requestIdFiltersProvider() {
+            return Stream.of(
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.REQUEST_ID, Operator.EQ, "req-123")),
+                        new Filter(new ArrayFilter(FilterName.REQUEST_ID, Operator.IN, List.of("req-123", "req-456")))
+                    ),
+                    new String[] { "req-123" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new ArrayFilter(FilterName.REQUEST_ID, Operator.IN, List.of("req-123", "req-456"))),
+                        new Filter(new ArrayFilter(FilterName.REQUEST_ID, Operator.IN, List.of("req-456", "req-789")))
+                    ),
+                    new String[] { "req-456" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.REQUEST_ID, Operator.EQ, "req-123")),
+                        new Filter(new StringFilter(FilterName.REQUEST_ID, Operator.EQ, "req-456"))
+                    ),
+                    new String[] {}
+                ),
+                Arguments.of(
+                    List.of(new Filter(new ArrayFilter(FilterName.REQUEST_ID, Operator.IN, List.of("req-123", "req-456", "req-789")))),
+                    new String[] { "req-123", "req-456", "req-789" }
+                )
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("uriFiltersProvider")
+        void should_map_uri_filter(List<Filter> filters, String expectedUri) {
+            var request = new SearchLogsRequest(null, filters, 1, 10);
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            if (expectedUri == null) {
+                assertThat(filtersCaptor.getValue().uri()).isNull();
+            } else {
+                assertThat(filtersCaptor.getValue().uri()).isEqualTo(expectedUri);
+            }
+        }
+
+        static Stream<Arguments> uriFiltersProvider() {
+            return Stream.of(
+                Arguments.of(List.of(new Filter(new StringFilter(FilterName.URI, Operator.EQ, "/api/users"))), "/api/users"),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.URI, Operator.EQ, "/api/users")),
+                        new Filter(new StringFilter(FilterName.URI, Operator.EQ, "/api/products"))
+                    ),
+                    "/api/products" // Last EQ wins
+                )
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2163

## Description

Enhance the environment logs search endpoint to support additional filters (MCP_METHOD, TRANSACTION_ID, REQUEST_ID, and URI). This aligns the API capabilities with the underlying Analytics Engine support.

See Jira issue for a full description.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

