### PR TITLE
fix: move timestamps to base trigger in alert api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/alert/AlertTriggerEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/alert/AlertTriggerEntity.java
@@ -36,12 +36,6 @@ public class AlertTriggerEntity extends Trigger {
     @JsonProperty("reference_id")
     private String referenceId;
 
-    @JsonProperty("created_at")
-    private Date createdAt;
-
-    @JsonProperty("updated_at")
-    private Date updatedAt;
-
     private String type;
 
     @JsonProperty("last_alert_at")
@@ -90,22 +84,6 @@ public class AlertTriggerEntity extends Trigger {
 
     public void setReferenceId(String referenceId) {
         this.referenceId = referenceId;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
     }
 
     public String getType() {
@@ -185,9 +163,9 @@ public class AlertTriggerEntity extends Trigger {
             referenceId +
             '\'' +
             ", createdAt=" +
-            createdAt +
+            getCreatedAt() +
             ", updatedAt=" +
-            updatedAt +
+            getUpdatedAt() +
             ", environmentId=" +
             environmentId +
             '}'

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/alert/AlertTriggerEntityWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/alert/AlertTriggerEntityWrapper.java
@@ -21,6 +21,7 @@ import io.gravitee.alert.api.trigger.Dampening;
 import io.gravitee.alert.api.trigger.Trigger;
 import io.gravitee.notifier.api.Notification;
 import io.gravitee.notifier.api.Period;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -155,6 +156,26 @@ public class AlertTriggerEntityWrapper extends AlertTriggerEntity {
     @Override
     public void setNotificationPeriods(List<Period> notificationPeriods) {
         trigger.setNotificationPeriods(notificationPeriods);
+    }
+
+    @Override
+    public Date getCreatedAt() {
+        return trigger.getCreatedAt();
+    }
+
+    @Override
+    public void setCreatedAt(Date createdAt) {
+        trigger.setCreatedAt(createdAt);
+    }
+
+    @Override
+    public Date getUpdatedAt() {
+        return trigger.getUpdatedAt();
+    }
+
+    @Override
+    public void setUpdatedAt(Date updatedAt) {
+        trigger.setUpdatedAt(updatedAt);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven-lombok.version>1.18.36</maven-lombok.version>
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
+        <gravitee-alert-api.version>3.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.0</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.3.1</gravitee-cloud-initializer.version>
         <logback-ecs-encoder.version>1.7.0</logback-ecs-encoder.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-4041

## Description

Remove the timestamp fields in trigger superclass as they are added in trigger base class to be sent through to alert engine. 

Alert api change here - https://github.com/gravitee-io/gravitee-alert-api/pull/76

I made this a breaking change on alert api side since apim can only use the new alert-api version with the changes in this PR (as otherwise will fail to compile with duplicate fields).

(Version will be updated from snapshot once alert api released and before merging this PR but wanted to check this PR before doing that release) 

Applying on master and 4.10.x as timestamps will be used to fix alert engine consistent schedule which needs to be delivered before 4.11
