### PR TITLE
Rename response time test methods and update filter name

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -69,10 +69,10 @@ paths:
                     from: "2025-01-01T00:00:00Z"
                     to: "2025-01-31T23:59:59Z"
                   filters:
-                    - name: "RESPONSE_TIME_RANGE"
+                    - name: "RESPONSE_TIME"
                       operator: "GTE"
                       value: 100
-                    - name: "RESPONSE_TIME_RANGE"
+                    - name: "RESPONSE_TIME"
                       operator: "LTE"
                       value: 500
               filter-by-entrypoint:
@@ -221,7 +221,7 @@ components:
         value:
           type: integer
           description: Filter value (number for GTE/LTE)
-      example: { name: "RESPONSE_TIME_RANGE", operator: "GTE", value: 100 }
+      example: { name: "RESPONSE_TIME", operator: "GTE", value: 100 }
 
     FilterName:
       type: string
@@ -236,7 +236,7 @@ components:
         - TRANSACTION_ID
         - REQUEST_ID
         - URI
-        - RESPONSE_TIME_RANGE
+        - RESPONSE_TIME
       description: Available filter names for filtering analytics data
 
     Operator:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -774,7 +774,7 @@ class LogsSearchResourceTest extends AbstractResourceTest {
         }
 
         @Test
-        void should_filter_logs_by_response_time_range() {
+        void should_filter_logs_by_response_time() {
             connectionLogsCrudService.initWith(
                 List.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().gatewayResponseTime(50).build(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -731,7 +731,7 @@ class LogsSearchResourceTest extends AbstractResourceTest {
                         .from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z"))
                         .to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
                 )
-                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME_RANGE).operator(Operator.GTE).value(100)));
+                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME).operator(Operator.GTE).value(100)));
 
             var response = searchTarget.request().post(Entity.json(request));
 
@@ -760,7 +760,7 @@ class LogsSearchResourceTest extends AbstractResourceTest {
                         .from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z"))
                         .to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
                 )
-                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME_RANGE).operator(Operator.LTE).value(200)));
+                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME).operator(Operator.LTE).value(200)));
 
             var response = searchTarget.request().post(Entity.json(request));
 
@@ -790,8 +790,8 @@ class LogsSearchResourceTest extends AbstractResourceTest {
                         .from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z"))
                         .to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
                 )
-                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME_RANGE).operator(Operator.GTE).value(150)))
-                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME_RANGE).operator(Operator.LTE).value(300)));
+                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME).operator(Operator.GTE).value(150)))
+                .addFiltersItem(new Filter(new NumericFilter().name(FilterName.RESPONSE_TIME).operator(Operator.LTE).value(300)));
 
             var response = searchTarget.request().post(Entity.json(request));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
@@ -26,5 +26,5 @@ public enum FilterName {
     TRANSACTION_ID,
     REQUEST_ID,
     URI,
-    RESPONSE_TIME_RANGE,
+    RESPONSE_TIME,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -172,7 +172,7 @@ public class SearchEnvironmentLogsUseCase {
     }
 
     private void applyNumericFilter(NumericFilter filter, FilterContext filterContext) {
-        if (filter.name() == FilterName.RESPONSE_TIME_RANGE) {
+        if (filter.name() == FilterName.RESPONSE_TIME) {
             if (filter.operator() == Operator.GTE) {
                 filterContext.limitByResponseTimeFrom(filter.value().longValue());
             } else if (filter.operator() == Operator.LTE) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -624,44 +624,44 @@ class SearchEnvironmentLogsUseCaseTest {
             return Stream.of(
                 // Single GTE filter -> range with from only
                 Arguments.of(
-                    List.of(new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 100))),
+                    List.of(new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 100))),
                     List.of(new Range(100L, null))
                 ),
                 // Single LTE filter -> range with to only
                 Arguments.of(
-                    List.of(new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.LTE, 500))),
+                    List.of(new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.LTE, 500))),
                     List.of(new Range(null, 500L))
                 ),
                 // GTE + LTE -> range with both bounds
                 Arguments.of(
                     List.of(
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 100)),
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.LTE, 500))
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 100)),
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.LTE, 500))
                     ),
                     List.of(new Range(100L, 500L))
                 ),
                 // Overlapping GTE: GTE 100 then GTE 200 -> last wins (200)
                 Arguments.of(
                     List.of(
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 100)),
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 200))
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 100)),
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 200))
                     ),
                     List.of(new Range(200L, null))
                 ),
                 // Overlapping LTE: LTE 500 then LTE 300 -> last wins (300)
                 Arguments.of(
                     List.of(
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.LTE, 500)),
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.LTE, 300))
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.LTE, 500)),
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.LTE, 300))
                     ),
                     List.of(new Range(null, 300L))
                 ),
                 // Overlapping GTE + LTE combined: GTE 100, GTE 200, LTE 500 -> last GTE wins
                 Arguments.of(
                     List.of(
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 100)),
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.GTE, 200)),
-                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.LTE, 500))
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 100)),
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.GTE, 200)),
+                        new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.LTE, 500))
                     ),
                     List.of(new Range(200L, 500L))
                 ),
@@ -675,8 +675,8 @@ class SearchEnvironmentLogsUseCaseTest {
             var request = new SearchLogsRequest(
                 null,
                 List.of(
-                    new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.EQ, 100)),
-                    new Filter(new NumericFilter(FilterName.RESPONSE_TIME_RANGE, Operator.IN, 200))
+                    new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.EQ, 100)),
+                    new Filter(new NumericFilter(FilterName.RESPONSE_TIME, Operator.IN, 200))
                 ),
                 1,
                 10

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -608,8 +608,8 @@ class SearchEnvironmentLogsUseCaseTest {
         }
 
         @ParameterizedTest
-        @MethodSource("responseTimeRangeFiltersProvider")
-        void should_map_response_time_range_filters(List<Filter> filters, List<Range> expectedRanges) {
+        @MethodSource("responseTimeFiltersProvider")
+        void should_map_response_time_filters(List<Filter> filters, List<Range> expectedRanges) {
             var request = new SearchLogsRequest(null, filters, 1, 10);
 
             when_searching(request);
@@ -620,7 +620,7 @@ class SearchEnvironmentLogsUseCaseTest {
             assertThat(filtersCaptor.getValue().responseTimeRanges()).isEqualTo(expectedRanges);
         }
 
-        static Stream<Arguments> responseTimeRangeFiltersProvider() {
+        static Stream<Arguments> responseTimeFiltersProvider() {
             return Stream.of(
                 // Single GTE filter -> range with from only
                 Arguments.of(


### PR DESCRIPTION
```markdown
## Issue

https://gravitee.atlassian.net/browse/GKO-2323

## Description
Renamed the `RESPONSE_TIME_RANGE` filter to `RESPONSE_TIME` for clarity.

Additionally, renamed response time range test methods to ensure consistency.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
```