### PR TITLE
fix(console): load envs and current env when navigating to org settings

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/organization-environment.guard.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-environment.guard.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { OrganizationEnvironmentGuard } from './organization-environment.guard';
+
+import { CONSTANTS_TESTING } from '../../shared/testing';
+import { Constants } from '../../entities/Constants';
+import { Environment } from '../../entities/environment/environment';
+
+describe('OrganizationEnvironmentGuard', () => {
+  let httpTestingController: HttpTestingController;
+  let constants: Constants;
+
+  beforeEach(() => {
+    constants = {
+      ...CONSTANTS_TESTING,
+      org: {
+        ...CONSTANTS_TESTING.org,
+        environments: null,
+        currentEnv: null,
+      },
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Constants, useValue: constants }, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should fetch environments and set currentEnv when not already loaded', (done) => {
+    const fakeEnvironments: Environment[] = [
+      { id: 'env-1', name: 'Environment 1', organizationId: 'org-1', hrids: ['env-1'] },
+      { id: 'env-2', name: 'Environment 2', organizationId: 'org-1', hrids: ['env-2'] },
+    ];
+
+    const result = TestBed.runInInjectionContext(() => OrganizationEnvironmentGuard(null, null));
+
+    (result as Observable<boolean>).subscribe((canActivate) => {
+      expect(canActivate).toBe(true);
+      expect(constants.org.environments).toEqual(fakeEnvironments);
+      expect(constants.org.currentEnv).toEqual(fakeEnvironments[0]);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${constants.org.baseURL}/environments`);
+    expect(req.request.method).toEqual('GET');
+    req.flush(fakeEnvironments);
+  });
+
+  it('should skip fetch when environments are already loaded', () => {
+    const existingEnv: Environment = { id: 'existing-env', name: 'Existing', organizationId: 'org-1' };
+    constants.org.environments = [existingEnv];
+    constants.org.currentEnv = existingEnv;
+
+    const result = TestBed.runInInjectionContext(() => OrganizationEnvironmentGuard(null, null));
+
+    (result as Observable<boolean>).subscribe((canActivate) => {
+      expect(canActivate).toBe(true);
+    });
+
+    httpTestingController.expectNone(`${constants.org.baseURL}/environments`);
+    expect(constants.org.currentEnv).toEqual(existingEnv);
+  });
+
+  it('should still activate route when environment list is empty', (done) => {
+    const result = TestBed.runInInjectionContext(() => OrganizationEnvironmentGuard(null, null));
+
+    (result as Observable<boolean>).subscribe((canActivate) => {
+      expect(canActivate).toBe(true);
+      expect(constants.org.environments).toBeNull();
+      expect(constants.org.currentEnv).toBeNull();
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${constants.org.baseURL}/environments`);
+    req.flush([]);
+  });
+
+  it('should still navigate when environment fetch fails', (done) => {
+    const result = TestBed.runInInjectionContext(() => OrganizationEnvironmentGuard(null, null));
+
+    (result as Observable<boolean>).subscribe((canActivate) => {
+      expect(canActivate).toBe(true);
+      expect(constants.org.environments).toBeNull();
+      expect(constants.org.currentEnv).toBeNull();
+      done();
+    });
+
+    httpTestingController.expectOne(`${constants.org.baseURL}/environments`).flush({}, { status: 500, statusText: 'Server Error' });
+  });
+});

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-environment.guard.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-environment.guard.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { catchError, map } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+import { EnvironmentService } from '../../services-ngx/environment.service';
+import { Constants } from '../../entities/Constants';
+
+/**
+ * Guard that ensures environments are loaded into Constants before
+ * organization routes activate. This prevents services that rely on
+ * `constants.org.currentEnv` from falling back to "DEFAULT" when the
+ * user navigates directly to an organization page (e.g., on refresh).
+ *
+ * The management EnvironmentGuard will overwrite these values with
+ * URL-aware data when the user enters management routes.
+ */
+export const OrganizationEnvironmentGuard: CanActivateFn = () => {
+  const constants = inject(Constants);
+  const environmentService = inject(EnvironmentService);
+
+  if (constants.org.environments?.length > 0 && constants.org.currentEnv) {
+    return of(true);
+  }
+
+  return environmentService.list().pipe(
+    map((environments) => {
+      if (environments?.length > 0) {
+        constants.org.environments = environments;
+        constants.org.currentEnv = environments[0];
+      }
+      return true;
+    }),
+    catchError((_) => {
+      return of(true);
+    }),
+  );
+};

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings-routing.module.ts
@@ -34,6 +34,7 @@ import { OrgSettingsRoleComponent } from './roles/role/org-settings-role.compone
 import { OrgSettingsAuditComponent } from './audit/org-settings-audit.component';
 import { OrgNavigationComponent } from './navigation/org-navigation.component';
 import { OrganizationSettingsModule } from './organization-settings.module';
+import { OrganizationEnvironmentGuard } from './organization-environment.guard';
 
 import { HasLicenseGuard } from '../../shared/components/gio-license/has-license.guard';
 import { PermissionGuard } from '../../shared/components/gio-permission/gio-permission.guard';
@@ -42,6 +43,7 @@ const organizationRoutes: Routes = [
   {
     path: '',
     component: OrgNavigationComponent,
+    canActivate: [OrganizationEnvironmentGuard],
     canActivateChild: [PermissionGuard.checkRouteDataPermissions, HasLicenseGuard],
     children: [
       {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12616

## Description

When loading the organization settings > Policies view and not having an environment with an id of "DEFAULT", the user was seeing an error snackbar that Something went wrong! and the view was not loading.

This error was specifically reproducible when a user would refresh a view in the Organization settings part of Console.

The fix loads the environments if not already loaded and chooses the first one as the default organization.

**More info:**

Ideally, we would not call the backend for information scoped by the "currentEnv" environment when in the organizations section. However the work to address that change would be expansive. Especially since multiple components in this section call the backend to an environment-scoped endpoint.

The MAPI-v2 now has policies at the organization level. So there is promise that we have more and more resources that will be scoped by organization rather than environment in the future.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

