### PR TITLE
fix(http-proxy): prevent query param / headers leakage across failover retries

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -609,6 +609,13 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
         void should_success_on_second_retry(HttpClient client) {
             super.should_success_on_second_retry(client);
         }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-query-params.json")
+        void should_success_on_second_retry_with_endpoint_having_query_params(HttpClient client) {
+            super.should_success_on_second_retry_with_endpoint_having_query_params(client);
+        }
     }
 
     @Nested

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/failover/api-three-endpoints-query-params.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/failover/api-three-endpoints-query-params.json
@@ -1,0 +1,57 @@
+{
+  "id": "my-api-three-endpoints-query-params",
+  "name": "my-api-three-endpoints-query-params",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint-1?e=1",
+        "http": {
+          "connectTimeout": 1000,
+          "readTimeout": 1000
+        }
+      },
+      {
+        "name": "second",
+        "target": "http://localhost:8080/endpoint-2?e=2",
+        "http": {
+          "connectTimeout": 1000,
+          "readTimeout": 1000
+        }
+      },
+      {
+        "name": "third",
+        "target": "http://localhost:8080/endpoint-3?e=3",
+        "http": {
+          "connectTimeout": 1000,
+          "readTimeout": 1000
+        }
+      }
+    ],
+    "failover": {
+      "maxAttempts": 2,
+      "retryTimeout": 500,
+      "cases": [
+        "TIMEOUT"
+      ]
+    }
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [],
+      "post": []
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-query-params.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-query-params.json
@@ -1,0 +1,99 @@
+{
+  "id": "my-api-v4-three-endpoints-query-params",
+  "name": "my-api-v4-three-endpoints-query-params",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "perSubscription": false
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-1?e=1"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-2?e=2"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "third",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-3?e=3"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -30,6 +30,7 @@ import static io.gravitee.plugin.endpoint.http.proxy.client.UriHelper.URI_QUERY_
 import static io.gravitee.plugin.endpoint.http.proxy.client.UriHelper.URI_QUERY_DELIMITER_CHAR_SEQUENCE;
 
 import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.common.util.URIUtils;
 import io.gravitee.gateway.api.buffer.Buffer;
@@ -285,7 +286,8 @@ public class HttpConnector implements ProxyConnector {
 
     private void prepareUriAndQueryParameters(final HttpExecutionContext ctx, final RequestOptions requestOptions) {
         final HttpRequest request = ctx.request();
-        final MultiValueMap<String, String> requestParameters = request.parameters();
+        final MultiValueMap<String, String> requestParameters = new LinkedMultiValueMap<>();
+        request.parameters().forEach((k, v) -> v.forEach(value -> requestParameters.add(k, value)));
         addParameters(requestParameters, targetParameters);
 
         String customEndpointTarget = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ApiType;
@@ -126,6 +127,8 @@ class HttpProxyEndpointConnectorTest {
         lenient().when(ctx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
 
         requestHeaders = HttpHeaders.create();
+        // request.parameters() can't be null. See https://github.com/gravitee-io/gravitee-common/blob/master/src/main/java/io/gravitee/common/util/URIUtils.java#L74
+        lenient().when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
         lenient().when(request.pathInfo()).thenReturn("");
         lenient().when(request.headers()).thenReturn(requestHeaders);
         lenient().when(request.chunks()).thenReturn(Flowable.empty());

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -156,6 +156,8 @@ class HttpConnectorTest {
         lenient().when(ctx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
 
         requestHeaders = HttpHeaders.create();
+        // request.parameters() can't be null. See https://github.com/gravitee-io/gravitee-common/blob/master/src/main/java/io/gravitee/common/util/URIUtils.java#L74
+        lenient().when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
         lenient().when(request.pathInfo()).thenReturn("");
         lenient().when(request.headers()).thenReturn(requestHeaders);
         lenient().when(request.chunks()).thenReturn(Flowable.empty());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12805

## Description

When endpoint targets include query parameters, retries were mutating a shared request parameter map, causing params from previous attempts to leak into subsequent endpoint calls.

Copy request parameters before merging endpoint target params so each retry builds a clean URI.
Add V3/V4 integration tests for failover with endpoint query params.



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

