### PR TITLE
feat(env logs details): connect backend to frontend 

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
@@ -17,7 +17,14 @@
 -->
 
 <div class="logs-details">
-  @if (log(); as log) {
+  @if (isLoading()) {
+    <div class="logs-details__loading">
+      <mat-spinner diameter="32"></mat-spinner>
+      <span>Loading log details…</span>
+    </div>
+  } @else if (error(); as errorMsg) {
+    <gio-banner-error data-testid="error-banner">{{ errorMsg }}</gio-banner-error>
+  } @else if (log(); as log) {
     <div class="logs-details__container">
       <a class="back-button" mat-flat-button [routerLink]="['..']" aria-label="Back to logs"
         ><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a
@@ -39,7 +46,7 @@
                     <env-logs-details-row label="Method">
                       <div [class]="'gio-method-badge-' + log.method.toLocaleLowerCase()">{{ log.method }}</div>
                     </env-logs-details-row>
-                    <env-logs-details-row label="URI" dataTestId="overview-uri">{{ log.api ?? '—' }}</env-logs-details-row>
+                    <env-logs-details-row label="URI" dataTestId="overview-uri">{{ log.path ?? '—' }}</env-logs-details-row>
                     <env-logs-details-row label="Request ID">{{ log.requestId ?? '—' }}</env-logs-details-row>
                     <env-logs-details-row label="Transaction ID">{{ log.transactionId ?? '—' }}</env-logs-details-row>
                     <env-logs-details-row label="Remote IP">{{ log.remoteAddress ?? '—' }}</env-logs-details-row>
@@ -102,6 +109,24 @@
                       <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
                     }
                   </dl>
+
+                  <!-- Body for Consumer Request -->
+                  <div class="payload">
+                    <div class="mat-body card__section__label">Body</div>
+                    @if (requestBody()) {
+                      <div gioMonacoClipboardCopy class="editor">
+                        <gio-monaco-editor
+                          disabled
+                          [options]="monacoEditorOptions"
+                          [singleLineMode]="false"
+                          [ngModel]="requestBody()"
+                          [disableMiniMap]="true"
+                        ></gio-monaco-editor>
+                      </div>
+                    } @else {
+                      <p class="payload__empty">No request body captured.</p>
+                    }
+                  </div>
                 </div>
 
                 <div class="card__section">
@@ -122,6 +147,24 @@
                       <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
                     }
                   </dl>
+
+                  <!-- Body for Gateway Request -->
+                  <div class="payload">
+                    <div class="mat-body card__section__label">Body</div>
+                    @if (gatewayRequestBody()) {
+                      <div gioMonacoClipboardCopy class="editor">
+                        <gio-monaco-editor
+                          disabled
+                          [options]="monacoEditorOptions"
+                          [singleLineMode]="false"
+                          [ngModel]="gatewayRequestBody()"
+                          [disableMiniMap]="true"
+                        ></gio-monaco-editor>
+                      </div>
+                    } @else {
+                      <p class="payload__empty">No request body captured.</p>
+                    }
+                  </div>
                 </div>
               </div>
             </mat-card-content>
@@ -135,12 +178,13 @@
                   <span class="mat-body-strong">Response</span>
                   <dl class="card__section__kv">
                     <env-logs-details-row label="Status">
-                      @if (log.entrypointResponse?.status !== undefined) {
+                      @if (log.entrypointResponse?.status != null) {
+                        @let status = log.entrypointResponse!.status;
                         <span
-                          [class.gio-badge-success]="log.entrypointResponse!.status < 400"
-                          [class.gio-badge-warning]="log.entrypointResponse!.status >= 400 && log.entrypointResponse!.status <= 499"
-                          [class.gio-badge-error]="log.entrypointResponse!.status >= 500 || log.entrypointResponse!.status === 0"
-                          >{{ log.entrypointResponse!.status }}</span
+                          [class.gio-badge-success]="status < 400"
+                          [class.gio-badge-warning]="status >= 400 && status <= 499"
+                          [class.gio-badge-error]="status >= 500 || status === 0"
+                          >{{ status }}</span
                         >
                       } @else {
                         —
@@ -177,12 +221,13 @@
                   <span class="mat-body-strong">Gateway</span>
                   <dl class="card__section__kv">
                     <env-logs-details-row label="Status">
-                      @if (log.endpointResponse?.status !== undefined) {
+                      @if (log.endpointResponse?.status != null) {
+                        @let status = log.endpointResponse!.status;
                         <span
-                          [class.gio-badge-success]="log.endpointResponse!.status < 400"
-                          [class.gio-badge-warning]="log.endpointResponse!.status >= 400 && log.endpointResponse!.status <= 499"
-                          [class.gio-badge-error]="log.endpointResponse!.status >= 500 || log.endpointResponse!.status === 0"
-                          >{{ log.endpointResponse!.status }}</span
+                          [class.gio-badge-success]="status < 400"
+                          [class.gio-badge-warning]="status >= 400 && status <= 499"
+                          [class.gio-badge-error]="status >= 500 || status === 0"
+                          >{{ status }}</span
                         >
                       } @else {
                         —

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
@@ -29,6 +29,16 @@
 }
 
 .logs-details {
+  &__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 48px 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker');
+    font-style: italic;
+  }
+
   &__container {
     display: flex;
     flex-direction: column;

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
@@ -13,41 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvLogsDetailsComponent } from './env-logs-details.component';
 import { EnvLogsDetailsHarness } from './env-logs-details.harness';
 
-import { fakeEnvLogs } from '../../models/env-log.fixture';
+import { GioTestingModule } from '../../../../../shared/testing/gio-testing.module';
+import { fakeConnectionLogDetail } from '../../../../../entities/management-api-v2/log/connectionLog.fixture';
+import { fakeApiMetricResponse } from '../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture';
+import { SearchLogsResponse } from '../../../../../services-ngx/environment-logs.service';
 
 describe('EnvLogsDetailsComponent', () => {
-  const logId = 'log-1';
-  const log = fakeEnvLogs().find(l => l.id === logId)!;
+  const logId = 'req-abc-123';
+  const apiId = 'api-xyz-456';
 
-  async function createComponent(params: Record<string, string> = { logId }) {
+  const MOCK_SEARCH_RESPONSE: SearchLogsResponse = {
+    data: [
+      {
+        apiId,
+        timestamp: '2025-06-15T12:00:00Z',
+        id: logId,
+        requestId: logId,
+        method: 'GET',
+        status: 200,
+        requestEnded: true,
+        gatewayResponseTime: 44,
+        gateway: 'gw-uuid-1',
+        uri: '/poke',
+        plan: { id: 'plan-1', name: 'Free Plan' },
+        application: { id: 'app-1', name: 'My App' },
+        transactionId: 'txn-001',
+      },
+    ],
+    pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+  };
+
+  const MOCK_DETAIL = fakeConnectionLogDetail({ apiId, requestId: logId });
+  const MOCK_METRICS = fakeApiMetricResponse({ apiId, requestId: logId });
+
+  let httpTestingController: HttpTestingController;
+  let fixture: ComponentFixture<EnvLogsDetailsComponent>;
+
+  async function createComponent(params: Record<string, string> = { logId }, queryParams: Record<string, string> = { apiId }) {
     await TestBed.configureTestingModule({
-      imports: [EnvLogsDetailsComponent, NoopAnimationsModule],
+      imports: [EnvLogsDetailsComponent, NoopAnimationsModule, GioTestingModule],
       providers: [
         provideRouter([]),
-        provideHttpClient(),
-        provideHttpClientTesting(),
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: {
-              params,
-            },
+            snapshot: { params, queryParams },
           },
         },
       ],
     }).compileComponents();
 
-    const fixture = TestBed.createComponent(EnvLogsDetailsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture = TestBed.createComponent(EnvLogsDetailsComponent);
     fixture.detectChanges();
 
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, EnvLogsDetailsHarness);
@@ -55,78 +82,190 @@ describe('EnvLogsDetailsComponent', () => {
     return { fixture, harness };
   }
 
-  it('should display log details', async () => {
-    const { fixture, harness } = await createComponent();
+  function expectSearchRequest(): ReturnType<HttpTestingController['expectOne']> {
+    return httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
+  }
+
+  function expectDetailRequest(): ReturnType<HttpTestingController['expectOne']> {
+    return httpTestingController.expectOne(req => req.method === 'GET' && req.url.includes(`/apis/${apiId}/logs/${logId}`));
+  }
+
+  function expectMetricsRequest(): ReturnType<HttpTestingController['expectOne']> {
+    return httpTestingController.expectOne(req => req.method === 'GET' && req.url.includes(`/apis/${apiId}/analytics/${logId}`));
+  }
+
+  function flushRequests(searchResponse = MOCK_SEARCH_RESPONSE, detail = MOCK_DETAIL, metrics = MOCK_METRICS) {
+    expectSearchRequest().flush(searchResponse);
+    expectDetailRequest().flush(detail);
+    expectMetricsRequest().flush(metrics);
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+    httpTestingController.verify();
+  });
+
+  it('should show loading initially before data arrives', async () => {
+    const { harness } = await createComponent();
+
+    expect(await harness.isLoading()).toBe(true);
+
+    flushRequests();
+    fixture.detectChanges();
+
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should display log details from backend', async () => {
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
 
     expect(await harness.getTitleText()).toContain('Log');
-    expect(fixture.nativeElement.textContent).toContain(log.method);
-    expect(await harness.getOverviewUri()).toEqual(log.api);
-    expect(fixture.nativeElement.textContent).toContain(String(log.status));
+    expect(f.nativeElement.textContent).toContain('GET');
+    expect(await harness.getStatusBadgeText()).toBe('200');
+  });
+
+  it('should display the URI in the overview URI row', async () => {
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
+
+    expect(await harness.getOverviewUri()).toContain('/poke');
   });
 
   it('should navigate back when the back button is clicked', async () => {
-    const { harness } = await createComponent();
-    await harness.clickBack();
-  });
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
 
-  it('should show "Log not found" banner when logId does not match any log', async () => {
-    const { fixture } = await createComponent({ logId: 'non-existent-id' });
-
-    const banner = fixture.nativeElement.querySelector('gio-banner-info');
-    expect(banner).toBeTruthy();
-    expect(banner.textContent).toContain('Log not found');
+    // Verify back button is present and clickable (navigation is handled by routerLink)
+    await expect(harness.clickBack()).resolves.not.toThrow();
   });
 
   it('should show "Log not found" banner when logId is missing', async () => {
-    const { fixture } = await createComponent({});
+    const { harness } = await createComponent({}, { apiId });
 
-    const banner = fixture.nativeElement.querySelector('gio-banner-info');
-    expect(banner).toBeTruthy();
-    expect(banner.textContent).toContain('Log not found');
+    expect(await harness.getNotFoundBannerText()).toContain('Log not found');
   });
 
-  it('should display formatted headers sorted alphabetically', async () => {
-    const { fixture } = await createComponent();
-    const component = fixture.componentInstance;
+  it('should show "Log not found" banner when apiId is missing', async () => {
+    const { harness } = await createComponent({ logId }, {});
 
-    const headers = component.requestHeaders();
-
-    const headerKeys = headers.map(h => h.key);
-    const sortedKeys = [...headerKeys].sort((a, b) => a.localeCompare(b));
-    expect(headerKeys).toEqual(sortedKeys);
-
-    expect(headers.length).toBeGreaterThan(0);
+    expect(await harness.getNotFoundBannerText()).toContain('Log not found');
   });
 
-  it('should display expansion panel with Application, Plan, and Endpoint', async () => {
-    const { fixture } = await createComponent();
+  it('should show "Log not found" banner when search returns no results', async () => {
+    const { fixture: f, harness } = await createComponent();
 
-    const expansionPanel = fixture.nativeElement.querySelector('.more-details');
-    expect(expansionPanel).toBeTruthy();
-    expect(expansionPanel.textContent).toContain('More details');
+    const emptyResponse: SearchLogsResponse = {
+      data: [],
+      pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 },
+    };
 
-    const header = expansionPanel.querySelector('mat-expansion-panel-header');
-    header.click();
-    fixture.detectChanges();
+    expectSearchRequest().flush(emptyResponse);
+    f.detectChanges();
 
-    expect(expansionPanel.textContent).toContain(log.application);
-    expect(expansionPanel.textContent).toContain(log.plan.name);
-    expect(expansionPanel.textContent).toContain(log.endpoint);
+    expect(await harness.getNotFoundBannerText()).toContain('Log not found');
   });
 
-  it('should render the method badge with the correct class', async () => {
-    const { fixture } = await createComponent();
+  it('should show error banner when search request fails', async () => {
+    const { fixture: f, harness } = await createComponent();
 
-    const methodBadge = fixture.nativeElement.querySelector(`.gio-method-badge-${log.method.toLowerCase()}`);
-    expect(methodBadge).toBeTruthy();
-    expect(methodBadge.textContent.trim()).toBe(log.method);
+    expectSearchRequest().flush('Server Error', { status: 500, statusText: 'Internal Server Error' });
+    f.detectChanges();
+
+    expect(await harness.getErrorBannerText()).toContain('500');
+    expect(await harness.isLoading()).toBe(false);
   });
 
-  it('should render the status badge with the success class for status 200', async () => {
-    const { fixture } = await createComponent();
+  it('should return request headers sorted alphabetically', async () => {
+    const { fixture: f } = await createComponent();
+    flushRequests();
+    f.detectChanges();
 
-    const statusBadge = fixture.nativeElement.querySelector('.gio-badge-success');
-    expect(statusBadge).toBeTruthy();
-    expect(statusBadge.textContent.trim()).toBe(String(log.status));
+    const headers = f.componentInstance.requestHeaders();
+    const keys = headers.map(h => h.key);
+    expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('should display Application and Plan in the More Details panel', async () => {
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
+
+    await harness.expandMoreDetails();
+    f.detectChanges();
+
+    const moreDetailsText = await harness.getMoreDetailsText();
+    expect(moreDetailsText).toContain('My App');
+    expect(moreDetailsText).toContain('Free Plan');
+  });
+
+  it('should render the success status badge for HTTP 200', async () => {
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
+
+    expect(await harness.getStatusBadgeText()).toBe('200');
+    expect(f.nativeElement.querySelector('.gio-badge-success')).toBeTruthy();
+  });
+
+  it('should display metrics-sourced fields (host, latency, response times)', async () => {
+    const { fixture: f } = await createComponent();
+    flushRequests();
+    f.detectChanges();
+
+    const text = f.nativeElement.textContent;
+    expect(text).toContain(MOCK_METRICS.host);
+    expect(text).toContain(MOCK_METRICS.remoteAddress);
+    expect(text).toContain(`${MOCK_METRICS.gatewayResponseTime} ms`);
+    expect(text).toContain(`${MOCK_METRICS.endpointResponseTime} ms`);
+    expect(text).toContain(`${MOCK_METRICS.gatewayLatency} ms`);
+    expect(text).toContain(`${MOCK_METRICS.responseContentLength}`);
+  });
+
+  it('should send a wide time range when searching by requestId', async () => {
+    await createComponent();
+
+    const searchReq = expectSearchRequest();
+    const body = searchReq.request.body;
+    expect(body.timeRange).toBeDefined();
+    expect(body.filters).toEqual([{ name: 'REQUEST_ID', operator: 'EQ', value: logId }]);
+    // Verify it's a wide window (> 1 year) not just 24h
+    const from = new Date(body.timeRange.from).getTime();
+    const to = new Date(body.timeRange.to).getTime();
+    const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+    expect(to - from).toBeGreaterThan(oneYearMs);
+
+    searchReq.flush(MOCK_SEARCH_RESPONSE);
+    expectDetailRequest().flush(MOCK_DETAIL);
+    expectMetricsRequest().flush(MOCK_METRICS);
+  });
+
+  it('should gracefully degrade when detail endpoint fails', async () => {
+    const { fixture: f, harness } = await createComponent();
+
+    expectSearchRequest().flush(MOCK_SEARCH_RESPONSE);
+    expectDetailRequest().flush('Not Found', { status: 404, statusText: 'Not Found' });
+    expectMetricsRequest().flush(MOCK_METRICS);
+    f.detectChanges();
+
+    // Should still show the page with overview data from search + metrics
+    expect(await harness.getTitleText()).toContain('Log');
+    expect(f.nativeElement.textContent).toContain(MOCK_METRICS.host);
+  });
+
+  it('should gracefully degrade when metrics endpoint fails', async () => {
+    const { fixture: f, harness } = await createComponent();
+
+    expectSearchRequest().flush(MOCK_SEARCH_RESPONSE);
+    expectDetailRequest().flush(MOCK_DETAIL);
+    expectMetricsRequest().flush('Not Found', { status: 404, statusText: 'Not Found' });
+    f.detectChanges();
+
+    // Should still show the page with overview data from search + detail
+    expect(await harness.getTitleText()).toContain('Log');
+    expect(await harness.getStatusBadgeText()).toBe('200');
   });
 });

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
@@ -13,20 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { editor } from 'monaco-editor';
 import { GioBannerModule, GioClipboardModule, GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 
-import { fakeEnvLogs } from '../../models/env-log.fixture';
 import { EnvLog } from '../../models/env-log.model';
 import { EnvLogsDetailsRowComponent } from '../env-logs-details-row/env-logs-details-row.component';
 import { GioHeaderComponent } from '../../../../../shared/components/gio-header/gio-header.component';
+import { EnvironmentLogsService } from '../../../../../services-ngx/environment-logs.service';
+import { ApiLogsV2Service } from '../../../../../services-ngx/api-logs-v2.service';
+import { ApiAnalyticsV2Service } from '../../../../../services-ngx/api-analytics-v2.service';
 
 @Component({
   selector: 'env-logs-details',
@@ -42,15 +49,35 @@ import { GioHeaderComponent } from '../../../../../shared/components/gio-header/
     GioBannerModule,
     GioClipboardModule,
     GioMonacoEditorModule,
+    MatProgressSpinnerModule,
     EnvLogsDetailsRowComponent,
     GioHeaderComponent,
   ],
   standalone: true,
 })
 export class EnvLogsDetailsComponent {
+  // 1. Injections
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly environmentLogsService = inject(EnvironmentLogsService);
+  private readonly apiLogsV2Service = inject(ApiLogsV2Service);
+  private readonly apiAnalyticsV2Service = inject(ApiAnalyticsV2Service);
 
-  log = signal<EnvLog | undefined>(undefined);
+  // 2. State
+  private readonly logId = this.activatedRoute.snapshot.params['logId'] as string | undefined;
+  /**
+   * The apiId query param acts as a guard: we only fetch data when both logId and apiId are present.
+   * Inside the forkJoin we intentionally use overviewLog.apiId (from the search response) rather than
+   * this value, so the detail/metrics calls always target the correct API even if the query param
+   * was stale or incorrect.
+   */
+  private readonly apiId = this.activatedRoute.snapshot.queryParams['apiId'] as string | undefined;
+
+  error = signal<string | null>(null);
+  private loaded = signal(false);
+
+  // 3. Computed signals derived from the log signal
+  log = toSignal(this.buildLogStream(), { initialValue: undefined });
+  isLoading = computed(() => !this.loaded() && this.error() === null && !!this.logId && !!this.apiId);
 
   requestHeaders = computed(() => this.formatHeaders(this.log()?.entrypointRequest?.headers));
   requestBody = computed(() => this.log()?.entrypointRequest?.body ?? '');
@@ -75,17 +102,70 @@ export class EnvLogsDetailsComponent {
     },
   };
 
-  constructor() {
-    const logId = this.activatedRoute.snapshot.params.logId;
-    if (!logId) {
-      return;
+  // 4. Private methods
+
+  private buildLogStream(): Observable<EnvLog | undefined> {
+    if (!this.logId || !this.apiId) {
+      return of(undefined);
     }
 
-    // TODO: Replace with a real API call to fetch the log by ID from the backend.
-    const foundLog = fakeEnvLogs().find(l => l.id === logId);
-    if (foundLog) {
-      this.log.set(foundLog);
-    }
+    return this.environmentLogsService.searchLogs({ requestId: this.logId }).pipe(
+      switchMap(searchResponse => {
+        const overviewLog = searchResponse.data[0];
+        if (!overviewLog) {
+          return of(undefined);
+        }
+
+        return forkJoin({
+          overview: of(overviewLog),
+          detail: this.apiLogsV2Service.searchConnectionLogDetail(overviewLog.apiId, overviewLog.id).pipe(catchError(() => of(null))),
+          metrics: this.apiAnalyticsV2Service.getApiMetricsDetail(overviewLog.apiId, overviewLog.id).pipe(catchError(() => of(null))),
+        }).pipe(map(({ overview, detail, metrics }) => this.mapToEnvLog(overview, detail, metrics)));
+      }),
+      tap(() => this.loaded.set(true)),
+      catchError(err => {
+        this.loaded.set(true);
+        const message =
+          err instanceof HttpErrorResponse
+            ? `Failed to load log: ${err.status} ${err.statusText}`
+            : 'An unexpected error occurred while loading the log.';
+        this.error.set(message);
+        return of(undefined);
+      }),
+    );
+  }
+
+  private mapToEnvLog(overview: any, detail: any, metrics: any): EnvLog {
+    return {
+      id: overview.id,
+      apiId: overview.apiId,
+      timestamp: this.formatTimestamp(overview.timestamp),
+      api: overview.apiId,
+      application: overview.application?.name ?? overview.application?.id ?? '—',
+      method: overview.method ?? '—',
+      path: overview.uri ?? '—',
+      status: overview.status,
+      responseTime: overview.gatewayResponseTime != null ? `${overview.gatewayResponseTime} ms` : '—',
+      gateway: overview.gateway,
+      plan: this.resolvePlanName(overview.plan?.name, metrics?.plan?.name),
+      requestEnded: overview.requestEnded,
+      errorKey: overview.errorKey,
+      transactionId: overview.transactionId,
+      requestId: detail?.requestId,
+      clientIdentifier: detail?.clientIdentifier,
+      warnings: overview.warnings?.map((w: any) => ({ key: w.key ?? '' })),
+      entrypointRequest: detail?.entrypointRequest,
+      endpointRequest: detail?.endpointRequest,
+      entrypointResponse: detail?.entrypointResponse,
+      endpointResponse: detail?.endpointResponse,
+      host: metrics?.host,
+      remoteAddress: metrics?.remoteAddress,
+      gatewayResponseTime: metrics?.gatewayResponseTime != null ? `${metrics.gatewayResponseTime} ms` : undefined,
+      endpointResponseTime: metrics?.endpointResponseTime != null ? `${metrics.endpointResponseTime} ms` : undefined,
+      gatewayLatency: metrics?.gatewayLatency != null ? `${metrics.gatewayLatency} ms` : undefined,
+      responseContentLength: metrics?.responseContentLength != null ? `${metrics.responseContentLength}` : undefined,
+      endpoint: metrics?.endpoint ?? overview.endpoint,
+    };
   }
 
   private formatHeaders(headers?: Record<string, string[]>): { key: string; value: string }[] {
@@ -99,5 +179,18 @@ export class EnvLogsDetailsComponent {
         value: values.join(', '),
       }))
       .sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  private formatTimestamp(iso: string): string {
+    try {
+      return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'medium' }).format(new Date(iso));
+    } catch {
+      return iso;
+    }
+  }
+
+  private resolvePlanName(overviewName?: string, metricsName?: string): { name: string } | undefined {
+    const name = overviewName ?? metricsName;
+    return name ? { name } : undefined;
   }
 }

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.harness.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.harness.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
 
 export class EnvLogsDetailsHarness extends ComponentHarness {
   static hostSelector = 'env-logs-details';
 
   private readonly backButton = this.locatorFor('.back-button');
+  private readonly moreDetailsPanel = this.locatorFor(MatExpansionPanelHarness);
 
   async clickBack(): Promise<void> {
     const button = await this.backButton();
@@ -33,5 +35,35 @@ export class EnvLogsDetailsHarness extends ComponentHarness {
   async getOverviewUri(): Promise<string> {
     const uriDd = await this.locatorFor('[data-testid="overview-uri"]')();
     return uriDd.text();
+  }
+
+  async getNotFoundBannerText(): Promise<string | null> {
+    const banner = await this.locatorForOptional('gio-banner-info')();
+    return banner ? banner.text() : null;
+  }
+
+  async getErrorBannerText(): Promise<string | null> {
+    const banner = await this.locatorForOptional('[data-testid="error-banner"]')();
+    return banner ? (await banner.text()).trim() : null;
+  }
+
+  async getStatusBadgeText(): Promise<string | null> {
+    const badge = await this.locatorForOptional('.gio-badge-success, .gio-badge-warning, .gio-badge-error')();
+    return badge ? (await badge.text()).trim() : null;
+  }
+
+  async expandMoreDetails(): Promise<void> {
+    const panel = await this.moreDetailsPanel();
+    await panel.expand();
+  }
+
+  async getMoreDetailsText(): Promise<string> {
+    const panel = await this.moreDetailsPanel();
+    return panel.getTextContent();
+  }
+
+  async isLoading(): Promise<boolean> {
+    const loadingEl = await this.locatorForOptional('.logs-details__loading')();
+    return loadingEl !== null;
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
@@ -22,7 +22,7 @@ import { Constants } from '../entities/Constants';
 /**
  * Matches the backend EnvironmentApiLog schema from openapi-logs.yaml.
  */
-export interface EnvironmentApiLog {
+export type EnvironmentApiLog = {
   apiId: string;
   apiName?: string;
   timestamp: string;
@@ -45,9 +45,9 @@ export interface EnvironmentApiLog {
   errorComponentType?: string;
   warnings?: Array<{ componentType?: string; componentName?: string; key?: string; message?: string }>;
   additionalMetrics?: Record<string, unknown>;
-}
+};
 
-export interface SearchLogsResponse {
+export type SearchLogsResponse = {
   data: EnvironmentApiLog[];
   pagination: {
     page: number;
@@ -56,18 +56,34 @@ export interface SearchLogsResponse {
     pageItemsCount: number;
     totalCount: number;
   };
-}
+};
 
-export interface TimeRange {
+export type TimeRange = {
   from: string;
   to: string;
-}
+};
 
-export interface SearchLogsParam {
+export type SearchLogsParam = {
   page?: number;
   perPage?: number;
   timeRange?: TimeRange;
-}
+  /** Filter by a specific request ID (maps to backend FilterName.REQUEST_ID) */
+  requestId?: string;
+};
+
+type SearchLogsFilter = {
+  name: string;
+  operator: string;
+  value: string;
+};
+
+type SearchLogsRequestBody = {
+  timeRange: TimeRange;
+  filters?: SearchLogsFilter[];
+};
+
+/** ~10 years in milliseconds – wide enough to find any log regardless of age. */
+const WIDE_SEARCH_WINDOW_MS = 10 * 365.25 * 24 * 60 * 60 * 1000;
 
 @Injectable({
   providedIn: 'root',
@@ -83,16 +99,37 @@ export class EnvironmentLogsService {
     params = params.append('page', param?.page ?? 1);
     params = params.append('perPage', param?.perPage ?? 10);
 
-    const now = new Date();
-    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const filters: SearchLogsFilter[] = [];
+    if (param?.requestId) {
+      filters.push({ name: 'REQUEST_ID', operator: 'EQ', value: param.requestId });
+    }
 
-    const body = {
-      timeRange: param?.timeRange ?? {
-        from: oneDayAgo.toISOString(),
-        to: now.toISOString(),
-      },
-    };
+    const body: SearchLogsRequestBody = { timeRange: this.resolveTimeRange(param) };
+
+    if (filters.length > 0) {
+      body.filters = filters;
+    }
 
     return this.http.post<SearchLogsResponse>(`${this.constants.env.v2BaseURL}/logs/search`, body, { params });
+  }
+
+  /** Determines the time range for a search request based on the provided parameters. */
+  private resolveTimeRange(param?: SearchLogsParam): TimeRange {
+    if (param?.timeRange) {
+      return param.timeRange;
+    }
+
+    const now = new Date();
+
+    // When searching by requestId (detail page), use a wide window so the
+    // log is always found regardless of age. The backend requires timeRange.
+    if (param?.requestId) {
+      const wideWindowStart = new Date(now.getTime() - WIDE_SEARCH_WINDOW_MS);
+      return { from: wideWindowStart.toISOString(), to: now.toISOString() };
+    }
+
+    // Default: last 24 hours for table view
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    return { from: oneDayAgo.toISOString(), to: now.toISOString() };
   }
 }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/GKO-2013
https://gravitee.atlassian.net/browse/GKO-2390
## Description

Hooks up backend to frontend for env logging log detals view. 
<img width="1269" height="682" alt="Screenshot 2026-02-18 at 4 35 39 PM" src="https://github.com/user-attachments/assets/97d4832e-ff88-46ca-a0fc-6134ba18d179" />

host, remoteAddress, endpointResponseTime, gatewayLatency, responseContentLength don't exist in either backend endpoint's response schema.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

