### PR TITLE
feat(console): implement subscription form management

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
@@ -47,4 +47,5 @@ export * from './portalCustomization';
 export * from './portalMenuLink';
 export * from './portalNavigationItem';
 export * from './portalPageContent';
+export * from './subscriptionForm';
 export * from './cluster';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './subscriptionForm';
+export * from './subscriptionForm.fixture';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.fixture.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SubscriptionForm } from './subscriptionForm';
+
+export function fakeSubscriptionForm(attributes?: Partial<SubscriptionForm>): SubscriptionForm {
+  const base: SubscriptionForm = {
+    id: 'subscription-form-id',
+    gmdContent: '# Subscription Form\n\n<gmd-input name="name" label="Name" fieldKey="name" required="true"></gmd-input>',
+    enabled: false,
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
@@ -34,9 +34,9 @@ export interface SubscriptionForm {
 }
 
 /**
- * Payload for creating or updating a subscription form
+ * Payload for updating a subscription form
  */
-export interface CreateOrUpdateSubscriptionForm {
+export interface UpdateSubscriptionForm {
   /**
    * Gravitee Markdown (GMD) content defining the form.
    * Content is validated for security - malicious HTML/scripts will be rejected.

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscriptionForm/subscriptionForm.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Subscription form definition used by API consumers when subscribing to APIs
+ */
+export interface SubscriptionForm {
+  /**
+   * Unique identifier of the subscription form
+   */
+  id: string;
+  /**
+   * Gravitee Markdown (GMD) content defining the form.
+   * Supports form components like gmd-input, gmd-textarea, gmd-select, gmd-checkbox, gmd-radio.
+   */
+  gmdContent: string;
+  /**
+   * Whether the form is enabled and visible to API consumers in the Developer Portal
+   */
+  enabled: boolean;
+}
+
+/**
+ * Payload for creating or updating a subscription form
+ */
+export interface CreateOrUpdateSubscriptionForm {
+  /**
+   * Gravitee Markdown (GMD) content defining the form.
+   * Content is validated for security - malicious HTML/scripts will be rejected.
+   */
+  gmdContent: string;
+}

--- a/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
@@ -129,9 +129,10 @@ const portalRoutes: Routes = [
       {
         path: 'subscription-form',
         component: SubscriptionFormComponent,
+        canDeactivate: [HasUnsavedChangesGuard],
         data: {
           permissions: {
-            anyOf: ['environment-settings-r', 'environment-settings-u'],
+            anyOf: ['environment-metadata-r', 'environment-metadata-u'],
           },
         },
       },

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
@@ -18,7 +18,31 @@
 <portal-header
   subtitle="Define the subscription form that will be displayed to users when subscribing to APIs"
   [title]="'Subscription Form'"
-  [showActions]="false"
+  [showActions]="true"
 >
+  <div additionalActions class="actions">
+    <mat-slide-toggle
+      aria-label="Visible to API consumers"
+      labelPosition="before"
+      [formControl]="enabledControl"
+      [matTooltip]="enabledControlTooltip()"
+      [matTooltipDisabled]="!enabledControlTooltip()"
+      data-testid="enable-toggle"
+    >
+      Visible to API consumers
+    </mat-slide-toggle>
+    <button
+      *gioPermission="{ anyOf: ['environment-metadata-u'] }"
+      mat-flat-button
+      color="primary"
+      aria-label="Update subscription form"
+      (click)="updateSubscriptionForm()"
+      [disabled]="isSaveDisabled()"
+      [matTooltip]="saveButtonTooltip()"
+      [matTooltipDisabled]="!saveButtonTooltip()"
+    >
+      Save
+    </button>
+  </div>
 </portal-header>
 <gmd-form-editor [formControl]="contentControl" />

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
@@ -13,6 +13,12 @@
   }
 }
 
+.actions {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
 gmd-form-editor {
   @include gmd.editor-overrides(
     (

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -15,9 +15,9 @@
  */
 
 import {
-  ConfigureTestingGmdFormEditor,
   ConfigureTestingGraviteeMarkdownEditor,
   GmdFormEditorHarness,
+  GMD_FORM_STATE_STORE,
   provideGmdFormStore,
 } from '@gravitee/gravitee-markdown';
 
@@ -25,20 +25,27 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
 
 import { SubscriptionFormComponent } from './subscription-form.component';
 
-import { GioTestingModule } from '../../shared/testing';
+import { GioTestingModule, CONSTANTS_TESTING } from '../../shared/testing';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../services-ngx/snack-bar.service';
+import { fakeSubscriptionForm } from '../../entities/management-api-v2/subscriptionForm/subscriptionForm.fixture';
+import { SubscriptionForm } from '../../entities/management-api-v2';
 
 describe('SubscriptionFormComponent', () => {
   let fixture: ComponentFixture<SubscriptionFormComponent>;
-  let component: SubscriptionFormComponent;
-  let loader: HarnessLoader;
-  let editorHarness: GmdFormEditorHarness;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
+  let snackBarService: SnackBarService;
 
-  const init = async (canUpdate: boolean) => {
-    ConfigureTestingGmdFormEditor();
+  const init = async (canUpdate: boolean, subscriptionForm = fakeSubscriptionForm()) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
       providers: [
@@ -55,47 +62,318 @@ describe('SubscriptionFormComponent', () => {
     ConfigureTestingGraviteeMarkdownEditor();
 
     fixture = TestBed.createComponent(SubscriptionFormComponent);
-    component = fixture.componentInstance;
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    // Spy on snackbar
+    snackBarService = TestBed.inject(SnackBarService);
+    jest.spyOn(snackBarService, 'success');
+    jest.spyOn(snackBarService, 'error');
 
     fixture.detectChanges();
-    loader = TestbedHarnessEnvironment.loader(fixture);
-    editorHarness = await loader.getHarness(GmdFormEditorHarness);
+
+    // Expect GET request for subscription form
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms`,
+    });
+    req.flush(subscriptionForm);
   };
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
 
   it('should create component', async () => {
     await init(true);
-    expect(component).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should load default boilerplate content', async () => {
-    await init(true);
+  it('should load subscription form content from API', async () => {
+    const gmdContent = '# Test Form\n\n<gmd-input name="email" label="Email" fieldKey="email" required="true"></gmd-input>';
+    const form = fakeSubscriptionForm({ gmdContent });
 
-    const contentValue = await editorHarness.getEditorValue();
+    await init(true, form);
 
-    expect(contentValue).toContain('Subscription Form Builder');
-    expect(contentValue).toContain('Example: Complete Subscription Request Form');
-    expect(contentValue).toContain('Applicant Information');
-    expect(contentValue).toContain('Usage Details');
-    expect(contentValue).toContain('Simplified Quick Access Form');
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
+    // The mock editor might normalize newlines to spaces or remove them if it's an input
+    const receivedValue = await editorHarness.getEditorValue();
+    expect(receivedValue.replace(/\s/g, '')).toEqual(gmdContent.replace(/\s/g, ''));
   });
 
   it('should disable editor when user has no update permission', async () => {
     await init(false);
-
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
     expect(await editorHarness.isEditorReadOnly()).toBe(true);
   });
 
   it('should enable editor when user has update permission', async () => {
     await init(true);
-
+    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
     expect(await editorHarness.isEditorReadOnly()).toBe(false);
   });
 
-  it('should allow updating content control value', async () => {
-    await init(true);
+  it('should disable save button when content is empty or unchanged', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: '# Hello world' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
 
-    component.contentControl.setValue('Custom subscription form content');
+    fixture.componentInstance.contentControl.setValue('Updated form content');
+    fixture.detectChanges();
 
-    expect(component.contentControl.value).toBe('Custom subscription form content');
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('# Hello world');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('     ');
+    fixture.detectChanges();
+    expect(await saveButton.isDisabled()).toBeTruthy();
   });
+
+  it('should update subscription form content', async () => {
+    const form = fakeSubscriptionForm();
+    const updatedContent = '# Updated Form\n\n<gmd-input name="name" label="Name" fieldKey="name"></gmd-input>';
+    await init(true, form);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.contentControl.setValue(updatedContent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+    await saveButton.click();
+
+    expectSubscriptionFormUpdate({ gmdContent: updatedContent }, { ...form, gmdContent: updatedContent });
+    expect(snackBarService.success).toHaveBeenCalledWith('The subscription form has been updated successfully');
+    expect(await saveButton.isDisabled()).toBeTruthy();
+  });
+
+  it('should disable save button when config errors exist', async () => {
+    await init(true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const store = getGmdFormStore();
+
+    fixture.componentInstance.contentControl.setValue('Updated form content');
+    fixture.detectChanges();
+
+    const saveButton = await getSaveButton();
+    expect(await saveButton.isDisabled()).toBeFalsy();
+
+    // Simulate config error by adding a field with a config error
+    store.updateField(fieldStateWithConfigError('warning'));
+    fixture.detectChanges();
+
+    expect(await saveButton.isDisabled()).toBeTruthy();
+  });
+
+  describe('enable/disable toggle functionality', () => {
+    it('should enable a disabled form after confirmation', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isChecked()).toBe(false);
+      await toggle.toggle();
+
+      await confirmDialog('Enable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ ...disabledForm, enabled: true });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should disable an enabled form after confirmation', async () => {
+      const enabledForm = fakeSubscriptionForm({ enabled: true });
+      await init(true, enabledForm);
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isChecked()).toBe(true);
+      await toggle.toggle();
+
+      await confirmDialog('Disable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${enabledForm.id}/_disable`,
+      });
+      req.flush({ ...enabledForm, enabled: false });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been disabled successfully.');
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should not perform any action if the confirmation dialog is cancelled', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      await dialog.close();
+
+      // Toggle should be reset to previous state
+      expect(await toggle.isChecked()).toBe(false);
+      httpTestingController.verify();
+    });
+
+    it('should show an error message if enabling fails', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+      await confirmDialog('Enable');
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ message: 'API error on enable' }, { status: 500, statusText: 'Server Error' });
+
+      expect(snackBarService.error).toHaveBeenCalledWith('API error on enable');
+      // Toggle should be reset to previous state
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should save changes before enabling when form has unsaved changes', async () => {
+      const disabledForm = fakeSubscriptionForm({ enabled: false });
+      await init(true, disabledForm);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      fixture.componentInstance.contentControl.setValue('Updated form content');
+      fixture.detectChanges();
+
+      const toggle = await getEnableToggle();
+      await toggle.toggle();
+
+      await confirmDialog('Save and enable');
+
+      expectSubscriptionFormUpdate({ gmdContent: 'Updated form content' }, { ...disabledForm, gmdContent: 'Updated form content' });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${disabledForm.id}/_enable`,
+      });
+      req.flush({ ...disabledForm, enabled: true });
+      fixture.detectChanges();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should disable toggle when config errors exist', async () => {
+      await init(true);
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const store = getGmdFormStore();
+
+      store.updateField(fieldStateWithConfigError('error'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const toggle = await getEnableToggle();
+      expect(await toggle.isDisabled()).toBe(true);
+    });
+  });
+
+  it('should have unsaved changes when content is modified', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: 'Initial content' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('Modified content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
+  });
+
+  it('should not have unsaved changes when content is modified and then reverted', async () => {
+    await init(true, fakeSubscriptionForm({ gmdContent: 'Initial content' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+
+    fixture.componentInstance.contentControl.setValue('Modified content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
+
+    fixture.componentInstance.contentControl.setValue('Initial content');
+    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
+  });
+
+  it('should show action bar, hide Save and disable toggle when user lacks permission', async () => {
+    await init(false);
+
+    const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
+
+    await expect(
+      harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' })),
+    ).rejects.toThrow();
+    await expect(toggle.isDisabled()).resolves.toBe(true);
+  });
+
+  async function getEnableToggle() {
+    return await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
+  }
+
+  async function confirmDialog(action: string) {
+    const dialog = await rootLoader.getHarness(MatDialogHarness);
+    const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: new RegExp(action) }));
+    await confirmButton.click();
+  }
+
+  async function getSaveButton() {
+    return await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' }));
+  }
+
+  function getGmdFormStore() {
+    return fixture.debugElement.injector.get(GMD_FORM_STATE_STORE);
+  }
+
+  /** Returns a field state with one config error, for tests that need hasConfigErrors() to be true. */
+  function fieldStateWithConfigError(severity: 'error' | 'warning') {
+    return {
+      id: 'field-1',
+      fieldKey: 'key-1',
+      valid: true,
+      value: '',
+      required: false,
+      touched: false,
+      validationErrors: [],
+      configErrors: [
+        severity === 'error'
+          ? { code: 'emptyFieldKey' as const, message: 'Missing property', severity: 'error' as const }
+          : { code: 'normalizedValue' as const, message: 'Missing property', severity: 'warning' as const },
+      ],
+    };
+  }
+
+  function expectSubscriptionFormUpdate(expected: { gmdContent: string }, response: SubscriptionForm) {
+    const req = httpTestingController.expectOne({
+      method: 'PUT',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/subscription-forms/${response.id}`,
+    });
+    expect(req.request.body).toStrictEqual(expected);
+    req.flush(response);
+  }
 });

--- a/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { CreateOrUpdateSubscriptionForm, SubscriptionForm } from '../entities/management-api-v2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SubscriptionFormService {
+  constructor(
+    private http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  public getSubscriptionForm(): Observable<SubscriptionForm> {
+    return this.http.get<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms`);
+  }
+
+  public updateSubscriptionForm(id: string, content: CreateOrUpdateSubscriptionForm): Observable<SubscriptionForm> {
+    return this.http.put<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}`, content);
+  }
+
+  public enableSubscriptionForm(id: string): Observable<SubscriptionForm> {
+    return this.http.post<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}/_enable`, {});
+  }
+
+  public disableSubscriptionForm(id: string): Observable<SubscriptionForm> {
+    return this.http.post<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}/_disable`, {});
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription-form.service.ts
@@ -18,7 +18,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { CreateOrUpdateSubscriptionForm, SubscriptionForm } from '../entities/management-api-v2';
+import { SubscriptionForm, UpdateSubscriptionForm } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -33,7 +33,7 @@ export class SubscriptionFormService {
     return this.http.get<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms`);
   }
 
-  public updateSubscriptionForm(id: string, content: CreateOrUpdateSubscriptionForm): Observable<SubscriptionForm> {
+  public updateSubscriptionForm(id: string, content: UpdateSubscriptionForm): Observable<SubscriptionForm> {
     return this.http.put<SubscriptionForm>(`${this.constants.env.v2BaseURL}/subscription-forms/${id}`, content);
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResource.java
@@ -63,7 +63,7 @@ public class SubscriptionFormResource extends AbstractResource {
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = { RolePermissionAction.UPDATE }) })
     public Response updateSubscriptionForm(@Valid @NotNull final UpdateSubscriptionForm request) {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 
@@ -77,7 +77,7 @@ public class SubscriptionFormResource extends AbstractResource {
     @POST
     @Path("/_enable")
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = { RolePermissionAction.UPDATE }) })
     public Response enableSubscriptionForm() {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 
@@ -91,7 +91,7 @@ public class SubscriptionFormResource extends AbstractResource {
     @POST
     @Path("/_disable")
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { RolePermissionAction.UPDATE }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = { RolePermissionAction.UPDATE }) })
     public Response disableSubscriptionForm() {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResource.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.core.subscription_form.use_case.EnableSubscriptionFormUs
 import io.gravitee.apim.core.subscription_form.use_case.UpdateSubscriptionFormUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.SubscriptionFormMapper;
-import io.gravitee.rest.api.management.v2.rest.model.CreateOrUpdateSubscriptionForm;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -64,7 +64,7 @@ public class SubscriptionFormResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { RolePermissionAction.UPDATE }) })
-    public Response updateSubscriptionForm(@Valid @NotNull final CreateOrUpdateSubscriptionForm request) {
+    public Response updateSubscriptionForm(@Valid @NotNull final UpdateSubscriptionForm request) {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 
         var output = updateSubscriptionFormUseCase.execute(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormsResource.java
@@ -49,7 +49,7 @@ public class SubscriptionFormsResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { RolePermissionAction.READ }) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = { RolePermissionAction.READ }) })
     public Response getSubscriptionForm() {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1045,7 +1045,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateOrUpdateSubscriptionForm"
+              $ref: "#/components/schemas/UpdateSubscriptionForm"
       responses:
         "200":
           description: Subscription form saved successfully
@@ -2318,9 +2318,9 @@ components:
         - id
         - gmdContent
         - enabled
-    CreateOrUpdateSubscriptionForm:
+    UpdateSubscriptionForm:
       type: object
-      description: Payload for creating or updating a subscription form
+      description: Payload for updating a subscription form
       properties:
         gmdContent:
           type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormResourceTest.java
@@ -23,8 +23,8 @@ import inmemory.InMemoryAlternative;
 import inmemory.SubscriptionFormCrudServiceInMemory;
 import inmemory.SubscriptionFormQueryServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.rest.api.management.v2.rest.model.CreateOrUpdateSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.model.SubscriptionForm;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -88,9 +88,7 @@ class SubscriptionFormResourceTest extends AbstractResourceTest {
             subscriptionFormQueryService.initWith(List.of(existingForm));
             subscriptionFormCrudService.initWith(List.of(existingForm));
 
-            CreateOrUpdateSubscriptionForm request = new CreateOrUpdateSubscriptionForm().gmdContent(
-                "<gmd-card>Updated Content</gmd-card>"
-            );
+            UpdateSubscriptionForm request = new UpdateSubscriptionForm().gmdContent("<gmd-card>Updated Content</gmd-card>");
 
             // When
             var response = rootTarget.path(existingForm.getId().toString()).request().put(Entity.json(request));
@@ -107,7 +105,7 @@ class SubscriptionFormResourceTest extends AbstractResourceTest {
         @Test
         void should_return_404_when_form_not_exists() {
             // Given
-            CreateOrUpdateSubscriptionForm request = new CreateOrUpdateSubscriptionForm().gmdContent("<gmd-card>Content</gmd-card>");
+            UpdateSubscriptionForm request = new UpdateSubscriptionForm().gmdContent("<gmd-card>Content</gmd-card>");
 
             // When
             var response = rootTarget.path("550e8400-e29b-41d4-a716-446655440000").request().put(Entity.json(request));
@@ -121,7 +119,7 @@ class SubscriptionFormResourceTest extends AbstractResourceTest {
             // Given
             var existingForm = SubscriptionFormFixtures.aSubscriptionFormBuilder().environmentId(ENVIRONMENT).build();
             subscriptionFormQueryService.initWith(List.of(existingForm));
-            CreateOrUpdateSubscriptionForm request = new CreateOrUpdateSubscriptionForm();
+            UpdateSubscriptionForm request = new UpdateSubscriptionForm();
 
             // When
             var response = rootTarget.path(existingForm.getId().toString()).request().put(Entity.json(request));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12634

## Description
This PR follows the work in the [gravitee-markdown refactor](https://github.com/gravitee-io/gravitee-api-management/pull/15268) and implements the subscription form management screen in the console. It uses the Management API v2 to load, update, and enable/disable the subscription form.

### Included in this PR
- subscription form entity, schema and fixture for Management API v2
- `SubscriptionFormService` with CRUD and enable/disable operations
- subscription form screen: edit GMD content, toggle visibility (enabled/disabled), save, unsaved changes guard, validation (content and config errors)
- action bar visible to all users; toggle and Save disabled when user lacks permission or when there are config errors
- use of `provideGmdFormStore()` in the subscription form component to own form state and disable Save when config errors are present

## Additional Context 

https://github.com/user-attachments/assets/46dee501-064e-4fae-95bc-d4fa50bfdd51

