### PR TITLE
Fix timestamp column precision in client_certificates changelog

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/02_add_client_certificates_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/02_add_client_certificates_table.yml
@@ -12,8 +12,8 @@ databaseChangeLog:
               - column: { name: name, type: nvarchar(512), constraints: { nullable: false } }
               - column: { name: starts_at, type: timestamp }
               - column: { name: ends_at, type: timestamp }
-              - column: { name: created_at, type: timestamp, constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
-              - column: { name: updated_at, type: timestamp, constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
               - column: { name: certificate, type: nclob, constraints: { nullable: false } }
               - column: { name: certificate_expiration, type: timestamp }
               - column: { name: subject, type: nvarchar(1024) }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Specified precision for timestamp columns in the `client_certificates` table changelog to be compatible with the default `CURRENT_TIMESTAMP(6)`.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->