### PR TITLE
chore(portal-next): remove unused gravitee dashboard route

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { inject } from '@angular/core';
 import { Routes } from '@angular/router';
 
-import { GraviteeDashboardComponent, GraviteeDashboardService } from '@gravitee/gravitee-dashboard';
 import { GraviteeMarkdownComponent } from '@gravitee/gravitee-markdown';
 
 import { ApiDetailsComponent } from './api/api-details/api-details.component';
@@ -249,14 +247,6 @@ export const routes: Routes = [
         component: DocumentationComponent,
       },
     ],
-  },
-  {
-    path: 'analytics',
-    component: GraviteeDashboardComponent,
-    resolve: {
-      widgets: () => inject(GraviteeDashboardService).getWidgets(),
-      baseURL: () => 'https://apim-master-api.team-apim.gravitee.dev/management/v2/organizations/DEFAULT/environments/DEFAULT',
-    },
   },
   {
     path: 'log-in',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Route no longer used for the gravitee dashboard in the NG Portal.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

