### PR TITLE
Add ProcessPendingCertificateTransitionsUseCase which activates/deactivates certificates

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
@@ -80,6 +80,7 @@ public class Audit {
         SHARED_POLICY_GROUP,
         CLUSTER,
         API_PRODUCT,
+        CLIENT_CERTIFICATE,
     }
 
     private String id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -60,6 +60,7 @@ import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
@@ -1187,5 +1188,10 @@ public class ResourceContextConfiguration {
     @Bean
     public UserContextLoader userContextLoader() {
         return mock(UserContextLoader.class);
+    }
+
+    @Bean
+    public ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
+        return mock(ApplicationCertificatesUpdateDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatus.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatus.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.application_certificate.model;
 
+import io.gravitee.apim.core.audit.model.event.ClientCertificateAuditEvent;
 import java.time.Instant;
 import java.util.Date;
 
@@ -44,5 +45,18 @@ public enum ClientCertificateStatus {
             return ACTIVE_WITH_END;
         }
         return ACTIVE;
+    }
+
+    /**
+     * Determines the appropriate audit event for a transition to this status.
+     *
+     * @return the corresponding audit event
+     */
+    public ClientCertificateAuditEvent toAuditEvent() {
+        return switch (this) {
+            case REVOKED -> ClientCertificateAuditEvent.CLIENT_CERTIFICATE_REVOKED;
+            case SCHEDULED -> ClientCertificateAuditEvent.CLIENT_CERTIFICATE_SCHEDULED;
+            case ACTIVE, ACTIVE_WITH_END -> ClientCertificateAuditEvent.CLIENT_CERTIFICATE_ACTIVATED;
+        };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatus.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatus.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.apim.core.application_certificate.model;
 
+import java.time.Instant;
+import java.util.Date;
+
 /**
  * Status of a client certificate.
  *
@@ -24,5 +27,22 @@ public enum ClientCertificateStatus {
     ACTIVE,
     ACTIVE_WITH_END,
     SCHEDULED,
-    REVOKED,
+    REVOKED;
+
+    public static ClientCertificateStatus computeStatus(Date startsAt, Date endsAt) {
+        return computeStatus(startsAt, endsAt, Instant.now());
+    }
+
+    public static ClientCertificateStatus computeStatus(Date startsAt, Date endsAt, Instant now) {
+        if (endsAt != null && endsAt.toInstant().isBefore(now)) {
+            return REVOKED;
+        }
+        if (startsAt != null && startsAt.toInstant().isAfter(now)) {
+            return SCHEDULED;
+        }
+        if (endsAt != null) {
+            return ACTIVE_WITH_END;
+        }
+        return ACTIVE;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApplicationAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.CustomLog;
+
+/**
+ * Use case that processes pending certificate transitions.
+ * <p>
+ * Certificates with {@code ACTIVE_WITH_END} status whose {@code endsAt} has passed are revoked.
+ * Certificates with {@code SCHEDULED} status whose {@code startsAt} has passed are activated.
+ * For each affected application, mTLS subscriptions are updated.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@CustomLog
+public class ProcessPendingCertificateTransitionsUseCase {
+
+    private final ClientCertificateCrudService clientCertificateCrudService;
+    private final EnvironmentCrudService environmentCrudService;
+    private final AuditDomainService auditDomainService;
+    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+
+    public ProcessPendingCertificateTransitionsUseCase(
+        ClientCertificateCrudService clientCertificateCrudService,
+        EnvironmentCrudService environmentCrudService,
+        AuditDomainService auditDomainService,
+        ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService
+    ) {
+        this.clientCertificateCrudService = clientCertificateCrudService;
+        this.environmentCrudService = environmentCrudService;
+        this.auditDomainService = auditDomainService;
+        this.applicationCertificatesUpdateDomainService = applicationCertificatesUpdateDomainService;
+    }
+
+    public Output execute(Input input) {
+        log.info("Processing pending certificate transitions");
+
+        var candidates = clientCertificateCrudService.findByStatuses(
+            ClientCertificateStatus.ACTIVE_WITH_END,
+            ClientCertificateStatus.SCHEDULED
+        );
+
+        log.info("Found {} candidate certificates to evaluate", candidates.size());
+
+        List<ClientCertificate> transitioned = new ArrayList<>();
+        Set<String> affectedApplicationIds = new HashSet<>();
+        int failedCount = 0;
+
+        for (var certificate : candidates) {
+            try {
+                if (shouldTransition(certificate)) {
+                    applyTransition(certificate, input.auditActor, transitioned, affectedApplicationIds);
+                }
+            } catch (Exception e) {
+                failedCount++;
+                log.error(
+                    "Failed to process certificate transition for [{}] on application [{}]: {}",
+                    certificate.getId(),
+                    certificate.getApplicationId(),
+                    e.getMessage(),
+                    e
+                );
+            }
+        }
+
+        int failedMtlsUpdateCount = 0;
+        for (var applicationId : affectedApplicationIds) {
+            try {
+                applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(applicationId);
+            } catch (Exception e) {
+                failedMtlsUpdateCount++;
+                log.error("Failed to update mTLS subscriptions for application [{}]: {}", applicationId, e.getMessage(), e);
+            }
+        }
+
+        if (failedCount > 0) {
+            log.error("Certificate transition processing completed with {} failures out of {} candidates", failedCount, candidates.size());
+        }
+
+        if (!candidates.isEmpty()) {
+            int successfulMtlsUpdates = affectedApplicationIds.size() - failedMtlsUpdateCount;
+            log.info(
+                "Completed pending certificate transitions: {} transitioned, {} failed, {} applications updated",
+                transitioned.size(),
+                failedCount,
+                successfulMtlsUpdates
+            );
+        }
+
+        return new Output(transitioned);
+    }
+
+    private boolean shouldTransition(ClientCertificate certificate) {
+        var computedStatus = ClientCertificateStatus.computeStatus(certificate.getStartsAt(), certificate.getEndsAt());
+        return computedStatus != certificate.getStatus();
+    }
+
+    private void applyTransition(
+        ClientCertificate certificate,
+        AuditActor auditActor,
+        List<ClientCertificate> transitioned,
+        Set<String> affectedApplicationIds
+    ) {
+        var oldCertificate = certificate.toBuilder().build();
+        var updated = clientCertificateCrudService.update(certificate.getId(), certificate);
+        // Audit log failure must not block executing the application update.
+        // Revocation/activation takes precedence over auditability -- a missing
+        // audit record is preferable to a certificate stuck in a stale state.
+        try {
+            createAuditLog(oldCertificate, updated, auditActor);
+        } catch (Exception e) {
+            log.error(
+                "Failed to create audit log for certificate [{}] on application [{}]: {}",
+                certificate.getId(),
+                certificate.getApplicationId(),
+                e.getMessage(),
+                e
+            );
+        }
+        transitioned.add(updated);
+        affectedApplicationIds.add(certificate.getApplicationId());
+    }
+
+    private void createAuditLog(ClientCertificate oldCertificate, ClientCertificate newCertificate, AuditActor actor) {
+        var environment = environmentCrudService.get(oldCertificate.getEnvironmentId());
+
+        auditDomainService.createApplicationAuditLog(
+            ApplicationAuditLogEntity.builder()
+                .organizationId(environment.getOrganizationId())
+                .environmentId(environment.getId())
+                .applicationId(oldCertificate.getApplicationId())
+                .actor(actor)
+                .event(newCertificate.getStatus().toAuditEvent())
+                .oldValue(oldCertificate)
+                .newValue(newCertificate)
+                .createdAt(ZonedDateTime.now())
+                .properties(Collections.singletonMap(AuditProperties.CLIENT_CERTIFICATE, oldCertificate.getId()))
+                .build()
+        );
+    }
+
+    public record Input(AuditActor auditActor) {
+        public Input {
+            Objects.requireNonNull(auditActor, "auditActor must not be null");
+        }
+    }
+
+    public record Output(List<ClientCertificate> transitionedCertificates) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
@@ -105,18 +105,29 @@ public class ProcessPendingCertificateTransitionsUseCase {
             }
         }
 
-        if (failedCount > 0) {
-            log.error("Certificate transition processing completed with {} failures out of {} candidates", failedCount, candidates.size());
-        }
-
         if (!candidates.isEmpty()) {
             int successfulMtlsUpdates = affectedApplicationIds.size() - failedMtlsUpdateCount;
-            log.info(
-                "Completed pending certificate transitions: {} transitioned, {} failed, {} applications updated",
-                transitioned.size(),
-                failedCount,
-                successfulMtlsUpdates
-            );
+            var message =
+                "Completed certificate transitions: {} transitioned, {} failed | mTLS updates: {} updated, {} failed over {} applications";
+            if (failedCount > 0 || failedMtlsUpdateCount > 0) {
+                log.warn(
+                    message,
+                    transitioned.size(),
+                    failedCount,
+                    successfulMtlsUpdates,
+                    failedMtlsUpdateCount,
+                    affectedApplicationIds.size()
+                );
+            } else {
+                log.info(
+                    message,
+                    transitioned.size(),
+                    failedCount,
+                    successfulMtlsUpdates,
+                    failedMtlsUpdateCount,
+                    affectedApplicationIds.size()
+                );
+            }
         }
 
         return new Output(transitioned);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ClientCertificateAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ClientCertificateAuditEvent.java
@@ -13,37 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.audit.model;
+package io.gravitee.apim.core.audit.model.event;
 
-public enum AuditProperties {
-    PLAN,
-    PAGE,
-    API_KEY,
-    METADATA,
-    GROUP,
-    USER,
-    ROLE,
-    API,
-    APPLICATION,
-    TAG,
-    TENANT,
-    CATEGORY,
-    PARAMETER,
-    DICTIONARY,
-    API_HEADER,
-    IDENTITY_PROVIDER,
-    ENTRYPOINT,
-    REQUEST_ID,
-    CLIENT_REGISTRATION_PROVIDER,
-    QUALITY_RULE,
-    API_QUALITY_RULE,
-    DASHBOARD,
-    THEME,
-    TOKEN,
-    USER_FIELD,
-    NOTIFICATION_TEMPLATE,
-    SHARED_POLICY_GROUP,
-    CLUSTER,
-    API_PRODUCT,
-    CLIENT_CERTIFICATE,
+public enum ClientCertificateAuditEvent implements AuditEvent {
+    CLIENT_CERTIFICATE_ACTIVATED,
+    CLIENT_CERTIFICATE_REVOKED,
+    CLIENT_CERTIFICATE_SCHEDULED,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClientCertificateAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClientCertificateAdapter.java
@@ -30,4 +30,5 @@ public interface ClientCertificateAdapter {
     ClientCertificate toDomain(io.gravitee.repository.management.model.ClientCertificate clientCertificate);
     io.gravitee.repository.management.model.ClientCertificate toRepo(ClientCertificate clientCertificate);
     io.gravitee.repository.management.model.ClientCertificateStatus[] toRepoStatuses(ClientCertificateStatus[] statuses);
+    io.gravitee.repository.management.model.ClientCertificateStatus toRepoStatus(ClientCertificateStatus status);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClientCertificateAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClientCertificateAdapter.java
@@ -29,5 +29,5 @@ public interface ClientCertificateAdapter {
     ClientCertificateAdapter INSTANCE = Mappers.getMapper(ClientCertificateAdapter.class);
     ClientCertificate toDomain(io.gravitee.repository.management.model.ClientCertificate clientCertificate);
     io.gravitee.repository.management.model.ClientCertificate toRepo(ClientCertificate clientCertificate);
-    io.gravitee.repository.management.model.ClientCertificateStatus[] toRepoStatus(ClientCertificateStatus[] clientCertificate);
+    io.gravitee.repository.management.model.ClientCertificateStatus[] toRepoStatuses(ClientCertificateStatus[] statuses);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -197,7 +197,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         try {
             log.debug("Find client certificates by application ID {} and statuses {}", applicationId, Arrays.toString(statuses));
             return clientCertificateRepository
-                .findByApplicationIdAndStatuses(applicationId, ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
+                .findByApplicationIdAndStatuses(applicationId, ClientCertificateAdapter.INSTANCE.toRepoStatuses(statuses))
                 .stream()
                 .map(ClientCertificateAdapter.INSTANCE::toDomain)
                 .collect(Collectors.toSet());
@@ -214,7 +214,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         try {
             log.debug("Find client certificates by application IDs {} and statuses {}", applicationIds, Arrays.toString(statuses));
             return clientCertificateRepository
-                .findByApplicationIdsAndStatuses(applicationIds, ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
+                .findByApplicationIdsAndStatuses(applicationIds, ClientCertificateAdapter.INSTANCE.toRepoStatuses(statuses))
                 .stream()
                 .map(ClientCertificateAdapter.INSTANCE::toDomain)
                 .collect(Collectors.toSet());
@@ -231,7 +231,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         try {
             log.debug("Find client certificates by statuses {}", Arrays.toString(statuses));
             return clientCertificateRepository
-                .findByStatuses(ClientCertificateAdapter.INSTANCE.toRepoStatus(statuses))
+                .findByStatuses(ClientCertificateAdapter.INSTANCE.toRepoStatuses(statuses))
                 .stream()
                 .map(ClientCertificateAdapter.INSTANCE::toDomain)
                 .collect(Collectors.toSet());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -264,21 +264,8 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     }
 
     private io.gravitee.repository.management.model.ClientCertificateStatus computeStatus(Date startsAt, Date endsAt) {
-        Date now = new Date();
-
-        if (endsAt != null && now.after(endsAt)) {
-            return io.gravitee.repository.management.model.ClientCertificateStatus.REVOKED;
-        }
-
-        if (startsAt != null && now.before(startsAt)) {
-            return io.gravitee.repository.management.model.ClientCertificateStatus.SCHEDULED;
-        }
-
-        if (endsAt != null) {
-            return io.gravitee.repository.management.model.ClientCertificateStatus.ACTIVE_WITH_END;
-        }
-
-        return io.gravitee.repository.management.model.ClientCertificateStatus.ACTIVE;
+        var status = ClientCertificateStatus.computeStatus(startsAt, endsAt);
+        return ClientCertificateAdapter.INSTANCE.toRepoStatus(status);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
@@ -44,6 +44,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .stream()
             .filter(cert -> clientCertificateId.equals(cert.getId()))
             .findFirst()
+            .map(cert -> cert.toBuilder().build())
             .orElseThrow(() -> new ClientCertificateNotFoundException(clientCertificateId));
     }
 
@@ -71,7 +72,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .build();
 
         storage.add(certificate);
-        return certificate;
+        return certificate.toBuilder().build();
     }
 
     @Override
@@ -103,7 +104,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .build();
 
         storage.set(index.getAsInt(), updated);
-        return updated;
+        return updated.toBuilder().build();
     }
 
     @Override
@@ -128,7 +129,13 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
         int fromIndex = Math.max(0, (pageNumber - 1) * pageSize);
         int toIndex = Math.min(fromIndex + pageSize, filtered.size());
 
-        List<ClientCertificate> pageContent = fromIndex < filtered.size() ? filtered.subList(fromIndex, toIndex) : Collections.emptyList();
+        List<ClientCertificate> pageContent = fromIndex < filtered.size()
+            ? filtered
+                .subList(fromIndex, toIndex)
+                .stream()
+                .map(cert -> cert.toBuilder().build())
+                .toList()
+            : Collections.emptyList();
 
         return new Page<>(pageContent, pageNumber, pageSize, filtered.size());
     }
@@ -143,6 +150,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .stream()
             .filter(cert -> applicationId.equals(cert.getApplicationId()))
             .filter(cert -> statusSet.contains(cert.getStatus()))
+            .map(cert -> cert.toBuilder().build())
             .collect(Collectors.toSet());
     }
 
@@ -156,6 +164,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .stream()
             .filter(cert -> applicationIds.contains(cert.getApplicationId()))
             .filter(cert -> statusSet.contains(cert.getStatus()))
+            .map(cert -> cert.toBuilder().build())
             .collect(Collectors.toSet());
     }
 
@@ -168,6 +177,7 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
         return storage
             .stream()
             .filter(cert -> statusSet.contains(cert.getStatus()))
+            .map(cert -> cert.toBuilder().build())
             .collect(Collectors.toSet());
     }
 
@@ -184,13 +194,17 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
             .filter(
                 cert -> cert.getStatus() == ClientCertificateStatus.ACTIVE || cert.getStatus() == ClientCertificateStatus.ACTIVE_WITH_END
             )
-            .max(Comparator.comparing(ClientCertificate::getCreatedAt));
+            .max(Comparator.comparing(ClientCertificate::getCreatedAt))
+            .map(cert -> cert.toBuilder().build());
     }
 
     @Override
     public void initWith(List<ClientCertificate> items) {
         storage.clear();
-        storage.addAll(items);
+        items
+            .stream()
+            .map(cert -> cert.toBuilder().build())
+            .forEach(storage::add);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatusTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/model/ClientCertificateStatusTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClientCertificateStatusTest {
+
+    static Stream<Arguments> computeStatusCases() {
+        var now = Instant.parse("2025-01-15T12:00:00Z");
+        var past = Date.from(now.minus(1, ChronoUnit.DAYS));
+        var future = Date.from(now.plus(1, ChronoUnit.DAYS));
+
+        return Stream.of(
+            // endsAt in past → REVOKED regardless of startsAt
+            Arguments.of(null, past, now, ClientCertificateStatus.REVOKED),
+            Arguments.of(past, past, now, ClientCertificateStatus.REVOKED),
+            // startsAt in future (and endsAt not expired) → SCHEDULED
+            Arguments.of(future, null, now, ClientCertificateStatus.SCHEDULED),
+            Arguments.of(future, future, now, ClientCertificateStatus.SCHEDULED),
+            // endsAt in future, startsAt not in future → ACTIVE_WITH_END
+            Arguments.of(null, future, now, ClientCertificateStatus.ACTIVE_WITH_END),
+            Arguments.of(past, future, now, ClientCertificateStatus.ACTIVE_WITH_END),
+            // no endsAt, startsAt not in future → ACTIVE
+            Arguments.of(null, null, now, ClientCertificateStatus.ACTIVE),
+            Arguments.of(past, null, now, ClientCertificateStatus.ACTIVE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("computeStatusCases")
+    void should_compute_correct_status(Date startsAt, Date endsAt, Instant now, ClientCertificateStatus expected) {
+        assertThat(ClientCertificateStatus.computeStatus(startsAt, endsAt, now)).isEqualTo(expected);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCaseTest.java
@@ -1,0 +1,589 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
+import inmemory.EnvironmentCrudServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditEntity.AuditReferenceType;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.environment.model.Environment;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProcessPendingCertificateTransitionsUseCaseTest {
+
+    private static final String USER_ID = "system";
+    private static final AuditActor AUDIT_ACTOR = AuditActor.builder().userId(USER_ID).build();
+
+    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
+    private final EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+
+    @Mock
+    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+
+    private ProcessPendingCertificateTransitionsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        UuidString.overrideGenerator(() -> "audit-id");
+
+        var auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+
+        useCase = new ProcessPendingCertificateTransitionsUseCase(
+            clientCertificateCrudService,
+            environmentCrudService,
+            auditDomainService,
+            applicationCertificatesUpdateDomainService
+        );
+
+        environmentCrudService.initWith(
+            List.of(
+                Environment.builder().id("env1").organizationId("org1").build(),
+                Environment.builder().id("env2").organizationId("org2").build()
+            )
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        clientCertificateCrudService.reset();
+        environmentCrudService.reset();
+        auditCrudService.reset();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+    }
+
+    @Test
+    void should_revoke_expired_active_with_end_certificates() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert1")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Expired cert")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(1);
+        assertThat(result.transitionedCertificates().get(0).getStatus()).isEqualTo(ClientCertificateStatus.REVOKED);
+        assertThat(clientCertificateCrudService.storage())
+            .filteredOn(c -> "cert1".equals(c.getId()))
+            .extracting(ClientCertificate::getStatus)
+            .containsExactly(ClientCertificateStatus.REVOKED);
+    }
+
+    @Test
+    void should_activate_scheduled_certificates_whose_start_date_has_passed() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var futureDate = Date.from(Instant.now().plus(30, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert2")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Scheduled cert with end date")
+                    .startsAt(pastDate)
+                    .endsAt(futureDate)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(1);
+        assertThat(result.transitionedCertificates().get(0).getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE_WITH_END);
+        assertThat(clientCertificateCrudService.storage())
+            .filteredOn(c -> "cert2".equals(c.getId()))
+            .extracting(ClientCertificate::getStatus)
+            .containsExactly(ClientCertificateStatus.ACTIVE_WITH_END);
+    }
+
+    @Test
+    void should_activate_scheduled_certificates_without_end_date() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert3")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Scheduled cert no end")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(1);
+        assertThat(result.transitionedCertificates().get(0).getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE);
+        assertThat(clientCertificateCrudService.storage())
+            .filteredOn(c -> "cert3".equals(c.getId()))
+            .extracting(ClientCertificate::getStatus)
+            .containsExactly(ClientCertificateStatus.ACTIVE);
+    }
+
+    @Test
+    void should_not_transition_certificates_that_are_not_yet_due() {
+        var futureStart = Date.from(Instant.now().plus(10, ChronoUnit.DAYS));
+        var futureEnd = Date.from(Instant.now().plus(30, ChronoUnit.DAYS));
+        var pastStart = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-scheduled-future")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Future scheduled cert")
+                    .startsAt(futureStart)
+                    .endsAt(null)
+                    .createdAt(new Date())
+                    .updatedAt(new Date())
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert-active-with-end-future")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Active with future end")
+                    .startsAt(pastStart)
+                    .endsAt(futureEnd)
+                    .createdAt(new Date())
+                    .updatedAt(new Date())
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).isEmpty();
+        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void should_create_audit_logs_for_each_transition() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+        var futureDate = Date.from(Instant.now().plus(30, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-revoked")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("To be revoked")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert-activated")
+                    .applicationId("app2")
+                    .environmentId("env2")
+                    .name("To be activated")
+                    .startsAt(pastDate)
+                    .endsAt(futureDate)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(auditCrudService.storage())
+            .hasSize(2)
+            .extracting(
+                AuditEntity::getOrganizationId,
+                AuditEntity::getEnvironmentId,
+                AuditEntity::getReferenceType,
+                AuditEntity::getReferenceId,
+                AuditEntity::getEvent,
+                AuditEntity::getUser,
+                AuditEntity::getProperties
+            )
+            .containsExactlyInAnyOrder(
+                tuple(
+                    "org1",
+                    "env1",
+                    AuditReferenceType.APPLICATION,
+                    "app1",
+                    "CLIENT_CERTIFICATE_REVOKED",
+                    USER_ID,
+                    Map.of(AuditProperties.CLIENT_CERTIFICATE.name(), "cert-revoked")
+                ),
+                tuple(
+                    "org2",
+                    "env2",
+                    AuditReferenceType.APPLICATION,
+                    "app2",
+                    "CLIENT_CERTIFICATE_ACTIVATED",
+                    USER_ID,
+                    Map.of(AuditProperties.CLIENT_CERTIFICATE.name(), "cert-activated")
+                )
+            );
+    }
+
+    @Test
+    void should_call_update_mtls_subscriptions_once_per_affected_application() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert1")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Cert 1 for app1")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert2")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Cert 2 for app1")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert3")
+                    .applicationId("app2")
+                    .environmentId("env2")
+                    .name("Cert for app2")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app1");
+        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+    }
+
+    @Test
+    void should_return_empty_when_no_certificates_need_processing() {
+        clientCertificateCrudService.initWith(List.of());
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).isEmpty();
+        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void should_capture_old_status_in_audit_patch() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-to-revoke")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Expiring cert")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build()
+            )
+        );
+
+        useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        // The patch should record the status change (replace op with new value REVOKED).
+        // An empty patch would mean old and new were identical — the bug this test guards against.
+        assertThat(auditCrudService.storage())
+            .hasSize(1)
+            .first()
+            .satisfies(audit -> {
+                assertThat(audit.getPatch()).isNotBlank();
+                assertThat(audit.getPatch()).contains("replace");
+                assertThat(audit.getPatch()).contains("REVOKED");
+            });
+    }
+
+    @Test
+    void should_still_transition_certificate_when_audit_log_creation_fails() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        // "env-missing" does not exist in environmentCrudService, causing audit to throw
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-audit-fails")
+                    .applicationId("app1")
+                    .environmentId("env-missing")
+                    .name("Cert with bad env")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(1);
+        assertThat(result.transitionedCertificates().get(0).getStatus()).isEqualTo(ClientCertificateStatus.REVOKED);
+        assertThat(auditCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_continue_updating_other_applications_when_one_mtls_update_fails() {
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+
+        clientCertificateCrudService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-app1")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Cert for app1")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert-app2")
+                    .applicationId("app2")
+                    .environmentId("env2")
+                    .name("Cert for app2")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        doThrow(new RuntimeException("mTLS update failed"))
+            .when(applicationCertificatesUpdateDomainService)
+            .updateActiveMTLSSubscriptions("app1");
+
+        var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(2);
+        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app1");
+        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+    }
+
+    @Test
+    void should_not_call_mtls_update_for_application_whose_certificate_update_fails() {
+        var spiedService = spy(clientCertificateCrudService);
+        var spiedUseCase = new ProcessPendingCertificateTransitionsUseCase(
+            spiedService,
+            environmentCrudService,
+            new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+            applicationCertificatesUpdateDomainService
+        );
+
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        spiedService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-fail")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Cert whose update fails")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert-succeed")
+                    .applicationId("app2")
+                    .environmentId("env2")
+                    .name("Cert whose update succeeds")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        doAnswer(invocation -> {
+            String certId = invocation.getArgument(0);
+            if ("cert-fail".equals(certId)) {
+                throw new RuntimeException("Update failed");
+            }
+            return invocation.callRealMethod();
+        })
+            .when(spiedService)
+            .update(anyString(), any());
+
+        spiedUseCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions("app1");
+        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+    }
+
+    @Test
+    void should_continue_processing_remaining_certificates_when_one_certificate_update_fails() {
+        var spiedService = spy(clientCertificateCrudService);
+        var spiedUseCase = new ProcessPendingCertificateTransitionsUseCase(
+            spiedService,
+            environmentCrudService,
+            new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+            applicationCertificatesUpdateDomainService
+        );
+
+        var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        var pastStartDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+
+        spiedService.initWith(
+            List.of(
+                ClientCertificate.builder()
+                    .id("cert-fail")
+                    .applicationId("app1")
+                    .environmentId("env1")
+                    .name("Cert that will fail update")
+                    .startsAt(pastStartDate)
+                    .endsAt(pastDate)
+                    .createdAt(pastStartDate)
+                    .updatedAt(pastStartDate)
+                    .status(ClientCertificateStatus.ACTIVE_WITH_END)
+                    .build(),
+                ClientCertificate.builder()
+                    .id("cert-succeed")
+                    .applicationId("app2")
+                    .environmentId("env2")
+                    .name("Cert that will succeed")
+                    .startsAt(pastDate)
+                    .endsAt(null)
+                    .createdAt(pastDate)
+                    .updatedAt(pastDate)
+                    .status(ClientCertificateStatus.SCHEDULED)
+                    .build()
+            )
+        );
+
+        doAnswer(invocation -> {
+            String certId = invocation.getArgument(0);
+            if ("cert-fail".equals(certId)) {
+                throw new RuntimeException("Update failed");
+            }
+            return invocation.callRealMethod();
+        })
+            .when(spiedService)
+            .update(anyString(), any());
+
+        var result = spiedUseCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.transitionedCertificates()).hasSize(1);
+        assertThat(result.transitionedCertificates().get(0).getId()).isEqualTo("cert-succeed");
+
+        // The failed certificate should remain unchanged in storage
+        assertThat(clientCertificateCrudService.storage())
+            .filteredOn(c -> "cert-fail".equals(c.getId()))
+            .extracting(ClientCertificate::getStatus)
+            .containsExactly(ClientCertificateStatus.ACTIVE_WITH_END);
+    }
+}


### PR DESCRIPTION
## Issue

[GKO-2338](https://gravitee.atlassian.net/browse/GKO-2338)

## Description

Implements the `ProcessPendingCertificateTransitionsUseCase` which handles automatic certificate lifecycle transitions:

- **ACTIVE_WITH_END -> REVOKED**: Certificates whose `endsAt` date has passed are automatically revoked
- **SCHEDULED -> ACTIVE/ACTIVE_WITH_END**: Certificates whose `startsAt` date has passed are automatically activated
- Audit logs (`CLIENT_CERTIFICATE_REVOKED`, `CLIENT_CERTIFICATE_ACTIVATED`) are created for each transition
- mTLS subscriptions are redeployed once per affected application via `ApplicationCertificatesUpdateDomainService`

Also introduces:
- `ClientCertificateAuditEvent` enum with `CLIENT_CERTIFICATE_ACTIVATED` and `CLIENT_CERTIFICATE_REVOKED` events
- `CLIENT_CERTIFICATE` property in `AuditProperties` enum

Follows the `CloseExpiredSubscriptionsUseCase` pattern.

## Additional context

This is part of the **Automatic client certificates revocation** feature (GKO-2001). Depends on GKO-2337 which added `findByStatuses` to `ClientCertificateCrudService`.

7 unit tests cover:
- Revoking expired ACTIVE_WITH_END certificates
- Activating SCHEDULED certificates (with and without end dates)
- Leaving not-yet-due certificates untouched
- Audit log creation for each transition
- `updateActiveMTLSSubscriptions` called once per affected application
- Empty result handling


[GKO-2338]: https://gravitee.atlassian.net/browse/GKO-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ