### PR TITLE
feat(service): add controls when parent of portal nav item is an api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -158,7 +158,7 @@ class PortalNavigationItemsMapperTest {
 
             var result = mapper.map(items);
 
-            assertThat(result).hasSize(11);
+            assertThat(result).hasSize(13);
             // Check that all items are mapped correctly
             assertThat(
                 result
@@ -176,7 +176,9 @@ class PortalNavigationItemsMapperTest {
                 UUID.fromString("00000000-0000-0000-0000-000000000008"),
                 UUID.fromString("00000000-0000-0000-0000-000000000009"),
                 UUID.fromString("00000000-0000-0000-0000-000000000010"),
-                UUID.fromString("00000000-0000-0000-0000-000000000011")
+                UUID.fromString("00000000-0000-0000-0000-000000000011"),
+                UUID.fromString("00000000-0000-0000-0000-000000000012"),
+                UUID.fromString("00000000-0000-0000-0000-000000000013")
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
@@ -104,7 +104,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
         assertThat(response)
             .hasStatus(OK_200)
             .asEntity(PortalNavigationItemsResponse.class)
-            .satisfies(entity -> assertThat(entity.getItems()).hasSize(10));
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(13));
     }
 
     @Test
@@ -199,7 +199,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
         assertThat(response)
             .hasStatus(OK_200)
             .asEntity(PortalNavigationItemsResponse.class)
-            .satisfies(entity -> assertThat(entity.getItems()).hasSize(6));
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(9));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiAncestorValidation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiAncestorValidation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.Map;
+
+/**
+ * Shared validation: ensures no API item appears in the parent hierarchy (used by create and update API rules).
+ */
+public final class ApiAncestorValidation {
+
+    private ApiAncestorValidation() {}
+
+    public static void ensureNoApiInAncestors(
+        PortalNavigationItemId parentId,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById
+    ) {
+        if (parentId == null) {
+            return;
+        }
+        var currentId = parentId;
+        while (currentId != null) {
+            var currentItem = itemsById.get(currentId);
+            if (currentItem == null) {
+                return;
+            }
+            if (currentItem.getType() == PortalNavigationItemType.API) {
+                throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApi();
+            }
+            currentId = currentItem.getParentId();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemCreateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemCreateRule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+
+/**
+ * For API type: parentId required, area TOP_NAVBAR, apiId required, apiId not already used, no API in ancestors.
+ */
+public class ApiItemCreateRule implements CreatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() == PortalNavigationItemType.API;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        PortalNavigationItemId parentId = item.getParentId();
+        PortalArea itemArea = item.getArea();
+        String apiId = item.getApiId();
+        List<PortalNavigationItem> navigationItems = ctx.navigationItems();
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById = ctx.itemsById();
+
+        if (parentId == null) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("parentId");
+        }
+        if (itemArea != PortalArea.TOP_NAVBAR) {
+            throw InvalidPortalNavigationItemDataException.apiMustBeInTopNavbar();
+        }
+        if (apiId == null || apiId.isBlank()) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("apiId");
+        }
+        if (isApiIdAlreadyUsed(apiId, navigationItems)) {
+            throw InvalidPortalNavigationItemDataException.apiIdAlreadyExists(apiId);
+        }
+        ApiAncestorValidation.ensureNoApiInAncestors(parentId, itemsById);
+    }
+
+    private static boolean isApiIdAlreadyUsed(@NonNull String apiId, List<PortalNavigationItem> navigationItems) {
+        return navigationItems
+            .stream()
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .anyMatch(apiItem -> apiId.equals(apiItem.getApiId()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemUpdateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemUpdateRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.Map;
+
+/**
+ * For existing API items: validates parentId required, area TOP_NAVBAR, no API in ancestors.
+ * Does not check apiId uniqueness (apiId cannot be updated).
+ */
+public class ApiItemUpdateRule implements UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem instanceof PortalNavigationApi;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        var payloadParentId = toUpdate.getParentId();
+
+        if (payloadParentId == null) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("parentId");
+        }
+        if (existingItem.getArea() != PortalArea.TOP_NAVBAR) {
+            throw InvalidPortalNavigationItemDataException.apiMustBeInTopNavbar();
+        }
+        ApiAncestorValidation.ensureNoApiInAncestors(payloadParentId, ctx.itemsById());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/BulkCreatePortalNavigationItemValidationRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/BulkCreatePortalNavigationItemValidationRule.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import java.util.List;
+
+/**
+ * Rule that runs once per batch (e.g. validateAll) before per-item rules. Used for payload-level checks like duplicate apiIds.
+ */
+public interface BulkCreatePortalNavigationItemValidationRule {
+    void validate(List<CreatePortalNavigationItem> items, String environmentId, CreateValidationContext ctx);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreatePortalNavigationItemValidationRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreatePortalNavigationItemValidationRule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+
+/**
+ * Rule that validates a single item during create. The orchestrator runs only rules where {@link #appliesTo(CreatePortalNavigationItem)} is true.
+ */
+public interface CreatePortalNavigationItemValidationRule {
+    boolean appliesTo(CreatePortalNavigationItem item);
+
+    void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Context built once per create validation (single or bulk) to hold shared data and avoid repeated fetches.
+ */
+public record CreateValidationContext(
+    List<PortalNavigationItem> navigationItems,
+    Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+    Set<String> seenApiIdsInPayload
+) {
+    public static CreateValidationContext empty() {
+        return new CreateValidationContext(List.of(), Map.of(), new HashSet<>());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiIdsInPayloadRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiIdsInPayloadRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.List;
+
+/**
+ * Bulk create rule: ensures no duplicate apiIds among API items in the request.
+ */
+public class DuplicateApiIdsInPayloadRule implements BulkCreatePortalNavigationItemValidationRule {
+
+    @Override
+    public void validate(List<CreatePortalNavigationItem> items, String environmentId, CreateValidationContext ctx) {
+        var seenApiIds = ctx.seenApiIdsInPayload();
+        for (CreatePortalNavigationItem item : items) {
+            if (item.getType() != PortalNavigationItemType.API) {
+                continue;
+            }
+            String apiId = item.getApiId();
+            if (apiId == null || apiId.isBlank()) {
+                continue;
+            }
+            if (!seenApiIds.add(apiId)) {
+                throw InvalidPortalNavigationItemDataException.apiIdAlreadyExists(apiId);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/HomepageUniquenessRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/HomepageUniquenessRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * For HOMEPAGE area, ensures no top-level item already exists in that area.
+ */
+@RequiredArgsConstructor
+public class HomepageUniquenessRule implements CreatePortalNavigationItemValidationRule {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getArea() == PortalArea.HOMEPAGE;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var existingHomepage = navigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, item.getArea());
+        if (!existingHomepage.isEmpty()) {
+            throw new HomepageAlreadyExistsException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/LinkUrlRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/LinkUrlRule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidUrlFormatException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.net.URL;
+
+/**
+ * For LINK type, ensures the URL is valid (create and update).
+ */
+public class LinkUrlRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() == PortalNavigationItemType.LINK;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        validateUrl(item.getUrl());
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem instanceof PortalNavigationLink;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        validateUrl(toUpdate.getUrl());
+    }
+
+    static void validateUrl(String url) {
+        try {
+            new URL(url);
+        } catch (Exception e) {
+            throw new InvalidUrlFormatException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PageContentExistsRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PageContentExistsRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * For PAGE type with a non-null portalPageContentId, ensures the page content exists.
+ */
+@RequiredArgsConstructor
+public class PageContentExistsRule implements CreatePortalNavigationItemValidationRule {
+
+    private final PortalPageContentQueryService pageContentQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() == PortalNavigationItemType.PAGE && item.getPortalPageContentId() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var existingPageContent = pageContentQueryService.findById(item.getPortalPageContentId());
+        if (existingPageContent.isEmpty()) {
+            throw new PageContentNotFoundException(item.getPortalPageContentId().toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.ParentAreaMismatchException;
+import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.ParentTypeMismatchException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * When parentId is set, ensures parent exists, is a folder or API, and matches the item's area (create and update).
+ */
+@RequiredArgsConstructor
+public class ParentRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getParentId() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        validateParent(navigationItemsQueryService, item.getParentId(), item.getArea(), environmentId);
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return toUpdate.getParentId() != null;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        validateParent(navigationItemsQueryService, toUpdate.getParentId(), existingItem.getArea(), existingItem.getEnvironmentId());
+    }
+
+    /**
+     * Shared logic for validating parent; can be used from create and update flows.
+     */
+    public static void validateParent(
+        PortalNavigationItemsQueryService navigationItemsQueryService,
+        PortalNavigationItemId parentId,
+        PortalArea itemArea,
+        String environmentId
+    ) {
+        if (parentId == null) {
+            return;
+        }
+        var parentItem = navigationItemsQueryService.findByIdAndEnvironmentId(environmentId, parentId);
+        if (parentItem == null) {
+            throw new ParentNotFoundException(parentId.toString());
+        }
+        if (!(parentItem instanceof PortalNavigationItemContainer)) {
+            throw new ParentTypeMismatchException(parentId.toString());
+        }
+        if (!parentItem.getArea().equals(itemArea)) {
+            throw new ParentAreaMismatchException(parentId.toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TitleRequiredRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TitleRequiredRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+
+/**
+ * Ensures the payload has a non-null, non-blank title (create and update).
+ * On create, API items are excluded because the domain sets title from the API name.
+ */
+public class TitleRequiredRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() != PortalNavigationItemType.API;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        requireNonBlankTitle(item.getTitle());
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return true;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        requireNonBlankTitle(toUpdate.getTitle());
+    }
+
+    private static void requireNonBlankTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("title");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+
+/**
+ * Ensures the update payload type matches the existing item's type (type cannot be changed).
+ */
+public class TypeConsistencyRule implements UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return true;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        PortalNavigationItemType existingType = switch (existingItem) {
+            case PortalNavigationFolder ignored -> PortalNavigationItemType.FOLDER;
+            case PortalNavigationPage ignored -> PortalNavigationItemType.PAGE;
+            case PortalNavigationLink ignored -> PortalNavigationItemType.LINK;
+            case PortalNavigationApi ignored -> PortalNavigationItemType.API;
+        };
+        if (existingType != toUpdate.getType()) {
+            throw InvalidPortalNavigationItemDataException.typeMismatch(toUpdate.getType().toString(), existingType.toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UniqueItemIdRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UniqueItemIdRule.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.ItemAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Ensures that when the item has an id, it does not already exist in the environment.
+ */
+@RequiredArgsConstructor
+public class UniqueItemIdRule implements CreatePortalNavigationItemValidationRule {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getId() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var existingItem = navigationItemsQueryService.findByIdAndEnvironmentId(environmentId, item.getId());
+        if (existingItem != null) {
+            throw new ItemAlreadyExistsException(item.getId().toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdatePortalNavigationItemValidationRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdatePortalNavigationItemValidationRule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+
+/**
+ * Rule that validates an update. The orchestrator runs only rules where {@link #appliesTo(UpdatePortalNavigationItem, PortalNavigationItem)} is true.
+ */
+public interface UpdatePortalNavigationItemValidationRule {
+    boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem);
+
+    void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Context built for update validation when the existing item is API (holds navigation items and itemsById for ancestor checks).
+ */
+public record UpdateValidationContext(
+    List<PortalNavigationItem> navigationItems,
+    Map<PortalNavigationItemId, PortalNavigationItem> itemsById
+) {
+    public static UpdateValidationContext empty() {
+        return new UpdateValidationContext(List.of(), Map.of());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApi.java
@@ -22,7 +22,7 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @SuperBuilder
-public final class PortalNavigationApi extends PortalNavigationItem {
+public final class PortalNavigationApi extends PortalNavigationItem implements PortalNavigationItemContainer {
 
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.API;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationFolder.java
@@ -19,7 +19,7 @@ import jakarta.annotation.Nonnull;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
-public final class PortalNavigationFolder extends PortalNavigationItem {
+public final class PortalNavigationFolder extends PortalNavigationItem implements PortalNavigationItemContainer {
 
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.FOLDER;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemContainer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemContainer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+/**
+ * Marker interface for PortalNavigationItem subtypes that can contain children.
+ */
+public interface PortalNavigationItemContainer {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCase.java
@@ -19,8 +19,8 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemHasChildrenException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +46,7 @@ public class DeletePortalNavigationItemUseCase {
     }
 
     private void validateItemHasNoChildren(PortalNavigationItem existing) {
-        if (!(existing instanceof PortalNavigationFolder)) {
+        if (!(existing instanceof PortalNavigationItemContainer)) {
             return;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -17,9 +17,9 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemComparator;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
@@ -37,7 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class ListPortalNavigationItemsUseCase {
 
     private final PortalNavigationItemsQueryService queryService;
-    private static final Predicate<PortalNavigationItem> IS_FOLDER_PREDICATE = i -> i instanceof PortalNavigationFolder;
+    private static final Predicate<PortalNavigationItem> IS_CONTAINER_PREDICATE = i -> i instanceof PortalNavigationItemContainer;
 
     public Output execute(Input input) {
         PortalNavigationItem parentItem;
@@ -82,7 +82,7 @@ public class ListPortalNavigationItemsUseCase {
         List<PortalNavigationItem> childrenAccumulator = new ArrayList<>();
         LinkedList<PortalNavigationItem> queue = new LinkedList<>();
 
-        initialItems.stream().filter(IS_FOLDER_PREDICATE).forEach(queue::add);
+        initialItems.stream().filter(IS_CONTAINER_PREDICATE).forEach(queue::add);
 
         while (!queue.isEmpty()) {
             var currentFolder = queue.removeFirst();
@@ -92,7 +92,7 @@ public class ListPortalNavigationItemsUseCase {
             if (!foundChildren.isEmpty()) {
                 childrenAccumulator.addAll(foundChildren);
 
-                foundChildren.stream().filter(IS_FOLDER_PREDICATE).forEach(queue::add);
+                foundChildren.stream().filter(IS_CONTAINER_PREDICATE).forEach(queue::add);
             }
         }
         return childrenAccumulator;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -42,6 +42,8 @@ public class PortalNavigationItemFixtures {
     public static final String LINK1_ID = "00000000-0000-0000-0000-000000000009";
     public static final String API1_ID = "00000000-0000-0000-0000-000000000010";
     public static final String API1_FOLDER_ID = "00000000-0000-0000-0000-000000000011";
+    public static final String API2_ID = "00000000-0000-0000-0000-000000000012";
+    private static final String API2_FOLDER_ID = "00000000-0000-0000-0000-000000000013";
 
     public static PortalNavigationFolder aFolder(String id, String title) {
         return aFolder(id, title, null);
@@ -175,6 +177,11 @@ public class PortalNavigationItemFixtures {
         var api1Folder = aFolder(API1_FOLDER_ID, "API 1 Folder", api1.getId());
         api1Folder.setOrder(0);
 
+        var api2Folder = aFolder(API2_FOLDER_ID, "API 2 Folder", category1.getId());
+        api2Folder.setOrder(0);
+        var api2 = anApi(API2_ID, "API 2", api2Folder.getId(), "api-2-id");
+        api2.setOrder(0);
+
         var page11 = aPage(PAGE11_ID, "page11", category1.getId());
         page11.setOrder(0);
         page11.setPublished(false);
@@ -183,6 +190,20 @@ public class PortalNavigationItemFixtures {
         page12.setPublished(true);
         page12.setVisibility(PortalVisibility.PRIVATE);
 
-        return List.of(apis, guides, support, overview, gettingStarted, category1, api1, api1Folder, page11, page12, link1);
+        return List.of(
+            apis,
+            guides,
+            support,
+            overview,
+            gettingStarted,
+            category1,
+            api1,
+            api2,
+            api1Folder,
+            api2Folder,
+            page11,
+            page12,
+            link1
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
@@ -26,6 +26,14 @@ public class PortalPageContentQueryServiceInMemory implements InMemoryAlternativ
 
     ArrayList<PortalPageContent> storage = new ArrayList<>();
 
+    public PortalPageContentQueryServiceInMemory() {
+        initWith(List.of());
+    }
+
+    public PortalPageContentQueryServiceInMemory(List<PortalPageContent> items) {
+        initWith(items);
+    }
+
     @Override
     public Optional<PortalPageContent> findById(PortalPageContentId id) {
         return storage

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
@@ -177,7 +177,7 @@ public class DeletePortalNavigationItemUseCaseTest {
     }
 
     @Test
-    void should_throw_when_parent() {
+    void should_throw_when_folder_has_children() {
         // Given
         var parent = PortalNavigationItemFixtures.aFolder("Parent");
         var child1 = PortalNavigationItemFixtures.aPage("Child 1", parent.getId());
@@ -193,6 +193,29 @@ public class DeletePortalNavigationItemUseCaseTest {
                     PortalNavigationItemFixtures.ORG_ID,
                     PortalNavigationItemFixtures.ENV_ID,
                     parent.getId()
+                )
+            )
+        );
+
+        // Then
+        Assertions.assertThat(throwable).isInstanceOf(PortalNavigationItemHasChildrenException.class).hasMessageContaining("has children");
+    }
+
+    @Test
+    void should_throw_when_api_has_children() {
+        // Given
+        var apiParent = PortalNavigationItemFixtures.anApi(PortalNavigationItemFixtures.API1_ID, "API Parent", null, "api-1");
+        var child = PortalNavigationItemFixtures.aFolder("Child Folder", apiParent.getId());
+        portalNavigationItemsCrudService.initWith(List.of(apiParent, child));
+        portalNavigationItemsQueryService.initWith(List.of(apiParent, child));
+
+        // When
+        var throwable = Assertions.catchThrowable(() ->
+            deletePortalNavigationItemUseCase.execute(
+                new DeletePortalNavigationItemUseCase.Input(
+                    PortalNavigationItemFixtures.ORG_ID,
+                    PortalNavigationItemFixtures.ENV_ID,
+                    apiParent.getId()
                 )
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -66,7 +66,7 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(10)
+            .hasSize(13)
             .extracting(PortalNavigationItem::getTitle)
             .containsExactly(
                 "APIs",
@@ -78,7 +78,10 @@ class ListPortalNavigationItemsUseCaseTest {
                 "Category1",
                 "API 1",
                 "page11",
-                "page12"
+                "API 2 Folder",
+                "page12",
+                "API 1 Folder",
+                "API 2"
             );
     }
 
@@ -123,9 +126,19 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(6)
+            .hasSize(9)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("Overview", "Getting Started", "Category1", "API 1", "page11", "page12");
+            .containsExactly(
+                "Overview",
+                "Getting Started",
+                "Category1",
+                "API 1",
+                "page11",
+                "API 2 Folder",
+                "page12",
+                "API 1 Folder",
+                "API 2"
+            );
     }
 
     @Test
@@ -146,9 +159,22 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items())
-            .hasSize(9)
+            .hasSize(12)
             .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("APIs", "Example Link", "Guides", "Support", "Overview", "Getting Started", "Category1", "API 1", "page12");
+            .containsExactly(
+                "APIs",
+                "Example Link",
+                "Guides",
+                "Support",
+                "Overview",
+                "Getting Started",
+                "Category1",
+                "API 1",
+                "API 2 Folder",
+                "page12",
+                "API 1 Folder",
+                "API 2"
+            );
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12791

## Description

This Pull Request introduces significant changes to how portal navigation items are validated and managed in the Gravitee API platform. It includes the introduction of a new validation framework with a rule-based mechanism for creating and updating portal navigation items.

**Main changes:**

- Replaced hardcoded validation methods with a flexible rule-based validation framework for both creation (CreatePortalNavigationItemValidationRule) and update (UpdatePortalNavigationItemValidationRule) of portal navigation items.
- Added new validation rules (e.g., TitleRequiredRule, ParentRule, and DuplicateApiIdsInPayloadRule) to modularize and streamline validation logic.
- Introduced CreateValidationContext and UpdateValidationContext classes to optimize data sharing during validation processes.
- Extracted complex validation logic (e.g., API ancestor checks) into reusable standalone components such as ApiAncestorValidation.
- Made PortalNavigationApi and PortalNavigationFolder implement a new PortalNavigationItemContainer interface to enforce hierarchical relationships.
- Modified unit tests to adhere to the new rule-based validation approach, ensuring proper test coverage for success and failure scenarios.
- Added new files for validation rules and updated test data to reflect changes in how items are created, updated, and deleted.

This PR improves the flexibility, maintainability, and testability of the validation mechanism for portal navigation items.


🚀 **Next PRs:**
- Allow user to select navigation items in the FE
- Return APIs and children in Portal + display Subscribe button

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

