### PR TITLE
feat: add environment filtering to entrypoint mappings

### DIFF
--- a/gravitee-apim-console-webui/src/entities/entrypoint/entrypoint.ts
+++ b/gravitee-apim-console-webui/src/entities/entrypoint/entrypoint.ts
@@ -20,5 +20,6 @@ export interface Entrypoint {
   id: string;
   value?: string;
   tags?: string[];
+  environmentIds?: string[];
   target?: 'HTTP' | 'TCP' | 'KAFKA';
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
@@ -35,6 +35,16 @@
         <mat-error *ngIf="mappingForm.get('tags').hasError('required')">At least one tag must be selected.</mat-error>
       </mat-form-field>
 
+      <mat-form-field>
+        <mat-label>Environments</mat-label>
+        <mat-select formControlName="environmentIds" aria-label="Environments selection" multiple>
+          <mat-option *ngFor="let env of environments$ | async" [value]="env.id">
+            {{ env.name || env.id }}
+          </mat-option>
+        </mat-select>
+        <mat-hint>Leave empty to apply to all environments</mat-hint>
+      </mat-form-field>
+
       @switch (target) {
         @case ('HTTP') {
           <mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.ts
@@ -19,6 +19,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { shareReplay } from 'rxjs/operators';
 
 import { Entrypoint } from '../../../../entities/entrypoint/entrypoint';
+import { EnvironmentService } from '../../../../services-ngx/environment.service';
 import { TagService } from '../../../../services-ngx/tag.service';
 import { kafkaBootstrapDomainPatternValidator, portValidator } from '../org-settings-entrypoints-and-sharding-tags.utils';
 
@@ -29,6 +30,7 @@ export type OrgSettingAddMappingDialogData = {
 
 type MappingFormGroup = {
   tags: FormControl<string[]>;
+  environmentIds: FormControl<string[]>;
   httpValue?: FormControl<string>;
   kafkaDomain?: FormControl<string>;
   kafkaPort?: FormControl<string>;
@@ -47,11 +49,13 @@ export class OrgSettingAddMappingDialogComponent {
   isUpdate = false;
   mappingForm: FormGroup<MappingFormGroup>;
   tags$? = this.tagService.list().pipe(shareReplay(1));
+  environments$ = this.environmentService.list().pipe(shareReplay(1));
 
   constructor(
     public dialogRef: MatDialogRef<OrgSettingAddMappingDialogComponent>,
     @Inject(MAT_DIALOG_DATA) confirmDialogData: OrgSettingAddMappingDialogData,
     private readonly tagService: TagService,
+    private readonly environmentService: EnvironmentService,
   ) {
     this.entrypoint = confirmDialogData.entrypoint;
     this.target = confirmDialogData.target;
@@ -59,6 +63,7 @@ export class OrgSettingAddMappingDialogComponent {
 
     this.mappingForm = new FormGroup({
       tags: new FormControl(this.entrypoint?.tags ?? []),
+      environmentIds: new FormControl(this.entrypoint?.environmentIds ?? []),
     });
 
     switch (this.target) {
@@ -104,6 +109,7 @@ export class OrgSettingAddMappingDialogComponent {
     const updatedEntrypoint = {
       ...(this.entrypoint?.id ? { id: this.entrypoint.id } : {}),
       tags: formValue.tags,
+      environmentIds: formValue.environmentIds,
       value,
       target: this.target,
     };

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
@@ -266,6 +266,14 @@
           <td mat-cell *matCellDef="let entrypoint">{{ entrypoint.tagsName.join(', ') }}</td>
         </ng-container>
 
+        <!-- Environments Column -->
+        <ng-container matColumnDef="environments">
+          <th mat-header-cell *matHeaderCellDef id="environments">Environments</th>
+          <td mat-cell *matCellDef="let entrypoint">
+            {{ entrypoint.environmentNames.length > 0 ? entrypoint.environmentNames.join(', ') : 'All' }}
+          </td>
+        </ng-container>
+
         <!-- Actions Column -->
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef></th>

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
@@ -286,6 +286,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
           target: 'Target',
           entrypoint: 'Entrypoint',
           tags: 'Sharding Tags',
+          environments: 'Environments',
           actions: '',
         },
       ]);
@@ -294,6 +295,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
           target: 'HTTP',
           entrypoint: expect.stringContaining('https://googl.co'),
           tags: 'External',
+          environments: 'All',
           actions: 'editdelete',
         },
       ]);
@@ -446,6 +448,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       await addButtonMenu.clickItem({ text: 'HTTP' });
 
       expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const submitButton = await rootLoader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
       expect(await submitButton.isDisabled()).toBeTruthy();
@@ -463,6 +466,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
         target: 'HTTP',
         value: 'https://my.entry',
         tags: ['tag-1'],
+        environmentIds: [],
       });
     });
 
@@ -476,6 +480,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       await addButtonMenu.clickItem({ text: 'Kafka' });
 
       expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const addMappingDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#addMappingDialog' }));
 
@@ -499,6 +504,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
         target: 'KAFKA',
         value: '{apiHost}.entry.my:9092',
         tags: ['tag-1'],
+        environmentIds: [],
       });
     });
 
@@ -518,6 +524,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       await editButton.click();
 
       expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+      expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const submitButton = await rootLoader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
 
@@ -536,6 +543,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
         target: 'HTTP',
         value: 'https://my.new.entry',
         tags: ['tag-2'],
+        environmentIds: [],
       });
     });
   });

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
@@ -58,6 +58,8 @@ type EntrypointTableDS = {
   url: string;
   tags: string[];
   tagsName: string[];
+  environmentIds: string[];
+  environmentNames: string[];
 }[];
 @Component({
   selector: 'org-settings-entrypoints-and-sharding-tags',
@@ -84,7 +86,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   entrypointsTableDS: EntrypointTableDS;
   filteredEntrypointsTableDS: EntrypointTableDS;
   entrypointsTableUnpaginatedLength = 0;
-  entrypointsTableDisplayedColumns: string[] = ['target', 'entrypoint', 'tags', 'actions'];
+  entrypointsTableDisplayedColumns: string[] = ['target', 'entrypoint', 'tags', 'environments', 'actions'];
   shardingTagsLicenseOptions = { feature: ApimFeature.APIM_SHARDING_TAGS };
   hasShardingTagsLock$: Observable<boolean>;
 
@@ -173,12 +175,15 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
         this.initialDefaultConfigFormValues = this.defaultConfigForm.getRawValue();
 
         this.entrypoints = entrypoints;
+        const envNameById = new Map(environmentsPortalSettings.map((eps) => [eps.environment.id, eps.environment.name]));
         this.entrypointsTableDS = entrypoints.map((entrypoint) => ({
           id: entrypoint.id,
           target: MAPPING_TARGET_DISPLAYABLE[entrypoint.target],
           url: entrypoint.value,
           tags: entrypoint.tags,
           tagsName: (entrypoint.tags ?? []).map((tagId) => tags.find((t) => t.id === tagId)?.name ?? tagId),
+          environmentIds: entrypoint.environmentIds ?? [],
+          environmentNames: (entrypoint.environmentIds ?? []).map((envId) => envNameById.get(envId) ?? envId),
         }));
         this.filteredEntrypointsTableDS = this.entrypointsTableDS;
         this.entrypointsTableUnpaginatedLength = this.entrypointsTableDS.length;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Entrypoint.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Entrypoint.java
@@ -33,6 +33,7 @@ public class Entrypoint {
     private String target;
     private String value;
     private String tags;
+    private String environmentIds;
     private String referenceId;
     private EntrypointReferenceType referenceType;
 
@@ -66,6 +67,14 @@ public class Entrypoint {
 
     public void setTags(String tags) {
         this.tags = tags;
+    }
+
+    public String getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public void setEnvironmentIds(String environmentIds) {
+        this.environmentIds = environmentIds;
     }
 
     public String getReferenceId() {
@@ -112,6 +121,9 @@ public class Entrypoint {
             '\'' +
             ", tags='" +
             tags +
+            '\'' +
+            ", environmentIds='" +
+            environmentIds +
             '\'' +
             ", referenceId='" +
             referenceId +

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEntryPointRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEntryPointRepository.java
@@ -50,6 +50,7 @@ public class JdbcEntryPointRepository extends JdbcAbstractCrudRepository<Entrypo
             .addColumn("target", Types.NVARCHAR, String.class)
             .addColumn("value", Types.NVARCHAR, String.class)
             .addColumn("tags", Types.NVARCHAR, String.class)
+            .addColumn("environment_ids", Types.NVARCHAR, String.class)
             .addColumn("reference_id", Types.NVARCHAR, String.class)
             .addColumn("reference_type", Types.NVARCHAR, EntrypointReferenceType.class)
             .build();

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_8_0/05_add_environment_ids_to_entrypoints_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_8_0/05_add_environment_ids_to_entrypoints_table.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.8.0_05_add_environment_ids_to_entrypoints_table_1
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}entrypoints
+            columns:
+              - column:
+                  name: environment_ids
+                  type: nvarchar(4000)
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -265,3 +265,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_8_0/03_add_hrid_to_shared_policy_group_table.yml
     - include:
         - file: liquibase/changelogs/v4_8_0/04_add_hrid_to_apis_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_8_0/05_add_environment_ids_to_entrypoints_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
@@ -101,6 +101,7 @@ public class MongoEntrypointRepository implements EntrypointRepository {
             entrypointMongo.setReferenceId(entrypoint.getReferenceId());
             entrypointMongo.setReferenceType(entrypoint.getReferenceType());
             entrypointMongo.setTags(entrypoint.getTags());
+            entrypointMongo.setEnvironmentIds(entrypoint.getEnvironmentIds());
 
             EntrypointMongo entrypointMongoUpdated = internalEntryPointRepo.save(entrypointMongo);
             return mapper.map(entrypointMongoUpdated);
@@ -133,6 +134,7 @@ public class MongoEntrypointRepository implements EntrypointRepository {
                 entrypointMongo.setReferenceType(entrypoint.getReferenceType());
                 entrypoint.setValue(entrypointMongo.getValue());
                 entrypoint.setTags(entrypointMongo.getTags());
+                entrypoint.setEnvironmentIds(entrypointMongo.getEnvironmentIds());
                 return entrypoint;
             })
             .collect(Collectors.toSet());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
@@ -130,8 +130,8 @@ public class MongoEntrypointRepository implements EntrypointRepository {
                 final Entrypoint entrypoint = new Entrypoint();
                 entrypoint.setId(entrypointMongo.getId());
                 entrypoint.setTarget(entrypointMongo.getTarget());
-                entrypointMongo.setReferenceId(entrypoint.getReferenceId());
-                entrypointMongo.setReferenceType(entrypoint.getReferenceType());
+                entrypoint.setReferenceId(entrypointMongo.getReferenceId());
+                entrypoint.setReferenceType(entrypointMongo.getReferenceType());
                 entrypoint.setValue(entrypointMongo.getValue());
                 entrypoint.setTags(entrypointMongo.getTags());
                 entrypoint.setEnvironmentIds(entrypointMongo.getEnvironmentIds());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/EntrypointMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/EntrypointMongo.java
@@ -41,6 +41,7 @@ public class EntrypointMongo {
     private String target;
     private String value;
     private String tags;
+    private String environmentIds;
     private String referenceId;
     private EntrypointReferenceType referenceType;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EntrypointRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EntrypointRepositoryTest.java
@@ -48,6 +48,10 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         assertTrue("Entrypoint with environmentIds not found", withEnvIds.isPresent());
         assertEquals("env1;env2", withEnvIds.get().getEnvironmentIds());
 
+        // Verify referenceId and referenceType are correctly mapped from storage
+        assertEquals("DEFAULT", withEnvIds.get().getReferenceId());
+        assertEquals(EntrypointReferenceType.ORGANIZATION, withEnvIds.get().getReferenceType());
+
         // Verify environmentIds is null for entrypoints that don't have it
         Optional<Entrypoint> withoutEnvIds = entrypoints
             .stream()

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EntrypointRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EntrypointRepositoryTest.java
@@ -39,6 +39,22 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         assertNotNull(entrypoints);
         assertEquals(3, entrypoints.size());
         assertEquals("HTTP", entrypoints.iterator().next().getTarget());
+
+        // Verify environmentIds is loaded for the entrypoint that has it
+        Optional<Entrypoint> withEnvIds = entrypoints
+            .stream()
+            .filter(e -> "fa29c012-a0d2-4721-a9c0-12a0d26721db".equals(e.getId()))
+            .findFirst();
+        assertTrue("Entrypoint with environmentIds not found", withEnvIds.isPresent());
+        assertEquals("env1;env2", withEnvIds.get().getEnvironmentIds());
+
+        // Verify environmentIds is null for entrypoints that don't have it
+        Optional<Entrypoint> withoutEnvIds = entrypoints
+            .stream()
+            .filter(e -> "aaeddaec-0e94-4f49-adda-ec0e947f4965".equals(e.getId()))
+            .findFirst();
+        assertTrue("Entrypoint without environmentIds not found", withoutEnvIds.isPresent());
+        assertNull(withoutEnvIds.get().getEnvironmentIds());
     }
 
     @Test
@@ -50,6 +66,7 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         entrypoint.setReferenceType(EntrypointReferenceType.ORGANIZATION);
         entrypoint.setValue("Entrypoint value");
         entrypoint.setTags("internal;product");
+        entrypoint.setEnvironmentIds("env1;env3");
 
         int nbEntryPointsBeforeCreation = entrypointRepository.findByReference("DEFAULT", EntrypointReferenceType.ORGANIZATION).size();
         entrypointRepository.create(entrypoint);
@@ -61,6 +78,24 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         Assert.assertTrue("Entrypoint saved not found", optional.isPresent());
         assertEquals("Invalid saved entrypoint.", entrypoint, optional.get());
         assertEquals("Invalid saved target.", "HTTP", optional.get().getTarget());
+        assertEquals("Invalid saved environmentIds.", "env1;env3", optional.get().getEnvironmentIds());
+    }
+
+    @Test
+    public void shouldCreateWithNullEnvironmentIds() throws Exception {
+        final Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setId("new-entrypoint-no-env");
+        entrypoint.setTarget("HTTP");
+        entrypoint.setReferenceId("DEFAULT");
+        entrypoint.setReferenceType(EntrypointReferenceType.ORGANIZATION);
+        entrypoint.setValue("Entrypoint value no env");
+        entrypoint.setTags("internal");
+
+        entrypointRepository.create(entrypoint);
+
+        Optional<Entrypoint> optional = entrypointRepository.findById("new-entrypoint-no-env");
+        Assert.assertTrue("Entrypoint saved not found", optional.isPresent());
+        assertNull("environmentIds should be null", optional.get().getEnvironmentIds());
     }
 
     @Test
@@ -68,12 +103,14 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         Optional<Entrypoint> optional = entrypointRepository.findById("fa29c012-a0d2-4721-a9c0-12a0d26721db");
         Assert.assertTrue("EntryPoint to update not found", optional.isPresent());
         Assert.assertEquals("Invalid saved entrypoint value.", "https://public-api.company.com", optional.get().getValue());
+        Assert.assertEquals("Invalid saved environmentIds.", "env1;env2", optional.get().getEnvironmentIds());
 
         final Entrypoint entrypoint = optional.get();
         entrypoint.setValue("New value");
         entrypoint.setReferenceId("DEFAULT");
         entrypoint.setReferenceType(EntrypointReferenceType.ORGANIZATION);
         entrypoint.setTags("New tags");
+        entrypoint.setEnvironmentIds("env3");
 
         int nbEntryPointsBeforeUpdate = entrypointRepository.findByReference("DEFAULT", EntrypointReferenceType.ORGANIZATION).size();
         entrypointRepository.update(entrypoint);
@@ -86,6 +123,7 @@ public class EntrypointRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("Invalid saved entrypoint.", entrypoint, optionalUpdated.get());
         assertEquals("Invalid saved value.", "New value", optionalUpdated.get().getValue());
         assertEquals("Invalid saved tags.", "New tags", optionalUpdated.get().getTags());
+        assertEquals("Invalid saved environmentIds.", "env3", optionalUpdated.get().getEnvironmentIds());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/entrypoint-tests/entrypoints.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/entrypoint-tests/entrypoints.json
@@ -5,7 +5,8 @@
       "referenceId": "DEFAULT",
       "referenceType": "ORGANIZATION",
       "value": "https://public-api.company.com",
-      "tags": "public"
+      "tags": "public",
+      "environmentIds": "env1;env2"
    },
    {
       "id": "aaeddaec-0e94-4f49-adda-ec0e947f4965",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/EntrypointEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/EntrypointEntity.java
@@ -26,6 +26,7 @@ public class EntrypointEntity {
     private String id;
     private String value;
     private String[] tags;
+    private String[] environmentIds;
     private Target target;
 
     public String getId() {
@@ -50,6 +51,14 @@ public class EntrypointEntity {
 
     public void setTags(String[] tags) {
         this.tags = tags;
+    }
+
+    public String[] getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public void setEnvironmentIds(String[] environmentIds) {
+        this.environmentIds = environmentIds;
     }
 
     public Target getTarget() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewEntryPointEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewEntryPointEntity.java
@@ -36,6 +36,8 @@ public class NewEntryPointEntity {
     @Size(min = 1)
     private String[] tags;
 
+    private String[] environmentIds;
+
     public EntrypointEntity.Target getTarget() {
         return target;
     }
@@ -58,6 +60,14 @@ public class NewEntryPointEntity {
 
     public void setTags(String[] tags) {
         this.tags = tags;
+    }
+
+    public String[] getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public void setEnvironmentIds(String[] environmentIds) {
+        this.environmentIds = environmentIds;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateEntryPointEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateEntryPointEntity.java
@@ -38,6 +38,8 @@ public class UpdateEntryPointEntity {
     @Size(min = 1)
     private String[] tags;
 
+    private String[] environmentIds;
+
     public String getId() {
         return id;
     }
@@ -68,6 +70,14 @@ public class UpdateEntryPointEntity {
 
     public void setTags(String[] tags) {
         this.tags = tags;
+    }
+
+    public String[] getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public void setEnvironmentIds(String[] environmentIds) {
+        this.environmentIds = environmentIds;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
@@ -179,6 +179,9 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
         entrypoint.setTarget(entrypointEntity.getTarget().name());
         entrypoint.setValue(entrypointEntity.getValue());
         entrypoint.setTags(String.join(SEPARATOR, entrypointEntity.getTags()));
+        entrypoint.setEnvironmentIds(
+            entrypointEntity.getEnvironmentIds() != null ? String.join(SEPARATOR, entrypointEntity.getEnvironmentIds()) : null
+        );
         entrypoint.setReferenceId(executionContext.getOrganizationId());
         entrypoint.setReferenceType(repoEntrypointReferenceType(EntrypointReferenceType.ORGANIZATION));
         return entrypoint;
@@ -190,6 +193,9 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
         entrypoint.setTarget(entrypointEntity.getTarget().name());
         entrypoint.setValue(entrypointEntity.getValue());
         entrypoint.setTags(String.join(SEPARATOR, entrypointEntity.getTags()));
+        entrypoint.setEnvironmentIds(
+            entrypointEntity.getEnvironmentIds() != null ? String.join(SEPARATOR, entrypointEntity.getEnvironmentIds()) : null
+        );
         return entrypoint;
     }
 
@@ -199,6 +205,11 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
         entrypointEntity.setTarget(EntrypointEntity.Target.valueOf(entrypoint.getTarget()));
         entrypointEntity.setValue(entrypoint.getValue());
         entrypointEntity.setTags(entrypoint.getTags().split(SEPARATOR));
+        entrypointEntity.setEnvironmentIds(
+            entrypoint.getEnvironmentIds() != null && !entrypoint.getEnvironmentIds().isEmpty()
+                ? entrypoint.getEnvironmentIds().split(SEPARATOR)
+                : null
+        );
         return entrypointEntity;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
@@ -256,9 +256,7 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
 
         if (host == null || !isOverride) {
             List<AccessPoint> accessPoints = this.accessPointQueryService.getGatewayAccessPoints(environmentId);
-            if (accessPoints.isEmpty()) {
-                entrypoints.add(createHttpApiEntrypointEntity(defaultScheme, entrypointHost, path, tags, host));
-            } else if (tags != null && !tags.isEmpty()) {
+            if (accessPoints.isEmpty() || (tags != null && !tags.isEmpty())) {
                 entrypoints.add(createHttpApiEntrypointEntity(defaultScheme, entrypointHost, path, tags, host));
             } else {
                 for (AccessPoint accessPoint : accessPoints) {
@@ -313,9 +311,7 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
         List<ApiEntrypointEntity> entrypoints = new ArrayList<>();
         List<AccessPoint> accessPoints = this.accessPointQueryService.getKafkaGatewayAccessPoints(environmentId);
 
-        if (accessPoints.isEmpty()) {
-            entrypoints.add(createKafkaNativeApiEntrypointEntity(host, domain, port, tags));
-        } else if (tags != null && !tags.isEmpty()) {
+        if (accessPoints.isEmpty() || (tags != null && !tags.isEmpty())) {
             entrypoints.add(createKafkaNativeApiEntrypointEntity(host, domain, port, tags));
         } else {
             for (AccessPoint accessPoint : accessPoints) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
@@ -109,6 +109,13 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
                 if (!isEntrypointMatching) {
                     return;
                 }
+                // Filter by environment
+                String[] entrypointEnvironmentIds = entrypoint.getEnvironmentIds();
+                if (entrypointEnvironmentIds != null && entrypointEnvironmentIds.length > 0) {
+                    if (!Arrays.asList(entrypointEnvironmentIds).contains(executionContext.getEnvironmentId())) {
+                        return;
+                    }
+                }
                 if (!hasSupportedListeners(genericApiEntity)) {
                     return;
                 }
@@ -249,7 +256,9 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
 
         if (host == null || !isOverride) {
             List<AccessPoint> accessPoints = this.accessPointQueryService.getGatewayAccessPoints(environmentId);
-            if (accessPoints.isEmpty() || (tags != null && !tags.isEmpty())) {
+            if (accessPoints.isEmpty()) {
+                entrypoints.add(createHttpApiEntrypointEntity(defaultScheme, entrypointHost, path, tags, host));
+            } else if (tags != null && !tags.isEmpty()) {
                 entrypoints.add(createHttpApiEntrypointEntity(defaultScheme, entrypointHost, path, tags, host));
             } else {
                 for (AccessPoint accessPoint : accessPoints) {
@@ -304,7 +313,9 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
         List<ApiEntrypointEntity> entrypoints = new ArrayList<>();
         List<AccessPoint> accessPoints = this.accessPointQueryService.getKafkaGatewayAccessPoints(environmentId);
 
-        if (accessPoints.isEmpty() || (tags != null && !tags.isEmpty())) {
+        if (accessPoints.isEmpty()) {
+            entrypoints.add(createKafkaNativeApiEntrypointEntity(host, domain, port, tags));
+        } else if (tags != null && !tags.isEmpty()) {
             entrypoints.add(createKafkaNativeApiEntrypointEntity(host, domain, port, tags));
         } else {
             for (AccessPoint accessPoint : accessPoints) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EntrypointServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EntrypointServiceTest.java
@@ -54,6 +54,8 @@ public class EntrypointServiceTest {
     private static final String VALUE = "https://api.mycompany.com";
     private static final String TAG = "private;product";
     private static final String[] TAGS = new String[] { "private", "product" };
+    private static final String ENVIRONMENT_IDS = "env1;env2";
+    private static final String[] ENVIRONMENT_IDS_ARRAY = new String[] { "env1", "env2" };
 
     private static final String NEW_VALUE = "https://public-api.mycompany.com";
     private static final String NEW_TAG = "public;product";
@@ -82,6 +84,7 @@ public class EntrypointServiceTest {
         entrypointCreated.setTarget(HTTP);
         entrypointCreated.setValue(VALUE);
         entrypointCreated.setTags(TAG);
+        entrypointCreated.setEnvironmentIds(ENVIRONMENT_IDS);
         when(entrypointRepository.create(any())).thenReturn(entrypointCreated);
         when(
             entrypointRepository.findByIdAndReference(
@@ -104,12 +107,17 @@ public class EntrypointServiceTest {
         entrypoint.setTarget(EntrypointEntity.Target.HTTP);
         entrypoint.setValue(VALUE);
         entrypoint.setTags(TAGS);
+        entrypoint.setEnvironmentIds(ENVIRONMENT_IDS_ARRAY);
         final EntrypointEntity entrypointEntity = entrypointService.create(GraviteeContext.getExecutionContext(), entrypoint);
         assertEquals(ID, entrypointEntity.getId());
         assertEquals(EntrypointEntity.Target.HTTP, entrypointEntity.getTarget());
         assertEquals(VALUE, entrypointEntity.getValue());
         assertNotNull(entrypointEntity.getTags());
         assertEquals(2, entrypointEntity.getTags().length);
+        assertNotNull(entrypointEntity.getEnvironmentIds());
+        assertEquals(2, entrypointEntity.getEnvironmentIds().length);
+        assertEquals("env1", entrypointEntity.getEnvironmentIds()[0]);
+        assertEquals("env2", entrypointEntity.getEnvironmentIds()[1]);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
@@ -725,6 +725,117 @@ class ApiEntrypointServiceImplTest {
             .anySatisfy(e -> assertThat(e.getTarget()).contains("https://gateway.example.com/v1"));
     }
 
+    @Test
+    void shouldIncludeEntrypointWhenEnvironmentIdsMatchesCurrentEnvironment() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("tag"));
+        HttpListener httpListener = HttpListener.builder().paths(List.of(Path.builder().host("host").path("path").build())).build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointEntity = new EntrypointEntity();
+        entrypointEntity.setTags(Arrays.array("tag"));
+        entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
+        entrypointEntity.setEnvironmentIds(new String[] { GraviteeContext.getExecutionContext().getEnvironmentId() });
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://tag-entrypoint/path");
+    }
+
+    @Test
+    void shouldExcludeEntrypointWhenEnvironmentIdsDoesNotMatchCurrentEnvironment() {
+        when(parameterService.find(any(), eq(Key.PORTAL_ENTRYPOINT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "https://default-entrypoint"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("tag"));
+        HttpListener httpListener = HttpListener.builder().paths(List.of(Path.builder().host("host").path("path").build())).build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointEntity = new EntrypointEntity();
+        entrypointEntity.setTags(Arrays.array("tag"));
+        entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
+        entrypointEntity.setEnvironmentIds(new String[] { "other-env" });
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://default-entrypoint/path");
+    }
+
+    @Test
+    void shouldIncludeEntrypointWhenEnvironmentIdsIsNull() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("tag"));
+        HttpListener httpListener = HttpListener.builder().paths(List.of(Path.builder().host("host").path("path").build())).build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointEntity = new EntrypointEntity();
+        entrypointEntity.setTags(Arrays.array("tag"));
+        entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
+        entrypointEntity.setEnvironmentIds(null);
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://tag-entrypoint/path");
+    }
+
+    @Test
+    void shouldIncludeEntrypointWhenEnvironmentIdsIsEmpty() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("tag"));
+        HttpListener httpListener = HttpListener.builder().paths(List.of(Path.builder().host("host").path("path").build())).build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointEntity = new EntrypointEntity();
+        entrypointEntity.setTags(Arrays.array("tag"));
+        entrypointEntity.setValue("https://tag-entrypoint");
+        entrypointEntity.setTarget(EntrypointEntity.Target.HTTP);
+        entrypointEntity.setEnvironmentIds(new String[] {});
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointEntity));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://tag-entrypoint/path");
+    }
+
     @Nested
     class createHttpApiEntrypointEntity {
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12407

## Description

When gateways across different environments share the same sharding tag, the Console UI displays ALL entrypoint URLs (e.g. Prod + Test) regardless of the current environment. This PR adds explicit environment association to entrypoint mappings.

### Changes

**Repository layer**
- Add `environmentIds` field to the `Entrypoint` domain model (semicolon-separated storage, like tags 🤷‍♂️ )
- MongoDB & JDBC persistence support
- JDBC Liquibase migration for the new column

**REST API & Service layer**
- Add `environmentIds` to `EntrypointEntity`, `NewEntryPointEntity`, `UpdateEntryPointEntity`
- Conversion logic (array <-> semicolon-separated string) in `EntrypointServiceImpl`
- Environment filter in `ApiEntrypointServiceImpl`: when an entrypoint has `environmentIds` set, it is only included if the current environment matches. If `environmentIds` is null/empty, the entrypoint applies to all environments (backward compatible).

**Console UI**
- Add multi-select "Environments" field to the entrypoint mapping dialog
- Display environment names in the entrypoints table ("All" when empty)

### Backward compatibility

Existing entrypoint mappings have no `environmentIds` set, so they continue to apply to all environments — no migration needed.

## Video

https://github.com/user-attachments/assets/dfa46e8a-60e2-45ce-a695-9e9eebc8f88e

