### PR TITLE
feat: close subscription in portal - create button and adapt components.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -36,6 +36,7 @@
         [updatedAt]="detailsVM.result.updatedAt"
         [isLoadingStatus]="isLoadingStatus"
         (resumeConsumerStatus)="resumeConsumerStatus()"
+        (closeSubscription)="closeSubscription()"
       />
       <app-api-access
         [planSecurity]="detailsVM.result.planSecurity"

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
@@ -15,7 +15,14 @@
     limitations under the License.
 
 -->
-<div class="next-gen-h3 subscription-info__header" i18n="@@subscriptionDetailsHeader">Subscription details</div>
+<div class="subscription-info__header">
+  <h1 class="next-gen-h3" i18n="@@subscriptionDetailsHeader">Subscription Details</h1>
+  @if (subscription?.status === 'ACCEPTED' || subscription?.status === 'PAUSED') {
+    <button mat-stroked-button color="warn" (click)="closeSubscription.emit()" data-testid="close-subscription-button">
+      <span class="next-gen-small-bold" i18n="@@subscriptionDetailsCloseSubscription">Close subscription</span>
+    </button>
+  }
+</div>
 <section class="subscription-info__content on-surface-variant">
   @if (isLoadingStatus) {
     <div class="subscription-info__content-row">
@@ -173,7 +180,7 @@
           (click)="resumeConsumerStatus.emit()"
           i18n="@@subscriptionDetailsRetryFailedSubscription"
         >
-          Retry Subscription
+          Retry subscription
         </button>
       </div>
     }

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.scss
@@ -19,7 +19,14 @@
   height: 100%;
 
   &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     padding-bottom: 32px;
+
+    h1 {
+      margin: 5px 0 5px;
+    }
   }
 
   &__content-row {

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
@@ -13,25 +13,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SubscriptionInfoComponent } from './subscription-info.component';
+import { SubscriptionInfoHarness } from './subscription-info.harness';
+import { Subscription } from '../../entities/subscription';
 
 describe('SubscriptionInfoComponent', () => {
   let component: SubscriptionInfoComponent;
   let fixture: ComponentFixture<SubscriptionInfoComponent>;
+  let harness: SubscriptionInfoHarness;
 
-  beforeEach(async () => {
+  const init = async (subscription: Subscription) => {
     await TestBed.configureTestingModule({
       imports: [SubscriptionInfoComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubscriptionInfoComponent);
     component = fixture.componentInstance;
+    component.subscription = subscription;
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionInfoHarness);
     fixture.detectChanges();
+  };
+
+  it('should create', async () => {
+    await init({ status: 'ACCEPTED' } as Subscription);
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('closeSubscription', () => {
+    it('should emit closeSubscription event when close button is clicked', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription);
+
+      const spy = jest.spyOn(component.closeSubscription, 'emit');
+      await harness.closeSubscription();
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should show close button when subscription status is ACCEPTED', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription);
+
+      expect(await harness.getCloseButton()).toBeTruthy();
+    });
+
+    it('should show close button when subscription status is PAUSED', async () => {
+      await init({ status: 'PAUSED' } as Subscription);
+
+      expect(await harness.getCloseButton()).toBeTruthy();
+    });
+
+    it('should NOT show close button when subscription status is PENDING', async () => {
+      await init({ status: 'PENDING' } as Subscription);
+
+      expect(await harness.getCloseButton()).toBeFalsy();
+    });
+
+    it('should NOT show close button when subscription status is REJECTED', async () => {
+      await init({ status: 'REJECTED' } as Subscription);
+
+      expect(await harness.getCloseButton()).toBeFalsy();
+    });
+
+    it('should NOT show close button when subscription status is CLOSED', async () => {
+      await init({ status: 'CLOSED' } as Subscription);
+
+      expect(await harness.getCloseButton()).toBeFalsy();
+    });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
@@ -85,6 +85,9 @@ export class SubscriptionInfoComponent implements OnInit {
   @Output()
   resumeConsumerStatus = new EventEmitter<void>();
 
+  @Output()
+  closeSubscription = new EventEmitter<void>();
+
   public authentication: string = '';
 
   protected readonly SubscriptionConsumerStatusEnum = SubscriptionConsumerStatusEnum;

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.harness.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class SubscriptionInfoHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-subscription-info';
+
+  private readonly getCloseButtonHarness = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="close-subscription-button"]' }),
+  );
+
+  async getCloseButton(): Promise<MatButtonHarness | null> {
+    return this.getCloseButtonHarness();
+  }
+
+  async closeSubscription(): Promise<void> {
+    const button = await this.getCloseButtonHarness();
+    if (button) {
+      await button.click();
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -24,6 +24,7 @@ mat-chip {
 
 mat-dialog-container {
   --mat-dialog-container-color: #{theme.$card-background-color};
+  --mat-dialog-container-shape: #{theme.$container-shape};
 }
 
 mat-form-field {
@@ -62,6 +63,11 @@ mat-datepicker-content.mat-datepicker-content.mat-primary {
       text-label-text-color: #{theme.$button-text-text-color},
     )
   );
+}
+
+.mat-warn.mat-mdc-button-base.mat-mdc-outlined-button {
+  --mat-button-outlined-label-text-color: #{theme.$error-main-color};
+  --mat-button-outlined-outline-color: #{theme.$error-main-color};
 }
 
 table.mat-mdc-table {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12271

## Description

This PR continues work started by [this PR](https://github.com/gravitee-io/gravitee-api-management/pull/15248) to introduce subscription closure feature in subscription details in the portal.

### Included in this PR:
- button "Close subscription"
- updates to subscription-details and subscription-info components (button handler, output)

### Excluded from this PR:
- generic dialog component
- misc styles updates

https://github.com/user-attachments/assets/46f31ca8-5fe3-4063-afda-8b406ca6b2d4