### PR TITLE
Apim 12791 UI add item to api

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -125,16 +125,20 @@
     }
 
     <mat-menu #moreMenu="matMenu">
-      @if (node.type === 'FOLDER') {
+      @if (node.type === 'FOLDER' || node.type === 'API') {
         @if (canCreate) {
           <button mat-menu-item (click)="onCreate(node, 'PAGE')">
             <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon>
             Add Page
           </button>
-          <button mat-menu-item (click)="onCreate(node, 'API')">
-            <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
-            Add API
-          </button>
+
+          @if (node.type != 'API') {
+            <button mat-menu-item (click)="onCreate(node, 'API')">
+              <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
+              Add API
+            </button>
+          }
+
           <button mat-menu-item (click)="onCreate(node, 'FOLDER')">
             <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon>
             Add Folder
@@ -154,18 +158,16 @@
           Edit
         </button>
 
-        @if (node.type !== 'API') {
-          @if (isUnpublished(node)) {
-            <button mat-menu-item (click)="onPublish(node)" data-testid="publish-node-button">
-              <mat-icon svgIcon="gio:eye-empty"></mat-icon>
-              Publish
-            </button>
-          } @else {
-            <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
-              <mat-icon svgIcon="gio:eye-off"></mat-icon>
-              Unpublish
-            </button>
-          }
+        @if (isUnpublished(node)) {
+          <button mat-menu-item (click)="onPublish(node)" data-testid="publish-node-button">
+            <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+            Publish
+          </button>
+        } @else {
+          <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
+            <mat-icon svgIcon="gio:eye-off"></mat-icon>
+            Unpublish
+          </button>
         }
       }
 

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -25,6 +25,7 @@ import { FlatTreeComponentHarness } from './flat-tree.component.harness';
 
 import { GioTestingModule } from '../../../shared/testing';
 import {
+  fakePortalNavigationApi,
   fakePortalNavigationFolder,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
@@ -59,7 +60,7 @@ describe('FlatTreeComponent', () => {
 
   const makeItem = (
     id: string,
-    type: 'PAGE' | 'FOLDER' | 'LINK',
+    type: PortalNavigationItem['type'],
     title: string,
     order?: number,
     parentId?: string | null,
@@ -70,6 +71,8 @@ describe('FlatTreeComponent', () => {
         return fakePortalNavigationFolder({ id, title, order, parentId, published });
       case 'LINK':
         return fakePortalNavigationLink({ id, title, order, parentId, published });
+      case 'API':
+        return fakePortalNavigationApi({ id, title, order, parentId, published });
       case 'PAGE':
       default:
         return fakePortalNavigationPage({ id, title, order, parentId, published });
@@ -343,6 +346,21 @@ describe('FlatTreeComponent', () => {
 
     const titles = await harness.getAllItemTitles();
     expect(titles).toContain('Folder 1');
+    expect(titles).toContain('Folder 2');
+    expect(titles).toContain('Page 1');
+  });
+
+  it('should handle nested api structure', async () => {
+    const links = [
+      makeItem('a1', 'API', 'API 1', 0),
+      makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1'),
+      makeItem('p1', 'PAGE', 'Page 1', 0, 'f1'),
+    ];
+
+    fixture.componentRef.setInput('links', links);
+    fixture.detectChanges();
+    const titles = await harness.getAllItemTitles();
+    expect(titles).toContain('API 1');
     expect(titles).toContain('Folder 2');
     expect(titles).toContain('Page 1');
   });

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -222,7 +222,7 @@ export class FlatTreeComponent {
       }
     }
 
-    if (nodeToMove.type === 'FOLDER') {
+    if (nodeToMove.type === 'FOLDER' || nodeToMove.type === 'API') {
       this.treeBase()?.expandAll();
     }
 
@@ -278,7 +278,7 @@ export class FlatTreeComponent {
         label: link.title,
         type,
         data: link,
-        children: type === 'FOLDER' ? [] : undefined,
+        children: type === 'FOLDER' || type === 'API' ? [] : undefined,
         __order: link.order ?? 0,
         __parentId: link.parentId ?? null,
       } as ProcessingNode);

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -77,22 +77,18 @@
           </div>
 
           <div class="panel-header__title__badges">
-            @if (isSelectedNotApiItem()) {
-              <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
-                {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
-              </span>
-            }
+            <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
+              {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
+            </span>
             <span class="gio-badge-primary">{{ selectedNavigationItem().data.visibility | titlecase }}</span>
           </div>
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">
         <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onEdit()">Edit</button>
-        @if (isSelectedNotApiItem()) {
-          <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onPublishToggle()">
-            {{ selectedNavigationItemIsPublished() ? 'Unpublish' : 'Publish' }}
-          </button>
-        }
+        <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onPublishToggle()">
+          {{ selectedNavigationItemIsPublished() ? 'Unpublish' : 'Publish' }}
+        </button>
         <button mat-flat-button color="primary" [disabled]="contentControl.pristine" (click)="onSave()">Save</button>
       </div>
     </header>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1379,7 +1379,7 @@ describe('PortalNavigationItemsComponent', () => {
       expect(result?.id).toBe('page-111');
     });
 
-    it('returns null when no pages exist', () => {
+    it('returns folder parent when no pages exist', () => {
       const folder1 = fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1', order: 0 });
       const folder11 = fakePortalNavigationFolder({
         id: 'folder-11',
@@ -1391,7 +1391,7 @@ describe('PortalNavigationItemsComponent', () => {
 
       const result = findFirstAvailablePage(null, items);
 
-      expect(result).toBeNull();
+      expect(result).toEqual(folder11);
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -143,9 +143,6 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   readonly selectedNavigationItemIsPublished: Signal<boolean> = computed(() => {
     return this.selectedNavigationItem()?.data?.published ?? false;
   });
-  readonly isSelectedNotApiItem: Signal<boolean> = computed(() => {
-    return this.selectedNavigationItem()?.type !== 'API';
-  });
 
   // --- Resize Configuration ---
   private readonly ngZone = inject(NgZone);
@@ -206,9 +203,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           break;
         case 'publish':
         case 'unpublish':
-          if (event.node.type !== 'API') {
-            this.handlePublishToggle(event.node.data);
-          }
+          this.handlePublishToggle(event.node.data);
           break;
         default:
           if (event.itemType === 'API' && event.action !== 'edit') {
@@ -556,12 +551,12 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   private getPublishDialogData(navItem: PortalNavigationItem): GioConfirmDialogData {
     const isPublished = navItem.published;
-    const typeLabel = navItem.type.toLowerCase();
+    const typeLabel = navItem.type === 'API' ? 'API' : navItem.type.toLowerCase();
 
     const action = isPublished ? 'Unpublish' : 'Publish';
     const pastAction = `${action.toLowerCase()}ed`;
 
-    const contentScope = navItem.type === 'FOLDER' ? ' and its content ' : ' ';
+    const contentScope = navItem.type === 'FOLDER' || navItem.type === 'API' ? ' and its content ' : ' ';
 
     return {
       title: `${action} "${navItem.title}" ${typeLabel}?`,
@@ -676,7 +671,7 @@ export function findFirstAvailablePage(
       if (element.type === 'PAGE') {
         return element;
       }
-      if (element.type === 'FOLDER') {
+      if (element.type === 'FOLDER' || element.type === 'API') {
         const found = search(element);
         if (found) return found;
         return element;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -679,6 +679,7 @@ export function findFirstAvailablePage(
       if (element.type === 'FOLDER') {
         const found = search(element);
         if (found) return found;
+        return element;
       }
     }
     return null;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12791

## Description

This Pull Request introduces updates to the navigation tree components of the Gravitee APIM console. It primarily adds support for managing "API" type nodes in the navigation tree, paving the way for API-specific functionalities in the UI and ensuring that their behavior aligns with existing node types.


https://github.com/user-attachments/assets/b37a08c6-56d0-4e93-a564-09b5fb1db5dd


**Main Changes:**

- Enhanced templates and logic in flat-tree.component.html to support actions for "API" type nodes such as creating pages, folders, and publishing/unpublishing.
- Adjusted flat-tree.component.ts to include "API" nodes in tree-handling features like expansion and child management.
- Added new test cases in flat-tree.component.spec.ts to ensure proper handling and actions for the new "API" node type.
- Removed unnecessary conditions for API node handling in portal-navigation-items.component.html.
- Updated business logic in portal-navigation-items.component.ts to simplify "publish/unpublish" workflows and include "API" nodes.
- Expanded test coverage in portal-navigation-items.component.spec.ts to cover newly added actions for API nodes.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

