### PR TITLE
chore: remove unused gravitee-markdown theme import in portal SCSS

### DIFF
--- a/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/gmd-overrides.scss
@@ -15,7 +15,6 @@
  */
 @use '@gravitee/gravitee-markdown' as gmd;
 @use './theme' as theme;
-@use '@gravitee/gravitee-markdown/src/lib/scss/theme' as gmd-theme;
 
 :root {
   @include gmd.theme-overrides(


### PR DESCRIPTION
## Issue

remove unused gravitee-markdown theme import in portal SCSS

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

