### PR TITLE
feat: implement subscription form management in the console

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
@@ -47,4 +47,5 @@ export * from './portalCustomization';
 export * from './portalMenuLink';
 export * from './portalNavigationItem';
 export * from './portalPageContent';
+export * from './subscriptionForm';
 export * from './cluster';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './subscriptionForm';
+export * from './subscriptionForm.fixture';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.fixture.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SubscriptionForm } from './subscriptionForm';
+
+export function fakeSubscriptionForm(attributes?: Partial<SubscriptionForm>): SubscriptionForm {
+  const base: SubscriptionForm = {
+    id: 'subscription-form-id',
+    gmdContent: '# Subscription Form\n\n<gmd-input name="name" label="Name" fieldKey="name" required="true"></gmd-input>',
+    enabled: false,
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Subscription form definition used by API consumers when subscribing to APIs
+ */
+export interface SubscriptionForm {
+  /**
+   * Unique identifier of the subscription form
+   */
+  id: string;
+  /**
+   * Gravitee Markdown (GMD) content defining the form.
+   * Supports form components like gmd-input, gmd-textarea, gmd-select, gmd-checkbox, gmd-radio.
+   */
+  gmdContent: string;
+  /**
+   * Whether the form is enabled and visible to API consumers in the Developer Portal
+   */
+  enabled: boolean;
+}
+
+/**
+ * Payload for creating or updating a subscription form
+ */
+export interface CreateOrUpdateSubscriptionForm {
+  /**
+   * Gravitee Markdown (GMD) content defining the form.
+   * Content is validated for security - malicious HTML/scripts will be rejected.
+   */
+  gmdContent: string;
+}

--- a/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
@@ -129,6 +129,7 @@ const portalRoutes: Routes = [
       {
         path: 'subscription-form',
         component: SubscriptionFormComponent,
+        canDeactivate: [HasUnsavedChangesGuard],
         data: {
           permissions: {
             anyOf: ['environment-settings-r', 'environment-settings-u'],

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
@@ -18,7 +18,30 @@
 <portal-header
   subtitle="Define the subscription form that will be displayed to users when subscribing to APIs"
   [title]="'Subscription Form'"
-  [showActions]="false"
+  [showActions]="true"
 >
+  <div additionalActions class="actions">
+    <mat-slide-toggle
+      aria-label="Visible to API consumers"
+      labelPosition="before"
+      [formControl]="enabledControl"
+      [matTooltip]="enabledControlTooltip()"
+      [matTooltipDisabled]="!enabledControlTooltip()"
+      data-testid="enable-toggle"
+    >
+      Visible to API consumers
+    </mat-slide-toggle>
+    <button
+      mat-flat-button
+      color="primary"
+      aria-label="Update subscription form"
+      (click)="updateSubscriptionForm()"
+      [disabled]="isSaveDisabled()"
+      [matTooltip]="saveButtonTooltip()"
+      [matTooltipDisabled]="!saveButtonTooltip()"
+    >
+      Save
+    </button>
+  </div>
 </portal-header>
 <gmd-form-editor [formControl]="contentControl" />

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
@@ -13,6 +13,12 @@
   }
 }
 
+.actions {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
 gmd-form-editor {
   @include gmd.editor-overrides(
     (

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -13,27 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { ConfigureTestingGmdFormEditor, ConfigureTestingGraviteeMarkdownEditor, GmdFormEditorHarness } from '@gravitee/gravitee-markdown';
+import { ConfigureTestingGmdFormEditor, GmdFormEditorHarness } from '@gravitee/gravitee-markdown';
+import { GMD_FORM_STATE_STORE } from '@gravitee/gravitee-markdown';
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
 
 import { SubscriptionFormComponent } from './subscription-form.component';
 
-import { GioTestingModule } from '../../shared/testing';
+import { GioTestingModule, CONSTANTS_TESTING } from '../../shared/testing';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../services-ngx/snack-bar.service';
+import { fakeSubscriptionForm } from '../../entities/management-api-v2/subscriptionForm/subscriptionForm.fixture';
+import { SubscriptionForm } from '../../entities/management-api-v2';
 
 describe('SubscriptionFormComponent', () => {
   let fixture: ComponentFixture<SubscriptionFormComponent>;
-  let component: SubscriptionFormComponent;
-  let loader: HarnessLoader;
-  let editorHarness: GmdFormEditorHarness;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
+  let snackBarService: SnackBarService;
 
-  const init = async (canUpdate: boolean) => {
-    ConfigureTestingGmdFormEditor();
+  const init = async (canUpdate: boolean, subscriptionForm = fakeSubscriptionForm()) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
       providers: [
@@ -46,50 +53,321 @@ describe('SubscriptionFormComponent', () => {
       ],
     }).compileComponents();
 
-    ConfigureTestingGraviteeMarkdownEditor();
+    ConfigureTestingGmdFormEditor();
 
     fixture = TestBed.createComponent(SubscriptionFormComponent);
-    component = fixture.componentInstance;
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    // Spy on snackbar
+    snackBarService = TestBed.inject(SnackBarService);
+    jest.spyOn(snackBarService, 'success');
+    jest.spyOn(snackBarService, 'error');
 
     fixture.detectChanges();
-    loader = TestbedHarnessEnvironment.loader(fixture);
-    editorHarness = await loader.getHarness(GmdFormEditorHarness);
+
+    // Expect GET request for subscription form
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms`,
+    });
+    req.flush(subscriptionForm);
   };
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
 
   it('should create component', async () => {
     await init(true);
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should load default boilerplate content', async () => {
-    await init(true);
+  it('should load subscription form content from API', async () => {
+    const gmdContent = '# Test Form\n\n<gmd-input name="email" label="Email" fieldKey="email" required="true"></gmd-input>';
+    const form = fakeSubscriptionForm({ gmdContent });
 
-    const contentValue = await editorHarness.getEditorValue();
+    await init(true, form);
 
-    expect(contentValue).toContain('Subscription Form Builder');
-    expect(contentValue).toContain('Example: Complete Subscription Request Form');
-    expect(contentValue).toContain('Applicant Information');
-    expect(contentValue).toContain('Usage Details');
-    expect(contentValue).toContain('Simplified Quick Access Form');
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
+    // The mock editor might normalize newlines to spaces or remove them if it's an input
+    const receivedValue = await editorHarness.getEditorValue();
+    expect(receivedValue.replace(/\s/g, '')).toEqual(gmdContent.replace(/\s/g, ''));
   });
 
   it('should disable editor when user has no update permission', async () => {
     await init(false);
-
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
     expect(await editorHarness.isEditorReadOnly()).toBe(true);
   });
 
   it('should enable editor when user has update permission', async () => {
     await init(true);
-
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
     expect(await editorHarness.isEditorReadOnly()).toBe(false);
   });
 
-  it('should allow updating content control value', async () => {
-    await init(true);
+  it('should disable save button when content is empty or unchanged', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: '# Hello world' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
 
-    component.contentControl.setValue('Custom subscription form content');
+    fixture.componentInstance.contentControl.setValue('Updated form content');
+    fixture.detectChanges();
 
-    expect(component.contentControl.value).toBe('Custom subscription form content');
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('# Hello world');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('     ');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
   });
+
+  it('should update subscription form content', async () => {
+    const form = fakeSubscriptionForm();
+    const updatedContent = '# Updated Form\n\n<gmd-input name="name" label="Name" fieldKey="name"></gmd-input>';
+    await init(true, form);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.contentControl.setValue(updatedContent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+    await saveButton.click();
+
+    expectSubscriptionFormUpdate({ gmdContent: updatedContent }, { ...form, gmdContent: updatedContent });
+    expect(snackBarService.success).toHaveBeenCalledWith('The subscription form has been updated successfully');
+    expect(await saveButton.isDisabled()).toBeTruthy();
+  });
+
+  it('should disable save button when config errors exist', async () => {
+    await init(true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const store: any = fixture.debugElement.injector.get(GMD_FORM_STATE_STORE as any);
+
+    fixture.componentInstance.contentControl.setValue('Updated form content');
+    fixture.detectChanges();
+
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+
+    // Simulate config error by adding a field with a config error
+    store.updateField({
+      id: 'field-1',
+      fieldKey: 'key-1',
+      valid: true,
+      value: '',
+      required: false,
+      validationErrors: [],
+      configErrors: [{ code: 'warning', message: 'Missing property', severity: 'warning' }],
+    });
+    fixture.detectChanges();
+
+    expect(await saveButton.isDisabled()).toBeTruthy();
+  });
+
+  describe('enable/disable toggle functionality', () => {
+    it('should enable a disabled form after confirmation', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isChecked()).toBe(false);
+      await toggle.toggle();
+
+      await confirmDialog('Enable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ ...disabledForm, enabled: true });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should disable an enabled form after confirmation', async () => {
+      const enabledForm = fakeSubscriptionForm({ enabled: true });
+      await init(true, enabledForm);
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isChecked()).toBe(true);
+      await toggle.toggle();
+
+      await confirmDialog('Disable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${enabledForm.id}/_disable`,
+      });
+      req.flush({ ...enabledForm, enabled: false });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been disabled successfully.');
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should not perform any action if the confirmation dialog is cancelled', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      await dialog.close();
+
+      // Toggle should be reset to previous state
+      expect(await toggle.isChecked()).toBe(false);
+      httpTestingController.verify();
+    });
+
+    it('should show an error message if enabling fails', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+      await confirmDialog('Enable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ message: 'API error on enable' }, { status: 500, statusText: 'Server Error' });
+
+      expect(snackBarService.error).toHaveBeenCalledWith('API error on enable');
+      // Toggle should be reset to previous state
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should save changes before enabling when form has unsaved changes', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      fixture.componentInstance.contentControl.setValue('Updated form content');
+      fixture.detectChanges();
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+
+      await confirmDialog('Save and enable');
+
+      expectSubscriptionFormUpdate({ gmdContent: 'Updated form content' }, { ...disabledForm, gmdContent: 'Updated form content' });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ ...disabledForm, enabled: true });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should disable toggle when config errors exist', async () => {
+      await init(true);
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const store: any = fixture.debugElement.injector.get(GMD_FORM_STATE_STORE as any);
+
+      store.updateField({
+        id: 'field-1',
+        fieldKey: 'key-1',
+        valid: true,
+        value: '',
+        required: false,
+        validationErrors: [],
+        configErrors: [{ code: 'error', message: 'Missing property', severity: 'error' }],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isDisabled()).toBe(true);
+    });
+
+    it('should NOT render toggle when user lacks permission', async () => {
+      await init(false, fakeSubscriptionForm({ enabled: true }));
+
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      expect(toggles.length).toBe(0);
+    });
+  });
+
+  it('should have unsaved changes when content is modified', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: 'Initial content' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('Modified content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
+  });
+
+  it('should not have unsaved changes when content is modified and then reverted', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: 'Initial content' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('Modified content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('Initial content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+  });
+
+  it('should show action bar but disable toggle and Save when user lacks permission', async () => {
+    await init(false);
+
+    const saveButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' }));
+    const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
+
+    await expect(saveButton.isDisabled()).resolves.toBe(true);
+    await expect(toggle.isDisabled()).resolves.toBe(true);
+  });
+
+  async function getEnableToggle() {
+    return await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
+  }
+
+  async function confirmDialog(action: string) {
+    const dialog = await rootLoader.getHarness(MatDialogHarness);
+    const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: new RegExp(action) }));
+    await confirmButton.click();
+  }
+
+  async function getSaveButton() {
+    return await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' }));
+  }
+
+  function expectSubscriptionFormUpdate(expected: { gmdContent: string }, response: SubscriptionForm) {
+    const req = httpTestingController.expectOne({
+      method: 'PUT',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${response.id}`,
+    });
+    expect(req.request.body).toStrictEqual(expected);
+    req.flush(response);
+  }
 });

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
@@ -13,170 +13,275 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GmdFormEditorComponent } from '@gravitee/gravitee-markdown';
+import { GMD_FORM_STATE_STORE, GmdFormEditorComponent, provideGmdFormStore } from '@gravitee/gravitee-markdown';
 
-import { Component, effect, inject, signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, HostListener, inject, signal, untracked, WritableSignal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { catchError, filter, startWith, switchMap, tap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  GIO_DIALOG_WIDTH,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioFormSlideToggleModule,
+} from '@gravitee/ui-particles-angular';
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../services-ngx/snack-bar.service';
+import { SubscriptionForm } from '../../entities/management-api-v2';
+import { SubscriptionFormService } from '../../services-ngx/subscription-form.service';
+import { HasUnsavedChanges } from '../../shared/guards/has-unsaved-changes.guard';
+import { normalizeContent } from '../../shared/utils/content.util';
 
 @Component({
   selector: 'subscription-form',
-  imports: [PortalHeaderComponent, ReactiveFormsModule, GmdFormEditorComponent],
+  imports: [
+    PortalHeaderComponent,
+    ReactiveFormsModule,
+    GmdFormEditorComponent,
+    MatButtonModule,
+    MatTooltipModule,
+    MatSlideToggleModule,
+    GioFormSlideToggleModule,
+  ],
   templateUrl: './subscription-form.component.html',
   styleUrl: './subscription-form.component.scss',
+  providers: [...provideGmdFormStore()],
 })
-export class SubscriptionFormComponent {
-  contentControl = new FormControl({
-    value: '',
-    disabled: true,
+export class SubscriptionFormComponent implements HasUnsavedChanges {
+  private readonly snackbarService = inject(SnackBarService);
+  private readonly subscriptionFormService = inject(SubscriptionFormService);
+  private readonly gioPermissionService = inject(GioPermissionService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly matDialog = inject(MatDialog);
+  private readonly store = inject(GMD_FORM_STATE_STORE);
+
+  private readonly subscriptionForm: WritableSignal<SubscriptionForm | null> = signal(null);
+  private readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-settings-u']));
+  contentControl = new FormControl<string>('', { nonNullable: true });
+  enabledControl = new FormControl<boolean>(false, { nonNullable: true });
+
+  private readonly contentValue = toSignal(this.contentControl.valueChanges.pipe(startWith(this.contentControl.value)));
+  private readonly subscriptionFormResult = toSignal(
+    this.subscriptionFormService.getSubscriptionForm().pipe(
+      catchError(({ error }) => {
+        this.snackbarService.error(error?.message ?? 'An error occurred while loading the subscription form');
+        return EMPTY;
+      }),
+    ),
+    { initialValue: null },
+  );
+  private readonly enabledControlChanges = toSignal(this.enabledControl.valueChanges.pipe(filter(() => this.canUpdate())), {
+    initialValue: undefined,
   });
 
-  private readonly gioPermissionService = inject(GioPermissionService);
-  private readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-settings-u']));
+  protected readonly hasConfigErrors = computed(() => this.store.allConfigErrors().length > 0);
+  readonly configErrorsTooltip = 'Fix configuration errors before continuing.';
+  readonly subscriptionFormEnabled = computed(() => this.subscriptionForm()?.enabled ?? false);
 
-  constructor() {
-    effect(() => {
-      this.contentControl.reset(this.getDefaultBoilerplate());
-    });
+  readonly enabledControlTooltip = computed(() => {
+    if (!this.canUpdate()) return 'You do not have permission to change this.';
+    if (this.hasConfigErrors()) return this.configErrorsTooltip;
+    return '';
+  });
 
-    effect(() => {
-      this.canUpdate() ? this.contentControl.enable() : this.contentControl.disable();
-    });
+  readonly saveButtonTooltip = computed(() => {
+    if (!this.canUpdate()) return 'You do not have permission to update the subscription form.';
+    if (this.hasConfigErrors()) return this.configErrorsTooltip;
+    return '';
+  });
+
+  isSaveDisabled = computed(() => {
+    const currentContent = this.contentValue() ?? '';
+    const normalized = normalizeContent(currentContent);
+    const isEmpty = normalized.length === 0;
+    const hasConfigErrors = this.hasConfigErrors();
+    const isUnchanged = !this.hasUnsavedChanges();
+    return !this.canUpdate() || isEmpty || hasConfigErrors || isUnchanged;
+  });
+
+  private readonly controlsDisabledStateEffect = effect(() => {
+    const canUpdate = this.canUpdate();
+    const hasConfigErrors = this.hasConfigErrors();
+    const options = { emitEvent: false };
+    canUpdate ? this.contentControl.enable(options) : this.contentControl.disable(options);
+    const enableToggle = canUpdate && !hasConfigErrors;
+    enableToggle ? this.enabledControl.enable(options) : this.enabledControl.disable(options);
+  });
+
+  private readonly subscriptionFormLoadEffect = effect(() => {
+    const result = this.subscriptionFormResult();
+    if (!result) return;
+    this.subscriptionForm.set(result);
+    this.contentControl.reset(result.gmdContent || '', { emitEvent: true });
+    this.enabledControl.setValue(result.enabled, { emitEvent: false });
+  });
+
+  private readonly enabledControlEffect = effect(() => {
+    const enabled = this.enabledControlChanges();
+    if (enabled === undefined) return;
+    untracked(() => this.handleToggleChange(enabled));
+  });
+
+  @HostListener('window:beforeunload', ['$event'])
+  beforeUnloadHandler(event: BeforeUnloadEvent) {
+    if (this.hasUnsavedChanges()) {
+      event.preventDefault();
+      event.returnValue = '';
+      return '';
+    }
   }
 
-  private getDefaultBoilerplate(): string {
-    return `<gmd-grid columns="1" class="hero-grid">
-  <gmd-card class="boilerplate-hero">
-    <gmd-card-title>🎨 Subscription Form Builder</gmd-card-title>
-    <gmd-md>
-      Welcome to your subscription form workspace! This is where you can design and customize the form that API consumers will see when subscribing to your APIs.
-
-      **How to use this space:**
-
-      - **✏️ Edit freely** - Modify the examples below or start from scratch
-      - **👀 Live preview** - See your changes instantly on the right side
-      - **🧪 Test validation** - Try filling out the form to test required fields and validation rules
-      - **💾 Save & publish** - When ready, save your form and publish it to make it available in the portal
-
-      ---
-
-      **💡 Pro tip:** Start by editing the example form below, then delete what you don't need and build your own!
-    </gmd-md>
-  </gmd-card>
-</gmd-grid>
-
-<style>
-  .hero-grid {
-    margin-bottom: 2rem;
+  hasUnsavedChanges(): boolean {
+    const current = normalizeContent(this.contentValue() ?? '');
+    const initial = normalizeContent(this.subscriptionForm()?.gmdContent ?? '');
+    return current !== initial;
   }
 
-  .boilerplate-hero {
-    --gmd-card-container-color: #dbeafe;
-    --gmd-card-text-color: #1e3a8a;
-    --gmd-card-outline-color: #60a5fa;
-    --gmd-card-outline-width: 2px;
-    --gmd-card-container-shape: 12px;
-  }
-</style>
+  updateSubscriptionForm(): void {
+    const form = this.subscriptionForm();
+    if (!form) return;
 
----
-
-## 📋 Example: Complete Subscription Request Form
-
-Below is a full example showing all available form components. Feel free to customize it or use it as inspiration!
-
-<gmd-grid columns="2" class="subscription-form-grid form-demo">
-  <gmd-card>
-    <gmd-card-title>👤 Applicant Information</gmd-card-title>
-    <gmd-md>Tell us about yourself and your organization.</gmd-md>
-
-    <gmd-input name="fullName" label="Full name" fieldKey="full_name" required="true"></gmd-input>
-    <gmd-input name="email" label="Email address" fieldKey="email" type="email" required="true" placeholder="you@company.com"></gmd-input>
-    <gmd-input name="company" label="Company" fieldKey="company" required="true" minLength="2" maxLength="100"></gmd-input>
-    <gmd-input name="website" label="Company website" fieldKey="company_website" type="url" placeholder="https://example.com"></gmd-input>
-    <gmd-select name="country" label="Country" fieldKey="country" required="true" options="United States,Canada,United Kingdom,Germany,France,Poland,Spain,Italy,Netherlands,Other"></gmd-select>
-  </gmd-card>
-
-  <gmd-card>
-    <gmd-card-title>🎯 Usage Details</gmd-card-title>
-    <gmd-md>Help us understand your API usage needs.</gmd-md>
-
-    <gmd-select name="plan" label="Requested plan" fieldKey="requested_plan" required="true" options="Free Tier,Starter,Professional,Enterprise"></gmd-select>
-    <gmd-radio name="env" label="Target environment" fieldKey="target_environment" required="true" options="Production,Staging,Development,Testing"></gmd-radio>
-    <gmd-input name="monthlyCalls" label="Expected monthly API calls" fieldKey="expected_monthly_calls" type="number" placeholder="e.g. 100000"></gmd-input>
-    <gmd-textarea
-      name="useCase"
-      label="Use case description"
-      fieldKey="use_case"
-      required="true"
-      minLength="20"
-      maxLength="500"
-      placeholder="Please describe how you plan to use this API and what problem it will solve for your business..."></gmd-textarea>
-
-    <gmd-checkbox name="terms" label="I confirm that all information provided is accurate" fieldKey="confirm_accuracy" required="true"></gmd-checkbox>
-    <gmd-checkbox name="newsletter" label="Subscribe to API updates and newsletters" fieldKey="subscribe_newsletter"></gmd-checkbox>
-  </gmd-card>
-</gmd-grid>
-
----
-
-## 🚀 Example: Simplified Quick Access Form
-
-Here's a minimal form variant for faster onboarding:
-
-<gmd-grid columns="1" class="compact-form-grid">
-  <gmd-card class="form-demo form-demo--compact">
-    <gmd-card-title>⚡ Quick Access Request</gmd-card-title>
-    <gmd-md>Get started quickly with just the essentials.</gmd-md>
-
-    <gmd-input name="appName" label="Application name" fieldKey="app_name" required="true" placeholder="My API Integration"></gmd-input>
-    <gmd-select name="team" label="Team or department" fieldKey="team" options="Engineering,Product,Data & Analytics,DevOps,Security,Partner Integration,Other"></gmd-select>
-    <gmd-radio name="priority" label="Request priority" fieldKey="priority" options="Low,Normal,High,Urgent"></gmd-radio>
-    <gmd-textarea name="notes" label="Additional notes" fieldKey="notes" maxLength="300" placeholder="Any additional context or special requirements..."></gmd-textarea>
-    <gmd-checkbox name="terms" label="I accept the terms and conditions" fieldKey="accept_terms" required="true"></gmd-checkbox>
-  </gmd-card>
-</gmd-grid>
-
-<style>
-  .subscription-form-grid {
-    align-items: stretch;
-    gap: 1.5rem;
+    this.subscriptionFormService
+      .updateSubscriptionForm(form.id, {
+        gmdContent: this.contentControl.value,
+      })
+      .pipe(
+        tap(updatedForm => {
+          this.snackbarService.success(`The subscription form has been updated successfully`);
+          this.subscriptionForm.set(updatedForm);
+        }),
+        catchError(({ error }) => {
+          this.snackbarService.error(error?.message ?? 'An error occurred while updating the subscription form');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
-  .form-demo {
-    --gmd-card-container-color: #f8fafc;
-    --gmd-card-outline-color: #e2e8f0;
-    --gmd-card-outline-width: 1px;
-    --gmd-card-container-shape: 10px;
-    --gmd-card-text-color: #0f172a;
-
-    --gmd-input-outlined-label-text-color: #0f172a;
-    --gmd-input-outlined-input-text-color: #0f172a;
-    --gmd-input-outlined-outline-color: #94a3b8;
-    --gmd-input-outlined-container-shape: 8px;
-
-    --gmd-textarea-outlined-label-text-color: #0f172a;
-    --gmd-textarea-outlined-input-text-color: #0f172a;
-    --gmd-textarea-outlined-outline-color: #94a3b8;
-    --gmd-textarea-outlined-container-shape: 8px;
-
-    --gmd-select-outlined-label-text-color: #0f172a;
-    --gmd-select-outlined-input-text-color: #0f172a;
-    --gmd-select-outlined-outline-color: #94a3b8;
-    --gmd-select-outlined-container-shape: 8px;
-
-    --gmd-checkbox-outlined-label-text-color: #0f172a;
-
-    --gmd-radio-outlined-label-text-color: #0f172a;
+  private resetEnabledToInitial(): void {
+    this.enabledControl.setValue(this.subscriptionFormEnabled(), { emitEvent: false });
   }
 
-  .form-demo--compact {
-    max-width: 600px;
-    margin: 0 auto;
+  private handleToggleChange(enabled: boolean): void {
+    if (this.hasConfigErrors()) {
+      this.resetEnabledToInitial();
+      return;
+    }
+    if (this.hasUnsavedChanges()) {
+      const action = enabled ? 'Enable' : 'Disable';
+      const data: GioConfirmDialogData = {
+        title: `${action} subscription form?`,
+        content: `You have unsaved changes. Save the form before changing visibility.`,
+        confirmButton: `Save and ${action.toLowerCase()}`,
+        cancelButton: 'Cancel',
+      };
+
+      this.matDialog
+        .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+          width: GIO_DIALOG_WIDTH.SMALL,
+          data,
+          role: 'alertdialog',
+          id: 'confirmDialog',
+        })
+        .afterClosed()
+        .pipe(
+          filter(confirmed => {
+            if (!confirmed) this.resetEnabledToInitial();
+            return confirmed;
+          }),
+          switchMap(() => this.saveAndToggleEnabled(enabled)),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe();
+    } else {
+      this.executeToggleEnabled(enabled);
+    }
   }
-</style>
-`;
+
+  private saveAndToggleEnabled(enabled: boolean) {
+    const form = this.subscriptionForm();
+    if (!form) {
+      this.resetEnabledToInitial();
+      return EMPTY;
+    }
+
+    const action = enabled ? 'enable' : 'disable';
+
+    return this.subscriptionFormService
+      .updateSubscriptionForm(form.id, {
+        gmdContent: this.contentControl.value,
+      })
+      .pipe(
+        tap(updatedForm => this.subscriptionForm.set(updatedForm)),
+        switchMap(() =>
+          enabled
+            ? this.subscriptionFormService.enableSubscriptionForm(form.id)
+            : this.subscriptionFormService.disableSubscriptionForm(form.id),
+        ),
+        tap(updatedForm => {
+          this.subscriptionForm.set(updatedForm);
+          this.enabledControl.setValue(updatedForm.enabled, { emitEvent: false });
+          this.snackbarService.success(`Subscription form has been ${updatedForm.enabled ? 'enabled' : 'disabled'} successfully.`);
+        }),
+        catchError(({ error }) => {
+          this.resetEnabledToInitial();
+          this.snackbarService.error(error?.message ?? `Failed to ${action} subscription form.`);
+          return EMPTY;
+        }),
+      );
+  }
+
+  private executeToggleEnabled(enabled: boolean): void {
+    const form = this.subscriptionForm();
+    if (!form) return;
+
+    const action = enabled ? 'enable' : 'disable';
+    const data: GioConfirmDialogData = {
+      title: `${action.charAt(0).toUpperCase() + action.slice(1)} subscription form?`,
+      content: enabled
+        ? `This action will enable the subscription form. It will be visible to API consumers in the Developer Portal.`
+        : `This action will disable the subscription form. It will no longer be visible in the Developer Portal, but you can enable it again at any time.`,
+      confirmButton: action.charAt(0).toUpperCase() + action.slice(1),
+    };
+
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: GIO_DIALOG_WIDTH.SMALL,
+        data,
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirmed => {
+          if (!confirmed) this.resetEnabledToInitial();
+          return confirmed;
+        }),
+        switchMap(() =>
+          enabled
+            ? this.subscriptionFormService.enableSubscriptionForm(form.id)
+            : this.subscriptionFormService.disableSubscriptionForm(form.id),
+        ),
+        tap(updatedForm => {
+          this.subscriptionForm.set(updatedForm);
+          this.enabledControl.setValue(updatedForm.enabled, { emitEvent: false });
+          this.snackbarService.success(`Subscription form has been ${updatedForm.enabled ? 'enabled' : 'disabled'} successfully.`);
+        }),
+        catchError(({ error }) => {
+          this.resetEnabledToInitial();
+          this.snackbarService.error(error?.message ?? `Failed to ${action} subscription form.`);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { CreateOrUpdateSubscriptionForm, SubscriptionForm } from '../entities/management-api-v2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SubscriptionFormService {
+  constructor(
+    private http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  public getSubscriptionForm(): Observable<SubscriptionForm> {
+    return this.http.get<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms`);
+  }
+
+  public updateSubscriptionForm(id: string, content: CreateOrUpdateSubscriptionForm): Observable<SubscriptionForm> {
+    return this.http.put<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}`, content);
+  }
+
+  public enableSubscriptionForm(id: string): Observable<SubscriptionForm> {
+    return this.http.post<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}/_enable`, {});
+  }
+
+  public disableSubscriptionForm(id: string): Observable<SubscriptionForm> {
+    return this.http.post<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}/_disable`, {});
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GmdFormEditorComponent } from './gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+import { provideGmdFormStore } from '../services/gmd-form-state.store';
 
 @Component({
   selector: 'gmd-monaco-editor',
@@ -45,6 +46,7 @@ describe('GmdFormEditorComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GmdFormEditorComponent, MockMonacoEditorComponent, MockGmdViewerComponent],
+      providers: [...provideGmdFormStore()],
     })
       .overrideComponent(GmdFormEditorComponent, {
         remove: { imports: [GraviteeMarkdownViewerModule] },

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
@@ -16,7 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GmdFormHostComponent } from './gmd-form-host.component';
-import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
+import { GMD_FORM_STATE_STORE, provideGmdFormStore } from '../services/gmd-form-state.store';
 
 describe('GmdFormHostComponent', () => {
   let component: GmdFormHostComponent;
@@ -25,6 +25,7 @@ describe('GmdFormHostComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GmdFormHostComponent],
+      providers: [...provideGmdFormStore()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GmdFormHostComponent);
@@ -35,7 +36,7 @@ describe('GmdFormHostComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should provide GMD_FORM_STATE_STORE to children', () => {
+  it('should use the provided GMD_FORM_STATE_STORE', () => {
     const store = fixture.debugElement.injector.get(GMD_FORM_STATE_STORE);
     expect(store).toBeTruthy();
   });

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
@@ -15,11 +15,10 @@
  */
 import { Component, effect, inject, input, untracked } from '@angular/core';
 
-import { GMD_FORM_STATE_STORE, GmdFormStateStore } from '../services/gmd-form-state.store';
+import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
 
 /**
- * Host component that provides a scoped form state store and manages its lifecycle.
- * Acts as a DI scope boundary for form state management.
+ * Host component that manages the form state lifecycle.
  *
  * Usage:
  * ```html
@@ -34,12 +33,6 @@ import { GMD_FORM_STATE_STORE, GmdFormStateStore } from '../services/gmd-form-st
   standalone: true,
   template: '<ng-content />',
   styleUrl: './gmd-form-host.component.scss',
-  providers: [
-    {
-      provide: GMD_FORM_STATE_STORE,
-      useFactory: () => new GmdFormStateStore(),
-    },
-  ],
 })
 export class GmdFormHostComponent {
   private readonly store = inject(GMD_FORM_STATE_STORE);

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
@@ -20,7 +20,7 @@ import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
 
 /**
  * Validation panel component that displays form diagnostics and validation status.
- * Injects the form state store from parent scope (gmd-form-host).
+ * Injects the form state store from the parent scope.
  *
  * Displays:
  * - Configuration errors (critical)

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { computed, Injectable, InjectionToken, signal } from '@angular/core';
+import { computed, Injectable, InjectionToken, Provider, signal } from '@angular/core';
 import { isEqual } from 'lodash';
 
 import { GmdConfigError, GmdFieldState } from '../models/formField';
@@ -210,3 +210,13 @@ export class GmdFormStateStore {
  * Injection token for GMD form state store.
  */
 export const GMD_FORM_STATE_STORE = new InjectionToken<GmdFormStateStore>('GMD_FORM_STATE_STORE');
+
+/**
+ * Provide a scoped GMD form state store instance.
+ */
+export const provideGmdFormStore = (): Provider[] => [
+  {
+    provide: GMD_FORM_STATE_STORE,
+    useFactory: () => new GmdFormStateStore(),
+  },
+];


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-12634

## Description

- Add subscription form schema and fixture for testing.
- Implement subscription form service with CRUD operations and enabling/disabling functionality.
- Update subscription form component:
  - Allow toggling form enable/disable states.
  - Add unsaved changes detection and validation handling.
  - Display validation errors (content and config) in the form editor.
- Extend tests to cover new functionality.

## Additional context


