### PR TITLE
chore: bump gravitee-alert-engine-connectors-ws.version version to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
 
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
+        <gravitee-alert-engine-connectors-ws.version>2.3.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>5.0.8</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>5.2.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>3.1.0</gravitee-policy-assign-attributes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-4045

## Description

Linked to this PR https://github.com/gravitee-io/gravitee-ae-connectors/pull/39

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

