### PR TITLE
fix: resolve lint warnings in openapi-logs spec

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -45,6 +45,7 @@ paths:
         - $ref: "#/components/parameters/pageParam"
         - $ref: "#/components/parameters/perPageParam"
       requestBody:
+        description: Search criteria including time range and optional filters
         required: true
         content:
           application/json:
@@ -109,6 +110,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchLogsResponse"
+              example:
+                data:
+                  - requestId: "req-001"
+                    apiId: "7b6ebef3-6236-4ac5-815e-d3dcef83df5d"
+                    timestamp: "2025-01-15T10:30:00Z"
+                    status: 200
+                    method: "GET"
+                    path: "/echo"
+                    responseTime: 42
+                    entrypoint: "http-proxy"
+                pagination:
+                  page: 1
+                  perPage: 10
+                  pageCount: 1
+                  pageItemsCount: 1
+                  totalCount: 1
         "500":
           description: Internal server error
           content:
@@ -140,6 +157,7 @@ components:
         maximum: 100
   schemas:
     SearchLogsRequest:
+      description: Request body for searching API connection logs
       type: object
       required:
         - timeRange
@@ -151,18 +169,46 @@ components:
           items:
             $ref: "#/components/schemas/Filter"
           description: Top-level filters
+          example:
+            - name: "API"
+              operator: "EQ"
+              value: "7b6ebef3-6236-4ac5-815e-d3dcef83df5d"
+      example:
+        timeRange:
+          from: "2025-01-01T00:00:00Z"
+          to: "2025-01-31T23:59:59Z"
+        filters:
+          - name: "API"
+            operator: "EQ"
+            value: "7b6ebef3-6236-4ac5-815e-d3dcef83df5d"
 
     SearchLogsResponse:
+      description: Paginated response containing API connection logs
       type: object
       properties:
         data:
           type: array
           items:
             $ref: "#/components/schemas/ApiLog"
+          example:
+            - requestId: "req-001"
+              apiId: "7b6ebef3-6236-4ac5-815e-d3dcef83df5d"
+              timestamp: "2025-01-15T10:30:00Z"
+              status: 200
         pagination:
-          $ref: "./openapi-apis.yaml#/components/schemas/Pagination"
+          allOf:
+            - $ref: "./openapi-apis.yaml#/components/schemas/Pagination"
+          example:
+            page: 1
+            perPage: 10
+            pageCount: 1
+            pageItemsCount: 1
+            totalCount: 1
         links:
-          $ref: "./openapi-apis.yaml#/components/schemas/Links"
+          allOf:
+            - $ref: "./openapi-apis.yaml#/components/schemas/Links"
+          example:
+            self: "/environments/DEFAULT/logs/search?page=1&perPage=10"
 
     ApiLog:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -26,6 +26,10 @@ servers:
         description: The unique ID of your organization
         default: DEFAULT
 
+tags:
+  - name: logs
+    description: Operations related to querying API connection logs
+
 paths:
   /environments/{envId}/logs/search:
     post:


### PR DESCRIPTION
## Jira issue
https://gravitee.atlassian.net/browse/GKO-2327

## Summary
- Add missing `tags` definition and descriptions to the `openapi-logs.yaml` spec
- Add examples to schemas (`SearchLogsRequest`, `SearchLogsResponse`), response bodies, and individual properties
- Use `allOf` wrapper for `$ref` fields (`pagination`, `links`) to allow co-locating examples alongside references

## Test plan
- [x] Verify the OpenAPI spec passes lint/validation (`vacuum` or Spectral)
- [x] Confirm no generated code is affected by the `allOf` wrapping change

🤖 Generated with [Claude Code](https://claude.com/claude-code)