### PR TITLE
feat: add ScheduledCertificateRevocationService and Spring configuration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.rest.api.services</groupId>
+        <artifactId>gravitee-apim-rest-api-services</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-rest-api-services-certificate-revocation</artifactId>
+    <name>Gravitee.io APIM - Management API - Services - Certificate Revocation</name>
+
+    <dependencies>
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/java/io/gravitee/rest/api/services/certificate/revocation/ScheduledCertificateRevocationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/java/io/gravitee/rest/api/services/certificate/revocation/ScheduledCertificateRevocationService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.certificate.revocation;
+
+import io.gravitee.apim.core.application_certificate.use_case.ProcessPendingCertificateTransitionsUseCase;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.common.service.AbstractService;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ScheduledCertificateRevocationService extends AbstractService implements Runnable {
+
+    private final TaskScheduler scheduler;
+    private final String cronTrigger;
+    private final boolean enabled;
+    private final ProcessPendingCertificateTransitionsUseCase processPendingCertificateTransitionsUseCase;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    public ScheduledCertificateRevocationService(
+        @Qualifier("certificateRevocationTaskScheduler") TaskScheduler scheduler,
+        @Value("${services.certificate-revocation.cron:0 0 0 * * *}") String cronTrigger,
+        @Value("${services.certificate-revocation.enabled:true}") boolean enabled,
+        ProcessPendingCertificateTransitionsUseCase processPendingCertificateTransitionsUseCase
+    ) {
+        this.scheduler = scheduler;
+        this.cronTrigger = cronTrigger;
+        this.enabled = enabled;
+        this.processPendingCertificateTransitionsUseCase = processPendingCertificateTransitionsUseCase;
+    }
+
+    @Override
+    protected String name() {
+        return "Certificate Revocation Service";
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        if (enabled) {
+            super.doStart();
+            log.info("Certificate Revocation service has been initialized with cron [{}]", cronTrigger);
+            try {
+                scheduler.schedule(this, new CronTrigger(cronTrigger));
+            } catch (IllegalArgumentException e) {
+                log.error(
+                    "Certificate Revocation service failed to start: invalid cron expression [{}] " +
+                        "in property 'services.certificate-revocation.cron'. Service will not run.",
+                    cronTrigger
+                );
+                throw e;
+            }
+        } else {
+            log.warn("Certificate Revocation service has been disabled");
+        }
+    }
+
+    @Override
+    public void run() {
+        log.debug("Certificate revocation #{} started at {}", counter.incrementAndGet(), Instant.now());
+
+        try {
+            processPendingCertificateTransitionsUseCase.execute(
+                new ProcessPendingCertificateTransitionsUseCase.Input(AuditActor.builder().userId("system").build())
+            );
+        } catch (Exception e) {
+            log.error("Error during certificate revocation processing", e);
+        }
+
+        log.debug("Certificate revocation #{} ended at {}", counter.get(), Instant.now());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/java/io/gravitee/rest/api/services/certificate/revocation/spring/CertificateRevocationConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/java/io/gravitee/rest/api/services/certificate/revocation/spring/CertificateRevocationConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.certificate.revocation.spring;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class CertificateRevocationConfiguration {
+
+    @Bean
+    @Qualifier("certificateRevocationTaskScheduler")
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("certificate-revocation-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/resources/plugin.properties
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=certificate-revocation
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.rest.api.services.certificate.revocation.ScheduledCertificateRevocationService
+type=service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/test/java/io/gravitee/rest/api/services/certificate/revocation/ScheduledCertificateRevocationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-certificate-revocation/src/test/java/io/gravitee/rest/api/services/certificate/revocation/ScheduledCertificateRevocationServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.certificate.revocation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.apim.core.application_certificate.use_case.ProcessPendingCertificateTransitionsUseCase;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ScheduledCertificateRevocationServiceTest {
+
+    @Mock
+    private TaskScheduler scheduler;
+
+    @Mock
+    private ProcessPendingCertificateTransitionsUseCase processPendingCertificateTransitionsUseCase;
+
+    private ScheduledCertificateRevocationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScheduledCertificateRevocationService(scheduler, "0 0 0 * * *", true, processPendingCertificateTransitionsUseCase);
+    }
+
+    @Test
+    void shouldScheduleTaskWhenEnabledAndStarted() throws Exception {
+        service.doStart();
+
+        verify(scheduler).schedule(eq(service), any(CronTrigger.class));
+    }
+
+    @Test
+    void shouldThrowWhenCronExpressionIsInvalid() {
+        service = new ScheduledCertificateRevocationService(scheduler, "not-a-cron", true, processPendingCertificateTransitionsUseCase);
+
+        assertThrows(IllegalArgumentException.class, () -> service.doStart());
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+    }
+
+    @Test
+    void shouldNotScheduleTaskWhenDisabled() throws Exception {
+        service = new ScheduledCertificateRevocationService(scheduler, "0 0 0 * * *", false, processPendingCertificateTransitionsUseCase);
+
+        service.doStart();
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+    }
+
+    @Test
+    void shouldProcessPendingCertificateTransitions() {
+        service.run();
+
+        verify(processPendingCertificateTransitionsUseCase, times(1)).execute(
+            new ProcessPendingCertificateTransitionsUseCase.Input(AuditActor.builder().userId("system").build())
+        );
+    }
+
+    @Test
+    void shouldNotThrowWhenUseCaseFails() {
+        doThrow(new RuntimeException("DB connection failed")).when(processPendingCertificateTransitionsUseCase).execute(any());
+
+        assertDoesNotThrow(() -> service.run());
+
+        verify(processPendingCertificateTransitionsUseCase, times(1)).execute(any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -45,6 +45,7 @@
         <module>gravitee-apim-rest-api-services-subscriptions</module>
         <module>gravitee-apim-rest-api-services-subscription-pre-expiration-notif</module>
         <module>gravitee-apim-rest-api-services-v3-upgrader</module>
+        <module>gravitee-apim-rest-api-services-certificate-revocation</module>
     </modules>
 
     <dependencies>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -224,6 +224,20 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api.services</groupId>
+            <artifactId>gravitee-apim-rest-api-services-certificate-revocation</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2339

## Description

New Maven module `gravitee-apim-rest-api-services-certificate-revocation` containing a scheduled service that periodically invokes `ProcessPendingCertificateTransitionsUseCase` to process automatic certificate lifecycle transitions.

### Changes

- **`ScheduledCertificateRevocationService`** — extends `AbstractService`, implements `Runnable`; scheduled via configurable cron expression (daily at midnight by default)
- **`CertificateRevocationConfiguration`** — Spring `@Configuration` providing a `TaskScheduler` bean
- **`plugin.properties`** — service plugin registration
- **`plugin-assembly.xml`** — Maven assembly descriptor for plugin packaging
- Registered the new module in `gravitee-apim-rest-api-services/pom.xml`

### Configuration

| Property | Default | Description |
|----------|---------|-------------|
| `services.certificate-revocation.cron` | `0 0 0 * * *` | Cron expression (daily at midnight) |
| `services.certificate-revocation.enabled` | `true` | Enable/disable the service |

## Additional context

Follows the exact same pattern as `ScheduledSubscriptionsService` / `gravitee-apim-rest-api-services-subscriptions`. This is a sub-task of GKO-2001 (Automatic client certificates revocation).
