### PR TITLE
feat(console): add API Products list, create, and configuration flows

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -28,7 +28,7 @@ export const API_PRODUCTS_ROUTES: Routes = [
     },
   },
   {
-    path: 'new',
+    path: 'create',
     loadComponent: () => import('./create/api-product-create.component').then(m => m.ApiProductCreateComponent),
     data: {
       permissions: {

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Routes } from '@angular/router';
+
+export const API_PRODUCTS_ROUTES: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    loadComponent: () => import('./list/api-product-list.component').then(m => m.ApiProductListComponent),
+    data: {
+      docs: {
+        page: 'management-api-products',
+      },
+    },
+  },
+  {
+    path: 'new',
+    loadComponent: () => import('./create/api-product-create.component').then(m => m.ApiProductCreateComponent),
+    data: {
+      permissions: {
+        anyOf: ['environment-api_product-c'],
+      },
+    },
+  },
+  {
+    path: ':apiProductId',
+    loadComponent: () => import('./navigation/api-product-navigation.component').then(m => m.ApiProductNavigationComponent),
+    children: [
+      {
+        path: '',
+        redirectTo: 'configuration',
+        pathMatch: 'full',
+      },
+      {
+        path: 'configuration',
+        loadComponent: () => import('./configuration/api-product-configuration.component').then(m => m.ApiProductConfigurationComponent),
+      },
+    ],
+  },
+];

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -16,24 +16,24 @@
 
 -->
 
-@if (form(); as formRef) {
+@if (apiProduct(); as product) {
   <div class="configuration-section">
     <h2 class="configuration-section__title">Configuration</h2>
     <p class="configuration-section__subtitle">Manage general settings and product details.</p>
   </div>
 
-  <form [formGroup]="formRef" gioFormFocusInvalid>
+  <form [formGroup]="form" gioFormFocusInvalid>
     <mat-card class="configuration-card">
       <mat-card-content>
         <div class="configuration-card__fields">
           <mat-form-field appearance="outline" class="configuration-card__fields__name">
             <mat-label>Name</mat-label>
             <input matInput formControlName="name" [maxlength]="nameMaxLength" />
-            @if (formRef.controls.name.hasError('required')) {
+            @if (form.controls.name.hasError('required')) {
               <mat-error>Name is required.</mat-error>
-            } @else if (formRef.controls.name.hasError('unique')) {
+            } @else if (form.controls.name.hasError('unique')) {
               <mat-error>API Product name must be unique</mat-error>
-            } @else if (formRef.controls.name.hasError('maxlength')) {
+            } @else if (form.controls.name.hasError('maxlength')) {
               <mat-error>Name must be at most {{ nameMaxLength }} characters</mat-error>
             }
           </mat-form-field>
@@ -41,9 +41,9 @@
           <mat-form-field appearance="outline" class="configuration-card__fields__version">
             <mat-label>Version</mat-label>
             <input matInput formControlName="version" [maxlength]="versionMaxLength" />
-            @if (formRef.controls.version.hasError('required')) {
+            @if (form.controls.version.hasError('required')) {
               <mat-error>Version is required.</mat-error>
-            } @else if (formRef.controls.version.hasError('maxlength')) {
+            } @else if (form.controls.version.hasError('maxlength')) {
               <mat-error>Version must be at most {{ versionMaxLength }} characters</mat-error>
             }
           </mat-form-field>
@@ -77,17 +77,18 @@
       </mat-card>
     }
 
-    @if (apiProduct(); as product) {
+    @if (product) {
       <api-product-danger-zone
         [apiProduct]="product"
         [isReadOnly]="isReadOnly"
-        (reloadDetails)="onReloadDetails()"
+        (removeApisClick)="onRemoveApis()"
+        (deleteApiProductClick)="onDeleteApiProduct()"
       ></api-product-danger-zone>
     }
 
-    @if (formRef.dirty && formRef.valid) {
+    @if (form.dirty && form.valid && form.status !== 'PENDING') {
       <gio-save-bar
-        [form]="formRef"
+        [form]="form"
         [formInitialValues]="initialFormValue()"
         (resetClicked)="onReset()"
         (submitted)="onSubmit()"

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -1,0 +1,97 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+@if (form(); as formRef) {
+  <div class="configuration-section">
+    <h2 class="configuration-section__title">Configuration</h2>
+    <p class="configuration-section__subtitle">Manage general settings and product details.</p>
+  </div>
+
+  <form [formGroup]="formRef" gioFormFocusInvalid>
+    <mat-card class="configuration-card">
+      <mat-card-content>
+        <div class="configuration-card__fields">
+          <mat-form-field appearance="outline" class="configuration-card__fields__name">
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" [maxlength]="nameMaxLength" />
+            @if (formRef.controls.name.hasError('required')) {
+              <mat-error>Name is required.</mat-error>
+            } @else if (formRef.controls.name.hasError('unique')) {
+              <mat-error>API Product name must be unique</mat-error>
+            } @else if (formRef.controls.name.hasError('maxlength')) {
+              <mat-error>Name must be at most {{ nameMaxLength }} characters</mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="configuration-card__fields__version">
+            <mat-label>Version</mat-label>
+            <input matInput formControlName="version" [maxlength]="versionMaxLength" />
+            @if (formRef.controls.version.hasError('required')) {
+              <mat-error>Version is required.</mat-error>
+            } @else if (formRef.controls.version.hasError('maxlength')) {
+              <mat-error>Version must be at most {{ versionMaxLength }} characters</mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="configuration-card__fields__description">
+            <mat-label>Description</mat-label>
+            <textarea matInput formControlName="description" rows="4"></textarea>
+          </mat-form-field>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    @if (apiIds().length) {
+      <mat-card class="configuration-card">
+        <mat-card-header>
+          <mat-card-title>APIs in this Product</mat-card-title>
+          <mat-card-subtitle>Remove individual APIs from the product</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="apis-list">
+            @for (apiId of apiIds(); track apiId) {
+              <div class="apis-list__item">
+                <span class="apis-list__item-id">{{ apiId }}</span>
+                <button mat-icon-button color="warn" (click)="onDeleteApi(apiId)" aria-label="Remove API">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
+            }
+          </div>
+        </mat-card-content>
+      </mat-card>
+    }
+
+    @if (apiProduct(); as product) {
+      <api-product-danger-zone
+        [apiProduct]="product"
+        [isReadOnly]="isReadOnly"
+        (reloadDetails)="onReloadDetails()"
+      ></api-product-danger-zone>
+    }
+
+    @if (formRef.dirty && formRef.valid) {
+      <gio-save-bar
+        [form]="formRef"
+        [formInitialValues]="initialFormValue()"
+        (resetClicked)="onReset()"
+        (submitted)="onSubmit()"
+      ></gio-save-bar>
+    }
+  </form>
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
@@ -14,30 +14,32 @@
  * limitations under the License.
  */
 
+@use 'sass:map';
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 
+$typography: map.get(gio.$mat-theme, typography);
+
 .configuration-section {
   &__title {
-    font-size: 1.5rem;
-    font-weight: 500;
-    margin: 0 0 0.5rem 0;
+    @include mat.m2-typography-level($typography, headline-6);
+    margin: 0 0 8px 0;
   }
 
   &__subtitle {
-    font-size: 0.875rem;
+    @include mat.m2-typography-level($typography, body-2);
     color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
-    margin: 0 0 1.5rem 0;
+    margin: 0 0 24px 0;
   }
 }
 
 .configuration-card {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 
   &__fields {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 16px;
 
     &__name,
     &__version {
@@ -57,19 +59,19 @@
 .apis-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 8px;
 
   &__item {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 0.75rem;
+    padding: 8px 12px;
     background: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'lighter40');
-    border-radius: 0.25rem;
+    border-radius: 4px;
 
     &-id {
+      @include mat.m2-typography-level($typography, body-2);
       font-family: monospace;
-      font-size: 0.875rem;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.configuration-section {
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin: 0 0 0.5rem 0;
+  }
+
+  &__subtitle {
+    font-size: 0.875rem;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    margin: 0 0 1.5rem 0;
+  }
+}
+
+.configuration-card {
+  margin-bottom: 1.5rem;
+
+  &__fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    &__name,
+    &__version {
+      width: 100%;
+    }
+
+    &__description {
+      width: 100%;
+
+      textarea {
+        min-height: 6.25rem;
+      }
+    }
+  }
+}
+
+.apis-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    background: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'lighter40');
+    border-radius: 0.25rem;
+
+    &-id {
+      font-family: monospace;
+      font-size: 0.875rem;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -16,12 +16,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
+import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 
 import { ApiProductConfigurationComponent } from './api-product-configuration.component';
 
@@ -29,6 +31,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { Constants } from '../../../entities/Constants';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 
 describe('ApiProductConfigurationComponent', () => {
   const API_PRODUCT_ID = 'product-1';
@@ -42,7 +45,9 @@ describe('ApiProductConfigurationComponent', () => {
 
   let fixture: ComponentFixture<ApiProductConfigurationComponent>;
   let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
   const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
 
   beforeEach(() => {
@@ -51,12 +56,12 @@ describe('ApiProductConfigurationComponent', () => {
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-api_product-u'] },
         {
           provide: ActivatedRoute,
           useValue: {
             params: of({ apiProductId: API_PRODUCT_ID }),
             snapshot: { params: { apiProductId: API_PRODUCT_ID } },
-            parent: null,
           },
         },
       ],
@@ -64,7 +69,9 @@ describe('ApiProductConfigurationComponent', () => {
 
     fixture = TestBed.createComponent(ApiProductConfigurationComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
+    routerNavigateSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
     fixture.detectChanges();
   });
 
@@ -73,7 +80,10 @@ describe('ApiProductConfigurationComponent', () => {
     jest.clearAllMocks();
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
     expect(fixture.componentInstance).toBeTruthy();
   });
 
@@ -84,7 +94,7 @@ describe('ApiProductConfigurationComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const form = fixture.componentInstance.form();
+    const form = fixture.componentInstance.form;
     expect(form).toBeTruthy();
     expect(form?.getRawValue().name).toBe('Test API Product');
     expect(form?.getRawValue().version).toBe('1.0');
@@ -104,7 +114,7 @@ describe('ApiProductConfigurationComponent', () => {
     await versionInput.blur();
     fixture.detectChanges();
 
-    const form = fixture.componentInstance.form();
+    const form = fixture.componentInstance.form;
     expect(form?.controls.name.hasError('required')).toBe(true);
     expect(form?.controls.version.hasError('required')).toBe(true);
   });
@@ -115,10 +125,12 @@ describe('ApiProductConfigurationComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const form = fixture.componentInstance.form();
+    const form = fixture.componentInstance.form;
     expect(form).toBeTruthy();
-    form!.patchValue({ name: 'Updated Name', version: '1.0', description: 'Updated desc' });
+    // Keep same name to avoid async validator's verify call (deterministic, CI-friendly)
+    form!.patchValue({ name: 'Test API Product', version: '1.0', description: 'Updated desc' });
     form!.markAsDirty();
+    await fixture.whenStable();
 
     fixture.componentInstance.onSubmit();
     await fixture.whenStable();
@@ -127,8 +139,14 @@ describe('ApiProductConfigurationComponent', () => {
       method: 'PUT',
       url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
     });
-    expect(updateReq.request.body.name).toBe('Updated Name');
-    updateReq.flush({ ...fakeApiProduct, name: 'Updated Name' });
+    expect(updateReq.request.body.name).toBe('Test API Product');
+    expect(updateReq.request.body.description).toBe('Updated desc');
+    updateReq.flush({ ...fakeApiProduct, description: 'Updated desc' });
+    await fixture.whenStable();
+
+    // Refetch triggered after save
+    const refetchReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    refetchReq.flush({ ...fakeApiProduct, description: 'Updated desc' });
     await fixture.whenStable();
 
     expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
@@ -140,5 +158,50 @@ describe('ApiProductConfigurationComponent', () => {
     await fixture.whenStable();
 
     expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+
+  it('should remove all APIs when confirmed', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const removeButton = await loader.getHarness(MatButtonHarness.with({ text: /Remove APIs/i }));
+    await removeButton.click();
+
+    const dialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+    await dialog.confirm();
+
+    const deleteReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
+    expect(deleteReq.request.method).toBe('DELETE');
+    deleteReq.flush({});
+    await fixture.whenStable();
+
+    const reloadReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    reloadReq.flush({ ...fakeApiProduct, apiIds: [] });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('All APIs have been removed from the API Product.');
+  });
+
+  it('should delete API product when confirmed', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    await deleteButton.click();
+
+    const dialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+    await dialog.confirm();
+
+    const deleteReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(deleteReq.request.method).toBe('DELETE');
+    deleteReq.flush({});
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('The API Product has been deleted.');
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], expect.anything());
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ApiProductConfigurationComponent } from './api-product-configuration.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductConfigurationComponent', () => {
+  const API_PRODUCT_ID = 'product-1';
+  const fakeApiProduct: ApiProduct = {
+    id: API_PRODUCT_ID,
+    name: 'Test API Product',
+    version: '1.0',
+    description: 'Test description',
+    apiIds: ['api-1'],
+  };
+
+  let fixture: ComponentFixture<ApiProductConfigurationComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductConfigurationComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID }),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: null,
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductConfigurationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should load and display API product configuration', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const form = fixture.componentInstance.form();
+    expect(form).toBeTruthy();
+    expect(form?.getRawValue().name).toBe('Test API Product');
+    expect(form?.getRawValue().version).toBe('1.0');
+  });
+
+  it('should validate required fields', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    await nameInput.setValue('');
+    await versionInput.setValue('');
+    await nameInput.blur();
+    await versionInput.blur();
+    fixture.detectChanges();
+
+    const form = fixture.componentInstance.form();
+    expect(form?.controls.name.hasError('required')).toBe(true);
+    expect(form?.controls.version.hasError('required')).toBe(true);
+  });
+
+  it('should update API product on submit', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const form = fixture.componentInstance.form();
+    expect(form).toBeTruthy();
+    form!.patchValue({ name: 'Updated Name', version: '1.0', description: 'Updated desc' });
+    form!.markAsDirty();
+
+    fixture.componentInstance.onSubmit();
+    await fixture.whenStable();
+
+    const updateReq = httpTestingController.expectOne({
+      method: 'PUT',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
+    });
+    expect(updateReq.request.body.name).toBe('Updated Name');
+    updateReq.flush({ ...fakeApiProduct, name: 'Updated Name' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
+  });
+
+  it('should show snackbar on load error', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { AsyncValidatorFn, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { EMPTY, merge, Observable, of, Subject, timer } from 'rxjs';
+import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioFormFocusInvalidModule,
+  GioSaveBarModule,
+} from '@gravitee/ui-particles-angular';
+
+import { ApiProductDangerZoneComponent } from './danger-zone/api-product-danger-zone.component';
+
+import { ApiProduct, UpdateApiProduct } from '../../../entities/management-api-v2/api-product';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+
+interface ConfigForm {
+  name: FormControl<string>;
+  version: FormControl<string>;
+  description: FormControl<string>;
+}
+
+@Component({
+  selector: 'api-product-configuration',
+  templateUrl: './api-product-configuration.component.html',
+  styleUrls: ['./api-product-configuration.component.scss'],
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    GioFormFocusInvalidModule,
+    GioSaveBarModule,
+    ApiProductDangerZoneComponent,
+  ],
+})
+export class ApiProductConfigurationComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly matDialog = inject(MatDialog);
+
+  protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['environment-api_product-u']);
+
+  readonly form = signal<FormGroup<ConfigForm> | null>(null);
+  readonly initialFormValue = signal<Record<string, unknown> | null>(null);
+  readonly nameMaxLength = 512;
+  readonly versionMaxLength = 64;
+  private readonly reload$ = new Subject<void>();
+  private readonly updatedProduct$ = new Subject<ApiProduct>();
+
+  readonly apiProduct = toSignal(
+    merge(
+      merge(
+        (this.activatedRoute.parent?.params ?? of({})).pipe(map(p => p['apiProductId'] ?? null)),
+        this.reload$.pipe(map(() => this.activatedRoute.parent?.snapshot?.params['apiProductId'] ?? null)),
+      ).pipe(
+        switchMap(apiProductId => {
+          if (apiProductId) {
+            return this.apiProductV2Service.get(apiProductId).pipe(
+              catchError(error => {
+                this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+                return of(null);
+              }),
+            );
+          }
+          return of(null);
+        }),
+      ),
+      this.updatedProduct$,
+    ),
+    { initialValue: null as ApiProduct | null },
+  );
+
+  readonly apiIds = computed(() => this.apiProduct()?.apiIds ?? []);
+
+  private readonly _formSync = effect(() => {
+    const p = this.apiProduct();
+    if (p) {
+      const f = this.createForm(p);
+      this.form.set(f);
+      this.initialFormValue.set(f.getRawValue());
+    }
+  });
+
+  onReloadDetails(): void {
+    this.reload$.next();
+  }
+
+  onSubmit(): void {
+    const f = this.form();
+    const product = this.apiProduct();
+    const apiProductId = product?.id;
+    if (f?.valid && apiProductId) {
+      const formValue = f.getRawValue();
+      const updateApiProduct: UpdateApiProduct = {
+        name: formValue.name?.trim() || '',
+        version: formValue.version?.trim() || '',
+        description: formValue.description?.trim() || undefined,
+        apiIds: product?.apiIds,
+      };
+
+      this.apiProductV2Service
+        .update(apiProductId, updateApiProduct)
+        .pipe(
+          tap(updatedApiProduct => {
+            this.updatedProduct$.next(updatedApiProduct);
+            this.initialFormValue.set(f.getRawValue());
+            f.markAsPristine();
+            f.markAsUntouched();
+            this.snackBarService.success('Configuration successfully saved!');
+          }),
+          catchError(error => {
+            this.snackBarService.error(error.error?.message || error.message || 'An error occurred while updating the API Product');
+            return EMPTY;
+          }),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe();
+    } else {
+      f?.markAllAsTouched();
+    }
+  }
+
+  onReset(): void {
+    const f = this.form();
+    const initial = this.initialFormValue();
+    if (f && initial) {
+      f.reset(initial);
+      f.markAsPristine();
+      f.markAsUntouched();
+    }
+  }
+
+  onDeleteApi(apiId: string): void {
+    const apiProductId = this.apiProduct()?.id;
+    if (!apiProductId) return;
+
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: '31.25rem',
+        data: {
+          title: 'Remove API',
+          content: 'Are you sure you want to remove this API from the API Product?',
+          confirmButton: 'Yes, remove it',
+        },
+        role: 'alertdialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm): confirm is true => confirm === true),
+        switchMap(() => this.apiProductV2Service.deleteApiFromApiProduct(apiProductId, apiId)),
+        tap(() => {
+          this.snackBarService.success('API removed from the product');
+          this.onReloadDetails();
+        }),
+        catchError(error => {
+          this.snackBarService.error(error.error?.message || 'An error occurred while removing the API');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private createForm(apiProduct: ApiProduct | null): FormGroup<ConfigForm> {
+    const product = apiProduct ?? undefined;
+    return new FormGroup<ConfigForm>({
+      name: new FormControl(product?.name ?? '', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.maxLength(this.nameMaxLength), Validators.minLength(1)],
+        asyncValidators: [this.nameUniquenessValidator(product)],
+        updateOn: 'blur',
+      }),
+      version: new FormControl(product?.version ?? '', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.maxLength(this.versionMaxLength), Validators.minLength(1)],
+      }),
+      description: new FormControl(product?.description ?? '', { nonNullable: true }),
+    });
+  }
+
+  private nameUniquenessValidator(currentProduct: ApiProduct | undefined): AsyncValidatorFn {
+    return (formControl: FormControl<string>): Observable<ValidationErrors | null> => {
+      if (!formControl || !formControl.value || formControl.value.trim() === '') {
+        return of(null);
+      }
+      const trimmedName = formControl.value.trim();
+      if (currentProduct && trimmedName === currentProduct.name) {
+        return of(null);
+      }
+      return timer(250).pipe(
+        switchMap(() => this.apiProductV2Service.verify(trimmedName)),
+        map(res => (res.ok ? null : { unique: true })),
+      );
+    };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -1,0 +1,43 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card class="danger-card">
+  <mat-card-content>
+    <h3 class="danger-card__title">Danger Zone</h3>
+    <div class="danger-card__actions">
+      <div class="danger-card__actions__action">
+        <span>Remove all the APIs of this API Product.</span>
+        <button
+          mat-button
+          color="warn"
+          [disabled]="isReadOnly() || !apiProduct().apiIds?.length"
+          (click)="removeApis()"
+        >
+          Remove APIs
+        </button>
+      </div>
+
+      <div class="danger-card__actions__action">
+        <span>Delete this API Product. This won't delete APIs associated to it.</span>
+        <button mat-button color="warn" [disabled]="isReadOnly()" data-testid="api_product_dangerzone_delete" (click)="deleteApiProduct()">
+          Delete API Product
+        </button>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -22,19 +22,20 @@
     <div class="danger-card__actions">
       <div class="danger-card__actions__action">
         <span>Remove all the APIs of this API Product.</span>
-        <button
-          mat-button
-          color="warn"
-          [disabled]="isReadOnly() || !apiProduct().apiIds?.length"
-          (click)="removeApis()"
-        >
+        <button mat-button color="warn" [disabled]="isReadOnly() || !apiProduct().apiIds?.length" (click)="onRemoveApis()">
           Remove APIs
         </button>
       </div>
 
       <div class="danger-card__actions__action">
         <span>Delete this API Product. This won't delete APIs associated to it.</span>
-        <button mat-button color="warn" [disabled]="isReadOnly()" data-testid="api_product_dangerzone_delete" (click)="deleteApiProduct()">
+        <button
+          mat-button
+          color="warn"
+          [disabled]="isReadOnly()"
+          data-testid="api_product_dangerzone_delete"
+          (click)="onDeleteApiProduct()"
+        >
           Delete API Product
         </button>
       </div>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  display: block;
+}
+
+.danger-card {
+  border: 0.0625rem solid mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+
+  &__title {
+    color: mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    &__action {
+      display: flex;
+      align-items: center;
+      flex-direction: row;
+      justify-content: space-between;
+      min-height: 3rem;
+
+      span {
+        display: block;
+        font-size: 0.75rem;
+        color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
@@ -18,12 +18,14 @@
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 
+$typography: map.get(gio.$mat-theme, typography);
+
 :host {
   display: block;
 }
 
 .danger-card {
-  border: 0.0625rem solid mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
 
   &__title {
     color: mat.m2-get-color-from-palette(gio.$mat-error-palette, 'default');
@@ -32,7 +34,7 @@
   &__actions {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 16px;
 
     &__action {
       display: flex;
@@ -42,8 +44,8 @@
       min-height: 3rem;
 
       span {
+        @include mat.m2-typography-level($typography, caption);
         display: block;
-        font-size: 0.75rem;
         color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
       }
     }

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { GioConfirmAndValidateDialogHarness } from '@gravitee/ui-particles-angular';
+
+import { ApiProductDangerZoneComponent } from './api-product-danger-zone.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../../entities/Constants';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+@Component({
+  standalone: true,
+  template: `<api-product-danger-zone [apiProduct]="apiProduct()" (reloadDetails)="onReload()"></api-product-danger-zone>`,
+  imports: [ApiProductDangerZoneComponent],
+})
+class TestHostComponent {
+  apiProduct = signal<ApiProduct>({
+    id: 'product-1',
+    name: 'Test Product',
+    version: '1.0',
+    apiIds: ['api-1', 'api-2'],
+  });
+  reloadEmitted = false;
+  onReload(): void {
+    this.reloadEmitted = true;
+  }
+}
+
+describe('ApiProductDangerZoneComponent', () => {
+  const API_PRODUCT_ID = 'product-1';
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
+  let hostComponent: TestHostComponent;
+  const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: {} },
+            parent: { snapshot: { params: { apiProductId: API_PRODUCT_ID } } },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    routerNavigateSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    expect(hostComponent).toBeTruthy();
+  });
+
+  it('should remove all APIs when confirmed', async () => {
+    const removeButton = await loader.getHarness(MatButtonHarness.with({ text: /Remove APIs/i }));
+    await removeButton.click();
+
+    const dialog = await rootLoader.getHarness(MatDialogHarness);
+    const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: /Yes, remove them/i }));
+    await confirmButton.click();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('All APIs have been removed from the API Product.');
+    expect(hostComponent.reloadEmitted).toBe(true);
+  });
+
+  it('should delete API product when confirmed', async () => {
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    await deleteButton.click();
+
+    const dialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+    await dialog.confirm();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('The API Product has been deleted.');
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], expect.anything());
+  });
+
+  it('should always show Remove APIs button', async () => {
+    const removeButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Remove APIs/i }));
+    expect(removeButtons.length).toBe(1);
+  });
+
+  it('should show Remove APIs button even when product has no APIs', async () => {
+    hostComponent.apiProduct.set({ id: 'product-2', name: 'Empty', version: '1.0', apiIds: [] });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const removeButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Remove APIs/i }));
+    expect(removeButtons.length).toBe(1);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, inject, input, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  GioConfirmAndValidateDialogComponent,
+  GioConfirmAndValidateDialogData,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+} from '@gravitee/ui-particles-angular';
+import { EMPTY } from 'rxjs';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+@Component({
+  selector: 'api-product-danger-zone',
+  templateUrl: './api-product-danger-zone.component.html',
+  styleUrls: ['./api-product-danger-zone.component.scss'],
+  standalone: true,
+  imports: [MatCardModule, MatButtonModule],
+})
+export class ApiProductDangerZoneComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly matDialog = inject(MatDialog);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly destroyRef = inject(DestroyRef);
+
+  apiProduct = input.required<ApiProduct>();
+  reloadDetails = output<void>();
+  isReadOnly = input<boolean>(false);
+
+  removeApis(): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: '31.25rem',
+        data: {
+          title: 'Remove all APIs',
+          content: 'Are you sure you want to remove all the APIs from this API Product?',
+          confirmButton: 'Yes, remove them',
+        },
+        role: 'alertdialog',
+        id: 'removeApisDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm): confirm is true => confirm === true),
+        switchMap(() => this.apiProductV2Service.deleteAllApisFromApiProduct(this.apiProduct().id)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message || 'An error occurred while removing APIs.');
+          return EMPTY;
+        }),
+        map(() => this.snackBarService.success('All APIs have been removed from the API Product.')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.reloadDetails.emit();
+      });
+  }
+
+  deleteApiProduct(): void {
+    this.matDialog
+      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData, boolean>(GioConfirmAndValidateDialogComponent, {
+        width: '31.25rem',
+        data: {
+          title: 'Delete API Product',
+          content: 'Are you sure you want to delete this API Product?',
+          confirmButton: 'Yes, delete it',
+          validationMessage: `Please, type in the name of the API Product ${this.apiProduct().name} to confirm.`,
+          validationValue: this.apiProduct().name,
+          warning: 'This operation is irreversible.',
+        },
+        role: 'alertdialog',
+        id: 'deleteApiProductDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm): confirm is true => confirm === true),
+        switchMap(() => this.apiProductV2Service.delete(this.apiProduct().id)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message || 'An error occurred while deleting the API Product.');
+          return EMPTY;
+        }),
+        map(() => this.snackBarService.success('The API Product has been deleted.')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+      });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
@@ -18,7 +18,7 @@
 
 <div class="api-product-create">
   <div class="api-product-create__header">
-    <button type="button" class="back-link" (click)="onExit()">
+    <button type="button" mat-button class="back-link" (click)="onExit()">
       <mat-icon>arrow_back</mat-icon>
       <span>Go back to API Products</span>
     </button>
@@ -77,8 +77,8 @@
     </mat-card-content>
     <mat-card-footer>
       <div class="api-product-create__footer">
-        <button mat-stroked-button class="cancel-button" (click)="onBack()" [disabled]="isCreating()">Cancel</button>
-        <button mat-raised-button class="create-button" color="primary" (click)="onCreate()" [disabled]="form.invalid || isCreating()">
+        <button mat-stroked-button (click)="onBack()" [disabled]="isCreating()">Cancel</button>
+        <button mat-raised-button color="primary" (click)="onCreate()" [disabled]="form.invalid || isCreating()">
           @if (!isCreating()) {
             <span>Create API Product</span>
           } @else {

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
@@ -1,0 +1,91 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<div class="api-product-create">
+  <div class="api-product-create__header">
+    <button type="button" class="back-link" (click)="onExit()">
+      <mat-icon>arrow_back</mat-icon>
+      <span>Go back to API Products</span>
+    </button>
+  </div>
+
+  <mat-card class="api-product-create__form-card">
+    <mat-card-content>
+      <h1 class="api-product-create__title">Create API Product</h1>
+      <p class="api-product-create__instructions">Fill in the details and select the APIs to include in this product.</p>
+
+      <div class="form-section">
+        <h2 class="form-section__title">Product Details</h2>
+
+        <form [formGroup]="form">
+          <div class="form-row form-row--inline">
+            <mat-form-field appearance="outline" class="form-field--name">
+              <mat-label>Name </mat-label>
+              <input matInput formControlName="name" required [maxlength]="nameMaxLength" />
+              @if (form.controls.name.hasError('required')) {
+                <mat-error>Name is required</mat-error>
+              }
+              @if (form.controls.name.hasError('maxlength')) {
+                <mat-error>Name must be at most {{ nameMaxLength }} characters</mat-error>
+              }
+              @if (form.controls.name.hasError('minlength')) {
+                <mat-error>Name must be at least 1 character</mat-error>
+              }
+              @if (form.controls.name.hasError('unique')) {
+                <mat-error>API Product name must be unique</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="form-field--version">
+              <mat-label>Version </mat-label>
+              <input matInput formControlName="version" required [maxlength]="versionMaxLength" />
+              @if (form.controls.version.hasError('required')) {
+                <mat-error>Version is required</mat-error>
+              }
+              @if (form.controls.version.hasError('maxlength')) {
+                <mat-error>Version must be at most {{ versionMaxLength }} characters</mat-error>
+              }
+              @if (form.controls.version.hasError('minlength')) {
+                <mat-error>Version must be at least 1 character</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Description</mat-label>
+              <textarea matInput formControlName="description" rows="4"></textarea>
+            </mat-form-field>
+          </div>
+        </form>
+      </div>
+    </mat-card-content>
+    <mat-card-footer>
+      <div class="api-product-create__footer">
+        <button mat-stroked-button class="cancel-button" (click)="onBack()" [disabled]="isCreating()">Cancel</button>
+        <button mat-raised-button class="create-button" color="primary" (click)="onCreate()" [disabled]="form.invalid || isCreating()">
+          @if (!isCreating()) {
+            <span>Create API Product</span>
+          } @else {
+            <span>Creating...</span>
+          }
+        </button>
+      </div>
+    </mat-card-footer>
+  </mat-card>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
@@ -1,0 +1,131 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-product-create {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__header {
+    margin-bottom: 1.5rem;
+  }
+
+  &__title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
+  }
+
+  &__instructions {
+    margin: 0 0 1.5rem 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    font-size: 0.875rem;
+  }
+
+  &__form-card {
+    flex: 1;
+    margin-bottom: 1.5rem;
+    padding: 1.5rem;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    padding: 1rem 0;
+    gap: 1rem;
+  }
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0;
+  margin-bottom: 1rem;
+  border: none;
+  background: none;
+  color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'default');
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-family: inherit;
+
+  mat-icon {
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    line-height: 1.25rem;
+  }
+
+  &:hover {
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'darker');
+    text-decoration: underline;
+  }
+}
+
+.form-section {
+  &__title {
+    margin: 0 0 1.5rem 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
+  }
+}
+
+.form-row {
+  margin-bottom: 1rem;
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  &--inline {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+
+    .form-field--name {
+      flex: 1;
+    }
+
+    .form-field--version {
+      flex: 0 0 12.5rem;
+    }
+  }
+}
+
+.cancel-button {
+  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
+  border-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+  background-color: white;
+
+  &:hover {
+    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'lighter40');
+  }
+}
+
+.create-button {
+  background-color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'default');
+  color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'default-contrast');
+  font-weight: 500;
+  min-width: 11.25rem;
+
+  &:hover:not(:disabled) {
+    background-color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'darker');
+  }
+
+  &:disabled {
+    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.scss
@@ -4,6 +4,8 @@
 @use '@gravitee/ui-particles-angular' as gio;
 @use '../../../scss/gio-layout' as gio-layout;
 
+$typography: map.get(gio.$mat-theme, typography);
+
 :host {
   @include gio-layout.gio-responsive-content-container;
   display: flex;
@@ -16,48 +18,47 @@
   min-height: 100%;
 
   &__header {
-    margin-bottom: 1.5rem;
+    margin-bottom: 24px;
   }
 
   &__title {
-    margin: 0 0 0.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    @include mat.m2-typography-level($typography, headline-6);
+    margin: 0 0 8px 0;
     color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
   }
 
   &__instructions {
-    margin: 0 0 1.5rem 0;
+    @include mat.m2-typography-level($typography, body-2);
+    margin: 0 0 24px 0;
     color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
-    font-size: 0.875rem;
   }
 
   &__form-card {
     flex: 1;
-    margin-bottom: 1.5rem;
-    padding: 1.5rem;
+    margin-bottom: 24px;
+    padding: 24px;
   }
 
   &__footer {
     display: flex;
     justify-content: space-between;
-    padding: 1rem 0;
-    gap: 1rem;
+    padding: 16px 0;
+    gap: 16px;
   }
 }
 
 .back-link {
+  @include mat.m2-typography-level($typography, body-2);
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   padding: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
   border: none;
   background: none;
   color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'default');
   text-decoration: none;
   cursor: pointer;
-  font-size: 0.875rem;
   font-family: inherit;
 
   mat-icon {
@@ -75,15 +76,14 @@
 
 .form-section {
   &__title {
-    margin: 0 0 1.5rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    @include mat.m2-typography-level($typography, subtitle-1);
+    margin: 0 0 24px 0;
     color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
   }
 }
 
 .form-row {
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
 
   mat-form-field {
     width: 100%;
@@ -91,7 +91,7 @@
 
   &--inline {
     display: flex;
-    gap: 1rem;
+    gap: 16px;
     align-items: flex-start;
 
     .form-field--name {
@@ -101,31 +101,5 @@
     .form-field--version {
       flex: 0 0 12.5rem;
     }
-  }
-}
-
-.cancel-button {
-  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
-  border-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
-  background-color: white;
-
-  &:hover {
-    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'lighter40');
-  }
-}
-
-.create-button {
-  background-color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'default');
-  color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'default-contrast');
-  font-weight: 500;
-  min-width: 11.25rem;
-
-  &:hover:not(:disabled) {
-    background-color: mat.m2-get-color-from-palette(gio.$mat-primary-palette, 'darker');
-  }
-
-  &:disabled {
-    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
-    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ApiProductCreateComponent } from './api-product-create.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductCreateComponent', () => {
+  let fixture: ComponentFixture<ApiProductCreateComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
+
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductCreateComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductCreateComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    const router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should validate required fields', async () => {
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.controls.name.hasError('required')).toBe(true);
+  });
+
+  it('should validate name uniqueness', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Existing Product');
+    await nameInput.blur();
+    await fixture.whenStable();
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    expect(verifyReq.request.body).toEqual({ name: 'Existing Product' });
+    verifyReq.flush({ ok: false });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.controls.name.hasError('unique')).toBe(true);
+  });
+
+  it('should create API product successfully', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+
+    await nameInput.setValue('New Product');
+    await nameInput.blur();
+    await fixture.whenStable();
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    await fixture.whenStable();
+
+    await versionInput.setValue('1.0');
+    await descriptionInput.setValue('Test description');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    expect(createReq.request.body).toEqual({
+      name: 'New Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: [],
+    });
+
+    const createdProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'New Product',
+      version: '1.0',
+      description: 'Test description',
+      apiIds: [],
+    };
+    createReq.flush(createdProduct);
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('New Product - Successfully created');
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], expect.anything());
+  });
+
+  it('should trim whitespace from form values', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+
+    await nameInput.setValue('  Trimmed Product  ');
+    await nameInput.blur();
+    await fixture.whenStable();
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    await fixture.whenStable();
+
+    await versionInput.setValue('  1.0  ');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    expect(createReq.request.body.name).toBe('Trimmed Product');
+    expect(createReq.request.body.version).toBe('1.0');
+  });
+
+  it('should handle creation error', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+
+    await nameInput.setValue('New Product');
+    await nameInput.blur();
+    await fixture.whenStable();
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    verifyReq.flush({ ok: true });
+    await fixture.whenStable();
+
+    await versionInput.setValue('1.0');
+    fixture.detectChanges();
+
+    const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create/i }));
+    await createButton.click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
+    createReq.flush({ message: 'Creation failed' }, { status: 400, statusText: 'Bad Request' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalledWith('Creation failed');
+  });
+
+  it('should show exit confirmation dialog when form is dirty', () => {
+    fixture.detectChanges();
+
+    const dialogOpenSpy = jest.spyOn(MatDialog.prototype, 'open').mockReturnValue({
+      afterClosed: () => ({ pipe: () => ({ subscribe: jest.fn() }) }),
+    } as any);
+
+    // Simulate dirty form (harness setValue doesn't reliably mark form dirty with updateOn configs)
+    Object.defineProperty(fixture.componentInstance.form, 'dirty', {
+      get: () => true,
+      configurable: true,
+    });
+
+    fixture.componentInstance.onExit();
+    fixture.detectChanges();
+
+    expect(dialogOpenSpy).toHaveBeenCalled();
+  });
+
+  it('should navigate back without dialog when form is not dirty', () => {
+    fixture.detectChanges();
+    fixture.componentInstance.onExit();
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], expect.anything());
+  });
+
+  it('should validate max length for name', async () => {
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('a'.repeat(513));
+    await nameInput.blur();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.controls.name.hasError('maxlength')).toBe(true);
+  });
+
+  it('should validate max length for version', async () => {
+    fixture.detectChanges();
+
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    await versionInput.setValue('a'.repeat(65));
+    await versionInput.blur();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.controls.version.hasError('maxlength')).toBe(true);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
@@ -103,7 +103,7 @@ describe('ApiProductCreateComponent', () => {
     const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
     const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
 
-    await nameInput.setValue('New Product');
+    await nameInput.setValue('New API Product');
     await nameInput.blur();
     await fixture.whenStable();
 
@@ -121,7 +121,7 @@ describe('ApiProductCreateComponent', () => {
 
     const createReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products`);
     expect(createReq.request.body).toEqual({
-      name: 'New Product',
+      name: 'New API Product',
       version: '1.0',
       description: 'Test description',
       apiIds: [],
@@ -129,7 +129,7 @@ describe('ApiProductCreateComponent', () => {
 
     const createdProduct: ApiProduct = {
       id: 'product-1',
-      name: 'New Product',
+      name: 'New API Product',
       version: '1.0',
       description: 'Test description',
       apiIds: [],
@@ -137,7 +137,7 @@ describe('ApiProductCreateComponent', () => {
     createReq.flush(createdProduct);
     await fixture.whenStable();
 
-    expect(fakeSnackBarService.success).toHaveBeenCalledWith('New Product - Successfully created');
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('New API Product - Successfully created');
     expect(routerNavigateSpy).toHaveBeenCalledWith(['..'], expect.anything());
   });
 
@@ -173,7 +173,7 @@ describe('ApiProductCreateComponent', () => {
     const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
     const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
 
-    await nameInput.setValue('New Product');
+    await nameInput.setValue('New API Product');
     await nameInput.blur();
     await fixture.whenStable();
 

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AsyncValidatorFn, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of, timer } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+
+import { CreateApiProduct } from '../../../entities/management-api-v2/api-product';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+interface CreateApiProductForm {
+  name: FormControl<string>;
+  version: FormControl<string>;
+  description: FormControl<string>;
+}
+
+@Component({
+  selector: 'api-product-create',
+  templateUrl: './api-product-create.component.html',
+  styleUrls: ['./api-product-create.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
+})
+export class ApiProductCreateComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly matDialog = inject(MatDialog);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly form = new FormGroup<CreateApiProductForm>({
+    name: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(512), Validators.minLength(1)],
+      asyncValidators: [this.nameUniquenessValidator()],
+      updateOn: 'blur',
+    }),
+    version: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(64), Validators.minLength(1)],
+    }),
+    description: new FormControl('', { nonNullable: true }),
+  });
+  readonly nameMaxLength = 512;
+  readonly versionMaxLength = 64;
+  readonly isCreating = signal(false);
+
+  private nameUniquenessValidator(): AsyncValidatorFn {
+    return (formControl: FormControl<string>): Observable<ValidationErrors | null> => {
+      if (!formControl || !formControl.value || formControl.value.trim() === '') {
+        return of(null);
+      }
+      const trimmedName = formControl.value.trim();
+      // Debounce API call to avoid too many requests
+      return timer(250).pipe(
+        switchMap(() => this.apiProductV2Service.verify(trimmedName)),
+        map(res => (res.ok ? null : { unique: true })),
+      );
+    };
+  }
+
+  onExit(): void {
+    if (this.form.dirty) {
+      this.matDialog
+        .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+          data: {
+            title: 'Exit without saving?',
+            content: 'You have unsaved changes. Are you sure you want to exit without saving?',
+            confirmButton: 'Exit without saving',
+            cancelButton: 'Cancel',
+          },
+        })
+        .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(confirmed => {
+          if (confirmed) {
+            this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+          }
+        });
+      return;
+    }
+    this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+  }
+
+  onBack(): void {
+    this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+  }
+
+  onCreate(): void {
+    if (this.form.valid && !this.isCreating()) {
+      this.isCreating.set(true);
+      const formValue = this.form.getRawValue();
+
+      // Sanitize input: trim whitespace and validate non-empty after trim
+      const trimmedName = formValue.name?.trim() || '';
+      const trimmedVersion = formValue.version?.trim() || '';
+      const trimmedDescription = formValue.description?.trim() || undefined;
+
+      // Validate that name and version are not empty (both required for creation)
+      if (!trimmedName || !trimmedVersion) {
+        this.snackBarService.error('Name and version are required and cannot be empty');
+        this.isCreating.set(false);
+        this.form.markAllAsTouched();
+        return;
+      }
+
+      const createApiProduct: CreateApiProduct = {
+        name: trimmedName,
+        version: trimmedVersion,
+        description: trimmedDescription,
+        apiIds: [], // TODO: Add API selection functionality
+      };
+
+      this.apiProductV2Service
+        .create(createApiProduct)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: apiProduct => {
+            this.isCreating.set(false);
+            this.snackBarService.success(`${apiProduct.name} - Successfully created`);
+            this.router.navigate(['..', apiProduct.id, 'configuration'], { relativeTo: this.activatedRoute });
+          },
+          error: err => {
+            this.isCreating.set(false);
+            const errorMessage =
+              err.error?.message || err.error?.errors?.[0]?.message || 'An error occurred while creating the API Product';
+            this.snackBarService.error(errorMessage);
+          },
+        });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -24,7 +24,7 @@
     </div>
     @if (canCreateApiProduct) {
       <button
-        [routerLink]="'./new'"
+        [routerLink]="'./create'"
         mat-raised-button
         color="primary"
         class="create-api-product-button"

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -86,7 +86,7 @@
         <ng-container matColumnDef="name">
           <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
           <td mat-cell *matCellDef="let element" title="{{ element.name }}">
-            {{ element.name }}
+            <a [routerLink]="'./' + element.id">{{ element.name }}</a>
           </td>
         </ng-container>
 
@@ -119,7 +119,15 @@
           <th mat-header-cell *matHeaderCellDef id="actions"></th>
           <td mat-cell *matCellDef="let element">
             <div class="actions__edit">
-              <!-- Edit button will be added in a future PR -->
+              <button
+                [routerLink]="'./' + element.id"
+                mat-icon-button
+                aria-label="Button to edit an API Product"
+                matTooltip="Edit API Product"
+                data-testid="api_product_list_edit_button"
+              >
+                <mat-icon>edit</mat-icon>
+              </button>
             </div>
           </td>
         </ng-container>

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
@@ -21,7 +21,7 @@ $typography: map.get(gio.$mat-theme, typography);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 2rem;
+    margin-bottom: 32px;
 
     h1 {
       @include mat.m2-typography-level($typography, headline-5);
@@ -30,7 +30,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
     .subtitle {
       @include mat.m2-typography-level($typography, body-2);
-      margin-top: 0.5rem;
+      margin-top: 8px;
       margin-bottom: 0;
       color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
     }
@@ -39,16 +39,16 @@ $typography: map.get(gio.$mat-theme, typography);
   &__content-card {
     flex: 1;
     min-height: 25rem;
-    border-radius: 0.5rem;
-    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   &__card-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1rem;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
     border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
 
     h2 {
@@ -64,7 +64,7 @@ $typography: map.get(gio.$mat-theme, typography);
   justify-content: center;
   align-items: center;
   min-height: 18.75rem;
-  padding: 3rem 1.5rem;
+  padding: 48px 24px;
 }
 
 .empty-state-card {
@@ -77,7 +77,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
   h3 {
     @include mat.m2-typography-level($typography, headline-6);
-    margin: 1.5rem 0 0.5rem 0;
+    margin: 24px 0 8px 0;
     color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, 'darker80');
   }
 
@@ -98,7 +98,7 @@ $typography: map.get(gio.$mat-theme, typography);
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
   border: 1px solid mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
 
   &__svg {
@@ -112,7 +112,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
 // Table styles
 .mat-column-picture {
-  padding: 0 0.5rem;
+  padding: 0 8px;
   width: 3rem;
   min-width: 3rem;
 }
@@ -121,12 +121,12 @@ $typography: map.get(gio.$mat-theme, typography);
 .mat-column-version,
 .mat-column-owner,
 .mat-column-actions {
-  padding: 0 0.5rem;
+  padding: 0 8px;
 }
 
 .mat-column-name {
   cursor: pointer;
-  padding: 0 0.5rem;
+  padding: 0 8px;
   width: auto;
 }
 

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -52,7 +52,7 @@ describe('ApiProductListComponent', () => {
       imports: [ApiProductListComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
-        { provide: GioTestingPermissionProvider, useValue: ['environment-api_products-c'] },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-api_product-c'] },
         { provide: SnackBarService, useValue: fakeSnackBarService },
         {
           provide: ActivatedRoute,

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -1,0 +1,52 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+@if (currentApiProduct$ | async; as currentApiProduct) {
+  <div class="api-product-navigation">
+    <div class="api-product-navigation__menu">
+      <gio-submenu class="api-product-navigation__submenu">
+        <div gioSubmenuTitle class="api-product-navigation__submenu__title">
+          <h2 class="api-product-navigation__submenu__title__name">{{ currentApiProduct.name }}</h2>
+        </div>
+        @for (menuItem of menuItemsWithActive(); track menuItem.routerLink) {
+          <a [routerLink]="menuItem.routerLink">
+            <gio-submenu-item tabIndex="1" [active]="menuItem.active">
+              @if (menuItem.icon) {
+                <mat-icon class="api-product-navigation__submenu__item__icon" [svgIcon]="menuItem.icon"></mat-icon>
+              }
+              {{ menuItem.displayName }}
+            </gio-submenu-item>
+          </a>
+        }
+      </gio-submenu>
+    </div>
+
+    <div class="api-product-navigation__content">
+      @if (hasBreadcrumb()) {
+        <gio-breadcrumb class="api-product-navigation__breadcrumb">
+          <a *gioBreadcrumbItem [routerLink]="['../../']" class="api-product-navigation__breadcrumb__item">API Products</a>
+          <span *gioBreadcrumbItem class="api-product-navigation__breadcrumb__item">{{ currentApiProduct.name }}</span>
+        </gio-breadcrumb>
+      }
+
+      <div class="api-product-navigation__content__view">
+        <router-outlet></router-outlet>
+      </div>
+    </div>
+  </div>
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -26,10 +26,12 @@
         @for (menuItem of menuItemsWithActive(); track menuItem.routerLink) {
           <a [routerLink]="menuItem.routerLink">
             <gio-submenu-item tabIndex="1" [active]="menuItem.active">
-              @if (menuItem.icon) {
-                <mat-icon class="api-product-navigation__submenu__item__icon" [svgIcon]="menuItem.icon"></mat-icon>
-              }
-              {{ menuItem.displayName }}
+              <div class="api-product-navigation__submenu__item">
+                @if (menuItem.icon) {
+                  <mat-icon class="api-product-navigation__submenu__item__icon" [svgIcon]="menuItem.icon"></mat-icon>
+                }
+                {{ menuItem.displayName }}
+              </div>
             </gio-submenu-item>
           </a>
         }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$textColor: map.get(gio.$mat-dove-palette, default);
+
+.api-product-navigation {
+  height: 100%;
+  display: grid;
+  grid-template-columns: min-content auto;
+  grid-template-areas: 'menu content';
+
+  a {
+    text-decoration: none;
+  }
+
+  &__menu {
+    grid-area: menu;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__submenu {
+    z-index: 70;
+    height: 100%;
+    color: $textColor;
+
+    &__title {
+      border-bottom: 0.0625rem solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+
+      &__name {
+        margin: 0;
+        padding: 1rem 1.25rem;
+        font-size: 1rem;
+        font-weight: 500;
+      }
+    }
+
+    &__item {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      &__icon {
+        margin-right: 0.5rem;
+        color: $textColor;
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+    }
+  }
+
+  &__breadcrumb {
+    padding: 1rem 2rem 0 2rem;
+
+    &__item {
+      display: contents;
+    }
+  }
+
+  &__content {
+    grid-area: content;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+
+    &__view {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      height: 100%;
+      margin: 0.75rem 1.5rem 0 1.5rem;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -18,6 +18,7 @@
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 
+$typography: map.get(gio.$mat-theme, typography);
 $textColor: map.get(gio.$mat-dove-palette, default);
 
 .api-product-navigation {
@@ -42,13 +43,12 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     color: $textColor;
 
     &__title {
-      border-bottom: 0.0625rem solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+      border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10');
 
       &__name {
+        @include mat.m2-typography-level($typography, subtitle-1);
         margin: 0;
-        padding: 1rem 1.25rem;
-        font-size: 1rem;
-        font-weight: 500;
+        padding: 16px 20px;
       }
     }
 
@@ -58,7 +58,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       align-items: center;
 
       &__icon {
-        margin-right: 0.5rem;
+        margin-right: 8px;
         color: $textColor;
         width: 1.25rem;
         height: 1.25rem;
@@ -67,7 +67,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
   }
 
   &__breadcrumb {
-    padding: 1rem 2rem 0 2rem;
+    padding: 16px 32px 0 32px;
 
     &__item {
       display: contents;
@@ -85,7 +85,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       flex-direction: column;
       flex: 1 1 auto;
       height: 100%;
-      margin: 0.75rem 1.5rem 0 1.5rem;
+      margin: 12px 24px 0 24px;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, RouterOutlet } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ApiProductNavigationComponent } from './api-product-navigation.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+describe('ApiProductNavigationComponent', () => {
+  const API_PRODUCT_ID = 'product-1';
+  const fakeApiProduct: ApiProduct = {
+    id: API_PRODUCT_ID,
+    name: 'Test API Product',
+    version: '1.0',
+    apiIds: ['api-1'],
+  };
+
+  let fixture: ComponentFixture<ApiProductNavigationComponent>;
+  let _loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductNavigationComponent, RouterOutlet, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID }),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: null,
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductNavigationComponent);
+    _loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should display API product name when loaded', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Test API Product');
+  });
+
+  it('should display Configuration menu item', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Configuration');
+  });
+
+  it('should show snackbar on load error', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -71,7 +71,10 @@ describe('ApiProductNavigationComponent', () => {
     jest.clearAllMocks();
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
     expect(fixture.componentInstance).toBeTruthy();
   });
 

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AsyncPipe } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { GioBreadcrumbModule, GioIconsModule, GioMenuModule, GioMenuService, GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import { catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+export interface MenuItem {
+  displayName: string;
+  routerLink: string;
+  icon?: string;
+}
+
+@Component({
+  selector: 'api-product-navigation',
+  templateUrl: './api-product-navigation.component.html',
+  styleUrls: ['./api-product-navigation.component.scss'],
+  standalone: true,
+  imports: [AsyncPipe, RouterModule, GioSubmenuModule, GioIconsModule, GioBreadcrumbModule, GioMenuModule, MatIconModule, MatTooltipModule],
+})
+export class ApiProductNavigationComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly gioMenuService = inject(GioMenuService);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+
+  readonly subMenuItems: MenuItem[] = [{ displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' }];
+  readonly hasBreadcrumb = toSignal(this.gioMenuService.reduced$, { initialValue: false });
+
+  private readonly navTrigger = toSignal(
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      startWith(null),
+    ),
+    { initialValue: null },
+  );
+  readonly menuItemsWithActive = computed(() => {
+    this.navTrigger();
+    return this.subMenuItems.map(item => ({
+      ...item,
+      active: this.isItemActive(item),
+    }));
+  });
+
+  readonly currentApiProduct$ = this.activatedRoute.params.pipe(
+    map(p => p['apiProductId'] ?? null),
+    switchMap(apiProductId => {
+      if (apiProductId) {
+        return this.apiProductV2Service.get(apiProductId).pipe(
+          catchError(error => {
+            this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+            return of(null);
+          }),
+        );
+      }
+      return of(null);
+    }),
+  );
+
+  private isItemActive(item: MenuItem): boolean {
+    if (!item.routerLink) {
+      return false;
+    }
+    return this.router.isActive(this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }), {
+      paths: 'subset',
+      queryParams: 'subset',
+      fragment: 'ignored',
+      matrixParams: 'ignored',
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/validators/api-product-name-unique-async.validator.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/validators/api-product-name-unique-async.validator.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AsyncValidatorFn, FormControl, ValidationErrors } from '@angular/forms';
+import { Observable, of, timer } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+
+/**
+ * Async validator for API Product name uniqueness.
+ * Verifies the name via the _verify API with 250ms debounce.
+ *
+ * @param apiProductV2Service - The API Product V2 service for verify calls
+ * @param getCurrentName - Optional getter for the current product name (when editing).
+ *   When the trimmed input equals the current name, validation is skipped (no API call).
+ */
+export function apiProductNameUniqueAsyncValidator(
+  apiProductV2Service: ApiProductV2Service,
+  getCurrentName?: () => string | undefined,
+): AsyncValidatorFn {
+  return (formControl: FormControl<string>): Observable<ValidationErrors | null> => {
+    if (!formControl?.value?.trim()) return of(null);
+
+    const trimmedName = formControl.value.trim();
+    const currentName = getCurrentName?.();
+    if (currentName !== undefined && trimmedName === currentName) return of(null);
+
+    return timer(250).pipe(
+      switchMap(() => apiProductV2Service.verify(trimmedName)),
+      map(res => (res.ok ? null : { unique: true })),
+    );
+  };
+}

--- a/gravitee-apim-console-webui/src/management/management-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/management-routing.module.ts
@@ -50,7 +50,7 @@ const managementRoutes: Routes = [
       },
       {
         path: 'api-products',
-        loadComponent: () => import('./api-products/list/api-product-list.component').then(m => m.ApiProductListComponent),
+        loadChildren: () => import('./api-products/api-products.routes').then(m => m.API_PRODUCTS_ROUTES),
         data: {
           requireLicense: {
             license: { feature: ApimFeature.APIM_API_PRODUCTS },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12799

## Summary

Adds API Products list, create, and configuration flows to the Gravitee APIM Console. Users can view paginated API Products, create new ones with name, version, and description, and edit existing products (name, version, description, APIs list) plus danger-zone actions. Implementation uses standalone components and routes-only configuration.

## Component Hierarchy

```
ManagementComponent (layout + router-outlet)
└── api-products (lazy-loaded child routes)
    ├── ApiProductListComponent          [path: '']
    │   └── GioTableWrapperComponent     (shared: table, pagination, search)
    │       └── MatTable (MDC)
    │       └── GioAvatarComponent
    │
    ├── ApiProductCreateComponent         [path: 'new']
    │   └── GioConfirmDialogComponent     (exit without saving confirmation)
    │
    └── ApiProductNavigationComponent    [path: ':apiProductId']
        └── GioSubmenuComponent          (sidebar nav + breadcrumb)
            └── ApiProductConfigurationComponent  [path: 'configuration']
                ├── Configuration form   (name, version, description)
                ├── APIs list             (remove individual APIs)
                ├── ApiProductDangerZoneComponent
                │   ├── Remove all APIs
                │   └── Delete API Product
                └── GioSaveBarModule     (save/reset)
```

## Important Services

| Service | Purpose |
|---------|---------|
| ApiProductV2Service | HTTP client for API Products V2 REST API (create, list, get, update, verify, delete, deleteApiFromApiProduct, deleteAllApisFromApiProduct) |
| GioPermissionService | Checks `environment-api_product-c` for create permission, `environment-api_product-u` for update/delete permission |
| SnackBarService | Success/error notifications |
| Constants | Environment config (`v2BaseURL` for API base URL) |

## Forms & Validation Rules

### Create API Product Form

| Field | Validators | Notes |
|-------|------------|-------|
| name | Required, minLength(1), maxLength(512) | Async: name uniqueness via `_verify` API (250ms debounce on blur) |
| version | Required, minLength(1), maxLength(64) | |
| description | None | Optional. No length limit (DB column is CLOB; backend/OpenAPI have no maxLength) |

### Configuration Form (edit existing API Product)

| Field | Validators | Notes |
|-------|------------|-------|
| name | Required, minLength(1), maxLength(512) | Async: name uniqueness (skips check when unchanged) |
| version | Required, minLength(1), maxLength(64) | |
| description | None | Optional |

## Routing Changes

| Path | Component | Permission | Notes |
|------|-----------|------------|-------|
| `/{env}/api-products` | ApiProductListComponent | — | List view with table and empty state |
| `/{env}/api-products/new` | ApiProductCreateComponent | `environment-api_product-c` | Create form; route guard enforces permission via `data.permissions.anyOf` |
| `/{env}/api-products/:apiProductId` | ApiProductNavigationComponent | — | Layout with submenu, breadcrumb, child router-outlet |
| `/{env}/api-products/:apiProductId/configuration` | ApiProductConfigurationComponent | `environment-api_product-u` (read-only when absent) | Configuration form, APIs list, danger zone |

- Replaced module-based routing with routes-only (`api-products.routes.ts`)
- Management routing: `loadChildren` now imports `API_PRODUCTS_ROUTES` instead of `ApiProductsModule`
- List, create, navigation, and configuration use `loadComponent` for lazy loading
- Default redirect from `:apiProductId` to `configuration`

## Feature Flags / Environment Variables

| Name | Purpose |
|------|---------|
| `environment-api_product-c` | Permission for create (button visibility + route guard) |
| `environment-api_product-u` | Permission for update/delete (configuration form edit, danger zone actions) |
| `Constants.env.v2BaseURL` | Base URL for Management API v2 |
| `docs.page: 'management-api-products'` | Route data for contextual docs |

## Lazy Loading

- **api-products routes** — `loadChildren` in management routing loads `API_PRODUCTS_ROUTES` when navigating to api-products
- **ApiProductListComponent** — `loadComponent` loads when path is `''`
- **ApiProductCreateComponent** — `loadComponent` loads when path is `new`
- **ApiProductNavigationComponent** — `loadComponent` loads when path is `:apiProductId`
- **ApiProductConfigurationComponent** — `loadComponent` loads when path is `configuration` under `:apiProductId`

## Testing

- Unit tests for `ApiProductCreateComponent`: form validation, name uniqueness, exit confirmation, successful create, error handling
- Unit tests for `ApiProductNavigationComponent`: creation, display of product name and Configuration menu
- Unit tests for `ApiProductConfigurationComponent` and `ApiProductDangerZoneComponent` (as applicable)
- Unit tests for `ApiProductV2Service`: create, list, get, update, verify, delete endpoints

## Description

- Added API Product create form with typed reactive forms, name uniqueness validation, and exit confirmation when form is dirty
- Added API Product configuration page with edit form (name, version, description), APIs list with per-API removal, and integrated danger zone
- Added danger zone: remove all APIs from product, delete API Product (with confirmation validation)
- Added `ApiProductNavigationComponent` with submenu and breadcrumb for product-level navigation
- Migrated to routes-only pattern: added `api-products.routes.ts`
- Updated management routing to use `loadChildren` with `Routes` instead of `NgModule`
- Added `ApiProductV2Service` for CRUD and verify endpoints
- List and create components are standalone with `loadComponent` lazy loading
- List table links product name and edit button to `/{env}/api-products/:apiProductId` (configuration)
- Create button on list navigates to `/api-products/new` (permission-gated)
- Configuration form is read-only when `environment-api_product-u` is not granted
- Description field has no length limit (aligned with DB CLOB and backend/OpenAPI spec)


https://github.com/user-attachments/assets/425f74f6-8db3-4ecc-ab08-97213f2564aa

