### PR TITLE
feat: allow deployment without plan for API Product APIs

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -33,6 +33,7 @@ import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.NodeApisEndpointInitializer;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.handlers.api.services.ApiKeyCacheService;
 import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
@@ -96,9 +97,10 @@ public class ApiHandlerConfiguration {
         EventManager eventManager,
         GatewayConfiguration gatewayConfiguration,
         LicenseManager licenseManager,
-        DataEncryptor dataEncryptor
+        DataEncryptor dataEncryptor,
+        @Autowired(required = false) ApiProductRegistry apiProductRegistry
     ) {
-        return new ApiManagerImpl(eventManager, gatewayConfiguration, licenseManager, dataEncryptor);
+        return new ApiManagerImpl(eventManager, gatewayConfiguration, licenseManager, dataEncryptor, apiProductRegistry);
     }
 
     @Bean

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiProductsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiProductsRepository.java
@@ -26,4 +26,5 @@ public interface ApiProductsRepository extends CrudRepository<ApiProduct, String
     Set<ApiProduct> findByEnvironmentId(String environmentId) throws TechnicalException;
     Set<ApiProduct> findByApiId(String apiId) throws TechnicalException;
     Set<ApiProduct> findByIds(Collection<String> ids) throws TechnicalException;
+    Set<ApiProduct> findApiProductsByApiIds(Collection<String> apiIds) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiProductRepository.java
@@ -146,4 +146,18 @@ public class MongoApiProductRepository implements ApiProductsRepository {
             throw new TechnicalException("Failed to find api products by ids", ex);
         }
     }
+
+    @Override
+    public Set<ApiProduct> findApiProductsByApiIds(Collection<String> apiIds) throws TechnicalException {
+        if (isEmpty(apiIds)) {
+            return Set.of();
+        }
+        log.debug("MongoApiProductRepository.findApiProductsByApiIds({})", apiIds);
+        try {
+            Set<ApiProductMongo> apiProductMongos = internalApiProductRepo.findApiProductsByApiIds(apiIds);
+            return apiProductMongos.stream().map(mapper::map).collect(Collectors.toSet());
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find api products by api ids", ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryCustom.java
@@ -16,8 +16,10 @@
 package io.gravitee.repository.mongodb.management.internal.apiproducts;
 
 import io.gravitee.repository.mongodb.management.internal.model.ApiProductMongo;
+import java.util.Collection;
 import java.util.Set;
 
 public interface ApiProductsMongoRepositoryCustom {
     Set<ApiProductMongo> findByApiId(String apiId);
+    Set<ApiProductMongo> findApiProductsByApiIds(Collection<String> apiIds);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
@@ -16,12 +16,14 @@
 package io.gravitee.repository.mongodb.management.internal.apiproducts;
 
 import io.gravitee.repository.mongodb.management.internal.model.ApiProductMongo;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.CollectionUtils;
 
 public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositoryCustom {
 
@@ -31,6 +33,15 @@ public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositor
     @Override
     public Set<ApiProductMongo> findByApiId(String apiId) {
         Query query = new Query(Criteria.where("apiIds").is(apiId));
+        return new HashSet<>(mongoTemplate.find(query, ApiProductMongo.class));
+    }
+
+    @Override
+    public Set<ApiProductMongo> findApiProductsByApiIds(Collection<String> apiIds) {
+        if (CollectionUtils.isEmpty(apiIds)) {
+            return Set.of();
+        }
+        Query query = new Query(Criteria.where("apiIds").in(apiIds));
         return new HashSet<>(mongoTemplate.find(query, ApiProductMongo.class));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiProductsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiProductsRepository.java
@@ -69,4 +69,9 @@ public class NoOpApiProductsRepository implements ApiProductsRepository {
     public Set<ApiProduct> findByIds(Collection<String> ids) throws TechnicalException {
         return Set.of();
     }
+
+    @Override
+    public Set<ApiProduct> findApiProductsByApiIds(Collection<String> apiIds) throws TechnicalException {
+        return Set.of();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
@@ -149,6 +149,19 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldFindApiProductsByApiIds() throws TechnicalException {
+        Set<ApiProduct> products = apiProductsRepository.findApiProductsByApiIds(Set.of("api1", "api2"));
+
+        assertThat(products).isNotEmpty();
+        assertThat(products).allMatch(p -> p.getApiIds() != null && (p.getApiIds().contains("api1") || p.getApiIds().contains("api2")));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenFindApiProductsByApiIdsWithEmptyCollection() throws TechnicalException {
+        assertThat(apiProductsRepository.findApiProductsByApiIds(Set.of())).isEmpty();
+    }
+
+    @Test
     public void shouldFindByIds() throws TechnicalException {
         var existingId = "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3";
         Set<ApiProduct> found = apiProductsRepository.findByIds(Set.of(existingId, "non-existent-id"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
@@ -16,20 +16,27 @@
 package io.gravitee.apim.core.api_product.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiFieldFilter;
 import io.gravitee.apim.core.api.model.ApiSearchCriteria;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +47,9 @@ import lombok.RequiredArgsConstructor;
 public class ValidateApiProductService {
 
     private final ApiQueryService apiQueryService;
+    private final ApiCrudService apiCrudService;
+    private final PlanQueryService planQueryService;
+    private final ApiProductQueryService apiProductQueryService;
 
     public void validate(ApiProduct apiProduct) {
         if (StringUtils.isEmpty(apiProduct.getName())) {
@@ -90,6 +100,88 @@ public class ValidateApiProductService {
         addError(notAllowedApiIds, "These APIs [%s] are not allowed in API Products", "notAllowedApiIds", messages, parameters);
 
         throw new ValidationDomainException(String.join(". ", messages), parameters);
+    }
+
+    public List<Api> getApisToUndeployOnRemoval(Set<String> apiIds, String currentApiProductId) {
+        if (apiIds == null || apiIds.isEmpty() || StringUtils.isEmpty(currentApiProductId)) {
+            return List.of();
+        }
+        List<Api> apis = apiCrudService.findByIds(apiIds.stream().toList());
+        Set<String> apiIdsWithPlan = findApiIdsWithPublishedOrDeprecatedPlan(apis);
+        List<Api> deployedWithoutPlan = findDeployedApisWithoutPlan(apis, apiIdsWithPlan);
+        if (deployedWithoutPlan.isEmpty()) {
+            return List.of();
+        }
+        Map<String, Set<ApiProduct>> productsByApiId = apiProductQueryService.findProductsByApiIds(
+            deployedWithoutPlan.stream().map(Api::getId).collect(Collectors.toSet())
+        );
+        Map<String, Set<String>> productIdToEnvsWithPlan = findProductEnvsWithPlan(deployedWithoutPlan, productsByApiId);
+        return filterApisNotCoveredByOtherProduct(deployedWithoutPlan, currentApiProductId, productsByApiId, productIdToEnvsWithPlan);
+    }
+
+    private Set<String> findApiIdsWithPublishedOrDeprecatedPlan(List<Api> apis) {
+        Set<String> apiIds = apis.stream().map(Api::getId).collect(Collectors.toSet());
+        Set<String> envIds = apis.stream().map(Api::getEnvironmentId).filter(Objects::nonNull).collect(Collectors.toSet());
+        if (apiIds.isEmpty() || envIds.isEmpty()) {
+            return Set.of();
+        }
+        List<Plan> plans = planQueryService.findAllByApiIds(apiIds, envIds);
+        return plans
+            .stream()
+            .filter(p -> p.getPlanStatus() == PlanStatus.PUBLISHED || p.getPlanStatus() == PlanStatus.DEPRECATED)
+            .map(Plan::getReferenceId)
+            .collect(Collectors.toSet());
+    }
+
+    private static List<Api> findDeployedApisWithoutPlan(List<Api> apis, Set<String> apiIdsWithPlan) {
+        return apis
+            .stream()
+            .filter(api -> api.getDeployedAt() != null && !apiIdsWithPlan.contains(api.getId()))
+            .toList();
+    }
+
+    private Map<String, Set<String>> findProductEnvsWithPlan(List<Api> deployedApis, Map<String, Set<ApiProduct>> productsByApiId) {
+        Set<String> productIds = productsByApiId.values().stream().flatMap(Set::stream).map(ApiProduct::getId).collect(Collectors.toSet());
+        Set<String> envIds = deployedApis.stream().map(Api::getEnvironmentId).filter(Objects::nonNull).collect(Collectors.toSet());
+        if (productIds.isEmpty() || envIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Plan> plans = planQueryService.findAllForApiProducts(productIds, envIds);
+        return plans
+            .stream()
+            .filter(p -> p.getPlanStatus() == PlanStatus.PUBLISHED || p.getPlanStatus() == PlanStatus.DEPRECATED)
+            .filter(p -> p.getReferenceId() != null && p.getEnvironmentId() != null)
+            .collect(Collectors.groupingBy(Plan::getReferenceId, Collectors.mapping(Plan::getEnvironmentId, Collectors.toSet())));
+    }
+
+    private static List<Api> filterApisNotCoveredByOtherProduct(
+        List<Api> apis,
+        String currentApiProductId,
+        Map<String, Set<ApiProduct>> productsByApiId,
+        Map<String, Set<String>> productIdToEnvsWithPlan
+    ) {
+        return apis
+            .stream()
+            .filter(api -> !isCoveredByOtherProduct(api, currentApiProductId, productsByApiId, productIdToEnvsWithPlan))
+            .toList();
+    }
+
+    private static boolean isCoveredByOtherProduct(
+        Api api,
+        String currentApiProductId,
+        Map<String, Set<ApiProduct>> productsByApiId,
+        Map<String, Set<String>> productIdToEnvsWithPlan
+    ) {
+        String apiEnv = api.getEnvironmentId();
+        Set<ApiProduct> products = productsByApiId.getOrDefault(api.getId(), Set.of());
+        return products
+            .stream()
+            .anyMatch(
+                product ->
+                    Objects.equals(product.getEnvironmentId(), apiEnv) &&
+                    !product.getId().equals(currentApiProductId) &&
+                    productIdToEnvsWithPlan.getOrDefault(product.getId(), Set.of()).contains(apiEnv)
+            );
     }
 
     private void addError(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api_product.query_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,4 +25,6 @@ public interface ApiProductQueryService {
     Set<ApiProduct> findByEnvironmentId(String environmentId);
     Optional<ApiProduct> findById(String apiProductId);
     Set<ApiProduct> findByApiId(String apiId);
+
+    Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
@@ -18,10 +18,14 @@ package io.gravitee.apim.core.plan.query_service;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.DefinitionVersion;
 import java.util.List;
+import java.util.Set;
 
 public interface PlanQueryService {
     List<Plan> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId);
 
     List<Plan> findAllByApiId(String apiId);
+    List<Plan> findAllByApiIds(Set<String> apiIds, Set<String> environmentIds);
+
     List<Plan> findAllForApiProduct(String referenceId);
+    List<Plan> findAllForApiProducts(Set<String> apiProductIds, Set<String> environmentIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
@@ -17,7 +17,9 @@ package inmemory;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -54,6 +56,18 @@ public class ApiProductQueryServiceInMemory extends AbstractQueryServiceInMemory
             if (apiProduct.getApiIds() != null && apiProduct.getApiIds().contains(apiId)) {
                 result.add(apiProduct);
             }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds) {
+        Map<String, Set<ApiProduct>> result = new HashMap<>();
+        if (apiIds == null || apiIds.isEmpty()) {
+            return result;
+        }
+        for (String apiId : apiIds) {
+            result.put(apiId, findByApiId(apiId));
         }
         return result;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlternative<Plan> {
 
@@ -60,6 +61,23 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
     }
 
     @Override
+    public List<Plan> findAllByApiIds(Set<String> apiIds, Set<String> environmentIds) {
+        if (apiIds == null || apiIds.isEmpty() || environmentIds == null || environmentIds.isEmpty()) {
+            return List.of();
+        }
+        return storage
+            .stream()
+            .filter(
+                plan ->
+                    apiIds.contains(plan.getReferenceId()) &&
+                    (plan.getReferenceType() == null || GenericPlanEntity.ReferenceType.API.equals(plan.getReferenceType())) &&
+                    (plan.getEnvironmentId() == null || environmentIds.contains(plan.getEnvironmentId()))
+            )
+            .map(plan -> (Plan) plan)
+            .toList();
+    }
+
+    @Override
     public List<Plan> findAllForApiProduct(String referenceId) {
         return storage
             .stream()
@@ -67,6 +85,23 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
                 plan ->
                     Objects.equals(referenceId, plan.getReferenceId()) &&
                     Objects.equals(GenericPlanEntity.ReferenceType.API_PRODUCT, plan.getReferenceType())
+            )
+            .map(p -> (Plan) p)
+            .toList();
+    }
+
+    @Override
+    public List<Plan> findAllForApiProducts(Set<String> apiProductIds, Set<String> environmentIds) {
+        if (apiProductIds == null || apiProductIds.isEmpty() || environmentIds == null || environmentIds.isEmpty()) {
+            return List.of();
+        }
+        return storage
+            .stream()
+            .filter(
+                plan ->
+                    apiProductIds.contains(plan.getReferenceId()) &&
+                    Objects.equals(GenericPlanEntity.ReferenceType.API_PRODUCT, plan.getReferenceType()) &&
+                    (plan.getEnvironmentId() == null || environmentIds.contains(plan.getEnvironmentId()))
             )
             .map(p -> (Plan) p)
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ValidateApiProductServiceTest {
+
+    private static final String ENV_ID = "env-id";
+
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+
+    private ValidateApiProductService validateApiProductService;
+
+    @BeforeEach
+    void setUp() {
+        Stream.of(apiCrudService, apiQueryService, planQueryService, apiProductQueryService).forEach(InMemoryAlternative::reset);
+        validateApiProductService = new ValidateApiProductService(
+            apiQueryService,
+            apiCrudService,
+            planQueryService,
+            apiProductQueryService
+        );
+    }
+
+    @Nested
+    class Validate {
+
+        @Test
+        void should_throw_when_name_is_empty() {
+            ApiProduct product = ApiProduct.builder().id("p1").name("").version("1.0").environmentId(ENV_ID).build();
+
+            assertThatThrownBy(() -> validateApiProductService.validate(product))
+                .isInstanceOf(InvalidDataException.class)
+                .hasMessage("API Product name is required.");
+        }
+
+        @Test
+        void should_throw_when_name_is_null() {
+            ApiProduct product = ApiProduct.builder().id("p1").version("1.0").environmentId(ENV_ID).build();
+
+            assertThatThrownBy(() -> validateApiProductService.validate(product))
+                .isInstanceOf(InvalidDataException.class)
+                .hasMessage("API Product name is required.");
+        }
+
+        @Test
+        void should_throw_when_version_is_empty() {
+            ApiProduct product = ApiProduct.builder().id("p1").name("Product").version("").environmentId(ENV_ID).build();
+
+            assertThatThrownBy(() -> validateApiProductService.validate(product))
+                .isInstanceOf(InvalidDataException.class)
+                .hasMessage("API Product version is required.");
+        }
+
+        @Test
+        void should_not_throw_when_name_and_version_are_set() {
+            ApiProduct product = ApiProduct.builder().id("p1").name("Product").version("1.0").environmentId(ENV_ID).build();
+
+            assertThatCode(() -> validateApiProductService.validate(product)).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ValidateApiIdsForProduct {
+
+        @Test
+        void should_do_nothing_when_apiIds_empty() {
+            assertThatCode(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of())).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_throw_when_api_does_not_exist() {
+            ApiProduct product = ApiProduct.builder().id("p1").name("P").version("1.0").environmentId(ENV_ID).build();
+            apiProductQueryService.initWith(List.of(product));
+
+            assertThatThrownBy(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("non-existent")))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("do not exist")
+                .hasMessageContaining("non-existent");
+        }
+
+        @Test
+        void should_throw_when_api_is_not_v4() {
+            Api v2Api = ApiFixtures.aProxyApiV2().toBuilder().id("api-v2").environmentId(ENV_ID).build();
+            apiCrudService.initWith(List.of(v2Api));
+
+            assertThatThrownBy(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("api-v2")))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("not V4")
+                .hasMessageContaining("api-v2");
+        }
+
+        @Test
+        void should_throw_when_api_not_allowed_in_api_products() {
+            Api api = createV4ProxyApi("api-1", false);
+            apiCrudService.initWith(List.of(api));
+
+            assertThatThrownBy(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("api-1")))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("not allowed in API Products")
+                .hasMessageContaining("api-1");
+        }
+
+        @Test
+        void should_not_throw_when_apis_valid_and_allowed() {
+            Api api = createV4ProxyApi("api-1", true);
+            apiCrudService.initWith(List.of(api));
+
+            assertThatCode(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("api-1"))).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class GetApisToUndeployOnRemoval {
+
+        @Test
+        void should_return_empty_when_apiIds_null() {
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(null, "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_when_apiIds_empty() {
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of(), "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_api_when_removing_deployed_api_without_plan_and_not_in_other_product() {
+            Api deployedNoPlan = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedNoPlan));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+
+            List<Api> toUndeploy = validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1");
+            assertThat(toUndeploy).hasSize(1).extracting(Api::getId).containsExactly("api-1");
+        }
+
+        @Test
+        void should_return_empty_when_removing_deployed_api_that_has_published_plan() {
+            Api deployedApi = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedApi));
+
+            Plan plan = PlanFixtures.HttpV4.aKeyless().toBuilder().referenceId("api-1").id("plan-1").build();
+            planQueryService.initWith(List.of(plan));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_when_removing_undeployed_api() {
+            Api undeployedApi = createV4ProxyApi("api-1", true).toBuilder().deployedAt(null).build();
+            apiCrudService.initWith(List.of(undeployedApi));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_when_removed_api_is_in_another_product_with_plan() {
+            Api deployedNoPlan = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedNoPlan));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P1")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            ApiProduct otherProduct = ApiProduct.builder()
+                .id("product-2")
+                .name("P2")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct, otherProduct));
+
+            Plan product2Plan = PlanFixtures.HttpV4.aKeyless()
+                .toBuilder()
+                .id("plan-product-2")
+                .referenceId("product-2")
+                .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                .environmentId(ENV_ID)
+                .build();
+            product2Plan.setPlanStatus(PlanStatus.PUBLISHED);
+            planQueryService.initWith(List.of(product2Plan));
+
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_api_when_only_other_product_containing_api_has_no_plans() {
+            Api deployedNoPlan = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedNoPlan));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P1")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            ApiProduct otherProductNoPlans = ApiProduct.builder()
+                .id("product-2")
+                .name("P2")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct, otherProductNoPlans));
+
+            List<Api> toUndeploy = validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1");
+            assertThat(toUndeploy).hasSize(1).extracting(Api::getId).containsExactly("api-1");
+        }
+
+        @Test
+        void should_return_api_when_only_other_product_containing_api_is_in_different_environment() {
+            Api deployedNoPlan = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedNoPlan));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P1")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            ApiProduct productInOtherEnv = ApiProduct.builder()
+                .id("product-2")
+                .name("P2")
+                .version("1.0")
+                .environmentId("other-env")
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct, productInOtherEnv));
+
+            List<Api> toUndeploy = validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1"), "product-1");
+            assertThat(toUndeploy).hasSize(1).extracting(Api::getId).containsExactly("api-1");
+        }
+
+        @Test
+        void should_return_empty_when_api_not_found_in_crud() {
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("missing-api"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of("missing-api"), "product-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_for_multiple_apis_when_other_product_has_plan() {
+            Api deployedNoPlan1 = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            Api deployedNoPlan2 = createV4ProxyApi("api-2", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+            apiCrudService.initWith(List.of(deployedNoPlan1, deployedNoPlan2));
+
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id("product-1")
+                .name("P1")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1", "api-2"))
+                .build();
+            ApiProduct otherProduct = ApiProduct.builder()
+                .id("product-2")
+                .name("P2")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1", "api-2"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct, otherProduct));
+
+            Plan product2Plan = PlanFixtures.HttpV4.aKeyless()
+                .toBuilder()
+                .id("plan-product-2")
+                .referenceId("product-2")
+                .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                .environmentId(ENV_ID)
+                .build();
+            product2Plan.setPlanStatus(PlanStatus.PUBLISHED);
+            planQueryService.initWith(List.of(product2Plan));
+
+            assertThat(validateApiProductService.getApisToUndeployOnRemoval(Set.of("api-1", "api-2"), "product-1")).isEmpty();
+        }
+    }
+
+    private static Api createV4ProxyApi(String id, boolean allowedInApiProducts) {
+        var apiDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionValue();
+        if (apiDefinition instanceof io.gravitee.definition.model.v4.Api v4Api) {
+            var updatedDef = v4Api.toBuilder().id(id).allowedInApiProducts(allowedInApiProducts).build();
+            return ApiFixtures.aProxyApiV4().toBuilder().id(id).environmentId(ENV_ID).apiDefinitionValue(updatedDef).build();
+        }
+        throw new IllegalStateException("Expected V4 API definition");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -34,6 +34,7 @@ import inmemory.LicenseCrudServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -65,7 +66,13 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
-    private final ValidateApiProductService validateApiProductService = new ValidateApiProductService(apiQueryService);
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final ValidateApiProductService validateApiProductService = new ValidateApiProductService(
+        apiQueryService,
+        apiCrudService,
+        planQueryService,
+        apiProductQueryService
+    );
     private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
     private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
@@ -18,18 +18,31 @@ package io.gravitee.apim.core.api_product.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import fixtures.core.model.ApiFixtures;
 import inmemory.AbstractUseCaseTest;
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,17 +50,29 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
 
     private final ApiProductCrudServiceInMemory apiProductCrudService = new ApiProductCrudServiceInMemory();
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private DeleteApiProductUseCase deleteApiProductUseCase;
 
     @BeforeEach
     void setUp() {
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var validateApiProductService = new ValidateApiProductService(
+            apiQueryService,
+            apiCrudService,
+            planQueryService,
+            apiProductQueryService
+        );
         deleteApiProductUseCase = new DeleteApiProductUseCase(
             apiProductCrudService,
             auditService,
             apiProductQueryService,
+            validateApiProductService,
+            apiStateDomainService,
             eventCrudService,
             eventLatestCrudService
         );
@@ -68,7 +93,8 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
         deleteApiProductUseCase.execute(input);
         assertThat(apiProductCrudService.findById(productId)).isEmpty();
 
-        // Verify UNDEPLOY event was published
+        // No APIs in product → stop must not be called
+        verify(apiStateDomainService, never()).stop(any(), any());
         verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
         verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq(productId), any());
     }
@@ -80,5 +106,79 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
         assertThatThrownBy(() -> deleteApiProductUseCase.execute(input))
             .isInstanceOf(ApiProductNotFoundException.class)
             .hasMessage("API Product not found.");
+    }
+
+    @Test
+    void should_auto_undeploy_deployed_api_without_plans_then_delete_product() {
+        var productId = "api-product-id";
+        var deployedApiNoPlans = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("api-deployed-no-plans")
+            .environmentId(ENV_ID)
+            .deployedAt(ZonedDateTime.now())
+            .build();
+        ApiProduct product = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .apiIds(Set.of("api-deployed-no-plans"))
+            .build();
+
+        apiCrudService.initWith(List.of(deployedApiNoPlans));
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        var input = new DeleteApiProductUseCase.Input(productId, AUDIT_INFO);
+
+        deleteApiProductUseCase.execute(input);
+
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
+        verify(apiStateDomainService).stop(argThat(api -> "api-deployed-no-plans".equals(api.getId())), eq(AUDIT_INFO));
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_not_call_stop_when_product_has_only_undeployed_apis() {
+        var productId = "api-product-id";
+        var undeployedApi = ApiFixtures.aProxyApiV4().toBuilder().id("api-undeployed").environmentId(ENV_ID).deployedAt(null).build();
+        ApiProduct product = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .apiIds(Set.of("api-undeployed"))
+            .build();
+
+        apiCrudService.initWith(List.of(undeployedApi));
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        deleteApiProductUseCase.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
+        verify(apiStateDomainService, never()).stop(any(), any());
+    }
+
+    @Test
+    void should_stop_each_deployed_api_without_plan_when_deleting_product_with_multiple_apis() {
+        var productId = "api-product-id";
+        var api1 = ApiFixtures.aProxyApiV4().toBuilder().id("api-1").environmentId(ENV_ID).deployedAt(ZonedDateTime.now()).build();
+        var api2 = ApiFixtures.aProxyApiV4().toBuilder().id("api-2").environmentId(ENV_ID).deployedAt(ZonedDateTime.now()).build();
+        ApiProduct product = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .apiIds(Set.of("api-1", "api-2"))
+            .build();
+
+        apiCrudService.initWith(List.of(api1, api2));
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        deleteApiProductUseCase.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
+        verify(apiStateDomainService, times(2)).stop(any(), eq(AUDIT_INFO));
+        verify(apiStateDomainService).stop(argThat(api -> "api-1".equals(api.getId())), eq(AUDIT_INFO));
+        verify(apiStateDomainService).stop(argThat(api -> "api-2".equals(api.getId())), eq(AUDIT_INFO));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -18,8 +18,11 @@ package io.gravitee.apim.core.api_product.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +34,8 @@ import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
@@ -44,6 +49,7 @@ import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
@@ -56,22 +62,30 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
 
     private UpdateApiProductUseCase updateApiProductUseCase;
 
     @BeforeEach
     void setUp() {
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
-        var validateApiProductService = new ValidateApiProductService(apiQueryService);
+        var validateApiProductService = new ValidateApiProductService(
+            apiQueryService,
+            apiCrudService,
+            planQueryService,
+            apiProductQueryService
+        );
         when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
         updateApiProductUseCase = new UpdateApiProductUseCase(
             apiProductCrudService,
             auditService,
             apiProductQueryService,
             validateApiProductService,
+            apiStateDomainService,
             eventCrudService,
             eventLatestCrudService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager)
@@ -229,6 +243,82 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
         // Empty apiIds should clear the entire list (replace, not merge)
         assertThat(output.apiProduct().getApiIds()).isEmpty();
+    }
+
+    @Test
+    void should_auto_undeploy_removed_deployed_api_without_plans_then_update_product() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-deployed-no-plans", "api-2"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api deployedApiNoPlans = createV4ProxyApi("api-deployed-no-plans", true);
+        deployedApiNoPlans = deployedApiNoPlans.toBuilder().deployedAt(ZonedDateTime.now()).build();
+        Api api2 = createV4ProxyApi("api-2", true);
+        apiCrudService.initWith(List.of(deployedApiNoPlans, api2));
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-2")).build();
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+
+        var output = updateApiProductUseCase.execute(input);
+
+        assertThat(output.apiProduct().getApiIds()).containsExactly("api-2");
+        verify(apiStateDomainService).stop(argThat(api -> "api-deployed-no-plans".equals(api.getId())), eq(AUDIT_INFO));
+    }
+
+    @Test
+    void should_not_call_stop_when_no_apis_removed() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+        Api api1 = createV4ProxyApi("api-1", true);
+        apiCrudService.initWith(List.of(api1));
+
+        var toUpdate = UpdateApiProduct.builder().name("New Name").apiIds(Set.of("api-1")).build();
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+
+        updateApiProductUseCase.execute(input);
+
+        verify(apiStateDomainService, never()).stop(any(), any());
+    }
+
+    @Test
+    void should_stop_each_removed_deployed_api_without_plan_when_multiple_removed() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-1", "api-2", "api-3"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api api1 = createV4ProxyApi("api-1", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+        Api api2 = createV4ProxyApi("api-2", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+        Api api3 = createV4ProxyApi("api-3", true).toBuilder().deployedAt(ZonedDateTime.now()).build();
+        apiCrudService.initWith(List.of(api1, api2, api3));
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-3")).build();
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+
+        var output = updateApiProductUseCase.execute(input);
+
+        assertThat(output.apiProduct().getApiIds()).containsExactly("api-3");
+        verify(apiStateDomainService, times(2)).stop(any(), eq(AUDIT_INFO));
+        verify(apiStateDomainService).stop(argThat(api -> "api-1".equals(api.getId())), eq(AUDIT_INFO));
+        verify(apiStateDomainService).stop(argThat(api -> "api-2".equals(api.getId())), eq(AUDIT_INFO));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12788

## Description

Acceptance Criteria - 
1. API should be allowed to deploy without any plan on GW if part of API Product.
2. API should not be allowed to deploy if it has no published/deprecated plan or not added in API PRODUCT
3. While removing the API from API Product, plan need to be verified on API and if not found then undeploy the API.
4. While deleting API Product, plan need to be verified on API/s and if not found then undeploy the API/s.

https://github.com/user-attachments/assets/7d2b722f-a6ef-46a8-ad96-56cfb8ba1069


After addressing review comments:
Now, APIs will be Undeployed if there is no plan on the API and it is removed from API Product or API Product is deleted.

https://github.com/user-attachments/assets/4059e9e5-bf6f-4ac1-879f-1adf363592e8



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

