### PR TITLE
fix(papi): handle null period time in quota/rate-limit config

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PlanMapperTest.java
@@ -579,6 +579,29 @@ public class PlanMapperTest {
         assertNull(responsePlan.getUsageConfiguration().getQuota());
     }
 
+    @Test
+    public void shouldMapMissingPeriodTimeForApiKeyPlan() {
+        var step = new io.gravitee.definition.model.v4.flow.step.Step();
+        step.setPolicy(RATE_LIMIT);
+        step.setConfiguration("{ \"rate\": { \"limit\": 10 } }");
+        step.setEnabled(true);
+
+        var flow1 = new io.gravitee.definition.model.v4.flow.Flow();
+        flow1.setRequest(List.of(step));
+        flow1.setEnabled(true);
+
+        planEntityV4.setFlows(List.of(flow1));
+
+        Plan responsePlan = planMapper.convert(planEntityV4, aV4Api);
+        assertNotNull(responsePlan);
+        assertNotNull(responsePlan.getUsageConfiguration());
+        var rateLimit = responsePlan.getUsageConfiguration().getRateLimit();
+        assertNotNull(rateLimit);
+        assertEquals(10L, rateLimit.getLimit());
+        assertNull(rateLimit.getPeriodTime());
+        assertNull(rateLimit.getPeriodTimeUnit());
+    }
+
     private void preparePlanEntityV2() {
         planEntityV2 = new PlanEntity();
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-policy-quota.version>4.1.1</gravitee-policy-quota.version>    -->
         <!--    <gravitee-policy-spikearrest.version>4.1.1</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>4.2.0</gravitee-policy-ratelimit.version>
+        <gravitee-policy-ratelimit.version>4.2.1</gravitee-policy-ratelimit.version>
         <gravitee-policy-regex-threat-protection.version>1.6.0</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.1</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.15.1</gravitee-policy-request-validation.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12640

## Description

After changes to the quota and rate-limit policies, sometimes the period time can be null. 
This change gracefully handles when the `periodTime` parameter is not defined.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

