### PR TITLE
fix: return 400 when RESPONSE_TIME filter value is null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -306,6 +306,17 @@ class LogsSearchResourceTest extends AbstractResourceTest {
 
             assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
         }
+
+        @Test
+        void should_return_400_if_response_time_filter_value_is_null() {
+            var json =
+                "{\"timeRange\":{\"from\":\"2020-01-01T00:00:00Z\",\"to\":\"2020-12-31T23:59:59Z\"}," +
+                "\"filters\":[{\"name\":\"RESPONSE_TIME\",\"operator\":\"LTE\",\"value\":null}]}";
+
+            var response = searchTarget.request().post(Entity.json(json));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.logs_engine.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.core.logs_engine.domain_service.FilterContext;
 import io.gravitee.apim.core.logs_engine.model.ApiLog;
@@ -173,6 +174,9 @@ public class SearchEnvironmentLogsUseCase {
 
     private void applyNumericFilter(NumericFilter filter, FilterContext filterContext) {
         if (filter.name() == FilterName.RESPONSE_TIME) {
+            if (filter.value() == null) {
+                throw new ValidationDomainException("Filter RESPONSE_TIME requires a non-null value");
+            }
             if (filter.operator() == Operator.GTE) {
                 filterContext.limitByResponseTimeFrom(filter.value().longValue());
             } else if (filter.operator() == Operator.LTE) {

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: GKO-2324
+
+## Bug Summary
+
+The logs search endpoint (`POST /management/v2/environments/{envId}/logs/search`) returns HTTP 500 when a `RESPONSE_TIME` numeric filter has a `null` value. It should return HTTP 400 with a validation error.
+
+**Root Cause:** In `SearchEnvironmentLogsUseCase.applyNumericFilter()`, calling `filter.value().longValue()` throws a `NullPointerException` when the value is `null`, which propagates as an unhandled 500 error.
+
+## Fix Strategy
+
+Add a null-check with validation in the use case layer before calling `.longValue()`. If the value is null, throw an appropriate validation exception that the REST layer maps to HTTP 400.
+
+## Files to Modify
+
+### 1. `SearchEnvironmentLogsUseCase.java`
+**Path:** `gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java`
+
+- Add a null-check in `applyNumericFilter()` for `filter.value()` before calling `.longValue()`
+- Throw a domain validation exception (e.g., `IllegalArgumentException` or an existing validation exception used in the codebase) when value is null
+
+### 2. `LogsSearchResourceTest.java`
+**Path:** `gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java`
+
+- Add a test in the `RequestValidation` nested class: `should_return_400_if_response_time_filter_value_is_null()`
+- Follow the existing test patterns in the class
+
+### 3. `SearchEnvironmentLogsUseCaseTest.java`
+**Path:** `gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java`
+
+- Add a unit test verifying that a null numeric filter value produces a validation error


### PR DESCRIPTION
## [GKO-2324](https://gravitee.atlassian.net/browse/GKO-2324)

Fixes the logs search endpoint to return HTTP 400 (Bad Request) instead of HTTP 500 when a RESPONSE_TIME numeric filter is provided with a null value. Adds proper input validation for numeric filter values.



[GKO-2324]: https://gravitee.atlassian.net/browse/GKO-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ