### PR TITLE
fix(papi): allow anonymous user access to portal nav items endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
@@ -295,6 +295,9 @@ public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
             // Portal Menu Links
             .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-menu-links")
             .permitAll()
+            // Portal Navigation Items
+            .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-navigation-items/**")
+            .permitAll()
             /* Others requests
              * i.e. :
              *   - /auth/login


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12696

## Description

The endpoint for listing the portal nav items of a given portal was returning 401. This fix permits all calls (anonymous and authenticated) to resources for portal nav items.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

