### PR TITLE
feat: add apiId to environment logs response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -154,11 +154,91 @@ components:
         data:
           type: array
           items:
-            $ref: "./openapi-apis.yaml#/components/schemas/ApiLog"
+            $ref: "#/components/schemas/ApiLog"
         pagination:
           $ref: "./openapi-apis.yaml#/components/schemas/Pagination"
         links:
           $ref: "./openapi-apis.yaml#/components/schemas/Links"
+
+    ApiLog:
+      type: object
+      properties:
+        apiId:
+          type: string
+          description: Id of the API.
+          example: 6c530064-0b2c-4004-9300-640b2ce0047b
+        timestamp:
+          type: string
+          format: date-time
+          description: The date (as timestamp) of the log.
+          example: 2023-05-18T12:40:46.184Z
+        id:
+          type: string
+          description: The internal UUID of the Log.
+          example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+        requestId:
+          type: string
+          description: The id of the request.
+          example: 1719d8d1-8d01-48f6-99d8-d18d0178f6d4
+        method:
+          $ref: "./openapi-apis.yaml#/components/schemas/HttpMethod"
+        clientIdentifier:
+          type: string
+          description: The client identifier of the request.
+          example: 12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0
+        plan:
+          $ref: "./openapi-apis.yaml#/components/schemas/BasePlan"
+        application:
+          $ref: "./openapi-apis.yaml#/components/schemas/BaseApplication"
+        transactionId:
+          type: string
+          description: The id of the transaction.
+          example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+        status:
+          type: integer
+          description: The response's status.
+          example: 200
+        requestEnded:
+          type: boolean
+          description: The flag indicating if the request has ended.
+          example: true
+        gatewayResponseTime:
+          type: integer
+          description: The response time in ms
+          example: 12
+        uri:
+          type: string
+          description: URI of the request.
+          example: /my-api
+        endpoint:
+          type: string
+          description: The endpoint URL.
+          example: "https://my-api-example.com"
+        message:
+          type: string
+          description: The error message.
+          example: "The timeout period of 1000ms has been exceeded"
+        errorKey:
+          type: string
+          description: The error key.
+          example: "TIMEOUT_ERROR"
+        errorComponentName:
+          type: string
+          description: The name of the component that generated the error.
+          example: "security"
+        errorComponentType:
+          type: string
+          description: The type of the component that generated the error.
+          example: "ENDPOINT"
+        warnings:
+          type: array
+          description: The warning diagnostics
+          items:
+            $ref: "./openapi-apis.yaml#/components/schemas/ApiLogDiagnostic"
+        additionalMetrics:
+          type: object
+          additionalProperties: true
+          description: A map of string keys to values
 
     Filter:
       description: |

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 public record ApiLog(
+    String apiId,
     OffsetDateTime timestamp,
     String id,
     String requestId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -246,6 +246,7 @@ public class SearchEnvironmentLogsUseCase {
 
     private ApiLog mapApiLog(BaseConnectionLog item) {
         return new ApiLog(
+            item.getApiId(),
             toOffsetDateTime(item.getTimestamp()),
             item.getRequestId(),
             item.getRequestId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -788,6 +788,7 @@ class SearchEnvironmentLogsUseCaseTest {
         void should_map_response_payload_fully() {
             var timestamp = OffsetDateTime.parse("2024-01-01T10:00:00Z");
             var connectionLog = BaseConnectionLog.builder()
+                .apiId("my-api-id")
                 .timestamp(timestamp.toString())
                 .requestId("req-id")
                 .clientIdentifier("client-id")
@@ -821,6 +822,7 @@ class SearchEnvironmentLogsUseCaseTest {
             var log = response.data().getFirst();
 
             SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(log.apiId()).isEqualTo("my-api-id");
                 soft.assertThat(log.requestId()).isEqualTo("req-id");
                 soft.assertThat(log.timestamp()).isEqualTo(timestamp);
                 soft.assertThat(log.clientIdentifier()).isEqualTo("client-id");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2328

## Description

Add the `apiId` field to the environment-level logs response so consumers can identify which API each log entry belongs to.

Changes:
- **Inline `ApiLog` schema** in `openapi-logs.yaml` — replaced the `$ref` to `openapi-apis.yaml` with a local schema definition, adding the new `apiId` string property
- **Add `String apiId`** to the `ApiLog` Java record (core model)
- **Update `mapApiLog()`** in `SearchEnvironmentLogsUseCase` to map `BaseConnectionLog.apiId` to the response
- **Update tests** to verify the `apiId` mapping

## Additional context

The source data model (`BaseConnectionLog`) already had the `apiId` field — this change surfaces it through the OpenAPI contract and the mapping layer.