### PR TITLE
fix: implement command TTL and expired command cleanup by primary node

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.services.sync.process.common.deployer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.common.utils.UUID;
 import io.gravitee.definition.model.command.SubscriptionFailureCommand;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
@@ -36,9 +35,7 @@ import io.gravitee.repository.management.model.MessageRecipient;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.vertx.core.json.JsonObject;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -167,13 +164,9 @@ public class SubscriptionDeployer implements Deployer<SubscriptionDeployable> {
     private Completable sendFailureCommand(Subscription subscription, Throwable throwable) {
         return Completable.fromRunnable(() -> {
             final Command command = new Command();
-            Instant now = Instant.now();
-            command.setId(UUID.random().toString());
             command.setFrom(node.id());
             command.setTo(MessageRecipient.MANAGEMENT_APIS.name());
             command.setTags(List.of(CommandTags.SUBSCRIPTION_FAILURE.name()));
-            command.setCreatedAt(Date.from(now));
-            command.setUpdatedAt(Date.from(now));
             command.setEnvironmentId(subscription.getEnvironmentId());
 
             convertSubscriptionCommand(subscription, command, throwable);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CommandRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -40,4 +41,11 @@ public interface CommandRepository extends CrudRepository<Command, String> {
      * @return List of IDs for deleted commands
      */
     List<String> deleteByOrganizationId(String organizationId) throws TechnicalException;
+
+    /**
+     * Delete commands that expired before the given instant
+     * @param before the cutoff instant
+     * @return number of deleted commands
+     */
+    int deleteByExpiredAtBefore(Instant before) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Command.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Command.java
@@ -15,23 +15,17 @@
  */
 package io.gravitee.repository.management.model;
 
+import io.gravitee.common.utils.UUID;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@AllArgsConstructor
-@NoArgsConstructor
 @Data
-@Builder
 public class Command {
 
     private String id;
@@ -45,4 +39,12 @@ public class Command {
     private Date expiredAt;
     private Date createdAt;
     private Date updatedAt;
+
+    public Command() {
+        var now = new Date();
+        this.id = UUID.random().toString();
+        this.expiredAt = Date.from(now.toInstant().plus(Duration.ofMinutes(5)));
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
@@ -22,10 +22,12 @@ import io.gravitee.repository.management.model.Command;
 import io.gravitee.repository.mongodb.management.internal.message.CommandMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.CommandMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,7 @@ import org.springframework.stereotype.Component;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 @Component
 public class MongoCommandRepository implements CommandRepository {
 
@@ -130,6 +133,18 @@ public class MongoCommandRepository implements CommandRepository {
         } catch (Exception ex) {
             logger.error("Failed to delete commands by organizationId: {}", organizationId, ex);
             throw new TechnicalException("Failed to delete commands by organizationId");
+        }
+    }
+
+    @Override
+    public int deleteByExpiredAtBefore(Instant before) throws TechnicalException {
+        log.debug("Delete by expiredAt before [{}]", before);
+        try {
+            int deletedCount = internalMessageRepo.deleteByExpiredAtBefore(before).size();
+            log.debug("Delete by expiredAt before [{}] - Done. Deleted {} commands", before, deletedCount);
+            return deletedCount;
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to delete expired commands before " + before, ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/message/CommandMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/message/CommandMongoRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management.internal.message;
 
 import io.gravitee.repository.mongodb.management.internal.model.CommandMongo;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
@@ -32,4 +33,7 @@ public interface CommandMongoRepository extends MongoRepository<CommandMongo, St
 
     @Query(value = "{ 'organizationId': ?0 }", fields = "{ _id : 1 }", delete = true)
     List<CommandMongo> deleteByOrganizationId(String organizationId);
+
+    @Query(value = "{ 'expiredAt': { $lt: ?0 } }", fields = "{ _id : 1 }", delete = true)
+    List<CommandMongo> deleteByExpiredAtBefore(Instant before);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpCommandRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -39,5 +40,10 @@ public class NoOpCommandRepository extends AbstractNoOpManagementRepository<Comm
     @Override
     public List<String> deleteByOrganizationId(String organizationId) {
         return List.of();
+    }
+
+    @Override
+    public int deleteByExpiredAtBefore(Instant before) {
+        return 0;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/command-tests/commands.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/command-tests/commands.json
@@ -55,7 +55,7 @@
     "to": "MANAGEMENT_API",
     "tags": ["DATA_TO_INDEX", "INSERT"],
     "acknowledgments": ["node1", "node2"],
-    "expiredAt": 2122484400000,
+    "expiredAt": 2127427200000,
     "createdAt": 1546305346000,
     "updatedAt": 1548983746000
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CommandService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CommandService.java
@@ -19,6 +19,7 @@ import io.gravitee.rest.api.model.command.CommandEntity;
 import io.gravitee.rest.api.model.command.CommandQuery;
 import io.gravitee.rest.api.model.command.NewCommandEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -33,4 +34,6 @@ public interface CommandService {
     List<CommandEntity> search(ExecutionContext executionContext, CommandQuery query);
     void ack(String messageId);
     void delete(String commandId);
+
+    int deleteByExpiredAtBefore(Instant before);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/CommandConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/CommandConverter.java
@@ -21,7 +21,6 @@ import io.gravitee.rest.api.model.command.CommandEntity;
 import io.gravitee.rest.api.model.command.CommandTags;
 import io.gravitee.rest.api.model.command.NewCommandEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -62,18 +61,14 @@ public class CommandConverter {
     }
 
     public Command toCommand(ExecutionContext executionContext, NewCommandEntity commandEntity) {
-        Instant now = Instant.now();
-        Instant expireAt = now.plus(Duration.ofSeconds(commandEntity.getTtlInSeconds()));
+        Instant expireAt = Instant.now().plus(Duration.ofSeconds(commandEntity.getTtlInSeconds()));
         Command command = new Command();
-        command.setId(UuidString.generateRandom());
         command.setOrganizationId(executionContext.getOrganizationId());
         command.setEnvironmentId(executionContext.hasEnvironmentId() ? executionContext.getEnvironmentId() : null);
         command.setFrom(node.id());
         command.setTo(commandEntity.getTo());
-        command.setTags(toStrings(commandEntity.getTags()));
-        command.setCreatedAt(Date.from(now));
-        command.setUpdatedAt(Date.from(now));
         command.setExpiredAt(Date.from(expireAt));
+        command.setTags(toStrings(commandEntity.getTags()));
         if (commandEntity.getContent() != null) {
             command.setContent(commandEntity.getContent());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
@@ -28,10 +28,12 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.converter.CommandConverter;
 import io.gravitee.rest.api.service.exceptions.Message2RecipientNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,7 @@ import org.springframework.stereotype.Component;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 @Component
 public class CommandServiceImpl extends AbstractService implements CommandService {
 
@@ -124,6 +127,17 @@ public class CommandServiceImpl extends AbstractService implements CommandServic
             final String error = "An error occurs while trying to delete command " + commandId;
             logger.error(error, ex);
             throw new TechnicalManagementException(error, ex);
+        }
+    }
+
+    @Override
+    public int deleteByExpiredAtBefore(Instant before) {
+        try {
+            int deletedCount = commandRepository.deleteByExpiredAtBefore(before);
+            log.debug("Deleted {} expired commands before {}", deletedCount, before);
+            return deletedCount;
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to delete expired commands", ex);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -440,16 +440,11 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         String memberId,
         ExecutionContext context
     ) {
-        Instant timestamp = Instant.now();
-        Command command = Command.builder()
-            .id(UUID.random().toString())
-            .organizationId(context.getOrganizationId())
-            .from(this.node.id())
-            .to(MessageRecipient.MANAGEMENT_APIS.name())
-            .tags(List.of(CommandTags.GROUP_DEFAULT_ROLES_UPDATE.name()))
-            .createdAt(Date.from(timestamp))
-            .updatedAt(Date.from(timestamp))
-            .build();
+        Command command = new Command();
+        command.setOrganizationId(context.getOrganizationId());
+        command.setFrom(node.id());
+        command.setTo(MessageRecipient.MANAGEMENT_APIS.name());
+        command.setTags(List.of(CommandTags.GROUP_DEFAULT_ROLES_UPDATE.name()));
 
         if (context.hasEnvironmentId()) {
             command.setEnvironmentId(context.getEnvironmentId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
@@ -28,7 +28,6 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import io.gravitee.apim.infra.template.FreemarkerConfigurationFactory;
 import io.gravitee.common.event.EventManager;
-import io.gravitee.common.utils.UUID;
 import io.gravitee.node.api.Node;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.CommandTags;
@@ -66,7 +65,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -539,18 +537,14 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
     }
 
     private void sendUpdateTemplateCommand(NotificationTemplateEntity notificationTemplate, String organization) {
-        Instant now = Instant.now();
-        var command = Command.builder()
-            .id(UUID.random().toString())
-            .from(node.id())
-            .to(MessageRecipient.MANAGEMENT_APIS.name())
-            .organizationId(organization)
-            .tags(List.of(CommandTags.EMAIL_TEMPLATE_UPDATE.name()))
-            .createdAt(Date.from(now))
-            .updatedAt(Date.from(now));
+        var command = new Command();
+        command.setFrom(node.id());
+        command.setTo(MessageRecipient.MANAGEMENT_APIS.name());
+        command.setOrganizationId(organization);
+        command.setTags(List.of(CommandTags.EMAIL_TEMPLATE_UPDATE.name()));
 
         try {
-            command.content(
+            command.setContent(
                 objectMapper.writeValueAsString(notificationTemplateMapper.toNotificationTemplateCommandEntity(notificationTemplate))
             );
         } catch (JsonProcessingException e) {
@@ -564,7 +558,7 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
         }
 
         try {
-            commandRepository.create(command.build());
+            commandRepository.create(command);
         } catch (TechnicalException e) {
             log.error("Failed to create template update command [{}] for organization [{}]", notificationTemplate.getId(), organization, e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -702,21 +702,17 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
         ParameterReferenceType referenceType,
         ExecutionContext context
     ) {
-        Instant timestamp = Instant.now();
-        Command command = Command.builder()
-            .id(UUID.random().toString())
-            .organizationId(context.getOrganizationId())
-            .from(this.node.id())
-            .to(MessageRecipient.MANAGEMENT_APIS.name())
-            .tags(List.of(CommandTags.PARAMETER_CACHE_UPDATE.name()))
-            .createdAt(Date.from(timestamp))
-            .updatedAt(Date.from(timestamp))
-            .build();
+        Command command = new Command();
+        command.setOrganizationId(context.getOrganizationId());
+        command.setFrom(node.id());
+        command.setTo(MessageRecipient.MANAGEMENT_APIS.name());
+        command.setTags(List.of(CommandTags.PARAMETER_CACHE_UPDATE.name()));
 
         if (context.hasEnvironmentId()) {
             command.setEnvironmentId(context.getEnvironmentId());
         }
 
+        Instant timestamp = Instant.now();
         InvalidateParameterCacheCommandEntity eventData = InvalidateParameterCacheCommandEntity.builder()
             .key(key)
             .referenceId(referenceId)
@@ -726,7 +722,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
             .build();
 
         try {
-            String content = this.objectMapper.writeValueAsString(eventData);
+            String content = objectMapper.writeValueAsString(eventData);
             command.setContent(content);
         } catch (JsonProcessingException e) {
             LOGGER.error("Failed to serialize parameter cache invalidation data {}", eventData, e);


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/APIM-12680
- https://gravitee.atlassian.net/browse/APIM-12757


## Description

- Set default TTL of 5 minutes for commands.
- Ensure primary node handles automatic cleanup of expired commands.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

