### PR TITLE
refactor(gravitee-markdown): allow parent to provide form state store

### DIFF
--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { ConfigureTestingGmdFormEditor, ConfigureTestingGraviteeMarkdownEditor, GmdFormEditorHarness } from '@gravitee/gravitee-markdown';
+import {
+  ConfigureTestingGmdFormEditor,
+  ConfigureTestingGraviteeMarkdownEditor,
+  GmdFormEditorHarness,
+  provideGmdFormStore,
+} from '@gravitee/gravitee-markdown';
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -37,6 +42,7 @@ describe('SubscriptionFormComponent', () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
       providers: [
+        provideGmdFormStore(),
         {
           provide: GioPermissionService,
           useValue: {

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
@@ -21,7 +21,7 @@ import { GmdCheckboxComponent } from './gmd-checkbox.component';
 import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
 import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
-import { GmdFormStateStore, GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
 
 export default {
   title: 'Gravitee Markdown/Components/Checkbox',
@@ -34,10 +34,7 @@ export default {
       imports: [GmdCheckboxComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
     }),
     applicationConfig({
-      providers: [
-        importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })),
-        { provide: GMD_FORM_STATE_STORE, useClass: GmdFormStateStore },
-      ],
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
     }),
   ],
 } as Meta<GmdCheckboxComponent>;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
@@ -21,7 +21,7 @@ import { GmdInputComponent } from './gmd-input.component';
 import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
 import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
-import { GmdFormStateStore, GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
 
 export default {
   title: 'Gravitee Markdown/Components/Input',
@@ -34,10 +34,7 @@ export default {
       imports: [GmdInputComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
     }),
     applicationConfig({
-      providers: [
-        importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })),
-        { provide: GMD_FORM_STATE_STORE, useClass: GmdFormStateStore },
-      ],
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
     }),
   ],
 } as Meta<GmdInputComponent>;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
@@ -21,7 +21,7 @@ import { GmdRadioComponent } from './gmd-radio.component';
 import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
 import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
-import { GmdFormStateStore, GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
 
 export default {
   title: 'Gravitee Markdown/Components/Radio',
@@ -34,10 +34,7 @@ export default {
       imports: [GmdRadioComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
     }),
     applicationConfig({
-      providers: [
-        importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })),
-        { provide: GMD_FORM_STATE_STORE, useClass: GmdFormStateStore },
-      ],
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
     }),
   ],
 } as Meta<GmdRadioComponent>;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
@@ -21,7 +21,7 @@ import { GmdSelectComponent } from './gmd-select.component';
 import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
 import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
-import { GmdFormStateStore, GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
 
 export default {
   title: 'Gravitee Markdown/Components/Select',
@@ -34,10 +34,7 @@ export default {
       imports: [GmdSelectComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
     }),
     applicationConfig({
-      providers: [
-        importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })),
-        { provide: GMD_FORM_STATE_STORE, useClass: GmdFormStateStore },
-      ],
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
     }),
   ],
 } as Meta<GmdSelectComponent>;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
@@ -21,7 +21,7 @@ import { GmdTextareaComponent } from './gmd-textarea.component';
 import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
 import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
-import { GmdFormStateStore, GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
 
 export default {
   title: 'Gravitee Markdown/Components/Textarea',
@@ -34,10 +34,7 @@ export default {
       imports: [GmdTextareaComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
     }),
     applicationConfig({
-      providers: [
-        importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })),
-        { provide: GMD_FORM_STATE_STORE, useClass: GmdFormStateStore },
-      ],
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
     }),
   ],
 } as Meta<GmdTextareaComponent>;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GmdFormEditorComponent } from './gmd-form-editor.component';
 import { GraviteeMarkdownViewerModule } from '../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+import { provideGmdFormStore } from '../services/gmd-form-state.store';
 
 @Component({
   selector: 'gmd-monaco-editor',
@@ -45,6 +46,7 @@ describe('GmdFormEditorComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GmdFormEditorComponent, MockMonacoEditorComponent, MockGmdViewerComponent],
+      providers: [provideGmdFormStore()],
     })
       .overrideComponent(GmdFormEditorComponent, {
         remove: { imports: [GraviteeMarkdownViewerModule] },

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
@@ -16,7 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GmdFormHostComponent } from './gmd-form-host.component';
-import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
+import { GMD_FORM_STATE_STORE, provideGmdFormStore } from '../services/gmd-form-state.store';
 
 describe('GmdFormHostComponent', () => {
   let component: GmdFormHostComponent;
@@ -25,6 +25,7 @@ describe('GmdFormHostComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GmdFormHostComponent],
+      providers: [provideGmdFormStore()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GmdFormHostComponent);
@@ -35,7 +36,7 @@ describe('GmdFormHostComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should provide GMD_FORM_STATE_STORE to children', () => {
+  it('should use the provided GMD_FORM_STATE_STORE', () => {
     const store = fixture.debugElement.injector.get(GMD_FORM_STATE_STORE);
     expect(store).toBeTruthy();
   });

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
@@ -15,11 +15,10 @@
  */
 import { Component, effect, inject, input, untracked } from '@angular/core';
 
-import { GMD_FORM_STATE_STORE, GmdFormStateStore } from '../services/gmd-form-state.store';
+import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
 
 /**
- * Host component that provides a scoped form state store and manages its lifecycle.
- * Acts as a DI scope boundary for form state management.
+ * Host component that manages the form state lifecycle.
  *
  * Usage:
  * ```html
@@ -34,12 +33,6 @@ import { GMD_FORM_STATE_STORE, GmdFormStateStore } from '../services/gmd-form-st
   standalone: true,
   template: '<ng-content />',
   styleUrl: './gmd-form-host.component.scss',
-  providers: [
-    {
-      provide: GMD_FORM_STATE_STORE,
-      useFactory: () => new GmdFormStateStore(),
-    },
-  ],
 })
 export class GmdFormHostComponent {
   private readonly store = inject(GMD_FORM_STATE_STORE);

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
@@ -20,7 +20,7 @@ import { GMD_FORM_STATE_STORE } from '../services/gmd-form-state.store';
 
 /**
  * Validation panel component that displays form diagnostics and validation status.
- * Injects the form state store from parent scope (gmd-form-host).
+ * Injects the form state store from the parent scope.
  *
  * Displays:
  * - Configuration errors (critical)

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { computed, Injectable, InjectionToken, signal } from '@angular/core';
+import { computed, Injectable, InjectionToken, Provider, signal } from '@angular/core';
 import { isEqual } from 'lodash';
 
 import { GmdConfigError, GmdFieldState } from '../models/formField';
@@ -210,3 +210,11 @@ export class GmdFormStateStore {
  * Injection token for GMD form state store.
  */
 export const GMD_FORM_STATE_STORE = new InjectionToken<GmdFormStateStore>('GMD_FORM_STATE_STORE');
+
+/**
+ * Provide a scoped GMD form state store instance.
+ */
+export const provideGmdFormStore = (): Provider => ({
+  provide: GMD_FORM_STATE_STORE,
+  useFactory: () => new GmdFormStateStore(),
+});


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12634

## Description
This PR is the first of two and updates the gravitee-markdown library so that the form state store can be provided by the parent component instead of being created inside `gmd-form-host`. This allows consumers (e.g. the subscription form screen) to own the store and use it for validation (e.g. disabling Save when there are config errors).

### Included in this PR
- add `provideGmdFormStore()` so the store can be provided at the call site
- remove store creation from `gmd-form-host`; host only consumes and resets store on content change
- update tests to provide the store via `provideGmdFormStore()`

### Excluded from this PR (will be done in subsequent PRs)
- console subscription form screen and REST integration