### PR TITLE
test: add test on secrets evaluation from API properties

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
@@ -71,14 +71,15 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
     private static final String VAULT_TOKEN = UUID.randomUUID().toString();
 
     @Container
-    private static final VaultContainer vaultContainer = new VaultContainer<>("hashicorp/vault:1.13.3")
+    private static final VaultContainer<?> vaultContainer = new VaultContainer<>("hashicorp/vault:1.13.3")
         .withVaultToken(VAULT_TOKEN)
         .withInitCommand(
             "kv put secret/test" +
                 " value1='initial value1'" +
                 " value2='initial value2'" +
                 " value3='initial value3'" +
-                " value4='initial value4'",
+                " value4='initial value4'" +
+                " value5='initial value5'",
             "kv put secret/test2 value1='initial testValue1'"
         );
 
@@ -172,6 +173,7 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
                 .withHeader("X-Secret-URI-renewable", equalTo("initial value2"))
                 .withHeader("X-Secret-URI-reloadOnChange", equalTo("initial value3"))
                 .withHeader("X-Secret-Dictionary", equalTo("initial value4"))
+                .withHeader("X-Secret-Properties", equalTo("initial value5"))
         );
 
         // Update the secret in the provider
@@ -183,7 +185,8 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
             "value1=updated value1",
             "value2=updated value2",
             "value3=updated value3",
-            "value4=updated value4"
+            "value4=updated value4",
+            "value5=updated value5"
         );
 
         // Wait and check that the API retrieves the updated secret
@@ -210,6 +213,7 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
                         .withHeader("X-Secret-URI-renewable", equalTo("updated value2"))
                         .withHeader("X-Secret-URI-reloadOnChange", equalTo("updated value3"))
                         .withHeader("X-Secret-Dictionary", equalTo("updated value4"))
+                        .withHeader("X-Secret-Properties", equalTo("updated value5"))
                 );
             });
     }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsV4IntegrationTest.java
@@ -142,12 +142,11 @@ public class SecretsV4IntegrationTest extends AbstractGatewayTest {
 
     @Override
     public void configureApi(ReactableApi<?> reactableApi, Class<?> definitionClass) {
-        if (!isV4Api(definitionClass)) {
+        if (reactableApi.getDefinition() instanceof Api apiDefinition) {
+            updateEndpointsPort(apiDefinition, backendPort);
+        } else {
             throw new AssertionError("Api should only be v4 api");
         }
-        final Api apiDefinition = (Api) reactableApi.getDefinition();
-
-        updateEndpointsPort(apiDefinition, backendPort);
     }
 
     @Test

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-with-secrets.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-with-secrets.json
@@ -48,6 +48,10 @@
                         {
                           "name": "X-Secret-Dictionary",
                           "value": "{#secrets.get(#dictionaries['test']['value4']?reloadOnChange=true)}"
+                        },
+                        {
+                          "name": "X-Secret-Properties",
+                          "value": "{#secrets.get(#api.properties['value5']?reloadOnChange=true)}"
                         }
                       ],
                         "http": {
@@ -73,6 +77,14 @@
             ]
         }
     ],
+  "properties": [
+    {
+      "key": "value5",
+      "value": "/vault/secret/test:value5?renewable=true",
+      "encrypted": false,
+      "dynamic": false
+    }
+  ],
     "analytics": {
         "enabled": false
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12734

## Description

I add a test to ensure that we are able to evaluate secrets from API’s properties

