### PR TITLE
test(cypress): add more specific query for home tabs

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/home-layout/home-layout.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-layout/home-layout.component.html
@@ -16,7 +16,15 @@
 
 -->
 <nav mat-tab-nav-bar [tabPanel]="tabPanel">
-  <a *ngFor="let tab of tabs" mat-tab-link routerLinkActive #rla="routerLinkActive" [active]="rla.isActive" [routerLink]="tab.routerLink">
+  <a
+    *ngFor="let tab of tabs"
+    mat-tab-link
+    routerLinkActive
+    #rla="routerLinkActive"
+    [active]="rla.isActive"
+    [routerLink]="tab.routerLink"
+    [attr.data-testid]="tab.dataTestId"
+  >
     <span [innerHTML]="tab.label | async"></span>
   </a>
 </nav>

--- a/gravitee-apim-console-webui/src/management/home/home-layout/home-layout.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/home-layout/home-layout.component.ts
@@ -35,22 +35,26 @@ export class HomeLayoutComponent {
     shareReplay(1),
   );
 
-  public tabs: { label: Observable<string>; routerLink: string }[] = [
+  public tabs: { label: Observable<string>; routerLink: string; dataTestId: string }[] = [
     {
       label: of('Overview'),
       routerLink: './overview',
+      dataTestId: 'home-tab-overview',
     },
     {
       label: of('API Health Check'),
       routerLink: './apiHealthCheck',
+      dataTestId: 'home-tab-api-health-check',
     },
     {
       label: this.taskLabel,
       routerLink: './tasks',
+      dataTestId: 'home-tab-tasks',
     },
     {
       label: of('Broadcasts'),
       routerLink: './broadcasts',
+      dataTestId: 'home-tab-broadcasts',
     },
   ];
 

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
@@ -35,9 +35,10 @@ describe('Login Feature', () => {
 
     cy.getByDataTestId('sign-in-button').click();
     cy.url().should('contain', '/home/overview');
-    cy.contains('Overview').should('be.visible');
-    cy.contains('API Health Check').should('be.visible');
-    cy.contains('Tasks').should('be.visible');
+    cy.getByDataTestId('home-tab-overview').should('be.visible');
+    cy.getByDataTestId('home-tab-api-health-check').should('be.visible');
+    cy.getByDataTestId('home-tab-tasks').should('be.visible');
+    cy.getByDataTestId('home-tab-broadcasts').should('be.visible');
     cy.contains('h2', 'API Events').should('be.visible');
   });
 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The cypress test `Login / should be able to login` was failing due to multiple "Overview" texts available in the DOM.
The tests now use data test ids to target the home tabs.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

