### PR TITLE
fix(gateway): eliminate health check thundering herd causing API response time spikes

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,6 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author GraviteeSource Team
  */
 public class GatewayConfiguration implements InitializingBean {
+
+    private static final Logger log = LoggerFactory.getLogger(GatewayConfiguration.class);
 
     static final String SHARDING_TAGS_SYSTEM_PROPERTY = "tags";
     private static final String SHARDING_TAGS_SEPARATOR = ",";
@@ -44,11 +48,16 @@ public class GatewayConfiguration implements InitializingBean {
     static final String ORGANIZATION_SYSTEM_PROPERTY = "organizations";
     private static final String ORGANIZATIONS_SEPARATOR = ",";
 
+    static final String HEALTHCHECK_JITTER_PROPERTY = "services.healthcheck.jitterInMs";
+    static final int DEFAULT_HEALTHCHECK_JITTER_MS = 900;
+    private static final int MAX_HEALTHCHECK_JITTER_MS = 5000;
+
     private Optional<List<String>> shardingTags;
     private Optional<String> zone;
     private Optional<String> tenant;
     private Optional<List<String>> environments;
     private Optional<List<String>> organizations;
+    private int healthCheckJitterMs;
 
     @Autowired
     private Configuration configuration;
@@ -60,6 +69,7 @@ public class GatewayConfiguration implements InitializingBean {
         this.initOrganizations();
         this.initEnvironments();
         this.initVertxWebsocket();
+        this.initHealthCheckJitter();
     }
 
     private void initVertxWebsocket() {
@@ -153,6 +163,31 @@ public class GatewayConfiguration implements InitializingBean {
 
     public Optional<List<String>> environments() {
         return environments;
+    }
+
+    private void initHealthCheckJitter() {
+        int value = configuration.getProperty(HEALTHCHECK_JITTER_PROPERTY, Integer.class, DEFAULT_HEALTHCHECK_JITTER_MS);
+        if (value < 0 || value > MAX_HEALTHCHECK_JITTER_MS) {
+            log.warn(
+                "Invalid {} value: {}. Must be between 0 and {}. Falling back to default: {}.",
+                HEALTHCHECK_JITTER_PROPERTY,
+                value,
+                MAX_HEALTHCHECK_JITTER_MS,
+                DEFAULT_HEALTHCHECK_JITTER_MS
+            );
+            value = DEFAULT_HEALTHCHECK_JITTER_MS;
+        }
+        healthCheckJitterMs = value;
+    }
+
+    /**
+     * Maximum scheduling offset in milliseconds applied per API.
+     * Health check timers are randomly shifted within [0, JITTER_MS] to prevent
+     * large numbers of checks from executing at the same cron boundary, which could
+     * otherwise overload system resources and temporarily increase API response times.
+     */
+    public int healthCheckJitterInMs() {
+        return healthCheckJitterMs;
     }
 
     public boolean hasMatchingTags(Set<String> tags) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/GatewayConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/GatewayConfigurationTest.java
@@ -46,6 +46,7 @@ public class GatewayConfigurationTest {
         System.clearProperty(GatewayConfiguration.MULTI_TENANT_SYSTEM_PROPERTY);
         System.clearProperty("vertx.disableWebsockets");
         when(configuration.getProperty("http.websocket.enabled", Boolean.class, false)).thenReturn(false);
+        when(configuration.getProperty("services.healthcheck.jitterInMs", Integer.class, 900)).thenReturn(900);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
@@ -21,6 +21,7 @@ import io.gravitee.common.event.EventManager;
 import io.gravitee.common.util.ChangeListener;
 import io.gravitee.common.util.ObservableSet;
 import io.gravitee.definition.model.Endpoint;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactorEvent;
@@ -72,6 +73,9 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
 
     @Autowired
     private Environment environment;
+
+    @Autowired
+    private GatewayConfiguration gatewayConfiguration;
 
     @Override
     public void start(final Promise<Void> startPromise) {
@@ -139,7 +143,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
             runner.setStatusHandler(statusReporter);
             runner.setAlertEventProducer(alertEventProducer);
             runner.setNode(node);
-            EndpointRuleCronHandler cronHandler = new EndpointRuleCronHandler(vertx, rule);
+            EndpointRuleCronHandler cronHandler = new EndpointRuleCronHandler(vertx, rule, gatewayConfiguration.healthCheckJitterInMs());
             cronHandler.schedule(runner);
 
             apiHandlers.get(api).add(cronHandler);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -639,6 +639,9 @@ services:
 #      cpu: # Default is 80%
 #      memory: # Default is 80%
 
+#  healthcheck:
+#    jitterInMs: 900
+
   # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
   # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
   # and management UI

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
@@ -62,6 +62,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -187,7 +188,10 @@ public class HttpHealthCheckService implements ApiService {
         final CronTrigger cron = new CronTrigger(hcConfiguration.getSchedule());
         final AtomicLong errorCount = new AtomicLong(0);
 
-        return Observable.defer(() -> Observable.timer(cron.nextExecutionIn(), TimeUnit.MILLISECONDS))
+        final int jitterMs = gatewayConfiguration.healthCheckJitterInMs();
+        final int spreadOffsetMs = Math.floorMod(Objects.hash(api.getId(), endpoint.getDefinition().getName()), jitterMs + 1);
+
+        return Observable.defer(() -> Observable.timer(cron.nextExecutionIn() + spreadOffsetMs, TimeUnit.MILLISECONDS))
             .switchMapCompletable(aLong -> {
                 final HttpHealthCheckExecutionContext ctx = new HttpHealthCheckExecutionContext(hcConfiguration, deploymentContext);
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.apim.plugin.apiservice.healthcheck.http.HttpHealthChec
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -117,6 +118,7 @@ public class HttpHealthCheckServiceTest {
     public void setup() {
         when(deploymentContext.getComponent(EndpointManager.class)).thenReturn(endpointManager);
         when(deploymentContext.getComponent(PluginConfigurationHelper.class)).thenReturn(pluginConfigurationHelper);
+        lenient().when(gatewayConfig.healthCheckJitterInMs()).thenReturn(900);
 
         apiDefinition.setId(API_ID);
     }

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -625,6 +625,7 @@ data:
       # Endpoint healthcheck service.
       healthcheck:
         threads: 3 # Threads core size used to check endpoint availability
+        jitterInMs: {{ .Values.gateway.services.healthcheck.jitterInMs | default 900 }}
 
       heartbeat: {{ toYaml .Values.gateway.services.heartbeat | nindent 8 }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1455,6 +1455,9 @@ gateway:
       #delay: 5000
       #unit: MILLISECONDS
 
+    healthcheck:
+      jitterInMs: 900
+
     heartbeat:
       enabled: true
       delay: 5000


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12701

## Description

API response time spikes when health checks are enabled running at the same cron. 

With this PR Health check timers are randomly shifted within [0, JITTER_MS] to prevent large numbers of checks from executing at the same cron boundary, which could otherwise overload system resources and temporarily increase API response times.

on the left load with fix, on the right before fix 
<img width="1527" height="511" alt="image" src="https://github.com/user-attachments/assets/3498aa06-30a7-4ab8-b19b-84f39174d699" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

