### PR TITLE
fix: correct off-by-one pagination in certificate list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -174,7 +174,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         try {
             log.debug("Find client certificates by application ID: {}", applicationId);
 
-            var repoPageable = new PageableBuilder().pageNumber(pageable.getPageNumber()).pageSize(pageable.getPageSize()).build();
+            var repoPageable = new PageableBuilder().pageNumber(pageable.getPageNumber() - 1).pageSize(pageable.getPageSize()).build();
 
             var page = clientCertificateRepository.findByApplicationId(applicationId, repoPageable);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
@@ -365,7 +365,7 @@ class ClientCertificateCrudServiceImplTest {
         io.gravitee.rest.api.model.common.Pageable pageable = new io.gravitee.rest.api.model.common.Pageable() {
             @Override
             public int getPageNumber() {
-                return 0;
+                return 1;
             }
 
             @Override


### PR DESCRIPTION
## Summary

- Fix off-by-one error in `ClientCertificateCrudServiceImpl.findByApplicationId()` that caused the `GET /applications/{appId}/certificates` endpoint to always return an empty page
- The REST layer uses 1-based page numbering but the repository `PageableBuilder` expects 0-based — the `- 1` conversion was missing, unlike every other service in the codebase

## Root Cause

`PageableBuilder().pageNumber(pageable.getPageNumber())` passed the 1-based page number directly to `PageRequest.of()` in the MongoDB repository, which is 0-based. Requesting `page=1` was interpreted as the second page, returning empty results.

## Jira

https://gravitee.atlassian.net/browse/GKO-2388

## Test plan

- [x] Unit test `ClientCertificateCrudServiceImplTest#should_find_by_application_id` updated and passing
- [x] `GetClientCertificatesUseCaseTest` passing (2 tests)
- [x] `ApplicationClientCertificatesResourceTest` passing (4 tests)
- [x] Manual verification: `GET /applications/{appId}/certificates?page=1&size=10` returns certificates after restart