### PR TITLE
fix(logs): validate null value in RESPONSE_TIME numeric filter

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -306,6 +306,17 @@ class LogsSearchResourceTest extends AbstractResourceTest {
 
             assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
         }
+
+        @Test
+        void should_return_400_if_response_time_filter_value_is_null() {
+            var json =
+                "{\"timeRange\":{\"from\":\"2020-01-01T00:00:00Z\",\"to\":\"2020-12-31T23:59:59Z\"}," +
+                "\"filters\":[{\"name\":\"RESPONSE_TIME\",\"operator\":\"LTE\",\"value\":null}]}";
+
+            var response = searchTarget.request().post(Entity.json(json));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.logs_engine.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.core.logs_engine.domain_service.FilterContext;
 import io.gravitee.apim.core.logs_engine.model.ApiLog;
@@ -173,6 +174,9 @@ public class SearchEnvironmentLogsUseCase {
 
     private void applyNumericFilter(NumericFilter filter, FilterContext filterContext) {
         if (filter.name() == FilterName.RESPONSE_TIME) {
+            if (filter.value() == null) {
+                throw new ValidationDomainException("Filter RESPONSE_TIME requires a non-null value");
+            }
             if (filter.operator() == Operator.GTE) {
                 filterContext.limitByResponseTimeFrom(filter.value().longValue());
             } else if (filter.operator() == Operator.LTE) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2324

## Description

Add null-check in applyNumericFilter() to throw ValidationDomainException when RESPONSE_TIME filter value is null, returning HTTP 400 instead of 500.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

