### PR TITLE
fix(failover): reset response headers between failover retries

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -612,6 +612,13 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
 
         @Override
         @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints.json")
+        void should_return_single_content_length_header_from_final_retry_response(HttpClient client) {
+            super.should_return_single_content_length_header_from_final_retry_response(client);
+        }
+
+        @Override
+        @Test
         @DeployApi("/apis/v4/http/failover/api-three-endpoints-query-params.json")
         void should_success_on_second_retry_with_endpoint_having_query_params(HttpClient client) {
             super.should_success_on_second_retry_with_endpoint_having_query_params(client);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12807

## Description

Restore response headers to their pre-failover baseline before each retry attempt in FailoverInvoker to prevent cross-attempt header leakage (e.g. duplicated Content-Length) while preserving gateway-managed headers.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

