### PR TITLE
feat: view portal subscriptions - update common styles.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.scss
@@ -13,3 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../../scss/theme' as theme;
+
+:host {
+  display: flex;
+  max-width: theme.$inner-content-width;
+  flex-direction: column;
+}

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.scss
@@ -22,7 +22,7 @@
 
 gmd-viewer {
   display: block;
-  max-width: theme.$gmd-viewer-max-width;
+  max-width: theme.$inner-content-width;
 }
 
 .empty-state {

--- a/gravitee-apim-portal-webui-next/src/scss/m3-adapter.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/m3-adapter.scss
@@ -21,7 +21,7 @@ After migrating to Material 3, these classes can be deleted.
 
 @use './theme';
 
-// Typography
+// Legacy typography (next gen typography is in ./typography.scss)
 
 .m3-display-large {
   font-size: 57px;

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -117,3 +117,30 @@ mat-card {
     )
   );
 }
+
+mat-icon,
+.material-icons {
+  display: inline-block;
+  direction: ltr;
+  font-family: 'Material Icons', serif;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
+  font-size: 24px; /* Preferred icon size */
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-height: 1;
+
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizelegibility;
+  text-transform: none;
+  white-space: nowrap;
+  word-wrap: normal;
+}

--- a/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
@@ -33,7 +33,10 @@ $tertiary-main-color: var(--gio-app-tertiary-main-color);
 $error-main-color: var(--gio-app-error-main-color);
 
 // -- Shapes --
-$container-shape: 4px;
+$container-shape: 8px;
+
+// Dimensions
+$inner-content-width: 1440px;
 
 // -- Borders --
 $border-color: var(--gio-app-outline-color, #c7c7c7);
@@ -117,4 +120,3 @@ $chip-background: var(--gio-app-chip-container-color, $card-background-color);
 $select-panel-background-color: color-mix(in srgb, $banner-background-color 12%, $card-background-color);
 $calendar-background-color: color-mix(in srgb, $banner-background-color 50%, $card-background-color);
 $primary-highlight-color: color-mix(in srgb, $primary-main-color 8%, white 92%);
-$gmd-viewer-max-width: 1400px;

--- a/gravitee-apim-portal-webui-next/src/scss/typography.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/typography.scss
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use './theme';
+
+// Next gen typography
+
+.next-gen-h1 {
+  font-size: 48px;
+  font-weight: bold;
+  line-height: 56px;
+}
+
+.next-gen-h2 {
+  font-size: 32px;
+  font-weight: bold;
+  line-height: 48px;
+}
+
+.next-gen-h3 {
+  font-size: 24px;
+  font-weight: bold;
+  line-height: 30px;
+}
+
+.next-gen-h4 {
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 25px;
+}
+
+.next-gen-h5 {
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 27px;
+}
+
+%next-gen-body-shared {
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.next-gen-body {
+  @extend %next-gen-body-shared;
+
+  font-weight: normal;
+}
+
+.next-gen-body-strong {
+  @extend %next-gen-body-shared;
+
+  font-weight: bold;
+}
+
+%next-gen-small-shared {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.next-gen-small {
+  @extend %next-gen-small-shared;
+
+  font-weight: normal;
+}
+
+.next-gen-small-bold {
+  @extend %next-gen-small-shared;
+
+  font-weight: bold;
+}
+
+.next-gen-caption {
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 16px;
+}
+
+// Icons sizes
+
+.material-icons.icon-small {
+  font-size: 16px;
+}

--- a/gravitee-apim-portal-webui-next/src/styles.scss
+++ b/gravitee-apim-portal-webui-next/src/styles.scss
@@ -72,30 +72,3 @@ body {
     }
   }
 }
-
-mat-icon,
-.material-icons {
-  display: inline-block;
-  direction: ltr;
-  font-family: 'Material Icons', serif;
-
-  /* Support for IE. */
-  font-feature-settings: 'liga';
-  font-size: 24px; /* Preferred icon size */
-
-  /* Support for all WebKit browsers. */
-  -webkit-font-smoothing: antialiased;
-
-  /* Support for Firefox. */
-  -moz-osx-font-smoothing: grayscale;
-  font-style: normal;
-  font-weight: normal;
-  letter-spacing: normal;
-  line-height: 1;
-
-  /* Support for Safari and Chrome. */
-  text-rendering: optimizelegibility;
-  text-transform: none;
-  white-space: nowrap;
-  word-wrap: normal;
-}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12270

## Description
This PR follows the work started in [this PR](https://github.com/gravitee-io/gravitee-api-management/pull/15138) and makes changes to common styles in the portal.

### Included in this PR
- new typography classes based on https://www.figma.com/design/eAS6p0kITPnEI0VPbmATi3/Developer-Portal?node-id=39873-3779&t=AKysU4hEn1k1Cmy5-0
- icon styles are moved out of global styles.scss to make them overridable and allow for different icon sizes
- new `inner-content()` mixin to replace the old `gmd-viewer-max-width` variable in the theme
- new `container-shape` radius
### Excluded from this PR (will be done in subsequent PRs)
- style changes specific to subscriptions