### PR TITLE
fix: don’t block start up if cockpit isn’t accessible

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -115,12 +115,11 @@ public class ScoreApiRequestUseCase {
                 var job = entry.getValue();
                 return scoringProvider
                     .requestScore(request)
-                    .onErrorResumeNext(throwable -> {
-                        log.error("An error occurs while triggering scoring API [{}]", input.apiId, throwable);
-                        return Completable.fromRunnable(() -> asyncJobCrudService.update(job.error(throwable.getMessage()))).andThen(
+                    .onErrorResumeNext(throwable ->
+                        Completable.fromRunnable(() -> asyncJobCrudService.update(job.error(throwable.getMessage()))).andThen(
                             Completable.error(throwable)
-                        );
-                    });
+                        )
+                    );
             });
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/CockpitCommandServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/CockpitCommandServiceImpl.java
@@ -18,9 +18,12 @@ package io.gravitee.rest.api.service.cockpit.command;
 import io.gravitee.cockpit.api.CockpitConnector;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeCommand;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReply;
+import io.reactivex.rxjava3.core.Single;
+import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+@CustomLog
 @Component
 public class CockpitCommandServiceImpl implements CockpitCommandService {
 
@@ -37,8 +40,15 @@ public class CockpitCommandServiceImpl implements CockpitCommandService {
     public BridgeReply send(BridgeCommand command) {
         return cockpitConnector
             .sendCommand(command)
-            .onErrorReturn(error -> new BridgeReply(command.getId(), error.getMessage() != null ? error.getMessage() : error.toString()))
-            .cast(BridgeReply.class)
+            .onErrorResumeNext(error -> {
+                log.debug("Failed on call of cockpit", error);
+                return Single.just(new BridgeReply(command.getId(), error.getMessage() != null ? error.getMessage() : error.toString()));
+            })
+            .flatMap(reply ->
+                reply instanceof BridgeReply bridgeReply
+                    ? Single.just(bridgeReply)
+                    : Single.just(new BridgeReply(command.getId(), "Unknown reply type: " + reply.getClass().getName()))
+            )
             .blockingGet();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gravitee-common.version>4.9.0</gravitee-common.version>
         <gravitee-common-mcp.version>1.0.0</gravitee-common-mcp.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
-        <gravitee-exchange.version>2.0.0</gravitee-exchange.version>
+        <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
         <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>4.3.0-alpha.5</gravitee-gateway-api.version>
@@ -246,7 +246,7 @@
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>5.1.39</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>5.1.65</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>2.1.1</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>2.1.2</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8519

## Description


This PR is a part of set ([gravitee-exchange](https://github.com/gravitee-io/gravitee-exchange/pull/89), [gravitee-cockpit-connectors](https://github.com/gravitee-io/gravitee-cockpit-connectors/pull/387) & [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management/pull/15121)) to handle the connection error to cockpit at start time.

In [gravitee-cockpit-connectors](https://github.com/gravitee-io/gravitee-cockpit-connectors/pull/387/changes#diff-f43f2130521d6a1f77297bbdb52d302ed90d299dd7f4da92ef4560a711e78286L120-R120), I make the connection async.

In all others part I handle this case to avoid NPE.
