### PR TITLE
feat: add logback-ecs-encoder

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -44,6 +44,12 @@
                 <version>4.5.1</version>
             </dependency>
 
+            <dependency>
+                <groupId>co.elastic.logging</groupId>
+                <artifactId>logback-ecs-encoder</artifactId>
+                <version>${logback-ecs-encoder.version}</version>
+            </dependency>
+
             <!-- Gravitee dependencies -->
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -272,6 +272,11 @@
             <artifactId>logback-json-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.logging</groupId>
+            <artifactId>logback-ecs-encoder</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Kafka -->
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -333,6 +333,11 @@
             <artifactId>logback-json-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.logging</groupId>
+            <artifactId>logback-ecs-encoder</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -230,6 +230,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>co.elastic.logging</groupId>
+            <artifactId>logback-ecs-encoder</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <scope>compile</scope>

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,6 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes:
+  artifacthub.io/changes: |
+    - kind: added
+      description: 'Allow configuration of ECS logging'

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -704,6 +704,10 @@ data:
                       <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                   </layout>
               </encoder>
+              {{- else if .Values.api.logging.stdout.ecs }}
+              <encoder class="co.elastic.logging.logback.EcsEncoder">
+                  <serviceName>gravitee-management-api</serviceName>
+              </encoder>
               {{- else }}
               <!-- encoders are assigned the type
                   ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -885,6 +885,10 @@ data:
                     <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                 </layout>
             </encoder>
+            {{- else if .Values.gateway.logging.stdout.ecs }}
+            <encoder class="co.elastic.logging.logback.EcsEncoder">
+                <serviceName>gravitee-gateway</serviceName>
+            </encoder>
             {{- else }}
             <!-- encoders are assigned the type
                 ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->

--- a/helm/tests/api/configmap_logback_yaml_test.yaml
+++ b/helm/tests/api/configmap_logback_yaml_test.yaml
@@ -190,6 +190,78 @@ tests:
                   </root>
               </configuration>
 
+  - it: should apply logback configuration with ECS encoder
+    template: api/api-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      api:
+        logging:
+          debug: true
+          stdout:
+            ecs: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["logback.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!--
+              ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+              ~
+              ~  Licensed under the Apache License, Version 2.0 (the "License");
+              ~  you may not use this file except in compliance with the License.
+              ~  You may obtain a copy of the License at
+              ~
+              ~  http://www.apache.org/licenses/LICENSE-2.0
+              ~
+              ~  Unless required by applicable law or agreed to in writing, software
+              ~  distributed under the License is distributed on an "AS IS" BASIS,
+              ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              ~  See the License for the specific language governing permissions and
+              ~  limitations under the License.
+              -->
+              <configuration>
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <encoder class="co.elastic.logging.logback.EcsEncoder">
+                          <serviceName>gravitee-management-api</serviceName>
+                      </encoder>
+                  </appender>
+
+                  <logger name="io.gravitee" level="DEBUG" />
+                  <logger name="org.eclipse.jetty" level="INFO" />
+
+                  <!-- Strictly speaking, the level attribute is not necessary since -->
+                  <!-- the level of the root level is set to DEBUG by default.       -->
+                  <root level="WARN">
+                      <appender-ref ref="STDOUT" />
+                  </root>
+              </configuration>
+
+  - it: should prefer JSON encoder over ECS encoder when both are enabled
+    template: api/api-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      api:
+        logging:
+          debug: true
+          stdout:
+            json: true
+            ecs: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["logback.xml"]
+          pattern: "ch.qos.logback.core.encoder.LayoutWrappingEncoder"
+      - notMatchRegex:
+          path: data["logback.xml"]
+          pattern: "co.elastic.logging.logback.EcsEncoder"
+
   - it: should apply logback configuration with custom loggers
     template: api/api-configmap.yaml
     chart:

--- a/helm/tests/gateway/configmap_logback_yaml_test.yaml
+++ b/helm/tests/gateway/configmap_logback_yaml_test.yaml
@@ -147,6 +147,88 @@ tests:
             
             </configuration>
 
+  - it: should apply logback configuration with ECS encoder
+    template: gateway/gateway-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      gateway:
+        logging:
+          debug: true
+          stdout:
+            ecs: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["logback.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+
+            <!--
+              ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+              ~
+              ~  Licensed under the Apache License, Version 2.0 (the "License");
+              ~  you may not use this file except in compliance with the License.
+              ~  You may obtain a copy of the License at
+              ~
+              ~  http://www.apache.org/licenses/LICENSE-2.0
+              ~
+              ~  Unless required by applicable law or agreed to in writing, software
+              ~  distributed under the License is distributed on an "AS IS" BASIS,
+              ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              ~  See the License for the specific language governing permissions and
+              ~  limitations under the License.
+              -->
+
+            <configuration>
+
+                <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                    <encoder class="co.elastic.logging.logback.EcsEncoder">
+                        <serviceName>gravitee-gateway</serviceName>
+                    </encoder>
+                </appender>
+
+                <appender name="async-console" class="ch.qos.logback.classic.AsyncAppender">
+                    <appender-ref ref="STDOUT" />
+                </appender>
+
+                <logger name="io.gravitee" level="DEBUG" />
+                <logger name="org.reflections" level="WARN" />
+                <logger name="org.springframework" level="WARN" />
+                <logger name="org.eclipse.jetty" level="WARN" />
+
+                <!-- Strictly speaking, the level attribute is not necessary since -->
+                <!-- the level of the root level is set to DEBUG by default.       -->
+                <root level="INFO">
+                    <appender-ref ref="async-console" />
+                </root>
+
+            </configuration>
+
+  - it: should prefer JSON encoder over ECS encoder when both are enabled
+    template: gateway/gateway-configmap.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    set:
+      gateway:
+        logging:
+          debug: true
+          stdout:
+            json: true
+            ecs: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["logback.xml"]
+          pattern: "ch.qos.logback.core.encoder.LayoutWrappingEncoder"
+      - notMatchRegex:
+          path: data["logback.xml"]
+          pattern: "co.elastic.logging.logback.EcsEncoder"
+
   - it: should apply logback configuration with custom loggers
     template: gateway/gateway-configmap.yaml
     chart:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -485,6 +485,7 @@ api:
     contextualLoggingEnabled: false
     stdout:
       json: false
+      ecs: false
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
       contextualLoggingEncoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n"
     file:
@@ -1182,6 +1183,7 @@ gateway:
     debug: false
     stdout:
       json: false
+      ecs: false
       encoderPattern: "%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n"
     file:
       enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.0</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.3.0</gravitee-cloud-initializer.version>
+        <logback-ecs-encoder.version>1.7.0</logback-ecs-encoder.version>
         <gravitee-common.version>4.9.0</gravitee-common.version>
         <gravitee-common-mcp.version>1.0.0</gravitee-common-mcp.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12554

## Description

Add the possibility to log using elasticsearch format

Output example :
```json
  {
    "@timestamp": "2026-02-17T10:35:30.593Z",
    "log.level": "INFO",
    "message": "1 apis synchronized in 321ms",
    "ecs.version": "1.2.0",
    "service.name": "gravitee-gateway",
    "event.dataset": "gravitee-gateway",
    "process.thread.name": "gio.sync-deployer-0",
    "log.logger": "io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiSynchronizer",
    "nodeId": "73952936-0ecc-4003-9529-360eccf00335",
    "nodeApplication": "gio-apim-gateway",
    "nodeHostname": "gravitee-apim-gateway-85b8496774-t6fw8"
  }
```

```json
{
	"@timestamp": "2026-02-17T10:56:39.434Z",
	"log.level": "INFO",
	"message": "API id[0a71e9f4-2def-4ef7-b1e9-f42deffef7bb] name[Azure Blob Test API] version[1.0.0] revision[3] has been deployed",
	"ecs.version": "1.2.0",
	"service.name": "gravitee-gateway",
	"event.dataset": "gravitee-gateway",
	"process.thread.name": "gio.sync-deployer-0",
	"log.logger": "io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl",
	"nodeApplication": "gio-apim-gateway",
	"api": "0a71e9f4-2def-4ef7-b1e9-f42deffef7bb",
	"nodeId": "784182db-1bc2-4464-8182-db1bc29464f1",
	"nodeHostname": "gravitee-apim-gateway-7dc89c45f8-qtxn7"
}
```
