### PR TITLE
feat(api-product) : added gateway license check + deployements endpoint creation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
@@ -21,8 +21,10 @@ import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
 import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.node.api.license.LicenseManager;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.CustomLog;
 
@@ -35,11 +37,13 @@ public class ApiProductManagerImpl implements ApiProductManager {
 
     private final ApiProductRegistry apiProductRegistry;
     private final EventManager eventManager;
+    private final LicenseManager licenseManager;
     private final Map<String, ReactableApiProduct> apiProducts = new ConcurrentHashMap<>();
 
-    public ApiProductManagerImpl(ApiProductRegistry apiProductRegistry, EventManager eventManager) {
+    public ApiProductManagerImpl(ApiProductRegistry apiProductRegistry, EventManager eventManager, LicenseManager licenseManager) {
         this.apiProductRegistry = apiProductRegistry;
         this.eventManager = eventManager;
+        this.licenseManager = licenseManager;
     }
 
     @Override
@@ -63,6 +67,16 @@ public class ApiProductManagerImpl implements ApiProductManager {
     }
 
     private boolean register(ReactableApiProduct apiProduct, boolean force) {
+        // License check: API Products require universe tier
+        var license = licenseManager.getOrganizationLicenseOrPlatform(apiProduct.getOrganizationId());
+        if (!Objects.equals(license.getTier(), "universe")) {
+            log.warn(
+                "The API Product [{}] can not be deployed because it is not allowed by the current license (universe tier)",
+                apiProduct.getName()
+            );
+            return false;
+        }
+
         // Get currently deployed API Product
         ReactableApiProduct deployedApiProduct = get(apiProduct.getId());
 
@@ -89,8 +103,6 @@ public class ApiProductManagerImpl implements ApiProductManager {
     }
 
     private void deploy(ReactableApiProduct apiProduct) {
-        // TODO: When API_PRODUCTS license feature is available, inject LicenseManager and call
-        // validateFeature(apiProduct.getOrganizationId(), "API_PRODUCTS") to block deployment if not allowed.
         log.debug("Deploying API Product [{}]", apiProduct.getId());
 
         apiProducts.put(apiProduct.getId(), apiProduct);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.handlers.api.registry.ApiProductPlanDefinitionCache;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.handlers.api.registry.impl.ApiProductPlanDefinitionCacheImpl;
 import io.gravitee.gateway.handlers.api.registry.impl.ApiProductRegistryImpl;
+import io.gravitee.node.api.license.LicenseManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,7 +44,11 @@ public class ApiProductConfiguration {
     }
 
     @Bean
-    public ApiProductManager apiProductManager(ApiProductRegistry apiProductRegistry, EventManager eventManager) {
-        return new ApiProductManagerImpl(apiProductRegistry, eventManager);
+    public ApiProductManager apiProductManager(
+        ApiProductRegistry apiProductRegistry,
+        EventManager eventManager,
+        LicenseManager licenseManager
+    ) {
+        return new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
@@ -17,11 +17,11 @@ package io.gravitee.rest.api.management.v2.rest.resource.api_product;
 
 import io.gravitee.apim.core.api_product.model.UpdateApiProduct;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
+import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
-import io.gravitee.rest.api.management.v2.rest.resource.api.ApiSubscriptionsResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
@@ -33,6 +33,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -48,6 +49,9 @@ public class ApiProductResource extends AbstractResource {
 
     @Inject
     private GetApiProductsUseCase getApiProductByIdUseCase;
+
+    @Inject
+    private DeployApiProductUseCase deployApiProductUseCase;
 
     @Inject
     private DeleteApiProductUseCase deleteApiProductUseCase;
@@ -81,6 +85,20 @@ public class ApiProductResource extends AbstractResource {
         AuditInfo audit = getAuditInfo();
         deleteApiProductUseCase.execute(DeleteApiProductUseCase.Input.of(apiProductId, audit));
         return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/deployments")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
+    public Response deployApiProduct(@PathParam("apiProductId") String apiProductId) {
+        AuditInfo audit = getAuditInfo();
+        var input = new DeployApiProductUseCase.Input(apiProductId, audit);
+        log.debug("Deploy API Product [{}]", apiProductId);
+        var output = deployApiProductUseCase.execute(input);
+        log.debug("API Product [{}] deployment triggered", apiProductId);
+        return Response.accepted().entity(output.apiProduct()).build();
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -346,6 +346,46 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /environments/{envId}/api-products/{apiProductId}/deployments:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    post:
+      tags:
+        - API Products
+      summary: Request a deployment to gateway instances
+      description: |-
+        Request a deployment for a given API Product. <br>
+        Triggers the API Product to be synchronized to gateway instances.
+
+        User must have the API_PRODUCT_DEFINITION[UPDATE] permission.
+      operationId: deployApiProduct
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Empty object or deployment options
+      responses:
+        "202":
+          description: API Product deployment request received
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiProduct'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /environments/{envId}/api-products/{apiProductId}/subscriptions:
     parameters:
       - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -15,11 +15,14 @@
  */
 package io.gravitee.rest.api.management.v2.rest.spring;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
+import fixtures.core.model.LicenseFixtures;
 import inmemory.ApiCRDExportDomainServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiExposedEntrypointDomainServiceInMemory;
@@ -68,6 +71,7 @@ import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
+import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductNameUseCase;
@@ -102,7 +106,9 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.license.crud_service.LicenseCrudService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -415,12 +421,19 @@ public class ResourceContextConfiguration {
 
     @Bean
     public LicenseManager licenseManager() {
-        return mock(LicenseManager.class);
+        LicenseManager mock = mock(LicenseManager.class);
+        when(mock.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
+        return mock;
     }
 
     @Bean
     public GraviteeLicenseDomainService graviteeLicenseDomainService(LicenseManager licenseManager) {
         return new GraviteeLicenseDomainService(licenseManager);
+    }
+
+    @Bean
+    public LicenseDomainService licenseDomainService(LicenseCrudService licenseCrudService, LicenseManager licenseManager) {
+        return new LicenseDomainService(licenseCrudService, licenseManager);
     }
 
     @Bean
@@ -873,23 +886,33 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    @Primary
     public CreateApiProductUseCase createApiProductUseCase() {
         return mock(CreateApiProductUseCase.class);
     }
 
     @Bean
+    @Primary
     public GetApiProductsUseCase getApiProductsUseCase() {
         return mock(GetApiProductsUseCase.class);
     }
 
     @Bean
+    @Primary
     public UpdateApiProductUseCase updateApiProductUseCase() {
         return mock(UpdateApiProductUseCase.class);
     }
 
     @Bean
+    @Primary
     public DeleteApiProductUseCase deleteApiProductUseCase() {
         return mock(DeleteApiProductUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public DeployApiProductUseCase deployApiProductUseCase() {
+        return mock(DeployApiProductUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -32,11 +32,13 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerFactory;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +57,7 @@ public class CreateApiProductUseCase {
     private final ApiProductPrimaryOwnerFactory apiProductPrimaryOwnerFactory;
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
+    private final LicenseDomainService licenseDomainService;
 
     public record Input(CreateApiProduct createApiProduct, AuditInfo auditInfo) {}
 
@@ -62,6 +65,9 @@ public class CreateApiProductUseCase {
 
     public Output execute(Input input) {
         var auditInfo = input.auditInfo;
+        if (!licenseDomainService.isApiProductDeploymentAllowed(auditInfo.organizationId())) {
+            throw new ForbiddenFeatureException("api-product");
+        }
         var payload = input.createApiProduct;
         var now = ZonedDateTime.now();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static java.util.Map.entry;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.event.crud_service.EventCrudService;
+import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Publishes DEPLOY_API_PRODUCT event to trigger gateway sync.
+ * Use when an API Product needs to be deployed or redeployed without updating its definition.
+ */
+@UseCase
+@RequiredArgsConstructor
+public class DeployApiProductUseCase {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final EventCrudService eventCrudService;
+    private final EventLatestCrudService eventLatestCrudService;
+    private final LicenseDomainService licenseDomainService;
+
+    public Output execute(Input input) {
+        if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
+            throw new ForbiddenFeatureException("api-product");
+        }
+        Optional<ApiProduct> apiProductOpt = apiProductQueryService.findById(input.apiProductId());
+        if (apiProductOpt.isEmpty()) {
+            throw new ApiProductNotFoundException(input.apiProductId());
+        }
+        ApiProduct apiProduct = apiProductOpt.get();
+        publishDeployEvent(input.auditInfo(), apiProduct);
+        return new Output(apiProduct);
+    }
+
+    private void publishDeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {
+        final Event event = eventCrudService.createEvent(
+            auditInfo.organizationId(),
+            auditInfo.environmentId(),
+            Set.of(auditInfo.environmentId()),
+            EventType.DEPLOY_API_PRODUCT,
+            apiProduct,
+            Map.ofEntries(
+                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
+                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
+            )
+        );
+
+        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
+    }
+
+    public record Input(String apiProductId, AuditInfo auditInfo) {}
+
+    public record Output(ApiProduct apiProduct) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -32,8 +32,10 @@ import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -49,8 +51,12 @@ public class UpdateApiProductUseCase {
     private final ValidateApiProductService validateApiProductService;
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
+    private final LicenseDomainService licenseDomainService;
 
     public Output execute(Input input) {
+        if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
+            throw new ForbiddenFeatureException("api-product");
+        }
         Optional<ApiProduct> existingApiProductOpt = apiProductQueryService.findById(input.apiProductId());
         if (existingApiProductOpt.isEmpty()) {
             throw new ApiProductNotFoundException(input.apiProductId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/domain_service/LicenseDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/domain_service/LicenseDomainService.java
@@ -46,6 +46,16 @@ public class LicenseDomainService {
     }
 
     /**
+     * Check that API Product deployment is allowed by the license (requires universe tier).
+     * @param organizationId The organization id
+     * @return <code>true</code> when API Product deployment is allowed.
+     */
+    public boolean isApiProductDeploymentAllowed(String organizationId) {
+        var license = licenseManager.getOrganizationLicenseOrPlatform(organizationId);
+        return Objects.equals(license.getTier(), "universe");
+    }
+
+    /**
      * Create or update license by organization ID.
      * If on create and license is null, no license is saved in the database.
      * If on update and license is the same, no license is updated.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.LicenseFixtures;
+import inmemory.AbstractUseCaseTest;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.LicenseCrudServiceInMemory;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.event.crud_service.EventCrudService;
+import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
+
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final EventCrudService eventCrudService = mock(EventCrudService.class);
+    private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private DeployApiProductUseCase deployApiProductUseCase;
+
+    @BeforeEach
+    void setUp() {
+        when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
+        deployApiProductUseCase = new DeployApiProductUseCase(
+            apiProductQueryService,
+            eventCrudService,
+            eventLatestCrudService,
+            new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager)
+        );
+    }
+
+    @Test
+    void should_deploy_api_product() {
+        var productId = "api-product-id";
+        var apiProduct = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).version("1.0.0").build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+
+        var input = new DeployApiProductUseCase.Input(productId, AUDIT_INFO);
+        var output = deployApiProductUseCase.execute(input);
+
+        assertThat(output.apiProduct())
+            .hasFieldOrPropertyWithValue("id", productId)
+            .hasFieldOrPropertyWithValue("name", "Product")
+            .hasFieldOrPropertyWithValue("environmentId", ENV_ID);
+
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+        verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq(productId), any());
+    }
+
+    @Test
+    void should_throw_exception_if_product_does_not_exist() {
+        var input = new DeployApiProductUseCase.Input("missing-id", AUDIT_INFO);
+
+        assertThatThrownBy(() -> deployApiProductUseCase.execute(input))
+            .isInstanceOf(ApiProductNotFoundException.class)
+            .hasMessage("API Product not found.");
+    }
+
+    @Test
+    void should_throw_exception_when_license_does_not_allow_api_product() {
+        when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anOssLicense());
+
+        var productId = "api-product-id";
+        var apiProduct = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).version("1.0.0").build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+
+        var input = new DeployApiProductUseCase.Input(productId, AUDIT_INFO);
+
+        assertThatThrownBy(() -> deployApiProductUseCase.execute(input)).isInstanceOf(ForbiddenFeatureException.class);
+    }
+}


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-12491

## Description
Adds license checks for API Product deployment and a dedicated deployment endpoint.

- Gateway: Uses LicenseManager in ApiProductManagerImpl to ensure the organization has the universe tier before deploying an API Product; skips deployment and logs a warning otherwise.
- Deployment API: Introduces POST /environments/{envId}/api-products/{apiProductId}/deployments to trigger deployment via a DEPLOY_API_PRODUCT event (handled by DeployApiProductUseCase). 
[similar to API's deployement endpoint, which we call, when we add, publish PLAN]

## Additional context
As per PRD, for api-product,
(P0) Packaging & availability - enterprise only, universe

This is PR dependent of approve-merge of another PR : https://github.com/gravitee-io/gravitee-api-management/pull/15141

