### PR TITLE
feat: validation rules when creating portal navigation item with type…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -155,7 +155,7 @@ class PortalNavigationItemsMapperTest {
 
             var result = mapper.map(items);
 
-            assertThat(result).hasSize(9);
+            assertThat(result).hasSize(11);
             // Check that all items are mapped correctly
             assertThat(
                 result
@@ -171,7 +171,9 @@ class PortalNavigationItemsMapperTest {
                 UUID.fromString("00000000-0000-0000-0000-000000000006"),
                 UUID.fromString("00000000-0000-0000-0000-000000000007"),
                 UUID.fromString("00000000-0000-0000-0000-000000000008"),
-                UUID.fromString("00000000-0000-0000-0000-000000000009")
+                UUID.fromString("00000000-0000-0000-0000-000000000009"),
+                UUID.fromString("00000000-0000-0000-0000-000000000010"),
+                UUID.fromString("00000000-0000-0000-0000-000000000011")
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
@@ -104,7 +104,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
         assertThat(response)
             .hasStatus(OK_200)
             .asEntity(PortalNavigationItemsResponse.class)
-            .satisfies(entity -> assertThat(entity.getItems()).hasSize(9));
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(10));
     }
 
     @Test
@@ -135,7 +135,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
         assertThat(response)
             .hasStatus(OK_200)
             .asEntity(PortalNavigationItemsResponse.class)
-            .satisfies(entity -> assertThat(entity.getItems()).hasSize(3));
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(4));
     }
 
     @Test
@@ -199,7 +199,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
         assertThat(response)
             .hasStatus(OK_200)
             .asEntity(PortalNavigationItemsResponse.class)
-            .satisfies(entity -> assertThat(entity.getItems()).hasSize(5));
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(6));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -59,7 +59,7 @@ public class PortalNavigationItemDomainService {
             createPortalNavigationItem.setPortalPageContentId(defaultPageContent.getId());
         }
 
-        if (createPortalNavigationItem.getType() == PortalNavigationItemType.API && createPortalNavigationItem.getApiId() != null) {
+        if (createPortalNavigationItem.getType() == PortalNavigationItemType.API) {
             Api api = apiCrudService.get(createPortalNavigationItem.getApiId());
             createPortalNavigationItem.setTitle(api.getName());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -32,4 +32,18 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
             "Navigation item type cannot be changed or is mismatched (expected %s, got %s).".formatted(expected, received)
         );
     }
+
+    public static InvalidPortalNavigationItemDataException apiMustBeInTopNavbar() {
+        return new InvalidPortalNavigationItemDataException("API items can only be added to TOP_NAVBAR area.");
+    }
+
+    public static InvalidPortalNavigationItemDataException apiIdAlreadyExists(String apiId) {
+        return new InvalidPortalNavigationItemDataException(
+            "The apiId %s is already used by another API navigation item.".formatted(apiId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException parentHierarchyContainsApi() {
+        return new InvalidPortalNavigationItemDataException("Parent hierarchy cannot include API items.");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -40,6 +40,8 @@ public class PortalNavigationItemFixtures {
     public static final String PAGE11_ID = "00000000-0000-0000-0000-000000000007";
     public static final String PAGE12_ID = "00000000-0000-0000-0000-000000000008";
     public static final String LINK1_ID = "00000000-0000-0000-0000-000000000009";
+    public static final String API1_ID = "00000000-0000-0000-0000-000000000010";
+    public static final String API1_FOLDER_ID = "00000000-0000-0000-0000-000000000011";
 
     public static PortalNavigationFolder aFolder(String id, String title) {
         return aFolder(id, title, null);
@@ -168,6 +170,10 @@ public class PortalNavigationItemFixtures {
         gettingStarted.setOrder(1);
         var category1 = aFolder(CATEGORY1_ID, "Category1", apis.getId());
         category1.setOrder(2);
+        var api1 = anApi(API1_ID, "API 1", apis.getId(), "api-1");
+        api1.setOrder(3);
+        var api1Folder = aFolder(API1_FOLDER_ID, "API 1 Folder", api1.getId());
+        api1Folder.setOrder(0);
 
         var page11 = aPage(PAGE11_ID, "page11", category1.getId());
         page11.setOrder(0);
@@ -177,6 +183,6 @@ public class PortalNavigationItemFixtures {
         page12.setPublished(true);
         page12.setVisibility(PortalVisibility.PRIVATE);
 
-        return List.of(apis, guides, support, overview, gettingStarted, category1, page11, page12, link1);
+        return List.of(apis, guides, support, overview, gettingStarted, category1, api1, api1Folder, page11, page12, link1);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -66,9 +66,20 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(9)
+            .hasSize(10)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("APIs", "Example Link", "Guides", "Support", "Overview", "Getting Started", "Category1", "page11", "page12");
+            .containsExactly(
+                "APIs",
+                "Example Link",
+                "Guides",
+                "Support",
+                "Overview",
+                "Getting Started",
+                "Category1",
+                "API 1",
+                "page11",
+                "page12"
+            );
     }
 
     @Test
@@ -89,9 +100,9 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(3)
+            .hasSize(4)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("Overview", "Getting Started", "Category1");
+            .containsExactly("Overview", "Getting Started", "Category1", "API 1");
     }
 
     @Test
@@ -112,9 +123,9 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(5)
+            .hasSize(6)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("Overview", "Getting Started", "Category1", "page11", "page12");
+            .containsExactly("Overview", "Getting Started", "Category1", "API 1", "page11", "page12");
     }
 
     @Test
@@ -135,9 +146,9 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(8)
+            .hasSize(9)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("APIs", "Example Link", "Guides", "Support", "Overview", "Getting Started", "Category1", "page12");
+            .containsExactly("APIs", "Example Link", "Guides", "Support", "Overview", "Getting Started", "Category1", "API 1", "page12");
     }
 
     @Test


### PR DESCRIPTION
validation rules when creating portal navigation item with type API

https://gravitee.atlassian.net/browse/APIM-12612

## Issue

https://gravitee.atlassian.net/browse/APIM-12612

## Description

Validation rules

APIs cannot be added as sections/root-level items in the tree

parentId should always be initialized

An API can only be added to TOP_NAVBAR area

An API can be added at most once to a given portal (a single instance across all sections of the portal)

check for existing API items with the same apiId and area, and if there are any, we can’t add it anymore

An API cannot be added inside another API

for the provided parentId we nee to check for all ancestors up to top level (parentId null) and make sure none of them is an API



