### PR TITLE
fix: add strict media type mismatch check on media upload and display upload errors in the console

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-attached-resources.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-attached-resources.components.ts
@@ -55,7 +55,10 @@ class EditPageAttachedResourcesComponentController implements IController {
 
           this.DocumentationService.addMedia(fd, this.page.id, this.apiId)
             .then(() => this.onSave())
-            .then(() => this.NotificationService.show(fileName + ' has been attached'));
+            .then(() => this.NotificationService.show(fileName + ' has been attached'))
+            .catch((error) => {
+              this.NotificationService.showError(error.data?.message || 'An error occurred while uploading the media.');
+            });
         }
       });
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11973

## Description

Add strict media type mismatch check on media upload and display upload errors in the console.
