### PR TITLE
WIP : fix(subscription): use referenceId/referenceType, remove duplicate Cl…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/SubscriptionMapper.java
@@ -36,6 +36,7 @@ import org.mapstruct.factory.Mappers;
 public interface SubscriptionMapper {
     SubscriptionMapper INSTANCE = Mappers.getMapper(SubscriptionMapper.class);
 
+    /** Maps the legacy REST model (io.gravitee.rest.api.model.SubscriptionEntity) which has "api" (String) and no referenceId/referenceType. */
     @Mapping(target = "api.id", source = "api")
     @Mapping(target = "plan.id", source = "plan")
     @Mapping(target = "application.id", source = "application")
@@ -46,7 +47,9 @@ public interface SubscriptionMapper {
     @Mapping(target = "consumerConfiguration", source = "configuration")
     Subscription map(SubscriptionEntity subscriptionEntity);
 
-    @Mapping(target = "api.id", source = "apiId")
+    @Mapping(target = "api", ignore = true)
+    @Mapping(target = "referenceId", source = "referenceId")
+    @Mapping(target = "referenceType", source = "referenceType", qualifiedByName = "mapSubscriptionReferenceType")
     @Mapping(target = "plan.id", source = "planId")
     @Mapping(target = "application.id", source = "applicationId")
     @Mapping(target = "processedBy.id", source = "processedBy")
@@ -126,5 +129,12 @@ public interface SubscriptionMapper {
             : OriginContext.Origin.KUBERNETES == origin
                 ? Subscription.OriginEnum.KUBERNETES
                 : Subscription.OriginEnum.MANAGEMENT;
+    }
+
+    @Named("mapSubscriptionReferenceType")
+    default Subscription.ReferenceTypeEnum mapSubscriptionReferenceType(
+        io.gravitee.apim.core.subscription.model.SubscriptionReferenceType type
+    ) {
+        return type == null ? null : Subscription.ReferenceTypeEnum.valueOf(type.name());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlanResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlanResource.java
@@ -44,9 +44,9 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
-import lombok.CustomLog;
+import lombok.extern.slf4j.Slf4j;
 
-@CustomLog
+@Slf4j
 public class ApiProductPlanResource extends AbstractResource {
 
     private final ApiProductPlanMapper planMapper = ApiProductPlanMapper.INSTANCE;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlansResource.java
@@ -56,9 +56,9 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.CustomLog;
+import lombok.extern.slf4j.Slf4j;
 
-@CustomLog
+@Slf4j
 public class ApiProductPlansResource extends AbstractResource {
 
     private final ApiProductPlanMapper planMapper = ApiProductPlanMapper.INSTANCE;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
@@ -21,7 +21,6 @@ import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
-import io.gravitee.rest.api.management.v2.rest.resource.api.ApiSubscriptionsResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
@@ -57,9 +56,6 @@ public class ApiProductResource extends AbstractResource {
 
     @Inject
     private UpdateApiProductUseCase updateApiProductUseCase;
-
-    @Context
-    private ResourceContext resourceContext;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionResource.java
@@ -42,7 +42,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 import java.util.Optional;
-import lombok.CustomLog;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * API Product Subscription REST resource (singular).
@@ -50,7 +50,7 @@ import lombok.CustomLog;
  *
  * @author GraviteeSource Team
  */
-@CustomLog
+@Slf4j
 public class ApiProductSubscriptionResource extends AbstractResource {
 
     private final SubscriptionMapper subscriptionMapper = SubscriptionMapper.INSTANCE;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
@@ -49,7 +49,7 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
-import lombok.CustomLog;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -59,7 +59,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @author GraviteeSource Team
  */
-@CustomLog
+@Slf4j
 public class ApiProductSubscriptionsResource extends AbstractResource {
 
     private final SubscriptionMapper subscriptionMapper = SubscriptionMapper.INSTANCE;
@@ -167,6 +167,7 @@ public class ApiProductSubscriptionsResource extends AbstractResource {
     }
 
     private Subscription filterSensitiveData(Subscription subscription) {
+        // TODO(Vikrant): Confirm if filterSensitiveData is needed for subscriptions; plans removed it with a TODO.
         // Similar to plan filtering: check if user has both API_PRODUCT_DEFINITION and API_PRODUCT_SUBSCRIPTION permissions
         if (
             hasPermission(
@@ -190,6 +191,8 @@ public class ApiProductSubscriptionsResource extends AbstractResource {
         // Subscriptions don't have sensitive data like flows/security definitions, so we return basic fields
         Subscription filtered = new Subscription();
         filtered.setId(subscription.getId());
+        filtered.setReferenceId(subscription.getReferenceId());
+        filtered.setReferenceType(subscription.getReferenceType());
         filtered.setStatus(subscription.getStatus());
         if (subscription.getPlan() != null) {
             filtered.setPlan(subscription.getPlan());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5449,6 +5449,15 @@ components:
                           enum:
                               - KUBERNETES
                               - MANAGEMENT
+                      referenceId:
+                          type: string
+                          description: The reference ID (API ID or API Product ID) this subscription belongs to.
+                      referenceType:
+                          type: string
+                          description: The reference type (API or API_PRODUCT).
+                          enum:
+                              - API
+                              - API_PRODUCT
         SubscriptionStatus:
             type: string
             description: The status of the subscription manageable by the api publisher.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/SubscriptionMapperTest.java
@@ -124,7 +124,8 @@ public class SubscriptionMapperTest extends AbstractMapperTest {
         io.gravitee.apim.core.subscription.model.SubscriptionEntity coreEntity =
             io.gravitee.apim.core.subscription.model.SubscriptionEntity.builder()
                 .id("sub-1")
-                .apiId("api-1")
+                .referenceId("api-1")
+                .referenceType(io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API)
                 .planId("plan-1")
                 .applicationId("app-1")
                 .status(io.gravitee.apim.core.subscription.model.SubscriptionEntity.Status.ACCEPTED)
@@ -140,7 +141,8 @@ public class SubscriptionMapperTest extends AbstractMapperTest {
 
         assertNotNull(subscription);
         assertEquals("sub-1", subscription.getId());
-        assertEquals("api-1", subscription.getApi().getId());
+        assertEquals("api-1", subscription.getReferenceId());
+        assertEquals(io.gravitee.rest.api.management.v2.rest.model.Subscription.ReferenceTypeEnum.API, subscription.getReferenceType());
         assertEquals("plan-1", subscription.getPlan().getId());
         assertEquals("app-1", subscription.getApplication().getId());
         assertEquals("request", subscription.getConsumerMessage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.use_case.api_product.AcceptApiProductSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.api_product.CloseApiProductSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.api_product.GetApiProductSubscriptionsUseCase;
@@ -38,7 +39,6 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -104,7 +104,8 @@ class ApiProductSubscriptionResourceTest extends AbstractResourceTest {
     private static SubscriptionEntity aSubscription() {
         return SubscriptionEntity.builder()
             .id(SUBSCRIPTION_ID)
-            .apiId(API_PRODUCT_ID)
+            .referenceId(API_PRODUCT_ID)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
             .planId("plan-1")
             .applicationId("app-1")
             .status(SubscriptionEntity.Status.ACCEPTED)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/promotions/PromotionsResourceTest.java
@@ -149,7 +149,8 @@ class PromotionsResourceTest extends AbstractResourceTest {
             .toBuilder()
             .id(PROMOTION_ID)
             .apiId(API_ID)
-            .apiDefinition("{ \"gravitee\" : \"2.0.0\", \"id\" : \"api-id\" }")
+            .targetEnvCockpitId(TARGET_ENV_COCKPIT_ID)
+            .apiDefinition("{ \"gravitee\" : \"2.0.0\", \"id\" : \"api-id\", \"crossId\" : \"api-cross-id\" }")
             .build();
         promotionCrudServiceInMemory.initWith(List.of(promotion));
         apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).crossId(API_CROSS_ID).environmentId(DEFAULT_ENV_ID).build()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
@@ -206,75 +206,6 @@ public class CloseSubscriptionDomainService {
             ApiProductAuditLogEntity.builder()
                 .organizationId(auditInfo.organizationId())
                 .environmentId(auditInfo.environmentId())
-                //TODO change this to subscription reference id
-                .apiProductId(originalSubscription.getApiId())
-                .event(SubscriptionAuditEvent.SUBSCRIPTION_CLOSED)
-                .oldValue(originalSubscription)
-                .newValue(closedSubscription)
-                .actor(auditInfo.actor())
-                .createdAt(closedSubscription.getUpdatedAt())
-                .properties(Collections.singletonMap(AuditProperties.APPLICATION, originalSubscription.getApplicationId()))
-                .build()
-        );
-        auditDomainService.createApplicationAuditLog(
-            ApplicationAuditLogEntity.builder()
-                .organizationId(auditInfo.organizationId())
-                .environmentId(auditInfo.environmentId())
-                .applicationId(originalSubscription.getApplicationId())
-                .event(SubscriptionAuditEvent.SUBSCRIPTION_CLOSED)
-                .oldValue(originalSubscription)
-                .newValue(closedSubscription)
-                .actor(auditInfo.actor())
-                .createdAt(closedSubscription.getUpdatedAt())
-                .properties(Collections.singletonMap(AuditProperties.API, originalSubscription.getApiId()))
-                .build()
-        );
-    }
-
-    private void revokeApiKeys(SubscriptionEntity subscriptionEntity, AuditInfo auditInfo) {
-        var application = applicationCrudService.findById(
-            new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId()),
-            subscriptionEntity.getApplicationId()
-        );
-        if (!application.hasApiKeySharedMode()) {
-            revokeApiKeyDomainService.revokeAllSubscriptionsApiKeys(subscriptionEntity, auditInfo);
-        }
-    }
-
-    public SubscriptionEntity closeSubscriptionForApiProduct(String subscriptionId, AuditInfo auditInfo) {
-        var subscription = subscriptionCrudService.get(subscriptionId);
-        return closeSubscriptionForApiProduct(subscription, auditInfo);
-    }
-
-    public SubscriptionEntity closeSubscriptionForApiProduct(SubscriptionEntity subscription, AuditInfo auditInfo) {
-        log.debug("Close subscription {}", subscription.getId());
-
-        return switch (subscription.getStatus()) {
-            case ACCEPTED, PAUSED -> closeAcceptedOrPausedSubscriptionForApiProduct(subscription, auditInfo);
-            case PENDING -> rejectSubscriptionDomainService.reject(subscription, "Subscription has been closed.", auditInfo);
-            case CLOSED, REJECTED -> subscription;
-        };
-    }
-
-    private SubscriptionEntity closeAcceptedOrPausedSubscriptionForApiProduct(SubscriptionEntity subscriptionEntity, AuditInfo auditInfo) {
-        var closedSubscriptionEntity = subscriptionCrudService.update(subscriptionEntity.close());
-
-        createApiProductAuditLog(subscriptionEntity, closedSubscriptionEntity, auditInfo);
-
-        revokeApiKeys(subscriptionEntity, auditInfo);
-
-        return closedSubscriptionEntity;
-    }
-
-    private void createApiProductAuditLog(
-        SubscriptionEntity originalSubscription,
-        SubscriptionEntity closedSubscription,
-        AuditInfo auditInfo
-    ) {
-        auditDomainService.createApiProductAuditLog(
-            ApiProductAuditLogEntity.builder()
-                .organizationId(auditInfo.organizationId())
-                .environmentId(auditInfo.environmentId())
                 .apiProductId(originalSubscription.getReferenceId())
                 .event(SubscriptionAuditEvent.SUBSCRIPTION_CLOSED)
                 .oldValue(originalSubscription)
@@ -297,5 +228,15 @@ public class CloseSubscriptionDomainService {
                 .properties(Collections.singletonMap(AuditProperties.API_PRODUCT, originalSubscription.getReferenceId()))
                 .build()
         );
+    }
+
+    private void revokeApiKeys(SubscriptionEntity subscriptionEntity, AuditInfo auditInfo) {
+        var application = applicationCrudService.findById(
+            new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId()),
+            subscriptionEntity.getApplicationId()
+        );
+        if (!application.hasApiKeySharedMode()) {
+            revokeApiKeyDomainService.revokeAllSubscriptionsApiKeys(subscriptionEntity, auditInfo);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductCrudServiceInMemory.java
@@ -49,13 +49,4 @@ public class ApiProductCrudServiceInMemory extends AbstractCrudServiceInMemory<A
     public void delete(String id) {
         storage.removeIf(apiProduct -> id.equals(apiProduct.getId()));
     }
-
-    @Override
-    public ApiProduct get(String id) {
-        return storage
-            .stream()
-            .filter(apiProduct -> id.equals(apiProduct.getId()))
-            .findFirst()
-            .get();
-    }
 }


### PR DESCRIPTION
…oseSubscriptionDomainService methods

- Subscription REST: add referenceId/referenceType to OpenAPI schema; mapper maps core entity to them (api ignored for core path)
- SubscriptionMapperTest: assert referenceId/referenceType instead of api.id
- ApiProductSubscriptionResourceTest: aSubscription() uses referenceId + referenceType
- ApiProductSubscriptionsResource: filterSensitiveData copies referenceId/referenceType; add TODO for Vikrant on filterSensitiveData
- CloseSubscriptionDomainService: remove duplicate API Product close/audit methods; createApiProductAuditLog uses getReferenceId() and API_PRODUCT

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

