### PR TITLE
fix: report not found at platform level when enabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -94,6 +94,8 @@ public class ReporterProcessor implements Processor {
                 } else {
                     // No api found report only metrics
                     reporterService.report(metrics);
+                    // Report v2 metrics as well so that the request can show up in platform analytics
+                    reporterService.report(metrics.toV2());
                 }
             }
         })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
@@ -232,6 +232,7 @@ class ReporterProcessorTest extends AbstractProcessorTest {
 
             // Then
             verify(reporterService).report(ctx.metrics());
+            verify(reporterService).report(ctx.metrics().toV2());
             assertNull(ctx.metrics().getLog());
             verify(reporterService, never()).report(ctx.metrics().getLog());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -71,6 +71,7 @@ import org.jetbrains.annotations.NotNull;
 public class EnvironmentAnalyticsResource extends AbstractResource {
 
     public static final String API_FIELD = "api";
+    public static final String UNKNOWN_ID = "1";
     public static final String APPLICATION_FIELD = "application";
     public static final String STATE_FIELD = "state";
     public static final String LIFECYCLE_STATE_FIELD = "lifecycle_state";
@@ -242,9 +243,11 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
                 applicationQuery.setStatus(ApplicationStatus.ACTIVE.name());
                 applicationQuery.setExcludeFilters(List.of(ApplicationExcludeFilter.OWNER));
                 ids = applicationService.searchIds(executionContext, applicationQuery, null);
+                ids.add(UNKNOWN_ID);
             } else {
                 fieldName = API_FIELD;
                 ids = apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId());
+                ids.add(UNKNOWN_ID);
             }
         } else {
             if (APPLICATION_FIELD.equalsIgnoreCase(analyticsParam.getField())) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -57,6 +57,8 @@ import org.jetbrains.annotations.NotNull;
 @Tag(name = "Platform Analytics")
 public class PlatformAnalyticsResource extends AbstractResource {
 
+    public static final String UNKNOWN_ID = "1";
+
     @Inject
     PermissionService permissionService;
 
@@ -125,7 +127,9 @@ public class PlatformAnalyticsResource extends AbstractResource {
     private Set<String> findApiIds() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (isAdmin()) {
-            return apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId());
+            var ids = apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId());
+            ids.add(UNKNOWN_ID);
+            return ids;
         }
         return apiAuthorizationService
             .findIdsByUser(executionContext, getAuthenticatedUser(), true)
@@ -138,7 +142,9 @@ public class PlatformAnalyticsResource extends AbstractResource {
     private Set<String> findApplicationIds() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (isAdmin()) {
-            return applicationService.findIdsByEnvironment(executionContext);
+            var ids = applicationService.findIdsByEnvironment(executionContext);
+            ids.add(UNKNOWN_ID);
+            return ids;
         }
         return applicationService.findIdsByUserAndPermission(executionContext, getAuthenticatedUser(), null, APPLICATION_ANALYTICS, READ);
     }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-2336

The reported metric was written to the v4-metrics index only and the query layer was not searching for unknown id "1", making the 404 not reflected in the platform analytics even with the parameter enabled at the reporter level

This fixes the issue, but only for admin:

<img width="1712" height="770" alt="Screenshot 2026-02-17 at 12 26 25" src="https://github.com/user-attachments/assets/189d77da-2997-438c-99b0-f8da6193c79e" />

There is also pr in reporter-common, because a ftl error occurred when the api was unknown

https://github.com/gravitee-io/gravitee-reporter-common/pull/110