### PR TITLE
Initialize Kafka Explorer module with basic structure and info endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.rest.api</groupId>
+        <artifactId>gravitee-apim-rest-api</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-rest-api-kafka-explorer</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Gravitee.io APIM - Management API - Kafka Explorer</name>
+    <description>Kafka cluster exploration and management</description>
+
+    <properties>
+        <openapi-generator.version>7.12.0</openapi-generator.version>
+        <openapi.modelPackage>io.gravitee.rest.api.kafkaexplorer.rest.model</openapi.modelPackage>
+        <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+    </properties>
+
+    <dependencies>
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- OpenAPI generated models dependency -->
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
+
+        <!-- MapStruct (provided by parent) -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+        </dependency>
+
+        <!-- Spring (for DI configuration only) -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator.version}</version>
+                <configuration>
+                    <inputSpec>${project.basedir}/src/main/resources/openapi/openapi-kafka-explorer.yaml</inputSpec>
+                    <generatorName>java</generatorName>
+                    <library>jersey3</library>
+                    <modelPackage>${openapi.modelPackage}</modelPackage>
+                    <generateApis>false</generateApis>
+                    <generateModels>true</generateModels>
+                    <generateModelTests>false</generateModelTests>
+                    <generateModelDocumentation>false</generateModelDocumentation>
+                    <generateSupportingFiles>true</generateSupportingFiles>
+                    <supportingFilesToGenerate>JSON.java,RFC3339DateFormat.java,AbstractOpenApiSchema.java,ApiException.java</supportingFilesToGenerate>
+                    <configOptions>
+                        <dateLibrary>java8</dateLibrary>
+                        <useBeanValidation>true</useBeanValidation>
+                    </configOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>model-kafka-explorer</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/UseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/UseCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class as a Use Case in the Kafka Explorer module.
+ *
+ * <p>Classes annotated with this annotation are discovered by
+ * {@link io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration}
+ * and registered as Spring beans.</p>
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseCase {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaExplorerInfo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaExplorerInfo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record KafkaExplorerInfo(String version, String status, List<String> features, String message) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/GetKafkaExplorerInfoUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/GetKafkaExplorerInfoUseCase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaExplorerInfo;
+import java.util.List;
+
+@UseCase
+public class GetKafkaExplorerInfoUseCase {
+
+    public Output execute(Input input) {
+        var info = new KafkaExplorerInfo("1.0.0-SNAPSHOT", "initialized", List.of(), "Kafka Explorer module initialized successfully");
+        return new Output(info);
+    }
+
+    public record Input() {}
+
+    public record Output(KafkaExplorerInfo info) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.mapper;
+
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaExplorerInfo;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerInfoResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface KafkaExplorerMapper {
+    KafkaExplorerMapper INSTANCE = Mappers.getMapper(KafkaExplorerMapper.class);
+
+    KafkaExplorerInfoResponse map(KafkaExplorerInfo info);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.GetKafkaExplorerInfoUseCase;
+import io.gravitee.rest.api.kafkaexplorer.mapper.KafkaExplorerMapper;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerInfoResponse;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/kafka-explorer")
+public class KafkaExplorerResource {
+
+    @Inject
+    private GetKafkaExplorerInfoUseCase getKafkaExplorerInfoUseCase;
+
+    @GET
+    @Path("/info")
+    @Produces(MediaType.APPLICATION_JSON)
+    public KafkaExplorerInfoResponse getInfo() {
+        var result = getKafkaExplorerInfoUseCase.execute(new GetKafkaExplorerInfoUseCase.Input());
+        return KafkaExplorerMapper.INSTANCE.map(result.info());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/spring/KafkaExplorerSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/spring/KafkaExplorerSpringConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.spring;
+
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration
+@ComponentScan(
+    basePackages = { "io.gravitee.rest.api.kafkaexplorer" },
+    includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class)
+)
+public class KafkaExplorerSpringConfiguration {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+    title: Gravitee.io APIM - Kafka Explorer
+    description: |-
+        Kafka cluster exploration and management API for Gravitee APIM.
+    contact:
+        email: team-apim@graviteesource.com
+    license:
+        name: Apache 2.0
+        url: http://www.apache.org/licenses/LICENSE-2.0.html
+    version: 1.0.0
+
+tags:
+    - name: Kafka Explorer
+      description: Kafka Explorer module information
+
+paths:
+    /kafka-explorer/info:
+        get:
+            tags:
+                - Kafka Explorer
+            summary: Get Kafka Explorer module information
+            description: |
+                Returns information about the Kafka Explorer module including version, status, and available features.
+            operationId: getKafkaExplorerInfo
+            responses:
+                "200":
+                    description: Module information
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerInfoResponse"
+
+components:
+    schemas:
+        KafkaExplorerInfoResponse:
+            type: object
+            properties:
+                version:
+                    type: string
+                    description: Module version
+                status:
+                    type: string
+                    description: Current module status
+                features:
+                    type: array
+                    description: List of available features
+                    items:
+                        type: string
+                message:
+                    type: string
+                    description: Human-readable status message

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/architecture/ArchitectureTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/architecture/ArchitectureTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.architecture;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ArchitectureTest {
+
+    private static final String BASE_PACKAGE = "io.gravitee.rest.api.kafkaexplorer";
+    private static final String DOMAIN_PACKAGE = BASE_PACKAGE + ".domain..";
+    private static final String RESOURCE_PACKAGE = BASE_PACKAGE + ".resource..";
+    private static final String MAPPER_PACKAGE = BASE_PACKAGE + ".mapper..";
+    private static final String GENERATED_MODEL_PACKAGE = BASE_PACKAGE + ".rest.model..";
+
+    private final JavaClasses classes = new ClassFileImporter()
+        .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+        .importPackages(BASE_PACKAGE);
+
+    private final JavaClasses allClasses = new ClassFileImporter().importPackages(BASE_PACKAGE);
+
+    @Nested
+    class DomainLayer {
+
+        @Test
+        void domain_should_not_depend_on_resource() {
+            noClasses()
+                .that()
+                .resideInAPackage(DOMAIN_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(RESOURCE_PACKAGE)
+                .because("Domain layer must not depend on the resource (REST) layer")
+                .check(classes);
+        }
+
+        @Test
+        void domain_should_not_depend_on_mapper() {
+            noClasses()
+                .that()
+                .resideInAPackage(DOMAIN_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(MAPPER_PACKAGE)
+                .because("Domain layer must not depend on mappers")
+                .check(classes);
+        }
+
+        @Test
+        void domain_should_not_depend_on_generated_models() {
+            noClasses()
+                .that()
+                .resideInAPackage(DOMAIN_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(GENERATED_MODEL_PACKAGE)
+                .because("Domain layer must not depend on OpenAPI generated models")
+                .check(classes);
+        }
+
+        @Test
+        void domain_should_not_depend_on_jakarta_ws_rs() {
+            noClasses()
+                .that()
+                .resideInAPackage(DOMAIN_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage("jakarta.ws.rs..")
+                .because("Domain layer must not depend on JAX-RS")
+                .check(classes);
+        }
+    }
+
+    @Nested
+    class UseCaseRules {
+
+        @Test
+        void use_cases_should_reside_in_use_case_package() {
+            classes()
+                .that()
+                .haveNameMatching(".*UseCase")
+                .and()
+                .areNotAnnotations()
+                .should()
+                .resideInAPackage("..use_case..")
+                .check(classes);
+        }
+
+        @Test
+        void use_cases_should_be_suffixed_with_UseCase() {
+            classes()
+                .that()
+                .resideInAPackage("..use_case..")
+                .and()
+                .areTopLevelClasses()
+                .should()
+                .haveSimpleNameEndingWith("UseCase")
+                .check(classes);
+        }
+
+        @Test
+        void use_cases_should_be_independent() {
+            slices()
+                .matching("..domain.(*).use_case..")
+                .namingSlices("UseCase $1")
+                .as("UseCase")
+                .should()
+                .notDependOnEachOther()
+                .allowEmptyShould(true)
+                .check(allClasses);
+        }
+    }
+
+    @Nested
+    class MapperLayer {
+
+        @Test
+        void mapper_should_not_depend_on_resource() {
+            noClasses()
+                .that()
+                .resideInAPackage(MAPPER_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(RESOURCE_PACKAGE)
+                .because("Mappers must be pure converters and not depend on the resource layer")
+                .check(classes);
+        }
+
+        @Test
+        void mapper_should_not_depend_on_use_cases() {
+            noClasses()
+                .that()
+                .resideInAPackage(MAPPER_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(BASE_PACKAGE + ".domain.use_case..")
+                .because("Mappers must be pure converters and not depend on use cases")
+                .check(classes);
+        }
+    }
+
+    @Nested
+    class DomainIndependence {
+
+        @Test
+        void domain_should_only_depend_on_allowed_packages() {
+            classes()
+                .that()
+                .resideInAPackage(DOMAIN_PACKAGE)
+                .should()
+                .onlyDependOnClassesThat(resideInAnyPackage(DOMAIN_PACKAGE, "java..", "lombok..", "org.slf4j.."))
+                .because("Domain should be free from framework dependencies")
+                .check(classes);
+        }
+    }
+
+    @Nested
+    class CycleChecks {
+
+        @Test
+        void should_be_free_of_cycles() {
+            slices().matching(BASE_PACKAGE + ".(**)..").should().beFreeOfCycles().check(allClasses);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/GetKafkaExplorerInfoUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/GetKafkaExplorerInfoUseCaseTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetKafkaExplorerInfoUseCaseTest {
+
+    private GetKafkaExplorerInfoUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetKafkaExplorerInfoUseCase();
+    }
+
+    @Test
+    void should_return_module_info_with_version() {
+        var result = useCase.execute(new GetKafkaExplorerInfoUseCase.Input());
+
+        assertThat(result.info().version()).isEqualTo("1.0.0-SNAPSHOT");
+        assertThat(result.info().status()).isEqualTo("initialized");
+        assertThat(result.info().message()).isEqualTo("Kafka Explorer module initialized successfully");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -49,6 +49,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.gravitee.apim.rest.api</groupId>
+			<artifactId>gravitee-apim-rest-api-kafka-explorer</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.gravitee.apim.rest.api</groupId>
 			<artifactId>gravitee-apim-rest-api-rest</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest;
 
+import io.gravitee.rest.api.kafkaexplorer.resource.KafkaExplorerResource;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.BadRequestExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ConstraintValidationExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.JsonMappingExceptionMapper;
@@ -89,6 +90,9 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(ResourcesResource.class);
         register(IntegrationsResource.class);
         register(AsyncJobsResource.class);
+
+        // Kafka Explorer
+        register(KafkaExplorerResource.class);
 
         register(MultiPartFeature.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.infra.domain_service.user.UserContextLoaderImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
@@ -38,7 +39,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class })
+@Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class, KafkaExplorerSpringConfiguration.class })
 @EnableAsync
 public class RestManagementConfiguration {
 

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -54,6 +54,7 @@
         <module>gravitee-apim-rest-api-spec-converter</module>
         <module>gravitee-apim-rest-api-test-fixtures</module>
         <module>gravitee-apim-rest-api-coverage</module>
+        <module>gravitee-apim-rest-api-kafka-explorer</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12789

## Description

Initialize Kafka Explorer module with basic structure and info endpoint
The idea is to create a Java package with the same clean architecture rules as in the services


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

