### PR TITLE
Add findByStatuses to ClientCertificateRepository and CrudService

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
@@ -63,6 +63,16 @@ public interface ClientCertificateRepository extends CrudRepository<ClientCertif
         throws TechnicalException;
 
     /**
+     * Find all client certificates matching the given statuses, regardless of application.
+     * Returns an empty set if {@code statuses} is null or empty.
+     *
+     * @param statuses one or more {@link ClientCertificateStatus} values to filter by
+     * @return a set of client certificates matching the criteria
+     * @throws TechnicalException if a database-level error occurs
+     */
+    Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) throws TechnicalException;
+
+    /**
      * Check if a client certificate with the given fingerprint exists for an active application,
      * excluding certificates with REVOKED status.
      *

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
@@ -93,7 +93,7 @@ public class JdbcClientCertificateRepository
     @Override
     public Set<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses)
         throws TechnicalException {
-        log.debug("JdbcClientCertificateRepository.findByApplicationIdAndStatuses({}, {})", applicationId, statuses);
+        log.debug("JdbcClientCertificateRepository.findByApplicationIdAndStatuses({}, {})", applicationId, Arrays.toString(statuses));
 
         if (statuses == null || statuses.length == 0) {
             return new HashSet<>();
@@ -120,7 +120,7 @@ public class JdbcClientCertificateRepository
     @Override
     public Set<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses)
         throws TechnicalException {
-        log.debug("JdbcClientCertificateRepository.findByApplicationIdsAndStatuses({}, {})", applicationIds, statuses);
+        log.debug("JdbcClientCertificateRepository.findByApplicationIdsAndStatuses({}, {})", applicationIds, Arrays.toString(statuses));
 
         if (applicationIds == null || applicationIds.isEmpty() || statuses == null || statuses.length == 0) {
             return new HashSet<>();
@@ -164,7 +164,7 @@ public class JdbcClientCertificateRepository
 
     @Override
     public Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) throws TechnicalException {
-        log.debug("JdbcClientCertificateRepository.findByStatuses({})", (Object) statuses);
+        log.debug("JdbcClientCertificateRepository.findByStatuses({})", Arrays.toString(statuses));
 
         if (statuses == null || statuses.length == 0) {
             return Set.of();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
@@ -167,6 +167,23 @@ public class MongoClientCertificateRepository implements ClientCertificateReposi
     }
 
     @Override
+    public Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) throws TechnicalException {
+        log.debug("Find client certificates by statuses [{}]", (Object) statuses);
+
+        if (statuses == null || statuses.length == 0) {
+            return Set.of();
+        }
+
+        try {
+            var statusStrings = Arrays.stream(statuses).map(ClientCertificateStatus::name).toList();
+            var clientCertificates = internalRepository.findByStatuses(statusStrings);
+            return clientCertificates.stream().map(mapper::map).collect(Collectors.toSet());
+        } catch (Exception e) {
+            throw new TechnicalException("Failed to find client certificates by statuses", e);
+        }
+    }
+
+    @Override
     public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) throws TechnicalException {
         log.debug(
             "Check if client certificate with fingerprint [{}] exists for an active application in environment [{}]",

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clientcertificate/ClientCertificateMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clientcertificate/ClientCertificateMongoRepository.java
@@ -40,5 +40,8 @@ public interface ClientCertificateMongoRepository extends MongoRepository<Client
     @Query("{ applicationId: { $in: ?0 }, status: { $in: ?1 } }")
     List<ClientCertificateMongo> findByApplicationIdsAndStatuses(Collection<String> applicationIds, Collection<String> statuses);
 
+    @Query("{ status: { $in: ?0 } }")
+    List<ClientCertificateMongo> findByStatuses(Collection<String> statuses);
+
     void deleteByApplicationId(String applicationId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import lombok.SneakyThrows;
 import org.junit.Test;
 
 /**
@@ -263,6 +264,49 @@ public class ClientCertificateRepositoryTest extends AbstractManagementRepositor
             List.of("unknown-app-1", "unknown-app-2"),
             ClientCertificateStatus.ACTIVE
         );
+
+        assertThat(certificates).isNotNull().isEmpty();
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_find_by_statuses() {
+        var certificates = clientCertificateRepository.findByStatuses(ClientCertificateStatus.ACTIVE);
+
+        assertThat(certificates).isNotNull().hasSize(2);
+        assertThat(certificates).extracting(ClientCertificate::getId).containsExactlyInAnyOrder("cert-1", "cert-to-update");
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_find_revoked_certificates_by_status() {
+        var certificates = clientCertificateRepository.findByStatuses(ClientCertificateStatus.REVOKED);
+
+        assertThat(certificates).isNotNull().hasSize(1);
+        assertThat(certificates).extracting(ClientCertificate::getId).containsExactly("cert-to-delete");
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_find_by_multiple_statuses() {
+        var certificates = clientCertificateRepository.findByStatuses(ClientCertificateStatus.ACTIVE, ClientCertificateStatus.SCHEDULED);
+
+        assertThat(certificates).isNotNull().hasSize(3);
+        assertThat(certificates).extracting(ClientCertificate::getId).containsExactlyInAnyOrder("cert-1", "cert-2", "cert-to-update");
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_return_empty_when_statuses_is_empty_for_findByStatuses() {
+        var certificates = clientCertificateRepository.findByStatuses();
+
+        assertThat(certificates).isNotNull().isEmpty();
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_return_empty_when_statuses_is_null_for_findByStatuses() {
+        var certificates = clientCertificateRepository.findByStatuses((ClientCertificateStatus[]) null);
 
         assertThat(certificates).isNotNull().isEmpty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
@@ -90,6 +90,15 @@ public interface ClientCertificateCrudService {
     Set<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses);
 
     /**
+     * Find all client certificates matching the given statuses, regardless of application.
+     * Returns an empty set if {@code statuses} is null or empty.
+     *
+     * @param statuses one or more {@link ClientCertificateStatus} values to filter by
+     * @return a set of client certificates matching the criteria
+     */
+    Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses);
+
+    /**
      * Delete all client certificates for a given application.
      *
      * @param applicationId the application ID

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -40,7 +40,6 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
@@ -223,6 +222,20 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
                 "An error occurs while trying to find client certificates by application IDs and statuses",
                 e
             );
+        }
+    }
+
+    @Override
+    public Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) {
+        try {
+            log.debug("Find client certificates by statuses {}", (Object) statuses);
+            return clientCertificateRepository
+                .findByStatuses(ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
+                .stream()
+                .map(ClientCertificateAdapter.INSTANCE::toDomain)
+                .collect(Collectors.toSet());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find client certificates by statuses", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -40,6 +40,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
@@ -194,7 +195,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     @Override
     public Set<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses) {
         try {
-            log.debug("Find client certificates by application ID {} and statuses {}", applicationId, statuses);
+            log.debug("Find client certificates by application ID {} and statuses {}", applicationId, Arrays.toString(statuses));
             return clientCertificateRepository
                 .findByApplicationIdAndStatuses(applicationId, ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
                 .stream()
@@ -211,7 +212,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     @Override
     public Set<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses) {
         try {
-            log.debug("Find client certificates by application IDs {} and statuses {}", applicationIds, statuses);
+            log.debug("Find client certificates by application IDs {} and statuses {}", applicationIds, Arrays.toString(statuses));
             return clientCertificateRepository
                 .findByApplicationIdsAndStatuses(applicationIds, ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
                 .stream()
@@ -228,7 +229,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     @Override
     public Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) {
         try {
-            log.debug("Find client certificates by statuses {}", (Object) statuses);
+            log.debug("Find client certificates by statuses {}", Arrays.toString(statuses));
             return clientCertificateRepository
                 .findByStatuses(ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
                 .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -211,7 +211,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     @Override
     public Set<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses) {
         try {
-            log.debug("Find client certificates by application IDs {} and statuses {}", applicationIds.size(), statuses);
+            log.debug("Find client certificates by application IDs {} and statuses {}", applicationIds, statuses);
             return clientCertificateRepository
                 .findByApplicationIdsAndStatuses(applicationIds, ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
                 .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
@@ -135,6 +135,9 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
 
     @Override
     public Set<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses) {
+        if (statuses == null || statuses.length == 0) {
+            return Set.of();
+        }
         Set<ClientCertificateStatus> statusSet = Set.of(statuses);
         return storage
             .stream()
@@ -145,6 +148,9 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
 
     @Override
     public Set<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses) {
+        if (statuses == null || statuses.length == 0) {
+            return Set.of();
+        }
         Set<ClientCertificateStatus> statusSet = Set.of(statuses);
         return storage
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
@@ -154,6 +154,18 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
     }
 
     @Override
+    public Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses) {
+        if (statuses == null || statuses.length == 0) {
+            return Set.of();
+        }
+        var statusSet = Set.of(statuses);
+        return storage
+            .stream()
+            .filter(cert -> statusSet.contains(cert.getStatus()))
+            .collect(Collectors.toSet());
+    }
+
+    @Override
     public void deleteByApplicationId(String applicationId) {
         storage.removeIf(cert -> applicationId.equals(cert.getApplicationId()));
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2337

## Description

Add a `findByStatuses` method to `ClientCertificateRepository` and `ClientCertificateCrudService` that queries certificates by status across **all applications** (not scoped to a single applicationId). This is needed by the cron job for automatic client certificate revocation.

### Changes

- **`ClientCertificateRepository`** (repository-api): added `Set<ClientCertificate> findByStatuses(ClientCertificateStatus... statuses)`
- **`ClientCertificateMongoRepository`** (repository-mongodb): MongoDB `@Query` implementation
- **`MongoClientCertificateRepository`**: delegates to internal repository
- **`JdbcClientCertificateRepository`** (repository-jdbc): SQL `WHERE status IN (...)` implementation
- **`ClientCertificateCrudService`** (core): added interface method
- **`ClientCertificateCrudServiceImpl`** (infra): delegates to repository with adapter conversion
- **`ClientCertificateCrudServiceInMemory`** (test): in-memory implementation
- **Repository tests**: 4 new test cases (single status, multiple statuses, empty, null)
- **CrudService tests**: 2 new test cases (success + exception wrapping)

## Additional context

Follows the same pattern as existing `findByApplicationIdAndStatuses` and `findByApplicationIdsAndStatuses` methods. The new method simply omits the application ID filter.
