### PR TITLE
fix(api-product): populate subscription cache before product deploy event

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiProductManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiProductManager.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.api.manager;
 
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
 
 /**
@@ -29,6 +30,18 @@ public interface ApiProductManager {
      * @param apiProduct the API Product to register
      */
     void register(ReactableApiProduct apiProduct);
+
+    /**
+     * Register (deploy or update) an API Product, running the given Completable before emitting
+     * the change event. Use this when subscription/API key cache must be populated before
+     * the event is emitted. The Completable is chained so the event is emitted only after
+     * it completes, avoiding thread blocking.
+     *
+     * @param apiProduct the API Product to register
+     * @param doBeforeEmit Completable to run after product is in registry but before the event is emitted
+     * @return Completable that completes when registration and event emission are done
+     */
+    Completable register(ReactableApiProduct apiProduct, Completable doBeforeEmit);
 
     /**
      * Unregister (undeploy) an API Product

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -30,6 +30,7 @@ import io.gravitee.gateway.handlers.sharedpolicygroup.manager.SharedPolicyGroupM
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
 import io.gravitee.gateway.services.sync.healthcheck.SyncProcessProbe;
+import io.gravitee.gateway.services.sync.process.common.deployer.ApiProductSubscriptionRefresher;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.gateway.services.sync.process.deployer.NoOpSubscriptionDispatcher;
@@ -203,7 +204,8 @@ public class SyncConfiguration {
         SharedPolicyGroupManager sharedPolicyGroupManager,
         DistributedSyncService distributedSyncService,
         ApiProductManager apiProductManager,
-        @Autowired(required = false) ApiProductPlanDefinitionCache apiProductPlanDefinitionCache
+        @Autowired(required = false) ApiProductPlanDefinitionCache apiProductPlanDefinitionCache,
+        @Autowired(required = false) ApiProductSubscriptionRefresher apiProductSubscriptionRefresher
     ) {
         Supplier<SubscriptionDispatcher> subscriptionDispatcherSupplier = provideSubscriptionDispatcher(subscriptionDispatcher);
         return new DeployerFactory(
@@ -225,7 +227,8 @@ public class SyncConfiguration {
             sharedPolicyGroupManager,
             distributedSyncService,
             apiProductManager,
-            apiProductPlanDefinitionCache
+            apiProductPlanDefinitionCache,
+            apiProductSubscriptionRefresher
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common.deployer;
+
+import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
+import static io.gravitee.repository.management.model.Subscription.Status.CLOSED;
+import static io.gravitee.repository.management.model.Subscription.Status.PAUSED;
+import static io.gravitee.repository.management.model.Subscription.Status.PENDING;
+
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
+import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
+import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.SubscriptionReferenceType;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@CustomLog
+@RequiredArgsConstructor
+public class ApiProductSubscriptionRefresher {
+
+    private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final ApiKeyRepository apiKeyRepository;
+    private final SubscriptionMapper subscriptionMapper;
+    private final ApiKeyMapper apiKeyMapper;
+    private final SubscriptionService subscriptionService;
+    private final ApiKeyService apiKeyService;
+
+    /**
+     * Refreshes subscriptions for the given API Product plans.
+     * Loads all subscriptions for the plans, explodes them to all APIs via SubscriptionMapper,
+     * and deploys them using the subscription and API key deployers.
+     *
+     * @param subscribablePlans the plan IDs to refresh subscriptions for
+     * @param environments the environments to filter by
+     * @return a Completable that completes when subscriptions are refreshed
+     */
+    public Completable refresh(final Set<String> subscribablePlans, final Set<String> environments) {
+        if (subscribablePlans == null || subscribablePlans.isEmpty()) {
+            log.debug("No subscribable plans to refresh subscriptions for");
+            return Completable.complete();
+        }
+
+        return Completable.fromRunnable(() -> {
+            try {
+                // Load subscriptions for the product plans
+                List<Subscription> subscriptions = loadSubscriptions(subscribablePlans, environments);
+                log.debug("Loaded {} subscriptions for API Product plans", subscriptions.size());
+
+                // Deploy subscriptions
+                subscriptions.forEach(subscription -> {
+                    try {
+                        subscriptionService.register(subscription);
+                        log.debug("Deployed subscription [{}] for api [{}]", subscription.getId(), subscription.getApi());
+                    } catch (Exception e) {
+                        log.warn("Failed to deploy subscription [{}]", subscription.getId(), e);
+                    }
+                });
+
+                // Load and deploy API keys
+                List<ApiKey> apiKeys = loadApiKeys(subscriptions, environments);
+                log.debug("Loaded {} API keys for subscriptions", apiKeys.size());
+
+                apiKeys.forEach(apiKey -> {
+                    try {
+                        apiKeyService.register(apiKey);
+                        log.debug("Deployed API key [{}] for api [{}]", apiKey.getId(), apiKey.getApi());
+                    } catch (Exception e) {
+                        log.warn("Failed to deploy API key [{}]", apiKey.getId(), e);
+                    }
+                });
+            } catch (Exception ex) {
+                throw new SyncException("Error occurred when refreshing subscriptions for API Product", ex);
+            }
+        });
+    }
+
+    /**
+     * Unregisters subscriptions and API keys for APIs that were removed from the API Product.
+     *
+     * @param removedApiIds APIs that were removed from the product
+     * @param subscribablePlans the product's plan IDs
+     * @param environments the environments to filter by
+     */
+    public Completable unregisterRemovedApis(
+        final Set<String> removedApiIds,
+        final Set<String> subscribablePlans,
+        final Set<String> environments
+    ) {
+        if (removedApiIds == null || removedApiIds.isEmpty() || subscribablePlans == null || subscribablePlans.isEmpty()) {
+            return Completable.complete();
+        }
+
+        return Completable.fromRunnable(() -> {
+            try {
+                var repoSubs = loadSubscriptionModels(subscribablePlans, environments);
+                var subsToUnregister = repoSubs
+                    .stream()
+                    .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
+                    .flatMap(s -> removedApiIds.stream().map(id -> subscriptionMapper.toSubscriptionForApi(s, id)))
+                    .toList();
+
+                subsToUnregister.forEach(sub ->
+                    unregisterQuietly(() -> subscriptionService.unregister(sub), sub.getId(), "subscription", sub.getApi())
+                );
+                loadApiKeys(subsToUnregister, environments)
+                    .stream()
+                    .filter(k -> removedApiIds.contains(k.getApi()))
+                    .forEach(k -> unregisterQuietly(() -> apiKeyService.unregister(k), k.getId(), "API key", k.getApi()));
+            } catch (Exception ex) {
+                throw new SyncException("Error occurred when unregistering subscriptions for removed APIs from API Product", ex);
+            }
+        });
+    }
+
+    private void unregisterQuietly(Runnable action, String itemId, String type, String apiId) {
+        try {
+            action.run();
+            log.debug("Unregistered {} [{}] for removed api [{}]", type, itemId, apiId);
+        } catch (Exception e) {
+            log.warn("Failed to unregister {} for api [{}]", type, apiId, e);
+        }
+    }
+
+    private List<io.gravitee.repository.management.model.Subscription> loadSubscriptionModels(
+        final Set<String> plans,
+        final Set<String> environments
+    ) {
+        SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
+            .plans(plans)
+            .environments(environments)
+            .statuses(INCREMENTAL_STATUS);
+
+        try {
+            return subscriptionRepository.search(
+                criteriaBuilder.build(),
+                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
+            );
+        } catch (Exception ex) {
+            throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
+        }
+    }
+
+    private List<Subscription> loadSubscriptions(final Set<String> plans, final Set<String> environments) {
+        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(plans, environments);
+        return repoSubscriptions
+            .stream()
+            .flatMap(subscription -> subscriptionMapper.to(subscription).stream())
+            .peek(subscriptionConverted -> subscriptionConverted.setForceDispatch(true))
+            .toList();
+    }
+
+    private List<ApiKey> loadApiKeys(final List<Subscription> subscriptions, final Set<String> environments) {
+        if (subscriptions.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions
+                .stream()
+                .collect(Collectors.groupingBy(Subscription::getId));
+
+            ApiKeyCriteria.ApiKeyCriteriaBuilder criteriaBuilder = ApiKeyCriteria.builder()
+                .subscriptions(subscriptionsByIdMulti.keySet())
+                .environments(environments)
+                .includeRevoked(true);
+
+            List<io.gravitee.repository.management.model.ApiKey> bySubscriptions = apiKeyRepository.findByCriteria(
+                criteriaBuilder.build(),
+                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
+            );
+
+            return bySubscriptions
+                .stream()
+                .flatMap(apiKey ->
+                    apiKey
+                        .getSubscriptions()
+                        .stream()
+                        .flatMap(subscriptionId -> {
+                            List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
+                            if (subsForId == null || subsForId.isEmpty()) {
+                                return java.util.stream.Stream.empty();
+                            }
+                            return subsForId.stream().map(subscription -> apiKeyMapper.to(apiKey, subscription));
+                        })
+                )
+                .toList();
+        } catch (Exception ex) {
+            throw new SyncException("Error occurred when retrieving API Keys for API Product", ex);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
@@ -73,6 +73,8 @@ public class DeployerFactory {
 
     private final ApiProductPlanDefinitionCache apiProductPlanDefinitionCache;
 
+    private final ApiProductSubscriptionRefresher apiProductSubscriptionRefresher;
+
     public SubscriptionDeployer createSubscriptionDeployer() {
         return new SubscriptionDeployer(
             subscriptionService,
@@ -121,6 +123,17 @@ public class DeployerFactory {
     }
 
     public ApiProductDeployer createApiProductDeployer() {
-        return new ApiProductDeployer(apiProductManager, planCache, distributedSyncService, apiProductPlanDefinitionCache);
+        if (apiProductSubscriptionRefresher == null) {
+            throw new IllegalStateException(
+                "ApiProductSubscriptionRefresher is not available. API Product deploy requires repository sync to be enabled."
+            );
+        }
+        return new ApiProductDeployer(
+            apiProductManager,
+            planCache,
+            distributedSyncService,
+            apiProductPlanDefinitionCache,
+            apiProductSubscriptionRefresher
+        );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -141,6 +141,25 @@ public class SubscriptionMapper {
         return subscription;
     }
 
+    /**
+     * Creates a Subscription for a specific API from a repository model.
+     * Used when unregistering product subscriptions for APIs removed from the product.
+     */
+    public Subscription toSubscriptionForApi(io.gravitee.repository.management.model.Subscription subscriptionModel, String apiId) {
+        Subscription sub = toSubscription(subscriptionModel);
+        sub.setApi(apiId);
+        Map<String, String> metadata = sub.getMetadata();
+        if (metadata == null) {
+            metadata = new HashMap<>();
+            sub.setMetadata(metadata);
+        }
+        if (subscriptionModel.getReferenceId() != null) {
+            metadata.put("productId", subscriptionModel.getReferenceId());
+        }
+        metadata.put("exploded", "true");
+        return sub;
+    }
+
     /** Resolve API id: API ref uses referenceId or legacy api; API Product uses api. */
     private String resolveApiId(io.gravitee.repository.management.model.Subscription subscriptionModel) {
         if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/PlanService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/PlanService.java
@@ -58,6 +58,17 @@ public class PlanService {
         }
     }
 
+    /**
+     * Returns subscribable plan IDs for the given API Product (before unregister)
+     */
+    public Set<String> getSubscribablePlansForApiProduct(final String apiProductId) {
+        if (apiProductId == null) {
+            return Set.of();
+        }
+        Set<String> plans = plansPerApiProduct.get(apiProductId);
+        return plans != null ? Set.copyOf(plans) : Set.of();
+    }
+
     public boolean isDeployed(final String apiId, final String planId) {
         return isDeployed(apiId, planId, Plan.PlanReferenceType.API);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -18,9 +18,12 @@ package io.gravitee.gateway.services.sync.process.repository.spring;
 import static io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_BULK_ITEMS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
+import io.gravitee.gateway.services.sync.process.common.deployer.ApiProductSubscriptionRefresher;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.gateway.services.sync.process.distributed.DistributedSynchronizer;
@@ -327,6 +330,25 @@ public class RepositorySyncConfiguration {
     @Bean
     public ApiProductPlanAppender apiProductPlanAppender(PlanRepository planRepository) {
         return new ApiProductPlanAppender(planRepository);
+    }
+
+    @Bean
+    public ApiProductSubscriptionRefresher apiProductSubscriptionRefresher(
+        SubscriptionRepository subscriptionRepository,
+        ApiKeyRepository apiKeyRepository,
+        SubscriptionMapper subscriptionMapper,
+        ApiKeyMapper apiKeyMapper,
+        SubscriptionService subscriptionService,
+        ApiKeyService apiKeyService
+    ) {
+        return new ApiProductSubscriptionRefresher(
+            subscriptionRepository,
+            apiKeyRepository,
+            subscriptionMapper,
+            apiKeyMapper,
+            subscriptionService,
+            apiKeyService
+        );
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common.deployer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
+import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.model.SubscriptionReferenceType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Arpit Mishra (arpit.mishra at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductSubscriptionRefresherTest {
+
+    private static final String PLAN_1 = "plan-1";
+    private static final String ENV_1 = "env-1";
+    private static final String SUB_1 = "sub-1";
+    private static final String API_1 = "api-1";
+    private static final String KEY_ID = "key-id";
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private ApiKeyRepository apiKeyRepository;
+
+    @Mock
+    private SubscriptionMapper subscriptionMapper;
+
+    @Mock
+    private ApiKeyMapper apiKeyMapper;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private ApiKeyService apiKeyService;
+
+    private ApiProductSubscriptionRefresher cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ApiProductSubscriptionRefresher(
+            subscriptionRepository,
+            apiKeyRepository,
+            subscriptionMapper,
+            apiKeyMapper,
+            subscriptionService,
+            apiKeyService
+        );
+    }
+
+    @Nested
+    class RefreshTest {
+
+        @Test
+        void returns_complete_when_plans_null_or_empty() throws TechnicalException {
+            cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
+            cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
+            verify(subscriptionRepository, never()).search(any(), any());
+        }
+
+        @Test
+        void loads_and_deploys_subscriptions() throws TechnicalException {
+            var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
+            var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
+            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
+
+            cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            verify(subscriptionService).register(gatewaySub);
+        }
+
+        @Test
+        void loads_and_deploys_api_keys() throws TechnicalException {
+            var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
+            var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
+            var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
+            var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
+            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
+            when(apiKeyRepository.findByCriteria(any(), any())).thenReturn(List.of(repoKey));
+            when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
+
+            cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            verify(subscriptionService).register(gatewaySub);
+            verify(apiKeyService).register(gatewayKey);
+        }
+
+        @Test
+        void does_not_call_api_key_repository_when_no_subscriptions() throws TechnicalException {
+            when(subscriptionRepository.search(any(), any())).thenReturn(List.of());
+
+            cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            verify(subscriptionRepository).search(any(), any());
+            verify(apiKeyRepository, never()).findByCriteria(any(), any());
+        }
+
+        @Test
+        void throws_when_repository_fails() throws TechnicalException {
+            when(subscriptionRepository.search(any(), any())).thenThrow(new TechnicalException("DB error"));
+
+            var thrown = catchThrowable(() -> cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).blockingAwait());
+
+            assertThat(thrown)
+                .isInstanceOf(SyncException.class)
+                .hasMessageContaining("Error occurred when refreshing subscriptions for API Product");
+            assertThat(thrown.getCause().getCause()).isInstanceOf(TechnicalException.class);
+        }
+    }
+
+    @Nested
+    class UnregisterRemovedApisTest {
+
+        @Test
+        void returns_complete_when_removedApiIds_null_or_empty() throws TechnicalException {
+            cut.unregisterRemovedApis(null, Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+            cut.unregisterRemovedApis(Set.of(), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+            verify(subscriptionRepository, never()).search(any(), any());
+        }
+
+        @Test
+        void returns_complete_when_plans_empty() throws TechnicalException {
+            cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(), Set.of(ENV_1)).test().assertComplete();
+            verify(subscriptionRepository, never()).search(any(), any());
+        }
+
+        @Test
+        void unregisters_subscriptions_and_api_keys_for_removed_apis() throws TechnicalException {
+            var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
+            var subForRemoved = Subscription.builder().id(SUB_1).api("api-removed").plan(PLAN_1).build();
+            var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
+            var gatewayKey = ApiKey.builder().id(KEY_ID).api("api-removed").subscription(SUB_1).build();
+
+            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
+            when(apiKeyRepository.findByCriteria(any(), any())).thenReturn(List.of(repoKey));
+            when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);
+
+            cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            verify(subscriptionService).unregister(subForRemoved);
+            verify(apiKeyService).unregister(gatewayKey);
+        }
+    }
+
+    private static io.gravitee.repository.management.model.Subscription productSubscription(String id, String plan, String env) {
+        var s = new io.gravitee.repository.management.model.Subscription();
+        s.setId(id);
+        s.setReferenceId("product-1");
+        s.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        s.setPlan(plan);
+        s.setStatus(io.gravitee.repository.management.model.Subscription.Status.ACCEPTED);
+        s.setEnvironmentId(env);
+        return s;
+    }
+
+    private static io.gravitee.repository.management.model.ApiKey productApiKey(String id, String env, String subscriptionId) {
+        var k = new io.gravitee.repository.management.model.ApiKey();
+        k.setId(id);
+        k.setKey("key-" + id);
+        k.setSubscriptions(List.of(subscriptionId));
+        k.setEnvironmentId(env);
+        return k;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12801

## Description

Fixes 401 when calling a newly added API in an API Product with an existing subscription key. Subscriptions and API keys are now refreshed before the product event is emitted, so the security chain finds them in cache.

Also unregisters subscriptions and API keys when an API is removed from a product or when the product is deleted, so removed APIs no longer accept the product's keys.

## Additional context

working video :
via script : 

https://github.com/user-attachments/assets/ede70ec6-802b-4d8b-92c3-0f299b8bc0b5

via postman :

https://github.com/user-attachments/assets/74f0e448-e71d-4e5a-8955-298d05f96d44

remove api from api product :

https://github.com/user-attachments/assets/9e666a9e-47a8-4224-b205-fce5a24f5d47



### Why this bug arose

`ApiProductChangedEvent` was emitted before the subscription/API key cache was populated. The security chain reacted to the event and refreshed before the cache, so lookups failed and returned 401.

### What we changed

- **ApiProductManager**: Added `register(product, beforeEmit)` so a callback runs after the product is in the registry but before the event is emitted.
- **ApiProductDeployer**: Uses the callback to run `ApiProductSubscriptionRefresher` (load subscriptions, explode to APIs, deploy to `SubscriptionService` and `ApiKeyService`) before the event.
- **ApiProductSubscriptionRefresher**: Loads subscriptions for product plans, explodes them via `SubscriptionMapper`, and registers them in both caches.
- **DeployerFactory**: Injects `ApiProductSubscriptionRefresher`; `createApiProductDeployer()` no longer takes parameters.

<img width="1436" height="793" alt="image" src="https://github.com/user-attachments/assets/eedac89e-d5d3-47db-b712-0ed73a7bd632" />





