### PR TITLE
feat: close subscription in portal - create confirmation popup and service method.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="close-subscription-dialog__title next-gen-h3" i18n="@@titleCancelSubscriptionDialog">
+  Close this subscription?
+</h2>
+
+<mat-dialog-content class="close-subscription-dialog__content">
+  <p class="next-gen-body" i18n="@@contentCancelSubscriptionDialog">You will lose access to the API.</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="close-subscription-dialog__actions">
+  <button
+    class="close-subscription-dialog__cancel-button next-gen-small-strong"
+    mat-button
+    [mat-dialog-close]="false"
+    i18n="@@cancelCancelSubscriptionDialog"
+  >
+    Cancel
+  </button>
+  <button
+    class="close-subscription-dialog__confirm-button next-gen-small-strong"
+    color="warn"
+    mat-flat-button
+    [mat-dialog-close]="true"
+    cdkFocusInitial
+    data-testid="close-subscription-dialog"
+    i18n="@@confirmCancelSubscriptionDialog"
+  >
+    Yes, close
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { CloseSubscriptionDialogComponent } from './close-subscription-dialog.component';
+import { CloseSubscriptionDialogHarness } from './close-subscription-dialog.harness';
+
+@Component({
+  selector: 'app-close-subscription-dialog-test',
+  imports: [MatButtonModule],
+  template: `<button mat-button id="open-confirm-dialog" (click)="openConfirmDialog()">Open confirm dialog</button>`,
+  standalone: true,
+})
+class TestComponent {
+  public confirmed?: boolean;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openConfirmDialog() {
+    this.matDialog
+      .open<CloseSubscriptionDialogComponent, void, boolean>(CloseSubscriptionDialogComponent, {
+        role: 'alertdialog',
+        id: 'closeSubscriptionDialog',
+      })
+      .afterClosed()
+      .subscribe(confirmed => (this.confirmed = confirmed));
+  }
+}
+
+describe('CloseSubscriptionDialogComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestComponent, NoopAnimationsModule],
+    }).overrideProvider(InteractivityChecker, {
+      useValue: {
+        isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+      },
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  });
+
+  it('should return true with the user confirms', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(CloseSubscriptionDialogHarness);
+    await confirmDialogHarness.confirm();
+
+    expect(component.confirmed).toBe(true);
+  });
+
+  it('should return false with the user cancels', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(CloseSubscriptionDialogHarness);
+    await confirmDialogHarness.cancel();
+
+    expect(component.confirmed).toBe(false);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-close-subscription-dialog',
+  templateUrl: './close-subscription-dialog.component.html',
+  imports: [MatDialogModule, MatButtonModule],
+})
+export class CloseSubscriptionDialogComponent {}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.harness.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class CloseSubscriptionDialogHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-close-subscription-dialog';
+
+  private readonly getConfirmButtonHarness = this.locatorFor(
+    MatButtonHarness.with({ selector: '.close-subscription-dialog__confirm-button' }),
+  );
+  private readonly getCancelButtonHarness = this.locatorFor(
+    MatButtonHarness.with({ selector: '.close-subscription-dialog__cancel-button' }),
+  );
+
+  public async confirm(): Promise<void> {
+    await this.getConfirmButtonHarness().then(button => button.click());
+  }
+
+  public async cancel(): Promise<void> {
+    await this.getCancelButtonHarness().then(button => button.click());
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -50,4 +50,15 @@ describe('SubscriptionService', () => {
 
     req.flush(subscriptionResponse);
   });
+
+  it('should close subscription', done => {
+    service.close('subscriptionId').subscribe(() => {
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions/subscriptionId/_close`);
+    expect(req.request.method).toEqual('POST');
+
+    req.flush(null);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -68,6 +68,10 @@ export class SubscriptionService {
     return this.http.put<Subscription>(`${this.configService.baseURL}/subscriptions/${subscriptionId}`, updatedSubscription);
   }
 
+  close(subscriptionId: string) {
+    return this.http.post<void>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/_close`, null);
+  }
+
   resumeConsumerStatus(subscriptionId: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/_resumeFailure`, null);
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12271

## Description

This PR is the first in the series to introduce subscription closure feature in subscription details in the portal.

### Included in this PR:
- new service method to close a subscription (uses existing back end endpoint)
- new confirmation popup component

### Excluded from this PR:
- button "Close subscription"
- updates to subscription-details and subscription-info components (button handler, output)
- generic dialog component
- styles updates
<img width="412" height="214" alt="Screenshot 2026-02-18 at 09 14 11" src="https://github.com/user-attachments/assets/af1f262e-3add-44de-88c4-8ce59fff1144" />