### PR TITLE
feat: view portal subscriptions - create subscription details component and add links in breadcrumbs.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -198,6 +198,10 @@ export const routes: Routes = [
         path: 'subscriptions',
         loadComponent: () => import('./dashboard/subscriptions/subscriptions.component'),
       },
+      {
+        path: 'subscriptions/:subscriptionId',
+        loadComponent: () => import('./dashboard/subscription-details/subscription-details.component'),
+      },
     ],
   },
   {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
@@ -16,7 +16,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
-import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { filter, map } from 'rxjs';
 
 import { Breadcrumb } from '../../components/breadcrumbs/breadcrumbs.component';
@@ -36,8 +36,7 @@ const MENU_ITEMS: MenuItem[] = [{ path: 'subscriptions', title: $localize`:@@sub
   styleUrl: './dashboard.component.scss',
 })
 export class DashboardComponent {
-  router = inject(Router);
-  activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   menuItems = signal<MenuItem[]>(MENU_ITEMS);
 
   breadcrumbs = toSignal<Breadcrumb[]>(

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (apiId.value(); as _apiId) {
+  <app-subscriptions-details [apiId]="_apiId" [subscriptionId]="subscriptionId()" />
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.scss
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { Component, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import SubscriptionDetailsComponent from './subscription-details.component';
+import { SubscriptionDetailsHarness } from './subscription-details.harness';
+import { Subscription } from '../../../entities/subscription/subscription';
+import { SubscriptionService } from '../../../services/subscription.service';
+import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
+
+@Component({
+  selector: 'app-subscriptions-details',
+  standalone: true,
+  template: '',
+  providers: [{ provide: SubscriptionsDetailsComponent, useExisting: MockSubscriptionsDetailsComponent }],
+})
+class MockSubscriptionsDetailsComponent {
+  @Input() apiId!: string;
+  @Input() subscriptionId!: string;
+}
+
+describe('SubscriptionDetailsComponent', () => {
+  let fixture: ComponentFixture<SubscriptionDetailsComponent>;
+  let subscriptionServiceMock: Partial<SubscriptionService>;
+
+  beforeEach(async () => {
+    subscriptionServiceMock = {
+      get: jest.fn().mockReturnValue(of({ api: 'my-api-id' } as Subscription)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SubscriptionDetailsComponent],
+      providers: [{ provide: SubscriptionService, useValue: subscriptionServiceMock }, provideHttpClient()],
+    })
+      .overrideComponent(SubscriptionDetailsComponent, {
+        remove: { imports: [SubscriptionsDetailsComponent] },
+        add: { imports: [MockSubscriptionsDetailsComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SubscriptionDetailsComponent);
+    fixture.componentRef.setInput('subscriptionId', 'subscription-id');
+  });
+
+  it('should show subscriptions details when apiId is retrieved', async () => {
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
+    expect(await harness.hasSubscriptionsDetails()).toBeTruthy();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject, input } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+import { SubscriptionService } from '../../../services/subscription.service';
+import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
+
+@Component({
+  selector: 'app-subscription-details',
+  imports: [SubscriptionsDetailsComponent],
+  templateUrl: './subscription-details.component.html',
+  styleUrl: './subscription-details.component.scss',
+})
+export default class SubscriptionDetailsComponent {
+  subscriptionService = inject(SubscriptionService);
+  subscriptionId = input.required<string>();
+  apiId = rxResource({
+    params: this.subscriptionId,
+    stream: ({ params }) => this.subscriptionService.get(params).pipe(map(subscription => subscription.api)),
+  });
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
@@ -27,7 +27,7 @@ import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-sub
   styleUrl: './subscription-details.component.scss',
 })
 export default class SubscriptionDetailsComponent {
-  subscriptionService = inject(SubscriptionService);
+  private readonly subscriptionService = inject(SubscriptionService);
   subscriptionId = input.required<string>();
   apiId = rxResource({
     params: this.subscriptionId,

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class SubscriptionDetailsHarness extends ComponentHarness {
+  static hostSelector = 'app-subscription-details';
+
+  private getSubscriptionsDetails = this.locatorForOptional('app-subscriptions-details');
+
+  async hasSubscriptionsDetails(): Promise<boolean> {
+    return !!(await this.getSubscriptionsDetails());
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import { Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 export interface Breadcrumb {
   id: string;
   label: string;
+  url?: string;
 }
 
 @Component({
@@ -27,7 +29,11 @@ export interface Breadcrumb {
       @if (i > 0) {
         <span class="breadcrumb-separator">/</span>
       }
-      <span class="breadcrumb-item">{{ breadcrumb.label }}</span>
+      @if (breadcrumb.url) {
+        <a class="internal-link" [routerLink]="breadcrumb.url">{{ breadcrumb.label }}</a>
+      } @else {
+        <span class="breadcrumb-item">{{ breadcrumb.label }}</span>
+      }
     }
   `,
   styles: [
@@ -39,6 +45,7 @@ export interface Breadcrumb {
       }
     `,
   ],
+  imports: [RouterLink],
 })
 export class BreadcrumbsComponent {
   breadcrumbs = input.required<Breadcrumb[]>();

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2026 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,11 +41,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
-    <tr
-      mat-row
-      class="paginated-table__row"
-      *matRowDef="let row; columns: displayedColumns()"
-      [routerLink]="['/subscriptions', row.id]"></tr>
+    <tr mat-row class="paginated-table__row" *matRowDef="let row; columns: displayedColumns()" [routerLink]="[row.id]"></tr>
   </table>
 </div>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12270

## Description
This PR follows the work started in [this PR](https://github.com/gravitee-io/gravitee-api-management/pull/15136) and introduces a new component to display subscriptions details when navigating from from the aggregated subscriptions view.

### Included in this PR
- new `app-subscription-details` component to plug an existing `app-subscriptions-details` component in the new aggregated subscription view
- changes to the breadcrumb component to make it clickable
### Excluded from this PR (will be done in subsequent PRs)
- all style changes (typography, margins, radiuses)

https://github.com/user-attachments/assets/1f76097c-6458-4088-aea5-72e017857d20