### PR TITLE
GKO-2002-manage-several-certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ gravitee-apim-e2e/ui-test/screenshots/
 !.yarn/sdks
 !.yarn/versions
 
+
 # project's maven repo
 /.m2/repository
 /.mvn/jvm.config

--- a/gravitee-apim-console-webui/src/entities/application/Application.ts
+++ b/gravitee-apim-console-webui/src/entities/application/Application.ts
@@ -57,6 +57,7 @@ export interface ApplicationSettings {
   };
   tls?: {
     client_certificate?: string;
+    certificate_count?: number;
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -219,6 +219,11 @@
         </div>
         <div class="details-card__header__info-inputs">
           <div class="details-card__header__info-inputs__client_id-row">
+            @if (certificateCount > 1) {
+              <gio-banner-warning>
+                This application has {{ certificateCount }} active certificates. The one displayed is the most recently created.
+              </gio-banner-warning>
+            }
             <mat-form-field>
               <mat-label>Client Certificate</mat-label>
               <textarea formControlName="client_certificate" matInput type="text" rows="6" gioClipboardCopyWrapper></textarea>
@@ -226,11 +231,6 @@
                 >The <code>client_certificate</code> of the application. This field is required to subscribe to mTLS plans.
               </mat-hint>
             </mat-form-field>
-            @if (certificateCount > 1) {
-              <gio-banner-warning>
-                This application has {{ certificateCount }} active certificates. The one displayed is the most recently created.
-              </gio-banner-warning>
-            }
           </div>
         </div>
       </mat-card-content>

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -226,6 +226,11 @@
                 >The <code>client_certificate</code> of the application. This field is required to subscribe to mTLS plans.
               </mat-hint>
             </mat-form-field>
+            @if (certificateCount > 1) {
+              <gio-banner-warning>
+                This application has {{ certificateCount }} active certificates. The one displayed is the most recently created.
+              </gio-banner-warning>
+            }
           </div>
         </div>
       </mat-card-content>

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
@@ -229,26 +229,52 @@ describe('ApplicationGeneralInfoComponent', () => {
       fixture.detectChanges();
       await waitImageCheck();
 
-      const banner = fixture.nativeElement.querySelector('gio-banner-warning');
+      const banner = getBanner();
       expect(banner).toBeTruthy();
-      expect(banner.textContent).toContain('This application has 3 certificates');
+      expect(banner.textContent).toContain('This application has 3 active certificates');
     });
 
-    it('should not display warning when application has one or no certificate', async () => {
+    it('should not display warning when application has one certificate', async () => {
       const applicationDetails = fakeApplication({ type: 'SIMPLE' });
       applicationDetails.settings.tls = {
         client_certificate: 'pem certificate',
         certificate_count: 1,
       };
+
+      await assertNoBanner(applicationDetails);
+    });
+
+    it('should not display warning when application no certificate', async () => {
+      const applicationDetails = fakeApplication({ type: 'SIMPLE' });
+      applicationDetails.settings.tls = {
+        client_certificate: 'pem certificate',
+        certificate_count: 0,
+      };
+
+      await assertNoBanner(applicationDetails);
+    });
+
+    it('should not display warning when application has no TLS settings', async () => {
+      const applicationDetails = fakeApplication({ type: 'SIMPLE' });
+      applicationDetails.settings = {};
+
+      await assertNoBanner(applicationDetails);
+    });
+
+    async function assertNoBanner(applicationDetails: Application) {
       const applicationType = fakeApplicationType();
       expectListApplicationRequest(applicationDetails);
       expectApplicationTypeRequest(applicationType);
       fixture.detectChanges();
       await waitImageCheck();
 
-      const banner = fixture.nativeElement.querySelector('gio-banner-warning');
+      const banner = getBanner();
       expect(banner).toBeFalsy();
-    });
+    }
+
+    function getBanner() {
+      return fixture.nativeElement.querySelector('gio-banner-warning');
+    }
   });
 
   describe('Application General details status is ARCHIVED', () => {

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
@@ -216,6 +216,41 @@ describe('ApplicationGeneralInfoComponent', () => {
     });
   });
 
+  describe('Certificate count warning banner', () => {
+    it('should display warning when application has multiple certificates', async () => {
+      const applicationDetails = fakeApplication({ type: 'SIMPLE' });
+      applicationDetails.settings.tls = {
+        client_certificate: 'pem certificate',
+        certificate_count: 3,
+      };
+      const applicationType = fakeApplicationType();
+      expectListApplicationRequest(applicationDetails);
+      expectApplicationTypeRequest(applicationType);
+      fixture.detectChanges();
+      await waitImageCheck();
+
+      const banner = fixture.nativeElement.querySelector('gio-banner-warning');
+      expect(banner).toBeTruthy();
+      expect(banner.textContent).toContain('This application has 3 certificates');
+    });
+
+    it('should not display warning when application has one or no certificate', async () => {
+      const applicationDetails = fakeApplication({ type: 'SIMPLE' });
+      applicationDetails.settings.tls = {
+        client_certificate: 'pem certificate',
+        certificate_count: 1,
+      };
+      const applicationType = fakeApplicationType();
+      expectListApplicationRequest(applicationDetails);
+      expectApplicationTypeRequest(applicationType);
+      fixture.detectChanges();
+      await waitImageCheck();
+
+      const banner = fixture.nativeElement.querySelector('gio-banner-warning');
+      expect(banner).toBeFalsy();
+    });
+  });
+
   describe('Application General details status is ARCHIVED', () => {
     it('details form should be set to readonly', async () => {
       const applicationDetails = fakeApplication({ status: 'ARCHIVED' });

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
@@ -44,6 +44,7 @@ export class ApplicationGeneralComponent implements OnInit {
   public applicationForm: UntypedFormGroup;
   public isLoadingData = true;
   public isReadOnly = false;
+  public certificateCount = 0;
   public initialApplicationGeneralFormsValue: unknown;
   private destroyRef = inject(DestroyRef);
 
@@ -71,6 +72,7 @@ export class ApplicationGeneralComponent implements OnInit {
       .subscribe(() => {
         this.isLoadingData = false;
         this.isReadOnly = this.initialApplication.status === 'ARCHIVED' || this.initialApplication.origin === 'KUBERNETES';
+        this.certificateCount = this.initialApplication.settings?.tls?.certificate_count ?? 0;
 
         this.applicationForm = new UntypedFormGroup({
           details: new UntypedFormGroup({

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -162,7 +162,7 @@ public class SubscriptionCacheService implements SubscriptionService {
     private void registerFromClientCertificate(final Subscription subscription) {
         final Set<String> servers = extractApiServersId(subscription);
 
-        // register new certs and remove old one
+        // Ensure trust store is updated before cache to maintain certificate validation consistency
         subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
 
         // keep the old one

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -178,8 +178,12 @@ public class SubscriptionCacheService implements SubscriptionService {
             Objects.equals(subscription.getApi(), cached.getApi()) &&
             !Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate())
         ) {
-            evictKeyForApi(cached.getApi(), identityCacheKey(cached));
-            evictKeyForApi(cached.getApi(), identityCacheKeyWithoutPlan(cached));
+            String cacheKey = identityCacheKey(cached);
+            String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
+            evictKeyForApi(cached.getApi(), cacheKey);
+            evictKeyForApi(cached.getApi(), cacheKeyWithoutPlan);
+            cacheByClientCertificate.remove(cacheKey);
+            cacheByClientCertificate.remove(cacheKeyWithoutPlan);
         }
     }
 
@@ -203,11 +207,13 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     private void updateIdentityCache(Subscription subscription, Map<String, Subscription> cache) {
         updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        updateCacheKeyByApiId(subscription.getApi(), identityCacheKey(subscription));
-        cache.put(identityCacheKey(subscription), subscription);
+        String cacheKey = identityCacheKey(subscription);
+        updateCacheKeyByApiId(subscription.getApi(), cacheKey);
+        cache.put(cacheKey, subscription);
         // Index the subscription without plan id to allow search without plan criteria.
-        cache.put(identityCacheKeyWithoutPlan(subscription), subscription);
-        updateCacheKeyByApiId(subscription.getApi(), identityCacheKeyWithoutPlan(subscription));
+        String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        cache.put(cacheKeyWithoutPlan, subscription);
+        updateCacheKeyByApiId(subscription.getApi(), cacheKeyWithoutPlan);
     }
 
     private void updateCacheKeyByApiId(final String apiId, final String cacheKey) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -25,6 +25,9 @@ import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -33,12 +36,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 
 @CustomLog
 @RequiredArgsConstructor
@@ -50,11 +52,10 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     // Caches only contains active subscriptions
     private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> cacheByApiClientCertificate = new ConcurrentHashMap<>();
+    private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     private final Map<String, Subscription> cacheBySubscriptionId = new ConcurrentHashMap<>();
     private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>(); // exploded subscriptions
-    private final Map<String, Set<String>> cacheByApiId = new ConcurrentHashMap<>();
-    private final Map<String, Object> locksBySubscriptionId = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -66,14 +67,14 @@ public class SubscriptionCacheService implements SubscriptionService {
                 .getByApiAndMd5Key(api, securityToken.getTokenValue())
                 .flatMap(apiKey -> getByApiAndId(api, apiKey.getSubscription()));
             case CLIENT_ID -> getByApiAndClientIdAndPlan(api, securityToken.getTokenValue(), plan);
-            case CERTIFICATE -> subscriptionTrustStoreLoaderManager.getByCertificate(api, securityToken.getTokenValue(), plan);
+            case CERTIFICATE -> subscriptionTrustStoreLoaderManager.getByCertificate(api, plan, securityToken.getTokenValue());
             default -> Optional.empty();
         };
     }
 
     @Override
     public Optional<Subscription> getByApiAndClientIdAndPlan(String api, String clientId, String plan) {
-        return Optional.ofNullable(cacheByApiClientId.get(buildCacheKeyFromClientInfo(api, clientId, plan)));
+        return Optional.ofNullable(cacheByApiClientId.get(cacheKey(api, plan, clientId)));
     }
 
     @Override
@@ -81,27 +82,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Optional.ofNullable(cacheBySubscriptionId.get(subscriptionId));
     }
 
-    /** Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions). */
+    /**
+     * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
+     */
     public Collection<Subscription> getAllById(String subscriptionId) {
         Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
         return subscriptions != null ? Set.copyOf(subscriptions) : Collections.emptySet();
     }
 
-    /** Returns subscription for the given API and ID (for exploded subscriptions). */
-    public Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
-            // Fallback to old cache for backward compatibility
-            return getById(subscriptionId);
-        }
-        return subscriptions
-            .stream()
-            .filter(sub -> Objects.equals(api, sub.getApi()))
-            .findFirst();
-    }
-
     @Override
     public void register(final Subscription subscription) {
+        // only once per synchronization window
+        // take all fields (including "updatedAt" in metadata) into account
         if (ACCEPTED.name().equals(subscription.getStatus())) {
             if (subscription.getClientCertificate() != null) {
                 registerFromClientCertificate(subscription);
@@ -115,177 +107,38 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void unregisterStaleIfChanged(
-        Subscription cached,
-        Subscription updated,
-        BiPredicate<Subscription, Subscription> hasChanged,
-        Consumer<Subscription> unregister
-    ) {
-        if (cached != null && hasChanged.test(cached, updated)) {
-            unregister.accept(cached);
-        }
-    }
-
-    private Object lockFor(String idKey) {
-        return locksBySubscriptionId.computeIfAbsent(idKey, k -> new Object());
-    }
-
-    private void registerFromClientCertificate(final Subscription subscription) {
-        final String idKey = subscription.getId();
-        final String clientCertificateKey = buildClientCertificateCacheKey(subscription);
-        // Index the subscription without plan id to allow search without plan criteria.
-        final String clientCertificateKeyWithoutPlan = buildCacheKeyFromClientInfo(
-            subscription.getApi(),
-            subscription.getClientCertificate(),
-            null
-        );
-
-        synchronized (lockFor(idKey)) {
-            Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(idKey);
-            if (cachedAll != null) {
-                for (Subscription cached : Set.copyOf(cachedAll)) {
-                    unregisterStaleIfChanged(
-                        cached,
-                        subscription,
-                        (c, u) -> c.getClientCertificate() != null && !c.getClientCertificate().equals(u.getClientCertificate()),
-                        this::unregister
-                    );
-                }
-            }
-
-            final Set<String> servers = extractApiServersId(subscription);
-            subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
-            // Update subscription
-            cacheBySubscriptionId.put(idKey, subscription);
-            cacheBySubscriptionIdAll.computeIfAbsent(idKey, k -> ConcurrentHashMap.newKeySet()).add(subscription);
-            addKeyForApi(subscription.getApi(), idKey);
-            // Put new client_id
-            cacheByApiClientCertificate.put(clientCertificateKey, subscription);
-            addKeyForApi(subscription.getApi(), clientCertificateKey);
-            cacheByApiClientCertificate.put(clientCertificateKeyWithoutPlan, subscription);
-            addKeyForApi(subscription.getApi(), clientCertificateKeyWithoutPlan);
-        }
-    }
-
-    private void registerFromClientId(final Subscription subscription) {
-        final String idKey = subscription.getId();
-        final String clientIdKey = buildClientIdCacheKey(subscription);
-        // Index the subscription without plan id to allow search without plan criteria.
-        final String clientIdKeyWithoutPlan = buildCacheKeyFromClientInfo(subscription.getApi(), subscription.getClientId(), null);
-
-        synchronized (lockFor(idKey)) {
-            Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(idKey);
-            if (cachedAll != null) {
-                for (Subscription cached : Set.copyOf(cachedAll)) {
-                    unregisterStaleIfChanged(
-                        cached,
-                        subscription,
-                        (c, u) -> c.getClientId() != null && !c.getClientId().equals(u.getClientId()),
-                        this::unregister
-                    );
-                }
-            }
-
-            // Update subscription
-            cacheBySubscriptionId.put(idKey, subscription);
-            cacheBySubscriptionIdAll.computeIfAbsent(idKey, k -> ConcurrentHashMap.newKeySet()).add(subscription);
-            addKeyForApi(subscription.getApi(), idKey);
-            // Put new client_id
-            cacheByApiClientId.put(clientIdKey, subscription);
-            addKeyForApi(subscription.getApi(), clientIdKey);
-            cacheByApiClientId.put(clientIdKeyWithoutPlan, subscription);
-            addKeyForApi(subscription.getApi(), clientIdKeyWithoutPlan);
-        }
-    }
-
-    private void registerFromId(final Subscription subscription) {
-        String cacheKey = subscription.getId();
-        synchronized (lockFor(cacheKey)) {
-            cacheBySubscriptionId.put(cacheKey, subscription);
-            cacheBySubscriptionIdAll.computeIfAbsent(cacheKey, k -> ConcurrentHashMap.newKeySet()).add(subscription);
-            addKeyForApi(subscription.getApi(), cacheKey);
-        }
-    }
-
-    private void addKeyForApi(final String apiId, final String cacheKey) {
-        Set<String> subscriptionsByApi = cacheByApiId.get(apiId);
-        if (subscriptionsByApi == null) {
-            subscriptionsByApi = new HashSet<>();
-        }
-        subscriptionsByApi.add(cacheKey);
-        cacheByApiId.put(apiId, subscriptionsByApi);
-    }
-
-    private void removeKeyForApi(final String apiId, final String cacheKey) {
-        Set<String> keysByApi = cacheByApiId.get(apiId);
-        if (keysByApi != null && keysByApi.remove(cacheKey)) {
-            if (keysByApi.isEmpty()) {
-                cacheByApiId.remove(apiId);
-            } else {
-                cacheByApiId.put(apiId, keysByApi);
-            }
-        }
-    }
-
     @Override
-    public void unregister(final Subscription subscription) {
-        final String idKey = subscription.getId();
-        synchronized (lockFor(idKey)) {
-            Subscription removeSubscription = cacheBySubscriptionId.remove(idKey);
+    public void unregister(final Subscription candidate) {
+        // only once per synchronization window
+        // take all fields (including "updatedAt" in metadata) into account
+        cacheBySubscriptionId.computeIfPresent(candidate.getId(), (h, existing) -> {
             // Remove from exploded subscriptions cache
-            Set<Subscription> allSubscriptions = cacheBySubscriptionIdAll.get(idKey);
+            Set<Subscription> allSubscriptions = cacheBySubscriptionIdAll.get(existing.getId());
             if (allSubscriptions != null) {
-                allSubscriptions.removeIf(s -> Objects.equals(subscription.getApi(), s.getApi()));
+                allSubscriptions.removeIf(s -> Objects.equals(existing.getApi(), s.getApi()));
                 if (allSubscriptions.isEmpty()) {
-                    cacheBySubscriptionIdAll.remove(idKey);
+                    cacheBySubscriptionIdAll.remove(existing.getId());
                 }
             }
-            if (removeSubscription != null) {
-                removeKeyForApi(subscription.getApi(), idKey);
-                unregisterFromClientId(removeSubscription);
-                unregisterFromClientCertificate(removeSubscription);
-            }
-            // In case new one has different client id than the one in cache
-            unregisterFromClientId(subscription);
-            unregisterFromClientCertificate(subscription);
-        }
-    }
+            evictKeyForApi(existing.getApi(), existing.getId());
+            unregisterFromClientId(existing);
+            unregisterFromClientCertificate(existing);
 
-    private void unregisterFromClientId(final Subscription subscription) {
-        if (subscription.getClientId() != null) {
-            final String clientIdKey = buildClientIdCacheKey(subscription);
-            if (cacheByApiClientId.remove(clientIdKey) != null) {
-                removeKeyForApi(subscription.getApi(), clientIdKey);
+            // In case new ones have different client id than the one in cache
+            if (!Objects.equals(candidate.getClientId(), existing.getClientId())) {
+                unregisterFromClientId(candidate);
             }
-            final String clientIdKeyWithoutPlan = buildCacheKeyFromClientInfo(subscription.getApi(), subscription.getClientId(), null);
-            if (cacheByApiClientId.remove(clientIdKeyWithoutPlan) != null) {
-                removeKeyForApi(subscription.getApi(), clientIdKeyWithoutPlan);
+            if (!Objects.equals(candidate.getClientCertificate(), existing.getClientCertificate())) {
+                unregisterFromClientCertificate(candidate);
             }
-        }
-    }
 
-    private void unregisterFromClientCertificate(final Subscription subscription) {
-        if (subscription.getClientCertificate() != null) {
-            final String clientCertificateKey = buildClientCertificateCacheKey(subscription);
-            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
-            if (cacheByApiClientCertificate.remove(clientCertificateKey) != null) {
-                removeKeyForApi(subscription.getApi(), clientCertificateKey);
-            }
-            final String clientCertificateKeyWithoutPlan = buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientCertificate(),
-                null
-            );
-            if (cacheByApiClientCertificate.remove(clientCertificateKeyWithoutPlan) != null) {
-                removeKeyForApi(subscription.getApi(), clientCertificateKeyWithoutPlan);
-            }
-        }
+            return null;
+        });
     }
 
     @Override
     public void unregisterByApiId(final String apiId) {
-        Set<String> subscriptionsByApi = cacheByApiId.remove(apiId);
-        if (subscriptionsByApi != null) {
+        cacheKeysByApiId.computeIfPresent(apiId, (k, subscriptionsByApi) -> {
             subscriptionsByApi.forEach(cacheKey -> {
                 Set<Subscription> all = cacheBySubscriptionIdAll.get(cacheKey);
                 if (all != null) {
@@ -294,20 +147,183 @@ public class SubscriptionCacheService implements SubscriptionService {
                 }
                 cacheBySubscriptionId.remove(cacheKey);
                 cacheByApiClientId.remove(cacheKey);
+                cacheByClientCertificate.remove(cacheKey);
             });
+            return null;
+        });
+    }
+
+    private void registerFromId(final Subscription subscription) {
+        String cacheKey = subscription.getId();
+        updateSubscriptionIdById(subscription);
+        updateCacheKeyByApiId(subscription.getApi(), cacheKey);
+    }
+
+    private void registerFromClientCertificate(final Subscription subscription) {
+        final Set<String> servers = extractApiServersId(subscription);
+
+        // register new certs and remove old one
+        subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
+
+        // keep the old one
+        Subscription cached = cacheBySubscriptionId.get(subscription.getId());
+
+        // Update cache
+        updateSubscriptionIdById(subscription);
+        updateIdentityCache(subscription, cacheByClientCertificate);
+
+        // Evict if cert bundle changed
+        if (
+            cached != null &&
+            Objects.equals(subscription.getApi(), cached.getApi()) &&
+            !Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate())
+        ) {
+            evictKeyForApi(cached.getApi(), identityCacheKey(cached));
+            evictKeyForApi(cached.getApi(), identityCacheKeyWithoutPlan(cached));
         }
     }
 
-    String buildClientCertificateCacheKey(Subscription subscription) {
-        return buildCacheKeyFromClientInfo(subscription.getApi(), subscription.getClientCertificate(), subscription.getPlan());
+    private void registerFromClientId(final Subscription subscription) {
+        // Snapshot old entries before registering
+        Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
+        Set<Subscription> oldEntries = cachedAll != null ? Set.copyOf(cachedAll) : Set.of();
+
+        updateSubscriptionIdById(subscription);
+
+        // Register new subscription first
+        updateIdentityCache(subscription, cacheByApiClientId);
+
+        // Then clean up old clientId entries if clientId changed
+        for (Subscription old : oldEntries) {
+            if (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) {
+                unregisterFromClientId(old);
+            }
+        }
     }
 
-    String buildClientIdCacheKey(Subscription subscription) {
-        return buildCacheKeyFromClientInfo(subscription.getApi(), subscription.getClientId(), subscription.getPlan());
+    private void updateIdentityCache(Subscription subscription, Map<String, Subscription> cache) {
+        updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
+        updateCacheKeyByApiId(subscription.getApi(), identityCacheKey(subscription));
+        cache.put(identityCacheKey(subscription), subscription);
+        // Index the subscription without plan id to allow search without plan criteria.
+        cache.put(identityCacheKeyWithoutPlan(subscription), subscription);
+        updateCacheKeyByApiId(subscription.getApi(), identityCacheKeyWithoutPlan(subscription));
     }
 
-    String buildCacheKeyFromClientInfo(String api, String clientIdOrCertificate, String plan) {
-        return String.format("%s.%s.%s", api, clientIdOrCertificate, plan);
+    private void updateCacheKeyByApiId(final String apiId, final String cacheKey) {
+        Set<String> subscriptionsByApi = cacheKeysByApiId.get(apiId);
+        if (subscriptionsByApi == null) {
+            subscriptionsByApi = new HashSet<>();
+        }
+        subscriptionsByApi.add(cacheKey);
+        cacheKeysByApiId.put(apiId, subscriptionsByApi);
+    }
+
+    private void updateSubscriptionIdById(Subscription subscription) {
+        cacheBySubscriptionId.put(subscription.getId(), subscription);
+        cacheBySubscriptionIdAll.computeIfAbsent(subscription.getId(), k -> ConcurrentHashMap.newKeySet()).add(subscription);
+    }
+
+    private void unregisterFromClientId(final Subscription subscription) {
+        if (subscription.getClientId() != null) {
+            evictIdentityCache(subscription, cacheByApiClientId);
+        }
+    }
+
+    private void unregisterFromClientCertificate(final Subscription subscription) {
+        if (subscription.getClientCertificate() != null) {
+            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+            evictIdentityCache(subscription, cacheByClientCertificate);
+        }
+    }
+
+    private void evictIdentityCache(Subscription subscription, Map<String, Subscription> cacheByApiClientId) {
+        final String identityCacheKey = identityCacheKey(subscription);
+        if (cacheByApiClientId.remove(identityCacheKey) != null) {
+            evictKeyForApi(subscription.getApi(), identityCacheKey);
+        }
+        final String identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        if (cacheByApiClientId.remove(identityCacheKeyWithoutPlan) != null) {
+            evictKeyForApi(subscription.getApi(), identityCacheKeyWithoutPlan);
+        }
+    }
+
+    private void evictKeyForApi(final String apiId, final String cacheKey) {
+        Set<String> keysByApi = cacheKeysByApiId.get(apiId);
+        if (keysByApi != null && keysByApi.remove(cacheKey)) {
+            if (keysByApi.isEmpty()) {
+                cacheKeysByApiId.remove(apiId);
+            } else {
+                cacheKeysByApiId.put(apiId, keysByApi);
+            }
+        }
+    }
+
+    // visible for testing
+    Optional<Subscription> getByClientCertificate(final Subscription subscription) {
+        if (subscription.getPlan() != null) {
+            return Optional.ofNullable(cacheByClientCertificate.get(identityCacheKey(subscription)));
+        } else {
+            return Optional.ofNullable(cacheByClientCertificate.get(identityCacheKeyWithoutPlan(subscription)));
+        }
+    }
+
+    // Visible for testing
+    Optional<Subscription> getByApiAndClientId(String api, String clientId) {
+        return Optional.ofNullable(cacheByApiClientId.get(cacheKey(api, clientId)));
+    }
+
+    // Visible for testing
+    Set<String> getByApiId(String apiId) {
+        return cacheKeysByApiId.getOrDefault(apiId, Collections.emptySet());
+    }
+
+    private Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
+        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null || subscriptions.isEmpty()) {
+            // Fallback to old cache for backward compatibility
+            return getById(subscriptionId);
+        }
+        return subscriptions
+            .stream()
+            .filter(sub -> Objects.equals(api, sub.getApi()))
+            .findFirst();
+    }
+
+    private String identityCacheKey(Subscription subscription) {
+        if (subscription.getClientId() != null) {
+            Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
+            return cacheKey(subscription.getApi(), subscription.getPlan(), subscription.getClientId());
+        } else {
+            Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
+            return cacheKey(subscription.getApi(), subscription.getPlan(), sha256(subscription.getClientCertificate()));
+        }
+    }
+
+    private String identityCacheKeyWithoutPlan(Subscription subscription) {
+        if (subscription.getClientId() != null) {
+            Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
+            return cacheKey(subscription.getApi(), subscription.getClientId());
+        } else {
+            Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
+            return cacheKey(subscription.getApi(), sha256(subscription.getClientCertificate()));
+        }
+    }
+
+    @SneakyThrows
+    private String sha256(String toProcess) {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(toProcess.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+
+    private String cacheKey(String api, String plan, String clientIdentity) {
+        Objects.requireNonNull(plan, "Plan must not be null");
+        return String.format("%s.%s.%s", api, plan, clientIdentity);
+    }
+
+    private String cacheKey(String api, String clientIdentity) {
+        return String.format("%s.%s", api, clientIdentity);
     }
 
     private Set<String> extractApiServersId(Subscription subscription) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
@@ -30,11 +29,14 @@ import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
-import io.vertx.core.cli.CLI;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -43,7 +45,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.DigestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,8 +53,9 @@ class SubscriptionCacheServiceTest {
     private static final String PLAN_ID = "my-test-plan-id";
     private static final String API_ID = "my-test-api-id";
     private static final String SUB_ID = "my-test-subscription-id";
+    private static final String API_ID_2 = "my-test-api-id-2";
+    private static final String PLAN_ID_2 = "my-test-plan-id-2";
     private static final String SUB_ID_2 = "my-test-subscription-id-2";
-    private static final String API_KEY = "my-test-api-key";
     private static final String CLIENT_ID = "my-test-client-id";
     private static final String CLIENT_CERTIFICATE = "my-test-client-certificate";
 
@@ -67,21 +69,10 @@ class SubscriptionCacheServiceTest {
     private ApiManager apiManager;
 
     private SubscriptionCacheService subscriptionService;
-    private Map<String, Subscription> cacheByApiClientId;
-    private Map<String, Subscription> cacheByApiClientCertificate;
-    private Map<String, Subscription> cacheBySubscriptionId;
-    private Map<String, Set<String>> cacheByApiId;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         subscriptionService = new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager);
-        cacheByApiClientId = (Map<String, Subscription>) ReflectionTestUtils.getField(subscriptionService, "cacheByApiClientId");
-        cacheByApiClientCertificate = (Map<String, Subscription>) ReflectionTestUtils.getField(
-            subscriptionService,
-            "cacheByApiClientCertificate"
-        );
-        cacheBySubscriptionId = (Map<String, Subscription>) ReflectionTestUtils.getField(subscriptionService, "cacheBySubscriptionId");
-        cacheByApiId = (Map<String, Set<String>>) ReflectionTestUtils.getField(subscriptionService, "cacheByApiId");
     }
 
     @Nested
@@ -92,26 +83,17 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientCertificateCacheKey(subscription);
-            Subscription byClientIdWithPlan = cacheByApiClientCertificate.get(cacheKeyWithPlan);
-            assertThat(byClientIdWithPlan).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isPresent().get().isEqualTo(subscription);
 
             // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientCertificate(),
-                null
-            );
-            Subscription byClientIdWithoutPlan = cacheByApiClientCertificate.get(cacheKeyWithoutPlan);
-            assertThat(byClientIdWithoutPlan).isNotNull().isEqualTo(subscription);
+            Subscription lookupWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, null);
+            assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(3).contains(cacheKeyWithPlan, cacheKeyWithoutPlan, SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -128,26 +110,17 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientCertificateCacheKey(subscription);
-            Subscription byClientIdWithPlan = cacheByApiClientCertificate.get(cacheKeyWithPlan);
-            assertThat(byClientIdWithPlan).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isPresent().get().isEqualTo(subscription);
 
             // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientCertificate(),
-                null
-            );
-            Subscription byClientIdWithoutPlan = cacheByApiClientCertificate.get(cacheKeyWithoutPlan);
-            assertThat(byClientIdWithoutPlan).isNotNull().isEqualTo(subscription);
+            Subscription lookupWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, null);
+            assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(3).contains(cacheKeyWithPlan, cacheKeyWithoutPlan, SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -159,32 +132,27 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription originalSub = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(originalSub).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
-            Subscription subscriptionUpdated = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "client_id_updated", PLAN_ID);
+            Subscription subscriptionUpdated = buildAcceptedSubscriptionWithClientCertificate(
+                SUB_ID,
+                API_ID,
+                "client_cert_updated",
+                PLAN_ID
+            );
             subscriptionService.register(subscriptionUpdated);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscriptionUpdated);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientCertificateCacheKey(subscriptionUpdated);
-            Subscription byClientIdWithPlan = cacheByApiClientCertificate.get(cacheKeyWithPlan);
-            assertThat(byClientIdWithPlan).isNotNull().isEqualTo(subscriptionUpdated);
+            assertThat(subscriptionService.getByClientCertificate(subscriptionUpdated)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscriptionUpdated.getApi(),
-                subscriptionUpdated.getClientCertificate(),
-                null
-            );
-            Subscription byClientIdWithoutPlan = cacheByApiClientCertificate.get(cacheKeyWithoutPlan);
-            assertThat(byClientIdWithoutPlan).isNotNull().isEqualTo(subscriptionUpdated);
+            Subscription lookupWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "client_cert_updated", null);
+            assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(3).contains(cacheKeyWithPlan, cacheKeyWithoutPlan, SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
         }
 
         @Test
@@ -192,26 +160,19 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientIdCacheKey(subscription);
-            Subscription byClientIdWithPlan = cacheByApiClientId.get(cacheKeyWithPlan);
-            assertThat(byClientIdWithPlan).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID))
+                .isPresent()
+                .get()
+                .isEqualTo(subscription);
 
             // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientId(),
-                null
-            );
-            Subscription byClientIdWithoutPlan = cacheByApiClientId.get(cacheKeyWithoutPlan);
-            assertThat(byClientIdWithoutPlan).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(3).contains(cacheKeyWithPlan, cacheKeyWithoutPlan, SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
         }
 
         @Test
@@ -219,32 +180,27 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription originalSub = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(originalSub).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             Subscription subscriptionUpdated = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, "client_id_updated", PLAN_ID);
             subscriptionService.register(subscriptionUpdated);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscriptionUpdated);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientIdCacheKey(subscriptionUpdated);
-            Subscription byClientIdWithPlan = cacheByApiClientId.get(cacheKeyWithPlan);
-            assertThat(byClientIdWithPlan).isNotNull().isEqualTo(subscriptionUpdated);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "client_id_updated", PLAN_ID))
+                .isPresent()
+                .get()
+                .isEqualTo(subscriptionUpdated);
 
             // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscriptionUpdated.getApi(),
-                subscriptionUpdated.getClientId(),
-                null
-            );
-            Subscription byClientIdWithoutPlan = cacheByApiClientId.get(cacheKeyWithoutPlan);
-            assertThat(byClientIdWithoutPlan).isNotNull().isEqualTo(subscriptionUpdated);
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, "client_id_updated"))
+                .isPresent()
+                .get()
+                .isEqualTo(subscriptionUpdated);
 
             // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(3).contains(cacheKeyWithPlan, cacheKeyWithoutPlan, SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
         }
 
         @Test
@@ -252,37 +208,79 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
-            assertThat(cacheByApiClientId).isEmpty();
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).hasSize(1).contains(SUB_ID);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(1).contains(SUB_ID);
+        }
+
+        @Test
+        void should_be_idempotent_when_registering_same_subscription_twice() {
+            Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
+            subscriptionService.register(subscription);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID))
+                .isPresent()
+                .get()
+                .isEqualTo(subscription);
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isPresent().get().isEqualTo(subscription);
+        }
+
+        @Test
+        void should_cleanup_old_client_id_when_updating() {
+            Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
+
+            Subscription updated = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, "new-client-id", PLAN_ID);
+            subscriptionService.register(updated);
+
+            // New client ID is found
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "new-client-id", PLAN_ID))
+                .isPresent()
+                .get()
+                .isEqualTo(updated);
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, "new-client-id")).isPresent().get().isEqualTo(updated);
+
+            // Old client ID is gone
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+        }
+
+        @Test
+        void should_register_new_cert_and_keep_old_cert_in_cache_when_updating() {
+            // Note: when a cert changes, the old cert entries in cacheByClientCertificate are NOT cleaned up.
+            // This is acceptable because the real security token lookup goes through
+            // subscriptionTrustStoreLoaderManager.getByCertificate, not through cacheByClientCertificate.
+            Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(subscription);
+
+            Subscription updated = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "new-client-cert", PLAN_ID);
+            subscriptionService.register(updated);
+
+            // New cert is found
+            assertThat(subscriptionService.getByClientCertificate(updated)).isPresent().get().isEqualTo(updated);
+            Subscription lookupNewWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "new-client-cert", null);
+            assertThat(subscriptionService.getByClientCertificate(lookupNewWithoutPlan)).isPresent().get().isEqualTo(updated);
+
+            // getById returns the updated subscription
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(updated);
+
+            // Old cert still present in cache (stale entry, but harmless — real lookup uses trust store)
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isPresent();
         }
 
         @Test
         void should_not_register_subscription_when_subscription_is_not_accepted() {
-            Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID);
+            Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscription.setStatus(io.gravitee.repository.management.model.Subscription.Status.CLOSED.name());
 
             subscriptionService.register(subscription);
 
-            assertThat(cacheBySubscriptionId).doesNotContainKey(SUB_ID);
-
-            // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientIdCacheKey(subscription);
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithPlan);
-
-            // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientId(),
-                null
-            );
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithoutPlan);
-
-            // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).isNull();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
     }
 
@@ -294,30 +292,15 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             subscriptionService.unregister(subscription);
 
-            assertThat(cacheBySubscriptionId).doesNotContainKey(SUB_ID);
-
-            // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientCertificateCacheKey(subscription);
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithPlan);
-            assertThat(cacheByApiClientCertificate).doesNotContainKey(cacheKeyWithPlan);
-
-            // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientId(),
-                null
-            );
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithoutPlan);
-            assertThat(cacheByApiClientCertificate).doesNotContainKey(cacheKeyWithoutPlan);
-
-            // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).isNull();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isEmpty();
+            Subscription lookupWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, null);
+            assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
 
         @Test
@@ -325,53 +308,25 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
 
-            Subscription byId = cacheBySubscriptionId.get(SUB_ID);
-            assertThat(byId).isNotNull().isEqualTo(subscription);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
 
             subscriptionService.unregister(subscription);
 
-            assertThat(cacheBySubscriptionId).doesNotContainKey(SUB_ID);
-
-            // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientIdCacheKey(subscription);
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithPlan);
-
-            // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientId(),
-                null
-            );
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithoutPlan);
-
-            // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).isNull();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
 
         @Test
         void should_do_nothing_when_unregistered_an_non_registered_subscription() {
-            Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID);
-
+            Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.unregister(subscription);
 
-            assertThat(cacheBySubscriptionId).doesNotContainKey(SUB_ID);
-
-            // With plan key
-            String cacheKeyWithPlan = subscriptionService.buildClientIdCacheKey(subscription);
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithPlan);
-
-            // Without plan key
-            String cacheKeyWithoutPlan = subscriptionService.buildCacheKeyFromClientInfo(
-                subscription.getApi(),
-                subscription.getClientId(),
-                null
-            );
-            assertThat(cacheByApiClientId).doesNotContainKey(cacheKeyWithoutPlan);
-
-            // By api
-            Set<String> byApiId = cacheByApiId.get(API_ID);
-            assertThat(byApiId).isNull();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
 
         @Test
@@ -382,11 +337,72 @@ class SubscriptionCacheServiceTest {
             }
             subscriptionService.unregisterByApiId(API_ID);
 
-            assertThat(cacheByApiClientId).isEmpty();
-            assertThat(cacheByApiClientCertificate).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+        }
 
-            // By api
-            assertThat(cacheByApiId).isEmpty();
+        @Test
+        void should_only_unregister_subscriptions_client_id_for_given_api() {
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID_2, API_ID_2, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent().get().isEqualTo(subApi1);
+            assertThat(subscriptionService.getByApiId(API_ID)).isNotEmpty();
+
+            subscriptionService.unregisterByApiId(API_ID);
+
+            // API_ID subscriptions are gone
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+
+            // API_ID_2 subscriptions are intact
+            assertThat(subscriptionService.getById(SUB_ID_2)).isPresent().get().isEqualTo(subApi2);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isPresent().get().isEqualTo(subApi2);
+            assertThat(subscriptionService.getByApiId(API_ID_2)).isNotEmpty();
+        }
+
+        @Test
+        void should_only_unregister_subscriptions_for_cert_given_api() {
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientCertificate(SUB_ID_2, API_ID_2, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+            assertThat(subscriptionService.getByClientCertificate(subApi1)).isPresent().get().isEqualTo(subApi1);
+            assertThat(subscriptionService.getByApiId(API_ID)).isNotEmpty();
+
+            subscriptionService.unregisterByApiId(API_ID);
+
+            // API_ID subscriptions are gone
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByClientCertificate(subApi1)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+
+            // API_ID_2 subscriptions are intact
+            assertThat(subscriptionService.getById(SUB_ID_2)).isPresent().get().isEqualTo(subApi2);
+            assertThat(subscriptionService.getByClientCertificate(subApi2)).isPresent().get().isEqualTo(subApi2);
+            assertThat(subscriptionService.getByApiId(API_ID_2)).isNotEmpty();
+        }
+
+        @Test
+        void should_evict_subscription_when_re_registered_as_closed() {
+            Subscription accepted = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(accepted);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+
+            // Re-register the same subscription as CLOSED
+            subscriptionService.unregister(accepted);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
     }
 
@@ -443,7 +459,7 @@ class SubscriptionCacheServiceTest {
             Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
             subscriptionService.register(subscription);
             SecurityToken securityToken = SecurityToken.forClientCertificate(CLIENT_CERTIFICATE);
-            when(subscriptionTrustStoreLoaderManager.getByCertificate(API_ID, CLIENT_CERTIFICATE, PLAN_ID)).thenReturn(
+            when(subscriptionTrustStoreLoaderManager.getByCertificate(API_ID, PLAN_ID, CLIENT_CERTIFICATE)).thenReturn(
                 Optional.of(subscription)
             );
 
@@ -478,6 +494,131 @@ class SubscriptionCacheServiceTest {
             SecurityToken securityToken = SecurityToken.builder().tokenValue("unknown").tokenType("unknown").build();
             Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
             assertThat(subscriptionOpt).isEmpty();
+        }
+
+        @Test
+        void should_get_all_exploded_subscriptions_by_id() {
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID_2);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID, SecurityToken.forClientId(CLIENT_ID), PLAN_ID)).contains(
+                subApi1
+            );
+            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forClientId(CLIENT_ID), PLAN_ID_2)).contains(
+                subApi2
+            );
+            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forClientId("unknown"), PLAN_ID_2)).isEmpty();
+        }
+    }
+
+    @Nested
+    //@Disabled
+    class ConcurrentUpdateTest {
+
+        private static final int READER_COUNT = 10;
+
+        @Test
+        void should_always_find_subscription_by_either_client_id_during_update() throws Exception {
+            String oldClientId = "client-old";
+            String newClientId = "client-new";
+            Subscription initial = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, oldClientId, PLAN_ID);
+            subscriptionService.register(initial);
+
+            AtomicBoolean updateDone = new AtomicBoolean(false);
+            AtomicBoolean foundEmpty = new AtomicBoolean(false);
+            CyclicBarrier barrier = new CyclicBarrier(READER_COUNT + 1);
+
+            try (
+                ExecutorService read = Executors.newFixedThreadPool(READER_COUNT);
+                ExecutorService write = Executors.newFixedThreadPool(1);
+            ) {
+                for (int i = 0; i < READER_COUNT; i++) {
+                    read.submit(() -> {
+                        barrier.await();
+                        while (!updateDone.get()) {
+                            Optional<Subscription> byOld = subscriptionService.getByApiAndSecurityToken(
+                                API_ID,
+                                SecurityToken.forClientId(oldClientId),
+                                PLAN_ID
+                            );
+                            Optional<Subscription> byNew = subscriptionService.getByApiAndSecurityToken(
+                                API_ID,
+                                SecurityToken.forClientId(newClientId),
+                                PLAN_ID
+                            );
+                            if (byOld.isEmpty() && byNew.isEmpty()) {
+                                foundEmpty.set(true);
+                            }
+                        }
+                        return null;
+                    });
+                }
+
+                write.submit(() -> {
+                    barrier.await();
+                    Subscription updated = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, newClientId, PLAN_ID);
+                    subscriptionService.register(updated);
+                    updateDone.set(true);
+                    return null;
+                });
+
+                read.shutdown();
+                write.shutdown();
+                assertThat(read.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+                assertThat(write.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            }
+            assertThat(foundEmpty).describedAs("Subscription must always be reachable by at least one clientId during update").isFalse();
+        }
+
+        @Test
+        void should_always_find_subscription_by_either_client_certificate_during_update() throws Exception {
+            String oldCert = "cert-old";
+            String newCert = "cert-new";
+            Subscription initial = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, oldCert, PLAN_ID);
+            subscriptionService.register(initial);
+
+            AtomicBoolean updateDone = new AtomicBoolean(false);
+            AtomicBoolean foundEmpty = new AtomicBoolean(false);
+            CyclicBarrier barrier = new CyclicBarrier(READER_COUNT + 1);
+
+            try (
+                ExecutorService read = Executors.newFixedThreadPool(READER_COUNT);
+                ExecutorService write = Executors.newFixedThreadPool(1);
+            ) {
+                for (int i = 0; i < READER_COUNT; i++) {
+                    read.submit(() -> {
+                        barrier.await();
+                        while (!updateDone.get()) {
+                            Subscription lookupOld = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, oldCert, PLAN_ID);
+                            Subscription lookupNew = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, newCert, PLAN_ID);
+                            Optional<Subscription> byOld = subscriptionService.getByClientCertificate(lookupOld);
+                            Optional<Subscription> byNew = subscriptionService.getByClientCertificate(lookupNew);
+                            if (byOld.isEmpty() && byNew.isEmpty()) {
+                                foundEmpty.set(true);
+                            }
+                        }
+                        return null;
+                    });
+                }
+
+                write.submit(() -> {
+                    barrier.await();
+                    Subscription updated = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, newCert, PLAN_ID);
+                    subscriptionService.register(updated);
+                    updateDone.set(true);
+                    return null;
+                });
+
+                read.shutdown();
+                write.shutdown();
+                assertThat(read.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+                assertThat(write.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            }
+            assertThat(foundEmpty)
+                .describedAs("Subscription must always be reachable by at least one client certificate during update")
+                .isFalse();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -266,8 +266,7 @@ class SubscriptionCacheServiceTest {
             // getById returns the updated subscription
             assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(updated);
 
-            // Old cert still present in cache (stale entry, but harmless — real lookup uses trust store)
-            assertThat(subscriptionService.getByClientCertificate(subscription)).isPresent();
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isEmpty();
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionCertificate.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionCertificate.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.security.core;
+
+import io.gravitee.common.security.CertificateUtils;
+import io.gravitee.gateway.api.service.Subscription;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * <p>A record that encapsulates information about a subscription certificate,
+ * including the associated subscription, certificate, and certificate fingerprint.</p>
+ *
+ * <p>This record ensures that all fields are non-null through its constructor validation
+ * and provides additional methods for equality and hashing based on the subscription ID
+ * and fingerprint.</p>
+ *
+ * <p>The SubscriptionCertificate is typically used to bind a subscription to its corresponding
+ * security certificate along with a unique fingerprint representation of the certificate.</p>
+ *
+ * <h3>Components:</h3>
+ * <ul>
+ * <li><code>subscription</code>: The subscription associated with the certificate.</li>
+ * <li><code>certificate</code>: The security certificate associated with the subscription.</li>
+ * <li><code>fingerprint</code>: A unique hash representation (fingerprint) of the certificate.</li>
+ * </ul>
+ *
+ * <h3>Additional Constructor:</h3>
+ * <p>Includes a secondary constructor that generates a SHA-256 fingerprint automatically
+ * from the given certificate using the {@code CertificateUtils.generateThumbprint} method.</p>
+ *
+ * <h3>Overrides:</h3>
+ * <ul>
+ * <li><code>hashCode</code>: Computes a hash code based on the subscription ID and fingerprint.</li>
+ * <li><code>equals</code>: Provides equality comparison based on the subscription ID and fingerprint.</li>
+ * <li><code>toString</code>: Provides a string representation including the subscription ID and fingerprint.</li>
+ * </ul>
+ *
+ * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record SubscriptionCertificate(Subscription subscription, Certificate certificate, String fingerprint) {
+    /**
+     * Constructs a {@code SubscriptionCertificate} record instance with the specified
+     * subscription, certificate, and fingerprint. Ensures that none of the input parameters are null.
+     *
+     * @param subscription The subscription associated with the certificate. Must not be null.
+     * @param certificate  The security certificate associated with the subscription. Must not be null.
+     * @param fingerprint  A unique hash representation (fingerprint) of the certificate. Must not be null.
+     * @throws NullPointerException if any of the provided parameters are null.
+     */
+    public SubscriptionCertificate {
+        Objects.requireNonNull(subscription, "Subscription must not be null");
+        Objects.requireNonNull(certificate, "Certificate must not be null");
+        Objects.requireNonNull(fingerprint, "Fingerprint must not be null");
+    }
+
+    /**
+     * Constructs a {@code SubscriptionCertificate} record instance using the specified
+     * subscription and certificate. Automatically generates the certificate fingerprint
+     * using the SHA-256 algorithm.
+     *
+     * @param subscription The subscription associated with the certificate. Must not be null.
+     * @param certificate  The security certificate associated with the subscription. Must not be null.
+     * @throws NullPointerException if the subscription or certificate is null.
+     */
+    public SubscriptionCertificate(Subscription subscription, Certificate certificate) {
+        this(subscription, certificate, CertificateUtils.generateThumbprint((X509Certificate) certificate, "SHA-256"));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subscription.getId(), fingerprint);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        SubscriptionCertificate that = (SubscriptionCertificate) obj;
+        return Objects.equals(subscription.getId(), that.subscription.getId()) && Objects.equals(fingerprint, that.fingerprint);
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return "SubscriptionCertificate{" + "subscription=" + subscription.getId() + ", fingerprint='" + fingerprint + '\'' + '}';
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionCertificate.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionCertificate.java
@@ -26,30 +26,7 @@ import org.jspecify.annotations.NonNull;
  * <p>A record that encapsulates information about a subscription certificate,
  * including the associated subscription, certificate, and certificate fingerprint.</p>
  *
- * <p>This record ensures that all fields are non-null through its constructor validation
- * and provides additional methods for equality and hashing based on the subscription ID
- * and fingerprint.</p>
- *
- * <p>The SubscriptionCertificate is typically used to bind a subscription to its corresponding
- * security certificate along with a unique fingerprint representation of the certificate.</p>
- *
- * <h3>Components:</h3>
- * <ul>
- * <li><code>subscription</code>: The subscription associated with the certificate.</li>
- * <li><code>certificate</code>: The security certificate associated with the subscription.</li>
- * <li><code>fingerprint</code>: A unique hash representation (fingerprint) of the certificate.</li>
- * </ul>
- *
- * <h3>Additional Constructor:</h3>
- * <p>Includes a secondary constructor that generates a SHA-256 fingerprint automatically
- * from the given certificate using the {@code CertificateUtils.generateThumbprint} method.</p>
- *
- * <h3>Overrides:</h3>
- * <ul>
- * <li><code>hashCode</code>: Computes a hash code based on the subscription ID and fingerprint.</li>
- * <li><code>equals</code>: Provides equality comparison based on the subscription ID and fingerprint.</li>
- * <li><code>toString</code>: Provides a string representation including the subscription ID and fingerprint.</li>
- * </ul>
+ * <code>hashCode() toString() equals()</code> use subscription ID and fingerprint only to avoid performing equal on the certificate.
  *
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
  * @author GraviteeSource Team

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.security.core;
 
-import io.gravitee.common.security.CertificateUtils;
 import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.gateway.api.service.Subscription;
@@ -24,18 +23,17 @@ import io.gravitee.node.api.certificate.AbstractStoreLoaderOptions;
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import io.gravitee.node.certificates.AbstractKeyStoreLoader;
 import java.security.KeyStore;
-import java.security.MessageDigest;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
+import java.security.cert.Certificate;
 import java.util.Base64;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.bouncycastle.util.encoders.Hex;
-import org.springframework.util.DigestUtils;
 
 @CustomLog
 public class SubscriptionTrustStoreLoader extends AbstractKeyStoreLoader<SubscriptionTrustStoreLoader.SubscriptionTrustStoreLoaderOption> {
@@ -43,33 +41,34 @@ public class SubscriptionTrustStoreLoader extends AbstractKeyStoreLoader<Subscri
     private final String id;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private final KeyStore keystore;
-    private final List<String> digests;
 
-    public SubscriptionTrustStoreLoader(Subscription subscription) throws MalformedCertificateException {
+    public SubscriptionTrustStoreLoader(SubscriptionCertificate subscriptionCertificate) throws MalformedCertificateException {
         super(SubscriptionTrustStoreLoaderOption.empty());
-        this.id = "subscription_cert_%s".formatted(subscription.getId());
-        digests = new ArrayList<>();
+        try {
+            // using hex for fingerprint, as uppercase letters found in base64 are lower cased in KeyStore aliases, cause unregistering issues
+            this.id = formatLoaderId(subscriptionCertificate);
+            keystore = KeyStore.getInstance("PKCS12");
+            keystore.load(null, getPassword().toCharArray());
+            keystore.setCertificateEntry("cert", subscriptionCertificate.certificate());
+        } catch (Exception e) {
+            throw new MalformedCertificateException("An error occurred while processing certificate for loader %s".formatted(this.id()), e);
+        }
+    }
+
+    public static Set<SubscriptionCertificate> readSubscriptionCertificate(Subscription subscription) throws MalformedCertificateException {
         try {
             final byte[] decodedData = Base64.getDecoder().decode(subscription.getClientCertificate());
-            List<String> aliases = new ArrayList<>();
-            keystore = PKCS7Utils.pkcs7ToTruststore(
-                decodedData,
-                getPassword(),
-                i -> {
-                    String alias = "%s_%d".formatted(subscription.getId(), i);
-                    aliases.add(alias);
-                    return alias;
-                },
-                false
-            ).orElseGet(() -> {
-                aliases.add(subscription.getId());
-                return KeyStoreUtils.initFromPemCertificate(new String(decodedData), getPassword(), subscription.getId());
-            });
+            var keystore = PKCS7Utils.pkcs7ToTruststore(decodedData, null, i -> "pkcs7-" + i, false).orElseGet(() ->
+                KeyStoreUtils.initFromPemCertificate(new String(decodedData), null, "solo")
+            );
 
+            Set<SubscriptionCertificate> subscriptionCertificates = new HashSet<>();
             // compute digests from all certificates to be able to find them later
-            for (String alias : aliases) {
-                digests.add(CertificateUtils.generateThumbprint((X509Certificate) keystore.getCertificate(alias), "SHA-256"));
+            for (String alias : Collections.list(keystore.aliases())) {
+                Certificate certificate = keystore.getCertificate(alias);
+                subscriptionCertificates.add(new SubscriptionCertificate(subscription, certificate));
             }
+            return subscriptionCertificates;
         } catch (Exception e) {
             throw new MalformedCertificateException(
                 "An error occurred while processing certificate for Subscription %s".formatted(subscription.getId()),
@@ -96,8 +95,14 @@ public class SubscriptionTrustStoreLoader extends AbstractKeyStoreLoader<Subscri
         // nothing to do
     }
 
-    public List<String> certificateDigests() {
-        return digests;
+    public static String formatLoaderId(SubscriptionCertificate subscriptionCertificate) {
+        // Base64 => hex (lowercase) and id in lower (just in case)
+        // keystore aliases are made lowercase...
+        // need to be compliant with it to avoid issue when removing the loader
+        return "sub_%s_cert_%s".formatted(
+            subscriptionCertificate.subscription().getId().toLowerCase(),
+            Hex.toHexString(Base64.getMimeDecoder().decode(subscriptionCertificate.fingerprint()))
+        );
     }
 
     @Getter

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.security.core;
 
+import com.nimbusds.jose.util.Base64URL;
 import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.gateway.api.service.Subscription;
@@ -99,9 +100,10 @@ public class SubscriptionTrustStoreLoader extends AbstractKeyStoreLoader<Subscri
         // Base64 => hex (lowercase) and id in lower (just in case)
         // keystore aliases are made lowercase...
         // need to be compliant with it to avoid issue when removing the loader
+
         return "sub_%s_cert_%s".formatted(
             subscriptionCertificate.subscription().getId().toLowerCase(),
-            Hex.toHexString(Base64.getMimeDecoder().decode(subscriptionCertificate.fingerprint()))
+            Hex.toHexString(Base64URL.from(subscriptionCertificate.fingerprint()).decode())
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -82,13 +82,11 @@ public class SubscriptionTrustStoreLoaderManager {
                 return currentState;
             }
 
-            // remove what is no longer needed
             toRemove.forEach(this::unregisterSubscriptionTrustStoreLoader);
 
-            // update the subscription that may have changed
             toUpdate.forEach(s -> subscriptions.put(new CacheKey(s), subscription));
 
-            // update
+            // update the entry with what was removed and added
             var state = new HashSet<>(currentState);
             state.addAll(toAdd);
             state.removeAll(toRemove);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -55,41 +55,44 @@ public class SubscriptionTrustStoreLoaderManager {
      */
     public void registerSubscription(Subscription subscription, Set<String> deployOnServers) {
         certificates.computeIfPresent(subscription.getId(), (id, currentState) -> {
-            try {
-                Set<SubscriptionCertificate> newState = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
-                // compute diff to minimize disruption: add new certificates before removing old ones to avoid traffic cuts
-                Set<SubscriptionCertificate> toAdd = newState
-                    .stream()
-                    .filter(newCert -> !currentState.contains(newCert))
-                    .collect(Collectors.toSet());
-                Set<SubscriptionCertificate> toRemove = currentState
-                    .stream()
-                    .filter(existing -> !newState.contains(existing))
-                    .collect(Collectors.toSet());
-                Set<SubscriptionCertificate> toUpdate = currentState.stream().filter(newState::contains).collect(Collectors.toSet());
+            Set<SubscriptionCertificate> newState = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+            // compute diff to minimize disruption: add new certificates before removing old ones to avoid traffic cuts
+            Set<SubscriptionCertificate> toAdd = newState
+                .stream()
+                .filter(newCert -> !currentState.contains(newCert))
+                .collect(Collectors.toSet());
+            Set<SubscriptionCertificate> toRemove = currentState
+                .stream()
+                .filter(existing -> !newState.contains(existing))
+                .collect(Collectors.toSet());
+            Set<SubscriptionCertificate> toUpdate = currentState.stream().filter(newState::contains).collect(Collectors.toSet());
 
+            try {
                 // manage truststore loaders
                 // register what is new first to avoid traffic cuts
                 for (SubscriptionCertificate s : toAdd) {
                     registerSubscriptionTrustStoreLoader(s, deployOnServers);
                 }
-
-                // remove what is no longer needed
-                toRemove.forEach(this::unregisterSubscriptionTrustStoreLoader);
-
-                // update the subscription that may have changed
-                toUpdate.forEach(s -> subscriptions.put(new CacheKey(s), subscription));
-
-                // update
-                var state = new HashSet<>(currentState);
-                state.addAll(toAdd);
-                state.removeAll(toRemove);
-                return state;
             } catch (MalformedCertificateException e) {
-                log.error(e.getMessage(), e.getCause());
+                log.error("Error while registering certificates", e);
+                for (SubscriptionCertificate s : toAdd) {
+                    unregisterSubscriptionTrustStoreLoader(s);
+                }
                 // keep the current state if anything goes wrong
                 return currentState;
             }
+
+            // remove what is no longer needed
+            toRemove.forEach(this::unregisterSubscriptionTrustStoreLoader);
+
+            // update the subscription that may have changed
+            toUpdate.forEach(s -> subscriptions.put(new CacheKey(s), subscription));
+
+            // update
+            var state = new HashSet<>(currentState);
+            state.addAll(toAdd);
+            state.removeAll(toRemove);
+            return state;
         });
         certificates.computeIfAbsent(subscription.getId(), id -> {
             try {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -75,10 +75,10 @@ public class SubscriptionTrustStoreLoaderManager {
                 toUpdate.forEach(s -> subscriptions.put(new CacheKey(s), subscription));
 
                 // update
-                var copy = new HashSet<>(currentState);
-                copy.addAll(toAdd);
-                copy.removeAll(toRemove);
-                return copy;
+                var state = new HashSet<>(currentState);
+                state.addAll(toAdd);
+                state.removeAll(toRemove);
+                return state;
             } catch (MalformedCertificateException e) {
                 log.error(e.getMessage(), e.getCause());
                 // keep the current state if anything goes wrong
@@ -88,9 +88,7 @@ public class SubscriptionTrustStoreLoaderManager {
         certificates.computeIfAbsent(subscription.getId(), id -> {
             try {
                 Set<SubscriptionCertificate> newState = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
-                for (SubscriptionCertificate s : newState) {
-                    registerSubscriptionTrustStoreLoader(s, deployOnServers);
-                }
+                newState.forEach(s -> registerSubscriptionTrustStoreLoader(s, deployOnServers));
                 return newState;
             } catch (MalformedCertificateException e) {
                 log.error(e.getMessage(), e.getCause());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -15,15 +15,20 @@
  */
 package io.gravitee.gateway.security.core;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.security.core.exception.MalformedCertificateException;
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import io.gravitee.node.api.server.ServerManager;
 import io.gravitee.node.vertx.server.VertxServer;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 
 /**
@@ -33,8 +38,9 @@ import lombok.CustomLog;
 @CustomLog
 public class SubscriptionTrustStoreLoaderManager {
 
-    private final Map<String, SubscriptionTrustStoreLoader> subscriptionTrustStoreLoaders = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> subscriptionsByApi = new ConcurrentHashMap<>();
+    private final Map<String, Set<SubscriptionCertificate>> certificates = new ConcurrentHashMap<>();
+    private final Map<CacheKey, Subscription> subscriptions = new ConcurrentHashMap<>();
+    private final Multimap<CacheKey, SubscriptionTrustStoreLoader> truststoreLoaders = MultimapBuilder.hashKeys().hashSetValues().build();
     private final ServerManager serverManager;
 
     public SubscriptionTrustStoreLoaderManager(ServerManager serverManager) {
@@ -42,54 +48,115 @@ public class SubscriptionTrustStoreLoaderManager {
     }
 
     public void registerSubscription(Subscription subscription, Set<String> deployOnServers) {
-        final SubscriptionTrustStoreLoader loader;
-        try {
-            loader = new SubscriptionTrustStoreLoader(subscription);
-        } catch (MalformedCertificateException e) {
-            log.error(e.getMessage(), e.getCause());
-            return;
-        }
-        if (subscriptionTrustStoreLoaders.containsKey(subscription.getId())) {
-            log.debug("A TrustStoreLoader for subscription {} is already registered", subscription.getId());
-            return;
-        }
-        log.debug("Registering TrustStoreLoader for subscription {}", subscription.getId());
+        certificates.computeIfPresent(subscription.getId(), (id, currentState) -> {
+            try {
+                Set<SubscriptionCertificate> newState = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+                // compute diff to minimize disruption: add new certificates before removing old ones to avoid traffic cuts
+                Set<SubscriptionCertificate> toAdd = newState
+                    .stream()
+                    .filter(newCert -> !currentState.contains(newCert))
+                    .collect(Collectors.toSet());
+                Set<SubscriptionCertificate> toRemove = currentState
+                    .stream()
+                    .filter(existing -> !newState.contains(existing))
+                    .collect(Collectors.toSet());
+                Set<SubscriptionCertificate> toUpdate = currentState.stream().filter(newState::contains).collect(Collectors.toSet());
+
+                // manage truststore loaders
+                // register what is new first to avoid traffic cuts
+                for (SubscriptionCertificate s : toAdd) {
+                    registerSubscriptionTrustStoreLoader(s, deployOnServers);
+                }
+
+                // remove what is no longer needed
+                toRemove.forEach(this::unregisterSubscriptionTrustStoreLoader);
+
+                // update the subscription that may have changed
+                toUpdate.forEach(s -> subscriptions.put(new CacheKey(s), subscription));
+
+                // update
+                var copy = new HashSet<>(currentState);
+                copy.addAll(toAdd);
+                copy.removeAll(toRemove);
+                return copy;
+            } catch (MalformedCertificateException e) {
+                log.error(e.getMessage(), e.getCause());
+                // keep the current state if anything goes wrong
+                return currentState;
+            }
+        });
+        certificates.computeIfAbsent(subscription.getId(), id -> {
+            try {
+                Set<SubscriptionCertificate> newState = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+                for (SubscriptionCertificate s : newState) {
+                    registerSubscriptionTrustStoreLoader(s, deployOnServers);
+                }
+                return newState;
+            } catch (MalformedCertificateException e) {
+                log.error(e.getMessage(), e.getCause());
+                return null;
+            }
+        });
+    }
+
+    public void unregisterSubscription(Subscription subscription) {
+        certificates.computeIfPresent(subscription.getId(), (id, currentState) -> {
+            currentState.forEach(this::unregisterSubscriptionTrustStoreLoader);
+            return null;
+        });
+    }
+
+    public Optional<Subscription> getByCertificate(String api, String plan, String certificateFingerprint) {
+        return Optional.ofNullable(subscriptions.get(new CacheKey(api, plan, certificateFingerprint)));
+    }
+
+    private void registerSubscriptionTrustStoreLoader(SubscriptionCertificate subscriptionCertificate, Set<String> deployOnServers) {
         serverManager
             .servers()
             .stream()
             .filter(server -> deployOnServers.isEmpty() || deployOnServers.contains(server.id()))
             .map(s -> (VertxServer<?, ?>) s)
-            .forEach(server -> server.trustStoreLoaderManager().registerLoader(loader));
-        subscriptionTrustStoreLoaders.putIfAbsent(subscription.getId(), loader);
-        loader
-            .certificateDigests()
-            .forEach(digest ->
-                subscriptionsByApi.put(
-                    buildCacheKeyFromCertificateDigest(subscription.getApi(), digest, subscription.getPlan()),
-                    subscription
-                )
-            );
-    }
-
-    public void unregisterSubscription(Subscription subscription) {
-        final SubscriptionTrustStoreLoader loader = subscriptionTrustStoreLoaders.remove(subscription.getId());
-        if (loader != null) {
-            loader
-                .certificateDigests()
-                .forEach(digest ->
-                    subscriptionsByApi.remove(buildCacheKeyFromCertificateDigest(subscription.getApi(), digest, subscription.getPlan()))
+            .forEach(server -> {
+                SubscriptionTrustStoreLoader loader = new SubscriptionTrustStoreLoader(subscriptionCertificate);
+                log.debug(
+                    "Registering TrustStoreLoader for subscription {} and certificate {} for server {}",
+                    subscriptionCertificate.subscription().getId(),
+                    subscriptionCertificate.fingerprint(),
+                    server.id()
                 );
-            log.debug("Stopping TrustStoreLoader for subscription {}", subscription.getId());
-            loader.stop();
-            loader.onEvent(new KeyStoreEvent.UnloadEvent(loader.id()));
+                server.trustStoreLoaderManager().registerLoader(loader);
+                truststoreLoaders.put(new CacheKey(subscriptionCertificate), loader);
+            });
+        subscriptions.put(new CacheKey(subscriptionCertificate), subscriptionCertificate.subscription());
+    }
+
+    private void unregisterSubscriptionTrustStoreLoader(SubscriptionCertificate subscriptionCertificate) {
+        log.debug(
+            "Stopping TrustStoreLoader for subscription {} and certificate {}",
+            subscriptionCertificate.subscription().getId(),
+            subscriptionCertificate.fingerprint()
+        );
+        truststoreLoaders
+            .removeAll(new CacheKey(subscriptionCertificate))
+            .forEach(loader -> {
+                loader.onEvent(new KeyStoreEvent.UnloadEvent(loader.id()));
+                loader.stop();
+            });
+        subscriptions.remove(new CacheKey(subscriptionCertificate));
+    }
+
+    record CacheKey(String api, String plan, String fingerPrint) {
+        public CacheKey {
+            Objects.requireNonNull(api, "API must not be null");
+            Objects.requireNonNull(fingerPrint, "Certificate fingerprint must not be null");
         }
-    }
 
-    public Optional<Subscription> getByCertificate(String api, String certificateDigest, String plan) {
-        return Optional.ofNullable(subscriptionsByApi.get(buildCacheKeyFromCertificateDigest(api, certificateDigest, plan)));
-    }
-
-    String buildCacheKeyFromCertificateDigest(String api, String certificateDigest, String plan) {
-        return String.format("%s.%s.%s", api, certificateDigest, plan);
+        public CacheKey(SubscriptionCertificate subscriptionCertificate) {
+            this(
+                subscriptionCertificate.subscription().getApi(),
+                subscriptionCertificate.subscription().getPlan(),
+                subscriptionCertificate.fingerprint()
+            );
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.security.core.exception.MalformedCertificateException
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import io.gravitee.node.api.server.ServerManager;
 import io.gravitee.node.vertx.server.VertxServer;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -38,7 +39,7 @@ import lombok.CustomLog;
 @CustomLog
 public class SubscriptionTrustStoreLoaderManager {
 
-    private final Map<String, Set<SubscriptionCertificate>> certificates = new ConcurrentHashMap<>();
+    private final Map<String, Set<SubscriptionCertificate>> certificates = new HashMap<>();
     private final Map<CacheKey, Subscription> subscriptions = new ConcurrentHashMap<>();
     private final Multimap<CacheKey, SubscriptionTrustStoreLoader> truststoreLoaders = MultimapBuilder.hashKeys().hashSetValues().build();
     private final ServerManager serverManager;
@@ -47,6 +48,11 @@ public class SubscriptionTrustStoreLoaderManager {
         this.serverManager = serverManager;
     }
 
+    /**
+     * Register a new subscription. This is called sequentially for each subscription, so no need for concurrent maps here
+     * @param subscription the subscription to register
+     * @param deployOnServers the servers on which the subscription is deployed
+     */
     public void registerSubscription(Subscription subscription, Set<String> deployOnServers) {
         certificates.computeIfPresent(subscription.getId(), (id, currentState) -> {
             try {
@@ -97,6 +103,10 @@ public class SubscriptionTrustStoreLoaderManager {
         });
     }
 
+    /**
+     * Unregister a subscription. This is called sequentially for each subscription, so no need for concurrent maps here
+     * @param subscription the subscription to unregister
+     */
     public void unregisterSubscription(Subscription subscription) {
         certificates.computeIfPresent(subscription.getId(), (id, currentState) -> {
             currentState.forEach(this::unregisterSubscriptionTrustStoreLoader);
@@ -104,6 +114,14 @@ public class SubscriptionTrustStoreLoaderManager {
         });
     }
 
+    /**
+     * Retrieves a {@link Subscription} based on the provided API, plan, and certificate fingerprint. It is in the critical path of the Gateway, hence the concurrent map is used to ensure fast and secure lookups.
+     *
+     * @param api the identifier of the API for which the subscription is associated; must not be null.
+     * @param plan the identifier of the plan associated with the subscription; must not be null.
+     * @param certificateFingerprint the fingerprint of the certificate used to uniquely identify the subscription; must not be null.
+     * @return an {@link Optional} containing the matching {@link Subscription} if found, or an empty {@link Optional} if no matching subscription exists.
+     */
     public Optional<Subscription> getByCertificate(String api, String plan, String certificateFingerprint) {
         return Optional.ofNullable(subscriptions.get(new CacheKey(api, plan, certificateFingerprint)));
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/exception/MalformedCertificateException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/exception/MalformedCertificateException.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.gateway.security.core.exception;
 
-public class MalformedCertificateException extends Exception {
+public class MalformedCertificateException extends RuntimeException {
 
     public MalformedCertificateException(String message, Throwable cause) {
         super(message, cause);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
@@ -16,36 +16,31 @@
 package io.gravitee.gateway.security.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.gateway.api.service.Subscription;
-import io.gravitee.node.api.certificate.KeyStoreEvent;
+import io.gravitee.node.api.certificate.AbstractStoreLoaderOptions;
 import io.gravitee.node.api.server.DefaultServerManager;
+import io.gravitee.node.certificates.AbstractKeyStoreLoader;
+import io.gravitee.node.certificates.AbstractKeyStoreLoaderManager;
 import io.gravitee.node.certificates.TrustStoreLoaderManager;
 import io.gravitee.node.vertx.server.VertxServer;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -54,178 +49,6 @@ import org.slf4j.LoggerFactory;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 class SubscriptionTrustStoreLoaderManagerTest {
-
-    private SubscriptionTrustStoreLoaderManager cut;
-    private ListAppender<ILoggingEvent> listAppender;
-
-    @Mock
-    private TrustStoreLoaderManager trustStoreLoaderManager;
-
-    @Mock
-    private VertxServer server1;
-
-    @Mock
-    private VertxServer server2;
-
-    @Mock
-    private VertxServer server3;
-
-    private DefaultServerManager serverManager;
-
-    @BeforeEach
-    void setUp() {
-        // get Logback Logger
-        Logger logger = (Logger) LoggerFactory.getLogger(SubscriptionTrustStoreLoaderManager.class);
-
-        // create and start a ListAppender
-        listAppender = new ListAppender<>();
-        listAppender.start();
-
-        // add the appender to the logger
-        // addAppender is outdated now
-        logger.addAppender(listAppender);
-
-        serverManager = new DefaultServerManager();
-        lenient().when(server1.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager);
-        lenient().when(server1.id()).thenReturn("server1");
-        lenient().when(server2.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager);
-        lenient().when(server2.id()).thenReturn("server2");
-        lenient().when(server3.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager);
-        lenient().when(server3.id()).thenReturn("server3");
-
-        serverManager.register(server1);
-        serverManager.register(server2);
-        serverManager.register(server3);
-        cut = new SubscriptionTrustStoreLoaderManager(serverManager);
-    }
-
-    @Test
-    void should_register_subscription_on_all_servers() {
-        cut.registerSubscription(Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build(), Set.of());
-
-        final List<ILoggingEvent> logList = listAppender.list;
-        assertThat(logList)
-            .hasSize(1)
-            .element(0)
-            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
-            .containsExactly("Registering TrustStoreLoader for subscription subscriptionId", Level.DEBUG);
-
-        ArgumentCaptor<SubscriptionTrustStoreLoader> captor = ArgumentCaptor.forClass(SubscriptionTrustStoreLoader.class);
-        verify(trustStoreLoaderManager, times(serverManager.servers().size())).registerLoader(captor.capture());
-        // Verify there is only one loader instance shared accross servers
-        assertThat(new HashSet<>(captor.getAllValues()))
-            .hasSize(1)
-            .first()
-            .satisfies(loader -> assertThat(loader.id()).contains("subscriptionId"));
-    }
-
-    @Test
-    void should_register_subscription_on_selected_servers() {
-        cut.registerSubscription(
-            Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build(),
-            Set.of("server1", "server3")
-        );
-
-        final List<ILoggingEvent> logList = listAppender.list;
-        assertThat(logList)
-            .hasSize(1)
-            .element(0)
-            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
-            .containsExactly("Registering TrustStoreLoader for subscription subscriptionId", Level.DEBUG);
-
-        ArgumentCaptor<SubscriptionTrustStoreLoader> captor = ArgumentCaptor.forClass(SubscriptionTrustStoreLoader.class);
-        verify(server1).trustStoreLoaderManager();
-        verify(server2, never()).trustStoreLoaderManager();
-        verify(server3).trustStoreLoaderManager();
-        verify(trustStoreLoaderManager, times(2)).registerLoader(captor.capture());
-        // Verify there is only one loader instance shared accross servers
-        assertThat(new HashSet<>(captor.getAllValues()))
-            .hasSize(1)
-            .first()
-            .satisfies(loader -> assertThat(loader.id()).contains("subscriptionId"));
-    }
-
-    @Test
-    void should_not_register_already_registered_subscription() {
-        cut.registerSubscription(Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build(), Set.of());
-
-        final List<ILoggingEvent> logList = listAppender.list;
-        assertThat(logList)
-            .hasSize(1)
-            .element(0)
-            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
-            .containsExactly("Registering TrustStoreLoader for subscription subscriptionId", Level.DEBUG);
-
-        cut.registerSubscription(Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build(), Set.of());
-        assertThat(logList)
-            .hasSize(2)
-            .element(1)
-            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
-            .containsExactly("A TrustStoreLoader for subscription subscriptionId is already registered", Level.DEBUG);
-    }
-
-    @Test
-    void should_unregister_subscription() {
-        final Subscription subscription = Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build();
-        cut.registerSubscription(subscription, Set.of());
-
-        ArgumentCaptor<SubscriptionTrustStoreLoader> captor = ArgumentCaptor.forClass(SubscriptionTrustStoreLoader.class);
-        verify(trustStoreLoaderManager, times(serverManager.servers().size())).registerLoader(captor.capture());
-        final List<KeyStoreEvent> keyStoreEvents = new ArrayList<>();
-        captor.getAllValues().forEach(loader -> loader.setEventHandler(keyStoreEvents::add));
-
-        cut.unregisterSubscription(subscription);
-
-        final List<ILoggingEvent> logList = listAppender.list;
-        assertThat(logList)
-            .hasSize(2)
-            .element(1)
-            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
-            .containsExactly("Stopping TrustStoreLoader for subscription subscriptionId", Level.DEBUG);
-
-        assertThat(keyStoreEvents)
-            .hasSize(1)
-            .first()
-            .satisfies(event -> {
-                assertThat(event).isInstanceOf(KeyStoreEvent.UnloadEvent.class);
-                assertThat(event.loaderId()).contains("subscriptionId");
-            });
-    }
-
-    @Test
-    void should_not_unregister_absent_subscription() {
-        final Subscription subscription = Subscription.builder().id("subscriptionId").build();
-        cut.unregisterSubscription(subscription);
-
-        final List<ILoggingEvent> logList = listAppender.list;
-        assertThat(logList).isEmpty();
-    }
-
-    @Test
-    void should_get_a_subscription() {
-        final Subscription subscription = Subscription.builder()
-            .id("subscriptionId")
-            .api("api")
-            .plan("plan")
-            .clientCertificate(BASE_64_CERTIFICATE_1)
-            .build();
-        cut.registerSubscription(subscription, Set.of("server1", "server3"));
-        final Optional<Subscription> result = cut.getByCertificate("api", CERTIFICATE_DIGEST, "plan");
-        assertThat(result).contains(subscription);
-    }
-
-    @Test
-    void should_get_a_subscription_with_two_certs() {
-        final Subscription subscription = Subscription.builder()
-            .id("subscriptionId")
-            .api("api")
-            .plan("plan")
-            .clientCertificate(Base64.getEncoder().encodeToString(PKCS7Utils.createBundle(List.of(PEM_CERTIFICATE_1, PEM_CERTIFICATE_2))))
-            .build();
-        cut.registerSubscription(subscription, Set.of("server1", "server3"));
-        final Optional<Subscription> result = cut.getByCertificate("api", CERTIFICATE_DIGEST, "plan");
-        assertThat(result).contains(subscription);
-    }
 
     public static final String PEM_CERTIFICATE_1 = """
         -----BEGIN CERTIFICATE-----
@@ -287,6 +110,342 @@ class SubscriptionTrustStoreLoaderManagerTest {
         """;
 
     private static final String BASE_64_CERTIFICATE_1 = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_1.getBytes());
+    private static final String BASE_64_CERTIFICATE_2 = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_2.getBytes());
 
-    private static final String CERTIFICATE_DIGEST = "u21dNKud2YsKNJn3HQTTon1_qSoZi8IrBTsLiZCFQLg";
+    private static final String CERTIFICATE_1_DIGEST = "u21dNKud2YsKNJn3HQTTon1_qSoZi8IrBTsLiZCFQLg";
+    private static final String CERTIFICATE_1_DIGEST_HEX = "bb6d5d34ab9dd98b0a3499f71d04d3a27d6a4a8662f08ac14ec2e26421502e";
+    private static final String CERTIFICATE_2_DIGEST = "wS8z98uyY4COjon55dsZ4xl1NDh4Hf_mkr3p0mRLv6E";
+    private static final String CERTIFICATE_2_DIGEST_HEX = "c12f33f7cbb263808e8e89f9e5db19e319753438781df9a4af7a749912efe8";
+
+    TrustStoreLoaderManager trustStoreLoaderManager1 = new TrustStoreLoaderManager("server1", new NoOpKeyStoreLoader(new NoOpOptions()));
+    TrustStoreLoaderManager trustStoreLoaderManager2 = new TrustStoreLoaderManager("server2", new NoOpKeyStoreLoader(new NoOpOptions()));
+    TrustStoreLoaderManager trustStoreLoaderManager3 = new TrustStoreLoaderManager("server3", new NoOpKeyStoreLoader(new NoOpOptions()));
+
+    @Mock
+    VertxServer server1;
+
+    @Mock
+    VertxServer server2;
+
+    @Mock
+    VertxServer server3;
+
+    DefaultServerManager serverManager;
+
+    SubscriptionTrustStoreLoaderManager cut;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        serverManager = new DefaultServerManager();
+        lenient().when(server1.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager1);
+        lenient().when(server1.id()).thenReturn("server1");
+        lenient().when(server2.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager2);
+        lenient().when(server2.id()).thenReturn("server2");
+        lenient().when(server3.trustStoreLoaderManager()).thenReturn(trustStoreLoaderManager3);
+        lenient().when(server3.id()).thenReturn("server3");
+
+        trustStoreLoaderManager1.start();
+        trustStoreLoaderManager2.start();
+        trustStoreLoaderManager3.start();
+
+        serverManager.register(server1);
+        serverManager.register(server2);
+        serverManager.register(server3);
+
+        cut = new SubscriptionTrustStoreLoaderManager(serverManager);
+    }
+
+    @Test
+    void should_get_a_subscription_from_cache_without_plan() {
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .clientCertificate(BASE_64_CERTIFICATE_1)
+            .build();
+
+        cut.registerSubscription(subscription, Set.of());
+
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_1_DIGEST)).contains(subscription);
+
+        // unregister
+        cut.unregisterSubscription(subscription);
+
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_1_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_get_a_subscription_from_cache_without_plan_several_certs() {
+        final Subscription subscription = Subscription.builder().id("subscriptionId").api("api").clientCertificate(getPKCS7()).build();
+
+        cut.registerSubscription(subscription, Set.of());
+
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_1_DIGEST)).contains(subscription);
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_2_DIGEST)).contains(subscription);
+
+        // unregister
+        cut.unregisterSubscription(subscription);
+
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("api", null, CERTIFICATE_2_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_get_subscription_from_single_and_multiple_certs() {
+        final Subscription subscriptionCert1 = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(BASE_64_CERTIFICATE_1)
+            .build();
+
+        cut.registerSubscription(subscriptionCert1, Set.of());
+
+        assertAllServers(1);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).contains(subscriptionCert1);
+
+        final Subscription updatedCert1And2 = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(getPKCS7())
+            .build();
+        cut.registerSubscription(updatedCert1And2, Set.of());
+
+        assertAllServers(2);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).contains(updatedCert1And2);
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_2_DIGEST)).contains(updatedCert1And2);
+
+        final Subscription updatedCert2 = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(BASE_64_CERTIFICATE_2)
+            .build();
+        cut.registerSubscription(updatedCert2, Set.of());
+
+        assertAllServers(1);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_2_DIGEST)).contains(updatedCert2);
+
+        // unregister
+        cut.unregisterSubscription(updatedCert2);
+
+        assertAllServers(0);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_2_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_register_subscription_on_all_servers() {
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(BASE_64_CERTIFICATE_1)
+            .build();
+        cut.registerSubscription(subscription, Set.of());
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).contains(subscription);
+
+        assertAllServers(1);
+
+        // unregister
+        cut.unregisterSubscription(subscription);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).isEmpty();
+
+        assertAllServers(0);
+    }
+
+    @Test
+    void should_register_subscription_on_selected_servers() {
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(BASE_64_CERTIFICATE_1)
+            .build();
+        cut.registerSubscription(subscription, Set.of("server1", "server3"));
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).contains(subscription);
+
+        assertThat(truststoreAliases(trustStoreLoaderManager1)).hasSize(1);
+        assertThat(truststoreAliases(trustStoreLoaderManager2)).isEmpty();
+        assertThat(truststoreAliases(trustStoreLoaderManager3)).hasSize(1);
+
+        // unregister
+        cut.unregisterSubscription(subscription);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).isEmpty();
+
+        assertThat(truststoreAliases(trustStoreLoaderManager1)).isEmpty();
+        assertThat(truststoreAliases(trustStoreLoaderManager3)).isEmpty();
+    }
+
+    @Test
+    void should_not_register_already_registered_subscription() {
+        cut.registerSubscription(
+            Subscription.builder().id("subscriptionId").api("apiId").clientCertificate(BASE_64_CERTIFICATE_1).build(),
+            Set.of()
+        );
+        assertAllServers(1);
+
+        cut.registerSubscription(Subscription.builder().id("subscriptionId").clientCertificate(BASE_64_CERTIFICATE_1).build(), Set.of());
+        assertAllServers(1);
+    }
+
+    @Test
+    void should_register_subscription_with_multiple_certs_on_all_servers() {
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .api("api")
+            .plan("plan")
+            .clientCertificate(getPKCS7())
+            .build();
+        cut.registerSubscription(subscription, Set.of());
+        final Optional<Subscription> result1 = cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST);
+        assertThat(result1).contains(subscription);
+        final Optional<Subscription> result2 = cut.getByCertificate("api", "plan", CERTIFICATE_2_DIGEST);
+        assertThat(result2).contains(subscription);
+        assertThat(result1).get().isEqualTo(result2.get());
+
+        assertAllServers(2);
+
+        // unregister
+        cut.unregisterSubscription(subscription);
+
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("api", "plan", CERTIFICATE_2_DIGEST)).isEmpty();
+
+        assertAllServers(0);
+    }
+
+    @Test
+    void should_unregister_subscription_with_multiple_certs() {
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .plan("planId")
+            .api("apiId")
+            .clientCertificate(getPKCS7())
+            .build();
+        cut.registerSubscription(subscription, Set.of());
+
+        assertAllServers(2);
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isPresent();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isPresent();
+
+        cut.unregisterSubscription(subscription);
+
+        assertAllServers(0);
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_register_subscription_with_multiple_certs_and_remove_one() {
+        cut.registerSubscription(
+            Subscription.builder().id("subscriptionId").api("apiId").plan("planId").clientCertificate(getPKCS7()).build(),
+            Set.of()
+        );
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isPresent();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isPresent();
+
+        assertAllServers(2);
+        // cert 2 is no longer there... no new registration
+        cut.registerSubscription(
+            Subscription.builder().id("subscriptionId").api("apiId").plan("planId").clientCertificate(BASE_64_CERTIFICATE_1).build(),
+            Set.of()
+        );
+
+        assertAllServers(1);
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isPresent();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_register_subscription_one_certs_replace_it() {
+        cut.registerSubscription(
+            Subscription.builder().id("subscriptionId").api("apiId").plan("planId").clientCertificate(BASE_64_CERTIFICATE_1).build(),
+            Set.of()
+        );
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isPresent();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isEmpty();
+
+        assertAllServers(1);
+        assertThat(truststoreAliases(trustStoreLoaderManager1)).first().asInstanceOf(STRING).contains(CERTIFICATE_1_DIGEST_HEX);
+
+        // Verify there is only one loader instance shared across servers
+        cut.registerSubscription(
+            Subscription.builder().id("subscriptionId").api("apiId").plan("planId").clientCertificate(BASE_64_CERTIFICATE_2).build(),
+            Set.of()
+        );
+
+        assertThat(truststoreAliases(trustStoreLoaderManager1)).first().asInstanceOf(STRING).contains(CERTIFICATE_2_DIGEST_HEX);
+
+        assertAllServers(1);
+
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isPresent();
+    }
+
+    private void assertAllServers(int expected) {
+        assertThat(truststoreAliases(trustStoreLoaderManager1)).hasSize(expected);
+        assertThat(truststoreAliases(trustStoreLoaderManager2)).hasSize(expected);
+        assertThat(truststoreAliases(trustStoreLoaderManager3)).hasSize(expected);
+    }
+
+    private static String getPKCS7() {
+        return Base64.getEncoder().encodeToString(PKCS7Utils.createBundle(List.of(PEM_CERTIFICATE_1, PEM_CERTIFICATE_2)));
+    }
+
+    List<String> truststoreAliases(TrustStoreLoaderManager trustStoreLoaderManager) {
+        try {
+            var method = AbstractKeyStoreLoaderManager.class.getDeclaredMethod("aliases");
+            method.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            List<String> aliases = (List<String>) method.invoke(trustStoreLoaderManager);
+            return aliases;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access aliases method", e);
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    @ToString
+    static class NoOpOptions extends AbstractStoreLoaderOptions {
+
+        protected NoOpOptions() {
+            super(NoOpOptions.builder());
+        }
+    }
+
+    static class NoOpKeyStoreLoader extends AbstractKeyStoreLoader<NoOpOptions> {
+
+        protected NoOpKeyStoreLoader(NoOpOptions o) {
+            super(o);
+        }
+
+        @Override
+        public void start() {
+            // no op
+        }
+
+        @Override
+        public void stop() {
+            // no op
+        }
+
+        @Override
+        public String id() {
+            return "test";
+        }
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
@@ -113,9 +113,9 @@ class SubscriptionTrustStoreLoaderManagerTest {
     private static final String BASE_64_CERTIFICATE_2 = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_2.getBytes());
 
     private static final String CERTIFICATE_1_DIGEST = "u21dNKud2YsKNJn3HQTTon1_qSoZi8IrBTsLiZCFQLg";
-    private static final String CERTIFICATE_1_DIGEST_HEX = "bb6d5d34ab9dd98b0a3499f71d04d3a27d6a4a8662f08ac14ec2e26421502e";
+    private static final String CERTIFICATE_1_DIGEST_HEX = "bb6d5d34ab9dd98b0a3499f71d04d3a27d7fa92a198bc22b053b0b89908540b8";
     private static final String CERTIFICATE_2_DIGEST = "wS8z98uyY4COjon55dsZ4xl1NDh4Hf_mkr3p0mRLv6E";
-    private static final String CERTIFICATE_2_DIGEST_HEX = "c12f33f7cbb263808e8e89f9e5db19e319753438781df9a4af7a749912efe8";
+    private static final String CERTIFICATE_2_DIGEST_HEX = "c12f33f7cbb263808e8e89f9e5db19e319753438781dffe692bde9d2644bbfa1";
 
     TrustStoreLoaderManager trustStoreLoaderManager1 = new TrustStoreLoaderManager("server1", new NoOpKeyStoreLoader(new NoOpOptions()));
     TrustStoreLoaderManager trustStoreLoaderManager2 = new TrustStoreLoaderManager("server2", new NoOpKeyStoreLoader(new NoOpOptions()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApplicationMapper.java
@@ -16,8 +16,10 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDSpec;
+import io.gravitee.rest.api.management.v2.rest.model.ApplicationCRDSettings;
 import io.gravitee.rest.api.management.v2.rest.model.BaseApplication;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import java.util.Collection;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -38,4 +40,7 @@ public interface ApplicationMapper {
     @Mapping(target = "picture", source = "pictureUrl")
     @Mapping(target = "disableMembershipNotifications", expression = "java(!spec.isNotifyMembers())")
     ApplicationCRDSpec map(io.gravitee.rest.api.management.v2.rest.model.ApplicationCRDSpec spec);
+
+    @Mapping(source = "content", target = "certificate")
+    CreateClientCertificate map(ApplicationCRDSettings.ClientCertificateCRD crd);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApplicationCRDSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApplicationCRDSettings.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.model;
 
+import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -38,7 +39,21 @@ public class ApplicationCRDSettings {
     @NoArgsConstructor
     public static class TLSSettings {
 
+        @Deprecated
         private String clientCertificate;
+
+        private List<ClientCertificateCRD> clientCertificates;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ClientCertificateCRD {
+
+        private String name;
+        private String content;
+        private Date startsAt;
+        private Date endsAt;
     }
 
     @Data

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationClientCertificatesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationClientCertificatesResource.java
@@ -110,7 +110,7 @@ public class ApplicationClientCertificatesResource extends AbstractResource {
                 new CreateClientCertificateUseCase.Input(application, ClientCertificateMapper.INSTANCE.toDomain(createClientCertificate))
             )
             .clientCertificate();
-        return Response.created(this.getLocationHeader(created.getId())).entity(ClientCertificateMapper.INSTANCE.toDto(created)).build();
+        return Response.created(this.getLocationHeader(created.id())).entity(ClientCertificateMapper.INSTANCE.toDto(created)).build();
     }
 
     @Path("{certId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -84,6 +85,9 @@ public class ApplicationResource extends AbstractResource {
     @Inject
     private ApplicationTypeService applicationTypeService;
 
+    @Inject
+    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+
     @PathParam("application")
     @Parameter(name = "application", required = true)
     private String application;
@@ -146,7 +150,11 @@ public class ApplicationResource extends AbstractResource {
             throw new BadRequestException("Invalid image format : " + e.getMessage());
         }
 
-        return applicationService.update(GraviteeContext.getExecutionContext(), application, updatedApplication);
+        var result = applicationService.update(GraviteeContext.getExecutionContext(), application, updatedApplication);
+        if (updatedApplication.getSettings() != null && updatedApplication.getSettings().getTls() != null) {
+            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(application);
+        }
+        return result;
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.ApplicationStatus;
@@ -64,6 +65,9 @@ public class ApplicationsResource extends AbstractResource {
 
     @Inject
     private ApplicationService applicationService;
+
+    @Inject
+    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
 
     /**
      * @deprecated must be replaced by /applications/_paged in future major release
@@ -234,6 +238,9 @@ public class ApplicationsResource extends AbstractResource {
             getAuthenticatedUser()
         );
         if (newApplication != null) {
+            if (newApplication.getSettings() != null && newApplication.getSettings().getTls() != null) {
+                applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
+            }
             return Response.created(this.getLocationHeader(newApplication.getId())).entity(newApplication).build();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/TlsSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/TlsSettings.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model.application;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +29,10 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 public class TlsSettings {
 
+    @Deprecated
     @JsonProperty("client_certificate")
     private String clientCertificate;
+
+    @JsonProperty("client_certificates")
+    private List<CreateClientCertificate> clientCertificates;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/TlsSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/TlsSettings.java
@@ -35,4 +35,7 @@ public class TlsSettings {
 
     @JsonProperty("client_certificates")
     private List<CreateClientCertificate> clientCertificates;
+
+    @JsonProperty("certificate_count")
+    private int certificateCount;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDo
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDSpec;
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDStatus;
 import io.gravitee.apim.core.application.model.crd.ApplicationMetadataCRD;
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_metadata.crud_service.ApplicationMetadataCrudService;
 import io.gravitee.apim.core.application_metadata.query_service.ApplicationMetadataQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -54,6 +55,7 @@ public class ImportApplicationCRDUseCase {
     private final ApplicationMetadataQueryService applicationMetadataQueryService;
     private final CRDMembersDomainService membersDomainService;
     private final ValidateApplicationCRDDomainService crdValidator;
+    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
 
     public ImportApplicationCRDUseCase(
         ApplicationCrudService applicationCrudService,
@@ -61,7 +63,8 @@ public class ImportApplicationCRDUseCase {
         ApplicationMetadataCrudService applicationMetadataCrudService,
         ApplicationMetadataQueryService applicationMetadataQueryService,
         CRDMembersDomainService membersDomainService,
-        ValidateApplicationCRDDomainService crdValidator
+        ValidateApplicationCRDDomainService crdValidator,
+        ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService
     ) {
         this.applicationCrudService = applicationCrudService;
         this.importApplicationCRDDomainService = importApplicationCRDDomainService;
@@ -69,6 +72,7 @@ public class ImportApplicationCRDUseCase {
         this.applicationMetadataQueryService = applicationMetadataQueryService;
         this.membersDomainService = membersDomainService;
         this.crdValidator = crdValidator;
+        this.applicationCertificatesUpdateDomainService = applicationCertificatesUpdateDomainService;
     }
 
     public record Output(ApplicationCRDStatus status) {}
@@ -108,6 +112,8 @@ public class ImportApplicationCRDUseCase {
                 sanitizedInput.crd.getMembers()
             );
 
+            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
+
             return ApplicationCRDStatus.builder()
                 .id(newApplication.getId())
                 .organizationId(sanitizedInput.auditInfo.organizationId())
@@ -137,6 +143,8 @@ public class ImportApplicationCRDUseCase {
                 updatedApplication.getId(),
                 sanitizedInput.crd.getMembers()
             );
+
+            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(updatedApplication.getId());
 
             return ApplicationCRDStatus.builder()
                 .id(updatedApplication.getId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificate.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/model/ClientCertificate.java
@@ -16,49 +16,59 @@
 package io.gravitee.apim.core.application_certificate.model;
 
 import java.util.Date;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Domain model for client certificate.
  *
  * @author GraviteeSource Team
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder(toBuilder = true)
-public class ClientCertificate {
+public record ClientCertificate(
+    String id,
+    String crossId,
+    String applicationId,
+    String name,
+    Date startsAt,
+    Date endsAt,
+    Date createdAt,
+    Date updatedAt,
+    String certificate,
+    Date certificateExpiration,
+    String subject,
+    String issuer,
+    String fingerprint,
+    String environmentId,
+    ClientCertificateStatus status
+) {
+    /** For create: only the fields the caller controls */
+    public ClientCertificate(String name, String certificate, Date startsAt, Date endsAt) {
+        this(null, null, null, name, startsAt, endsAt, null, null, certificate, null, null, null, null, null, null);
+    }
 
-    private String id;
+    /** For update: only name and date bounds */
+    public ClientCertificate(String name, Date startsAt, Date endsAt) {
+        this(null, null, null, name, startsAt, endsAt, null, null, null, null, null, null, null, null, null);
+    }
 
-    private String crossId;
-
-    private String applicationId;
-
-    private String name;
-
-    private Date startsAt;
-
-    private Date endsAt;
-
-    private Date createdAt;
-
-    private Date updatedAt;
-
-    private String certificate;
-
-    private Date certificateExpiration;
-
-    private String subject;
-
-    private String issuer;
-
-    private String fingerprint;
-
-    private String environmentId;
-
-    private ClientCertificateStatus status;
+    /**
+     * Copy constructor
+     */
+    public ClientCertificate(ClientCertificate other) {
+        this(
+            other.id,
+            other.crossId,
+            other.applicationId,
+            other.name,
+            other.startsAt,
+            other.endsAt,
+            other.createdAt,
+            other.updatedAt,
+            other.certificate,
+            other.certificateExpiration,
+            other.subject,
+            other.issuer,
+            other.fingerprint,
+            other.environmentId,
+            other.status
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
@@ -31,7 +31,7 @@ public class DeleteClientCertificateUseCase {
     public void execute(Input input) {
         ClientCertificate certificate = clientCertificateCrudService.findById(input.clientCertificateId());
         clientCertificateCrudService.delete(input.clientCertificateId());
-        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.getApplicationId());
+        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
     }
 
     public record Input(String clientCertificateId) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
@@ -30,7 +30,7 @@ public class UpdateClientCertificateUseCase {
 
     public Output execute(Input input) {
         ClientCertificate certificate = clientCertificateCrudService.update(input.clientCertificateId(), input.toUpdate());
-        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.getApplicationId());
+        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
         return new Output(certificate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -86,7 +86,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         try {
             log.debug("Create client certificate for application: {}", applicationId);
 
-            X509Certificate x509Certificate = parseCertificate(clientCertificateToCreate.getCertificate());
+            X509Certificate x509Certificate = parseCertificate(clientCertificateToCreate.certificate());
             String fingerprint = CertificateUtils.generateThumbprint(x509Certificate, "SHA-256");
             if (fingerprint == null) {
                 throw new ClientCertificateInvalidException();
@@ -109,7 +109,7 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
             clientCertificate.setFingerprint(fingerprint);
             clientCertificate.setEnvironmentId(environmentId);
             clientCertificate.setCreatedAt(new Date());
-            clientCertificate.setStatus(computeStatus(clientCertificateToCreate.getStartsAt(), clientCertificateToCreate.getEndsAt()));
+            clientCertificate.setStatus(computeStatus(clientCertificateToCreate.startsAt(), clientCertificateToCreate.endsAt()));
 
             return ClientCertificateAdapter.INSTANCE.toDomain(clientCertificateRepository.create(clientCertificate));
         } catch (TechnicalException e) {
@@ -123,8 +123,8 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     private void validateDateBounds(ClientCertificate clientCertificate) {
         if (
             !Duration.between(
-                Optional.ofNullable(clientCertificate.getStartsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MIN_VALUE)),
-                Optional.ofNullable(clientCertificate.getEndsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MAX_VALUE))
+                Optional.ofNullable(clientCertificate.startsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MIN_VALUE)),
+                Optional.ofNullable(clientCertificate.endsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MAX_VALUE))
             ).isPositive()
         ) {
             throw new ClientCertificateDateBoundsInvalidException();
@@ -142,11 +142,11 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
 
             validateDateBounds(update);
 
-            existingCertificate.setName(update.getName());
-            existingCertificate.setStartsAt(update.getStartsAt());
-            existingCertificate.setEndsAt(update.getEndsAt());
+            existingCertificate.setName(update.name());
+            existingCertificate.setStartsAt(update.startsAt());
+            existingCertificate.setEndsAt(update.endsAt());
             existingCertificate.setUpdatedAt(new Date());
-            existingCertificate.setStatus(computeStatus(update.getStartsAt(), update.getEndsAt()));
+            existingCertificate.setStatus(computeStatus(update.startsAt(), update.endsAt()));
 
             return ClientCertificateAdapter.INSTANCE.toDomain(clientCertificateRepository.update(existingCertificate));
         } catch (TechnicalException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -137,12 +137,12 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
         if (hasSingle) {
             errors.add(Error.warning("clientCertificate is deprecated, use clientCertificates instead"));
             errors.addAll(validateCertificatePem(tls.getClientCertificate()).errors());
-        }
-
-        if (hasList) {
+        } else if (hasList) {
             for (var cert : tls.getClientCertificates()) {
                 errors.addAll(validateCertificateEntry(cert));
             }
+        } else {
+            errors.add(Error.severe("tls configuration must contain either clientCertificate or clientCertificates"));
         }
 
         return errors;
@@ -157,10 +157,8 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
             errors.add(Error.severe("certificate [%s]: startsAt must be before endsAt", cert.name()));
         }
 
-        if (cert.endsAt() != null && parsed.certificate() != null) {
-            if (cert.endsAt().after(parsed.certificate().getNotAfter())) {
-                errors.add(Error.warning("certificate [%s]: endsAt is after certificate expiration date", cert.name()));
-            }
+        if (cert.endsAt() != null && parsed.certificate() != null && cert.endsAt().after(parsed.certificate().getNotAfter())) {
+            errors.add(Error.warning("certificate [%s]: endsAt is after certificate expiration date", cert.name()));
         }
 
         return errors;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -23,11 +23,14 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.core.utils.StringUtils;
+import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
+import io.gravitee.rest.api.model.application.TlsSettings;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import io.gravitee.rest.api.model.configuration.application.ApplicationGrantTypeEntity;
 import io.gravitee.rest.api.model.configuration.application.ApplicationTypeEntity;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -37,6 +40,8 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -69,32 +74,39 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
 
     @Override
     public Result<Input> validateAndSanitize(Input input) {
-        if (input.settings() != null) {
-            if (input.settings().getApp() != null) {
-                return validateAndSanitizeSimpleSettings(input);
-            }
-            return validateAndSanitizeOAuthSettings(input);
+        if (input.settings() == null) {
+            // default to empty simple app
+            return Result.ofValue(input.sanitized(ApplicationSettings.builder().app(new SimpleApplicationSettings()).build()));
         }
-        // default to empty simple app
-        return Result.ofValue(input.sanitized(ApplicationSettings.builder().app(new SimpleApplicationSettings()).build()));
+
+        var errors = new ArrayList<Error>();
+        var sanitizedBuilder = input.settings().toBuilder();
+
+        if (input.settings().getApp() != null) {
+            validateSimpleSettings(input, sanitizedBuilder, errors);
+        } else if (input.settings().getOauth() != null) {
+            validateOAuthSettings(input, sanitizedBuilder, errors);
+        }
+
+        if (input.settings().getTls() != null) {
+            errors.addAll(validateTlsSettings(input.settings().getTls()));
+        }
+
+        return Result.ofBoth(input.sanitized(sanitizedBuilder.build()), errors);
     }
 
-    private Result<Input> validateAndSanitizeSimpleSettings(Input input) {
-        var sanitizedBuilder = input.settings().toBuilder();
+    private void validateSimpleSettings(Input input, ApplicationSettings.ApplicationSettingsBuilder sanitizedBuilder, List<Error> errors) {
         var simpleSettings = input.settings().getApp().toBuilder().build();
-        var errors = new ArrayList<Error>();
 
         if (StringUtils.isNotEmpty(simpleSettings.getClientId())) {
             errors.addAll(validateClientId(input.auditInfo().environmentId(), input.applicationId(), simpleSettings));
         }
 
-        return Result.ofBoth(input.sanitized(sanitizedBuilder.app(simpleSettings).build()), errors);
+        sanitizedBuilder.app(simpleSettings);
     }
 
-    private Result<Input> validateAndSanitizeOAuthSettings(Input input) {
-        var sanitizedBuilder = input.settings().toBuilder();
+    private void validateOAuthSettings(Input input, ApplicationSettings.ApplicationSettingsBuilder sanitizedBuilder, List<Error> errors) {
         var oauthSettings = input.settings().getOauth().toBuilder().build();
-        var errors = new ArrayList<Error>();
 
         if (!isClientRegistrationEnabled(input.auditInfo())) {
             errors.add(
@@ -109,7 +121,79 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
         errors.addAll(validateGrantTypes(appType, oauthSettings));
         errors.addAll(validateRedirectURIs(appType, oauthSettings));
         oauthSettings.setResponseTypes(getResponseTypes(appType, oauthSettings));
-        return Result.ofBoth(input.sanitized(sanitizedBuilder.oauth(oauthSettings).build()), errors);
+        sanitizedBuilder.oauth(oauthSettings);
+    }
+
+    private List<Error> validateTlsSettings(TlsSettings tls) {
+        var errors = new ArrayList<Error>();
+        boolean hasSingle = StringUtils.isNotEmpty(tls.getClientCertificate());
+        boolean hasList = CollectionUtils.isNotEmpty(tls.getClientCertificates());
+
+        if (hasSingle && hasList) {
+            errors.add(Error.severe("cannot set both clientCertificate and clientCertificates, use clientCertificates only"));
+            return errors;
+        }
+
+        if (hasSingle) {
+            errors.add(Error.warning("clientCertificate is deprecated, use clientCertificates instead"));
+            errors.addAll(validateCertificatePem(tls.getClientCertificate()).errors());
+        }
+
+        if (hasList) {
+            for (var cert : tls.getClientCertificates()) {
+                errors.addAll(validateCertificateEntry(cert));
+            }
+        }
+
+        return errors;
+    }
+
+    private List<Error> validateCertificateEntry(CreateClientCertificate cert) {
+        var errors = new ArrayList<Error>();
+        var parsed = validateCertificatePem(cert.certificate());
+        errors.addAll(parsed.errors());
+
+        if (cert.startsAt() != null && cert.endsAt() != null && !cert.startsAt().before(cert.endsAt())) {
+            errors.add(Error.severe("certificate [%s]: startsAt must be before endsAt", cert.name()));
+        }
+
+        if (cert.endsAt() != null && parsed.certificate() != null) {
+            if (cert.endsAt().after(parsed.certificate().getNotAfter())) {
+                errors.add(Error.warning("certificate [%s]: endsAt is after certificate expiration date", cert.name()));
+            }
+        }
+
+        return errors;
+    }
+
+    private record CertificateParseResult(List<Error> errors, X509Certificate certificate) {
+        static CertificateParseResult ofErrors(List<Error> errors) {
+            return new CertificateParseResult(errors, null);
+        }
+
+        static CertificateParseResult of(X509Certificate cert) {
+            return new CertificateParseResult(List.of(), cert);
+        }
+    }
+
+    private CertificateParseResult validateCertificatePem(String pem) {
+        Certificate[] certificates;
+        try {
+            certificates = KeyStoreUtils.loadPemCertificates(pem);
+        } catch (Exception e) {
+            return CertificateParseResult.ofErrors(List.of(Error.severe("certificate is not a valid PEM")));
+        }
+
+        if (certificates == null || certificates.length == 0) {
+            return CertificateParseResult.ofErrors(List.of(Error.severe("certificate is empty")));
+        }
+
+        var x509 = (X509Certificate) certificates[0];
+        if (x509.getBasicConstraints() != -1) {
+            return CertificateParseResult.ofErrors(List.of(Error.severe("certificate is a CA certificate")));
+        }
+
+        return CertificateParseResult.of(x509);
     }
 
     private List<Error> validateGrantTypes(ApplicationTypeEntity type, OAuthClientSettings settings) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -75,7 +75,7 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
     @Override
     public Result<Input> validateAndSanitize(Input input) {
         if (input.settings() == null) {
-            // default to empty simple app
+            // treat missing settings as a valid simple application to allow creation without explicit configuration
             return Result.ofValue(input.sanitized(ApplicationSettings.builder().app(new SimpleApplicationSettings()).build()));
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -141,8 +141,6 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
             for (var cert : tls.getClientCertificates()) {
                 errors.addAll(validateCertificateEntry(cert));
             }
-        } else {
-            errors.add(Error.severe("tls configuration must contain either clientCertificate or clientCertificates"));
         }
 
         return errors;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -45,6 +45,8 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import joptsimple.internal.Strings;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
@@ -138,6 +140,11 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
             errors.add(Error.warning("clientCertificate is deprecated, use clientCertificates instead"));
             errors.addAll(validateCertificatePem(tls.getClientCertificate()).errors());
         } else if (hasList) {
+            Set<String> certs = tls.getClientCertificates().stream().map(CreateClientCertificate::certificate).collect(Collectors.toSet());
+            if (certs.size() != tls.getClientCertificates().size()) {
+                errors.add(Error.severe("client certificate content must be unique"));
+                return errors;
+            }
             for (var cert : tls.getClientCertificates()) {
                 errors.addAll(validateCertificateEntry(cert));
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ClientCertificateLastRemovalException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ClientCertificateLastRemovalException.java
@@ -19,13 +19,18 @@ import io.gravitee.common.http.HttpStatusCode;
 import java.util.Map;
 
 /**
+ * Exception thrown when a client certificate is already used by another active application.
+ *
  * @author GraviteeSource Team
  */
-public class ApplicationInvalidCertificateException extends AbstractManagementException {
+public class ClientCertificateLastRemovalException extends AbstractManagementException {
 
-    @Override
-    public String getMessage() {
-        return "An error has occurred while parsing client certificate";
+    public ClientCertificateLastRemovalException(String applicationId) {
+        super(
+            "Client certificate cannot be revoked for application '" +
+                applicationId +
+                "': active subscriptions exist, and this is the last certificate."
+        );
     }
 
     @Override
@@ -35,11 +40,11 @@ public class ApplicationInvalidCertificateException extends AbstractManagementEx
 
     @Override
     public String getTechnicalCode() {
-        return "application.certificate.invalid";
+        return "application.certificate.remove.last";
     }
 
     @Override
     public Map<String, String> getParameters() {
-        return null;
+        return Map.of();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -73,6 +73,7 @@ import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
 import io.gravitee.rest.api.model.application.TlsSettings;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.configuration.application.ApplicationGrantTypeEntity;
@@ -131,8 +132,8 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.xml.bind.DatatypeConverter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -143,6 +144,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -442,7 +444,10 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
         }
 
-        String clientCertificate = getClientCertificate(newApplicationEntity.getSettings());
+        List<CreateClientCertificate> clientCertificates = getClientCertificates(
+            newApplicationEntity.getName(),
+            newApplicationEntity.getSettings()
+        );
 
         if (newApplicationEntity.getGroups() != null && !newApplicationEntity.getGroups().isEmpty()) {
             //throw a NotFoundException if the group doesn't exist
@@ -472,14 +477,21 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         application.setCreatedAt(new Date());
         application.setUpdatedAt(application.getCreatedAt());
 
-        return createApplicationForEnvironment(executionContext, userId, application, clientCertificate);
+        return createApplicationForEnvironment(executionContext, userId, application, clientCertificates);
     }
 
-    private static String getClientCertificate(ApplicationSettings settings) {
-        if (settings.getTls() != null && StringUtils.isNotBlank(settings.getTls().getClientCertificate())) {
-            return settings.getTls().getClientCertificate();
+    private static List<CreateClientCertificate> getClientCertificates(String appName, ApplicationSettings settings) {
+        if (settings.getTls() == null) {
+            return List.of();
         }
-        return null;
+        var result = new ArrayList<CreateClientCertificate>();
+        if (CollectionUtils.isNotEmpty(settings.getTls().getClientCertificates())) {
+            result.addAll(settings.getTls().getClientCertificates());
+        }
+        if (StringUtils.isNotBlank(settings.getTls().getClientCertificate())) {
+            result.add(new CreateClientCertificate(appName, null, null, settings.getTls().getClientCertificate()));
+        }
+        return result;
     }
 
     private void creationPreFlightChecks(ExecutionContext executionContext, NewApplicationEntity newApplicationEntity) {
@@ -509,16 +521,21 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         final ExecutionContext executionContext,
         String userId,
         Application application,
-        String clientCertificate
+        List<CreateClientCertificate> clientCertificates
     ) {
         try {
             application.setEnvironmentId(executionContext.getEnvironmentId());
 
-            // Create client certificate if provided
-            if (clientCertificate != null) {
+            // Create client certificates if provided
+            for (var cert : clientCertificates) {
                 clientCertificateCrudService.create(
                     application.getId(),
-                    ClientCertificate.builder().name(application.getName()).certificate(clientCertificate).build()
+                    new ClientCertificate(
+                        cert.name() != null ? cert.name() : application.getName(),
+                        cert.certificate(),
+                        cert.startsAt(),
+                        cert.endsAt()
+                    )
                 );
             }
 
@@ -629,40 +646,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // Update application metadata
             Map<String, String> metadata = new HashMap<>();
 
-            // Handle TLS certificate changes via ClientCertificateCrudService
-            String newCertificateToCreate = null;
-            if (
-                updateApplicationEntity.getSettings().getTls() != null &&
-                !StringUtils.isBlank(updateApplicationEntity.getSettings().getTls().getClientCertificate())
-            ) {
-                String newCertificate = updateApplicationEntity.getSettings().getTls().getClientCertificate().trim();
-
-                // Check if certificate has changed by comparing with the most recent active certificate
-                Optional<ClientCertificate> existingCertOpt = clientCertificateCrudService.findMostRecentActiveByApplicationId(
-                    applicationId
-                );
-
-                boolean certificateChanged = existingCertOpt
-                    .map(existingCert -> !newCertificate.equals(existingCert.getCertificate()))
-                    .orElse(true);
-
-                if (certificateChanged) {
-                    // Expire the current active certificate if exists
-                    existingCertOpt.ifPresent(existingCert ->
-                        // update no validation as end-date is after now since the cert is active
-                        clientCertificateCrudService.update(
-                            existingCert.getId(),
-                            ClientCertificate.builder()
-                                .name(existingCert.getName())
-                                .startsAt(existingCert.getStartsAt())
-                                .endsAt(new Date())
-                                .build()
-                        )
-                    );
-                    // Mark new certificate for creation after application update
-                    newCertificateToCreate = newCertificate;
-                }
-            }
+            handleClientCertificates(applicationId, updateApplicationEntity);
 
             // Update a simple application
             if (applicationToUpdate.getType() == ApplicationType.SIMPLE && updateApplicationEntity.getSettings().getApp() != null) {
@@ -683,13 +667,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     updateClientRegistration(executionContext, updateApplicationEntity, registrationPayload, metadata, applicationToUpdate);
                 }
             }
-
-            // Create new certificate if certificate was changed
-            final Optional<String> clientCertificate = createNewCertificateIfNecessary(
-                applicationId,
-                updateApplicationEntity,
-                newCertificateToCreate
-            );
 
             Application application = applicationConverter.toApplication(updateApplicationEntity);
             application.setId(applicationId);
@@ -712,7 +689,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 updatedApplication
             );
 
-            updateActiveSubscriptions(executionContext, applicationId, application, clientCertificate);
+            updateActiveSubscriptions(executionContext, applicationId, application);
             return convertApplication(executionContext, Collections.singleton(updatedApplication)).iterator().next();
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException(
@@ -720,6 +697,61 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 ex
             );
         }
+    }
+
+    private void handleClientCertificates(String applicationId, UpdateApplicationEntity updateApplicationEntity) {
+        // Handle TLS certificate changes via ClientCertificateCrudService
+        List<CreateClientCertificate> incoming = getClientCertificates(
+            updateApplicationEntity.getName(),
+            updateApplicationEntity.getSettings()
+        );
+
+        // Get all currently active certificates, sorted by creation date desc
+        var existing = clientCertificateCrudService
+            .findByApplicationIdAndStatuses(applicationId, ClientCertificateStatus.ACTIVE, ClientCertificateStatus.ACTIVE_WITH_END)
+            .stream()
+            .sorted(Comparator.comparing(ClientCertificate::createdAt))
+            .toList();
+
+        // Build a map of existing certificates by their certificate content for matching
+        Map<String, ClientCertificate> existingByCertificate = existing
+            .stream()
+            .collect(Collectors.toMap(ClientCertificate::certificate, c -> c, (a, b) -> a));
+
+        Set<String> incomingCertificates = incoming.stream().map(CreateClientCertificate::certificate).collect(toSet());
+
+        // Create new certificates (incoming certificates not in existing) or update existing ones
+        for (CreateClientCertificate incomingCert : incoming) {
+            ClientCertificate existingCert = existingByCertificate.get(incomingCert.certificate());
+            if (existingCert == null) {
+                // Create new certificate
+                clientCertificateCrudService.create(
+                    applicationId,
+                    new ClientCertificate(incomingCert.name(), incomingCert.certificate(), incomingCert.startsAt(), incomingCert.endsAt())
+                );
+            } else if (hasChanges(incomingCert, existingCert)) {
+                // Update existing certificate only if there are changes (name, startsAt, endsAt)
+                clientCertificateCrudService.update(
+                    existingCert.id(),
+                    new ClientCertificate(incomingCert.name(), incomingCert.startsAt(), incomingCert.endsAt())
+                );
+            }
+        }
+
+        // Delete certificates that are no longer in incoming list
+        for (ClientCertificate existingCert : existing) {
+            if (!incomingCertificates.contains(existingCert.certificate())) {
+                clientCertificateCrudService.delete(existingCert.id());
+            }
+        }
+    }
+
+    private boolean hasChanges(CreateClientCertificate incoming, ClientCertificate existing) {
+        return (
+            !Objects.equals(incoming.name(), existing.name()) ||
+            !Objects.equals(incoming.startsAt(), existing.startsAt()) ||
+            !Objects.equals(incoming.endsAt(), existing.endsAt())
+        );
     }
 
     private void createAuditLog(
@@ -743,25 +775,14 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         );
     }
 
-    private void updateActiveSubscriptions(
-        ExecutionContext executionContext,
-        String applicationId,
-        Application application,
-        Optional<String> clientCertificate
-    ) {
-        // Set correct client_id for all active subscriptions
+    private void updateActiveSubscriptions(ExecutionContext executionContext, String applicationId, Application application) {
         SubscriptionQuery subQuery = new SubscriptionQuery();
         subQuery.setApplication(applicationId);
         subQuery.setStatuses(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED, SubscriptionStatus.PENDING));
 
         String clientId = application.getMetadata().get(METADATA_CLIENT_ID);
 
-        final String subscriptionClientCertificate = clientCertificate
-            .map(cert -> Base64.getEncoder().encodeToString(cert.getBytes()))
-            .orElse(null);
-
         Consumer<Subscription> clientIdSubscriptionModifier = s -> s.setClientId(clientId);
-        Consumer<Subscription> clientCertificateSubscriptionModifier = s -> s.setClientCertificate(subscriptionClientCertificate);
         Consumer<Subscription> applicationNameSubscriptionModifier = s -> s.setApplicationName(application.getName());
 
         subscriptionService
@@ -770,11 +791,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 Consumer<Subscription> subscriptionModifier = null;
                 if (areNotEmptyAndDifferent(clientId, subscriptionEntity.getClientId())) {
                     subscriptionModifier = clientIdSubscriptionModifier;
-                }
-                if (areNotEmptyAndDifferent(subscriptionClientCertificate, subscriptionEntity.getClientCertificate())) {
-                    subscriptionModifier = subscriptionModifier == null
-                        ? clientCertificateSubscriptionModifier
-                        : subscriptionModifier.andThen(clientCertificateSubscriptionModifier);
                 }
                 if (areNotEmptyAndDifferent(application.getName(), subscriptionEntity.getApplicationName())) {
                     subscriptionModifier = subscriptionModifier == null
@@ -790,21 +806,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     subscriptionService.update(executionContext, updateSubscriptionEntity, subscriptionModifier);
                 }
             });
-    }
-
-    private Optional<String> createNewCertificateIfNecessary(
-        String applicationId,
-        UpdateApplicationEntity updateApplicationEntity,
-        String newCertificateToCreate
-    ) {
-        if (newCertificateToCreate != null) {
-            clientCertificateCrudService.create(
-                applicationId,
-                ClientCertificate.builder().name(updateApplicationEntity.getName()).certificate(newCertificateToCreate).build()
-            );
-            return Optional.of(newCertificateToCreate);
-        }
-        return Optional.empty();
     }
 
     private void checkClientIdUniqueness(
@@ -1330,8 +1331,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             .stream()
             .collect(
                 Collectors.groupingBy(
-                    ClientCertificate::getApplicationId,
-                    Collectors.collectingAndThen(Collectors.maxBy(Comparator.comparing(ClientCertificate::getCreatedAt)), opt ->
+                    ClientCertificate::applicationId,
+                    Collectors.collectingAndThen(Collectors.maxBy(Comparator.comparing(ClientCertificate::createdAt)), opt ->
                         opt.orElse(null)
                     )
                 )
@@ -1341,7 +1342,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         apps.forEach(app -> {
             ClientCertificate mostRecent = mostRecentCertificates.get(app.getId());
             if (mostRecent != null) {
-                app.getSettings().setTls(TlsSettings.builder().clientCertificate(mostRecent.getCertificate()).build());
+                app.getSettings().setTls(TlsSettings.builder().clientCertificate(mostRecent.certificate()).build());
             }
         });
 
@@ -1395,9 +1396,28 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
         if (fetchCertificate) {
             // Fetch the most recent active certificate from ClientCertificateCrudService
-            clientCertificateCrudService
-                .findMostRecentActiveByApplicationId(application.getId())
-                .ifPresent(cert -> settings.setTls(TlsSettings.builder().clientCertificate(cert.getCertificate()).build()));
+            List<ClientCertificate> list = clientCertificateCrudService
+                .findByApplicationIdAndStatuses(
+                    application.getId(),
+                    ClientCertificateStatus.ACTIVE,
+                    ClientCertificateStatus.ACTIVE_WITH_END
+                )
+                .stream()
+                .sorted(Comparator.comparing(ClientCertificate::createdAt))
+                .toList();
+            if (!list.isEmpty()) {
+                settings.setTls(
+                    TlsSettings.builder()
+                        .clientCertificate(list.getFirst().certificate())
+                        .clientCertificates(
+                            list
+                                .stream()
+                                .map(c -> new CreateClientCertificate(c.name(), c.startsAt(), c.endsAt(), c.certificate()))
+                                .toList()
+                        )
+                        .build()
+                );
+            }
         }
 
         return settings;
@@ -1553,9 +1573,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 criteriaBuilder.query(applicationQuery.getQuery());
             }
 
-            if (CollectionUtils.isNotEmpty(applicationQuery.getGroups())) {
-                criteriaBuilder.groups(applicationQuery.getGroups());
-            }
+            criteriaBuilder.groups(applicationQuery.getGroups());
 
             if (StringUtils.isNotBlank(applicationQuery.getName())) {
                 criteriaBuilder.name(applicationQuery.getName());
@@ -1567,9 +1585,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 criteriaBuilder.status(applicationStatus);
             }
 
-            if (CollectionUtils.isNotEmpty(applicationQuery.getIds())) {
-                criteriaBuilder.restrictedToIds(applicationQuery.getIds());
-            }
+            criteriaBuilder.restrictedToIds(applicationQuery.getIds());
 
             if (StringUtils.isNotBlank(applicationQuery.getUser())) {
                 Set<String> userApplicationsIds = findUserApplicationsIds(executionContext, applicationQuery.getUser(), applicationStatus);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -48,6 +48,7 @@ import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.management.model.ApplicationType;
 import io.gravitee.repository.management.model.GroupEvent;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -129,6 +130,7 @@ import io.gravitee.rest.api.service.impl.configuration.application.registration.
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.HookScope;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionEndsAfterClientCertificateException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.xml.bind.DatatypeConverter;
 import java.io.IOException;
@@ -484,14 +486,13 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         if (settings.getTls() == null) {
             return List.of();
         }
-        var result = new ArrayList<CreateClientCertificate>();
         if (CollectionUtils.isNotEmpty(settings.getTls().getClientCertificates())) {
-            result.addAll(settings.getTls().getClientCertificates());
+            return List.copyOf(settings.getTls().getClientCertificates());
         }
         if (StringUtils.isNotBlank(settings.getTls().getClientCertificate())) {
-            result.add(new CreateClientCertificate(appName, null, null, settings.getTls().getClientCertificate()));
+            return List.of(new CreateClientCertificate(appName, null, null, settings.getTls().getClientCertificate()));
         }
-        return result;
+        return List.of();
     }
 
     private void creationPreFlightChecks(ExecutionContext executionContext, NewApplicationEntity newApplicationEntity) {
@@ -646,7 +647,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // Update application metadata
             Map<String, String> metadata = new HashMap<>();
 
-            handleClientCertificates(applicationId, updateApplicationEntity);
+            // Create, update, delete client certificate regarding of the new application state
+            syncClientCertificates(executionContext, applicationId, updateApplicationEntity);
 
             // Update a simple application
             if (applicationToUpdate.getType() == ApplicationType.SIMPLE && updateApplicationEntity.getSettings().getApp() != null) {
@@ -699,12 +701,39 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
     }
 
-    private void handleClientCertificates(String applicationId, UpdateApplicationEntity updateApplicationEntity) {
+    private void syncClientCertificates(
+        ExecutionContext executionContext,
+        String applicationId,
+        UpdateApplicationEntity updateApplicationEntity
+    ) {
         // Handle TLS certificate changes via ClientCertificateCrudService
         List<CreateClientCertificate> incoming = getClientCertificates(
             updateApplicationEntity.getName(),
             updateApplicationEntity.getSettings()
         );
+
+        // Find MTLS subscriptions that end after the certificate that ends the farthest (if any)
+        var maxEndDate = incoming
+            .stream()
+            .map(CreateClientCertificate::endsAt)
+            .map(Optional::ofNullable)
+            .mapToLong(end -> end.map(Date::getTime).orElse(Long.MAX_VALUE))
+            .max();
+        if (maxEndDate.isPresent()) {
+            // Queries active MTLS subscriptions ending after the latest certificate
+            var subscriptionEndingTooLate = subscriptionService.search(
+                executionContext,
+                SubscriptionQuery.builder()
+                    .applications(Set.of(applicationId))
+                    .planSecurityTypes(Set.of(Plan.PlanSecurityType.MTLS.name()))
+                    .endingAtAfter(maxEndDate.getAsLong())
+                    .statuses(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PENDING, SubscriptionStatus.PAUSED))
+                    .build()
+            );
+            if (!subscriptionEndingTooLate.isEmpty()) {
+                throw new SubscriptionEndsAfterClientCertificateException();
+            }
+        }
 
         // Get all currently active certificates, sorted by creation date desc
         var existing = clientCertificateCrudService
@@ -738,7 +767,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
         }
 
-        // Delete certificates that are no longer in incoming list
+        // Delete certificates that are no longer in the incoming list
         for (ClientCertificate existingCert : existing) {
             if (!incomingCertificates.contains(existingCert.certificate())) {
                 clientCertificateCrudService.delete(existingCert.id());
@@ -1403,7 +1432,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     ClientCertificateStatus.ACTIVE_WITH_END
                 )
                 .stream()
-                .sorted(Comparator.comparing(ClientCertificate::createdAt))
+                .sorted(Comparator.comparing(ClientCertificate::createdAt).reversed())
                 .toList();
             if (!list.isEmpty()) {
                 settings.setTls(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -1415,6 +1415,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                                 .map(c -> new CreateClientCertificate(c.name(), c.startsAt(), c.endsAt(), c.certificate()))
                                 .toList()
                         )
+                        .certificateCount(list.size())
                         .build()
                 );
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomai
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.plan.PlanMode;
@@ -84,6 +85,7 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntrypointEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.subscription.ReferenceDisplayInfo;
@@ -141,6 +143,7 @@ import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -827,7 +830,24 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             return Optional.empty();
         }
 
-        return Optional.ofNullable(Base64.getEncoder().encodeToString(settings.getTls().getClientCertificate().getBytes()));
+        List<String> certificates = new ArrayList<>();
+        if (settings.getTls().getClientCertificates() != null) {
+            certificates.addAll(settings.getTls().getClientCertificates().stream().map(CreateClientCertificate::certificate).toList());
+        } else if (settings.getTls().getClientCertificate() != null) {
+            certificates.add(settings.getTls().getClientCertificate());
+        }
+
+        if (certificates.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (certificates.size() == 1) {
+            String pem = certificates.getFirst();
+            return Optional.of(Base64.getEncoder().encodeToString(pem.getBytes(StandardCharsets.UTF_8)));
+        } else {
+            byte[] pkcs7Bundle = PKCS7Utils.createBundle(certificates);
+            return Optional.of(Base64.getEncoder().encodeToString(pkcs7Bundle));
+        }
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -150,7 +150,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1177,7 +1176,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             ) {
                 final GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
 
-                subscriptionValidationService.validateAndSanitize(genericPlanEntity, updateSubscription);
+                subscriptionValidationService.validateAndSanitize(genericPlanEntity, updateSubscription, subscription.getApplication());
 
                 Subscription previousSubscription = new Subscription(subscription);
                 setSubscriptionConfig(updateSubscription.getConfiguration(), subscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
@@ -100,7 +100,7 @@ public class ApplicationClientCertificateMigrationUpgrader implements Upgrader {
 
             clientCertificateCrudService.create(
                 applicationId,
-                ClientCertificate.builder().name(applicationName).certificate(decodeCert(base64Certificate)).build()
+                new ClientCertificate(applicationName, decodeCert(base64Certificate), null, null)
             );
 
             log.debug("Created ClientCertificate for application {} ({})", applicationName, applicationId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
@@ -64,7 +64,7 @@ public class ApplicationClientCertificateMigrationUpgrader implements Upgrader {
             int pageNumber = 0;
             Page<Application> page;
             do {
-                Pageable pageable = new PageableBuilder().pageNumber(pageNumber + 1).pageSize(100).build();
+                Pageable pageable = new PageableBuilder().pageNumber(pageNumber).pageSize(100).build();
                 page = applicationRepository.search(criteria, pageable);
                 for (Application application : page
                     .getContent()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/SubscriptionEndsAfterClientCertificateException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/SubscriptionEndsAfterClientCertificateException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Collections;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@AllArgsConstructor
+public class SubscriptionEndsAfterClientCertificateException extends AbstractManagementException {
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "subscription.endingAt";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Subscription cannot end after a certificate expiration";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -81,9 +81,15 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
                 applicationId,
                 ClientCertificateStatus.ACTIVE_WITH_END
             );
+
+            if (byApplicationIdAndStatuses.isEmpty()) {
+                // match all returns true on empty collections
+                return;
+            }
             boolean subscriptionEndsAfterCertificate = byApplicationIdAndStatuses
                 .stream()
-                .anyMatch(clientCertificate -> clientCertificate.endsAt().toInstant().isAfter(subscription.getEndingAt().toInstant()));
+                // all ending certificates must be before the subscription ending date
+                .allMatch(clientCertificate -> clientCertificate.endsAt().toInstant().isBefore(subscription.getEndingAt().toInstant()));
             if (subscriptionEndsAfterCertificate) {
                 throw new SubscriptionEndsAfterClientCertificateException();
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -15,17 +15,24 @@
  */
 package io.gravitee.rest.api.service.v4.impl.validation;
 
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
+import io.gravitee.rest.api.model.PlanSecurityType;
 import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionEndsAfterClientCertificateException;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionEntrypointIdMissingException;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionMetadataSanitizer;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
+import java.util.Objects;
+import java.util.Set;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -42,6 +49,8 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
     private final EntrypointConnectorPluginService entrypointService;
     private final SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
+    private final ClientCertificateCrudService clientCertificateCrudService;
+
     @Override
     public void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final NewSubscriptionEntity subscription) {
         subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
@@ -51,10 +60,33 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
     }
 
     @Override
-    public void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription) {
+    public void validateAndSanitize(
+        final GenericPlanEntity genericPlanEntity,
+        final UpdateSubscriptionEntity subscription,
+        String applicationId
+    ) {
+        validateTls(genericPlanEntity, subscription, applicationId);
         subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
         if (subscription.getMetadata() != null) {
             subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
+        }
+    }
+
+    private void validateTls(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription, String applicationId) {
+        if (
+            subscription.getEndingAt() != null &&
+            Objects.equals(genericPlanEntity.getPlanSecurity().getType(), PlanSecurityType.MTLS.name())
+        ) {
+            Set<ClientCertificate> byApplicationIdAndStatuses = clientCertificateCrudService.findByApplicationIdAndStatuses(
+                applicationId,
+                ClientCertificateStatus.ACTIVE_WITH_END
+            );
+            boolean subscriptionEndsAfterCertificate = byApplicationIdAndStatuses
+                .stream()
+                .anyMatch(clientCertificate -> clientCertificate.endsAt().toInstant().isAfter(subscription.getEndingAt().toInstant()));
+            if (subscriptionEndsAfterCertificate) {
+                throw new SubscriptionEndsAfterClientCertificateException();
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionValidationService.java
@@ -27,7 +27,7 @@ import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 public interface SubscriptionValidationService {
     void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final NewSubscriptionEntity subscription);
 
-    void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription);
+    void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription, String applicationId);
 
     void validateAndSanitize(
         final GenericPlanEntity genericPlanEntity,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCaseTest.java
@@ -54,19 +54,14 @@ class CreateClientCertificateUseCaseTest {
         var result = createClientCertificateUseCase.execute(
             new CreateClientCertificateUseCase.Input(
                 appId,
-                ClientCertificate.builder()
-                    .name("Test Certificate")
-                    .startsAt(new Date())
-                    .endsAt(new Date())
-                    .certificate("PEM_CONTENT")
-                    .build()
+                new ClientCertificate("Test Certificate", "PEM_CONTENT", new Date(), new Date())
             )
         );
 
         assertThat(result.clientCertificate()).isNotNull();
-        assertThat(result.clientCertificate().getId()).isNotNull();
-        assertThat(result.clientCertificate().getApplicationId()).isEqualTo(appId);
-        assertThat(result.clientCertificate().getName()).isEqualTo("Test Certificate");
+        assertThat(result.clientCertificate().id()).isNotNull();
+        assertThat(result.clientCertificate().applicationId()).isEqualTo(appId);
+        assertThat(result.clientCertificate().name()).isEqualTo("Test Certificate");
         assertThat(clientCertificateCrudService.storage()).hasSize(1);
         verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(appId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
@@ -55,23 +55,23 @@ class DeleteClientCertificateUseCaseTest {
     void should_delete_client_certificate() {
         var certId = "cert-id";
         var appId = "app-id";
-        var certificate = ClientCertificate.builder()
-            .id(certId)
-            .crossId("cross-id")
-            .applicationId(appId)
-            .name("Test Certificate")
-            .startsAt(new Date())
-            .endsAt(new Date())
-            .createdAt(new Date())
-            .updatedAt(new Date())
-            .certificate("PEM_CONTENT")
-            .certificateExpiration(new Date())
-            .subject("CN=Test")
-            .issuer("CN=Issuer")
-            .fingerprint("fingerprint")
-            .environmentId("env-id")
-            .status(ClientCertificateStatus.ACTIVE)
-            .build();
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            appId,
+            "Test Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
         clientCertificateCrudService.initWith(List.of(certificate));
 
         deleteClientCertificateUseCase.execute(new DeleteClientCertificateUseCase.Input(certId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCaseTest.java
@@ -41,30 +41,30 @@ class GetClientCertificateUseCaseTest {
     @Test
     void should_return_client_certificate_when_found() {
         var certId = "cert-id";
-        var certificate = ClientCertificate.builder()
-            .id(certId)
-            .crossId("cross-id")
-            .applicationId("app-id")
-            .name("Test Certificate")
-            .startsAt(new Date())
-            .endsAt(new Date())
-            .createdAt(new Date())
-            .updatedAt(new Date())
-            .certificate("PEM_CONTENT")
-            .certificateExpiration(new Date())
-            .subject("CN=Test")
-            .issuer("CN=Issuer")
-            .fingerprint("fingerprint")
-            .environmentId("env-id")
-            .status(ClientCertificateStatus.ACTIVE)
-            .build();
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            "app-id",
+            "Test Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
         clientCertificateCrudService.initWith(List.of(certificate));
 
         var result = getClientCertificateUseCase.execute(new GetClientCertificateUseCase.Input(certId));
 
         assertThat(result.clientCertificate()).isNotNull();
-        assertThat(result.clientCertificate().getId()).isEqualTo(certId);
-        assertThat(result.clientCertificate().getName()).isEqualTo("Test Certificate");
+        assertThat(result.clientCertificate().id()).isEqualTo(certId);
+        assertThat(result.clientCertificate().name()).isEqualTo("Test Certificate");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificatesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificatesUseCaseTest.java
@@ -40,40 +40,40 @@ class GetClientCertificatesUseCaseTest {
     @Test
     void should_return_certificates_for_application() {
         var appId = "app-id";
-        var certificate1 = ClientCertificate.builder()
-            .id("cert-1")
-            .crossId("cross-id-1")
-            .applicationId(appId)
-            .name("Certificate 1")
-            .startsAt(new Date())
-            .endsAt(new Date())
-            .createdAt(new Date())
-            .updatedAt(new Date())
-            .certificate("PEM_CONTENT_1")
-            .certificateExpiration(new Date())
-            .subject("CN=Test1")
-            .issuer("CN=Issuer")
-            .fingerprint("fingerprint1")
-            .environmentId("env-id")
-            .status(ClientCertificateStatus.ACTIVE)
-            .build();
-        var certificate2 = ClientCertificate.builder()
-            .id("cert-2")
-            .crossId("cross-id-2")
-            .applicationId(appId)
-            .name("Certificate 2")
-            .startsAt(new Date())
-            .endsAt(new Date())
-            .createdAt(new Date())
-            .updatedAt(new Date())
-            .certificate("PEM_CONTENT_2")
-            .certificateExpiration(new Date())
-            .subject("CN=Test2")
-            .issuer("CN=Issuer")
-            .fingerprint("fingerprint2")
-            .environmentId("env-id")
-            .status(ClientCertificateStatus.ACTIVE)
-            .build();
+        var certificate1 = new ClientCertificate(
+            "cert-1",
+            "cross-id-1",
+            appId,
+            "Certificate 1",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT_1",
+            new Date(),
+            "CN=Test1",
+            "CN=Issuer",
+            "fingerprint1",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        var certificate2 = new ClientCertificate(
+            "cert-2",
+            "cross-id-2",
+            appId,
+            "Certificate 2",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT_2",
+            new Date(),
+            "CN=Test2",
+            "CN=Issuer",
+            "fingerprint2",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
         clientCertificateCrudService.initWith(List.of(certificate1, certificate2));
 
         var result = getClientCertificatesUseCase.execute(new GetClientCertificatesUseCase.Input(appId, new PageableImpl(1, 10)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
@@ -55,39 +55,39 @@ class UpdateClientCertificateUseCaseTest {
     void should_update_client_certificate() {
         var certId = "cert-id";
         var appId = "app-id";
-        var certificate = ClientCertificate.builder()
-            .id(certId)
-            .crossId("cross-id")
-            .applicationId(appId)
-            .name("Original Name")
-            .startsAt(new Date())
-            .endsAt(new Date())
-            .createdAt(new Date())
-            .updatedAt(new Date())
-            .certificate("PEM_CONTENT")
-            .certificateExpiration(new Date())
-            .subject("CN=Test")
-            .issuer("CN=Issuer")
-            .fingerprint("fingerprint")
-            .environmentId("env-id")
-            .status(ClientCertificateStatus.ACTIVE)
-            .build();
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            appId,
+            "Original Name",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
         clientCertificateCrudService.initWith(List.of(certificate));
 
-        var updateRequest = ClientCertificate.builder().name("Updated Name").startsAt(new Date()).endsAt(new Date()).build();
+        var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
 
         var result = updateClientCertificateUseCase.execute(new UpdateClientCertificateUseCase.Input(certId, updateRequest));
 
         assertThat(result.clientCertificate()).isNotNull();
-        assertThat(result.clientCertificate().getId()).isEqualTo(certId);
-        assertThat(result.clientCertificate().getName()).isEqualTo("Updated Name");
+        assertThat(result.clientCertificate().id()).isEqualTo(certId);
+        assertThat(result.clientCertificate().name()).isEqualTo("Updated Name");
 
         verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(appId);
     }
 
     @Test
     void should_throw_exception_when_certificate_not_found() {
-        var updateRequest = ClientCertificate.builder().name("Updated Name").startsAt(new Date()).endsAt(new Date()).build();
+        var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
 
         var input = new UpdateClientCertificateUseCase.Input("non-existent-id", updateRequest);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
@@ -133,9 +133,9 @@ class ClientCertificateCrudServiceImplTest {
         ClientCertificate result = clientCertificateCrudService.findById(CERTIFICATE_ID);
 
         assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(CERTIFICATE_ID);
-        assertThat(result.getName()).isEqualTo("Test Certificate");
-        assertThat(result.getApplicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(result.id()).isEqualTo(CERTIFICATE_ID);
+        assertThat(result.name()).isEqualTo("Test Certificate");
+        assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
     }
 
     @Test
@@ -163,15 +163,15 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate created = clientCertificateCrudService.create(
             APPLICATION_ID,
-            ClientCertificate.builder().name("New Certificate").certificate(PEM_CERTIFICATE).build()
+            new ClientCertificate("New Certificate", PEM_CERTIFICATE, null, null)
         );
 
-        assertThat(created.getId()).isNotNull();
-        assertThat(created.getCrossId()).isNotNull();
-        assertThat(created.getApplicationId()).isEqualTo(APPLICATION_ID);
-        assertThat(created.getName()).isEqualTo("New Certificate");
-        assertThat(created.getCreatedAt()).isNotNull();
-        assertThat(created.getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE);
+        assertThat(created.id()).isNotNull();
+        assertThat(created.crossId()).isNotNull();
+        assertThat(created.applicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(created.name()).isEqualTo("New Certificate");
+        assertThat(created.createdAt()).isNotNull();
+        assertThat(created.status()).isEqualTo(ClientCertificateStatus.ACTIVE);
 
         ArgumentCaptor<io.gravitee.repository.management.model.ClientCertificate> captor = ArgumentCaptor.forClass(
             io.gravitee.repository.management.model.ClientCertificate.class
@@ -187,14 +187,10 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate created = clientCertificateCrudService.create(
             APPLICATION_ID,
-            ClientCertificate.builder()
-                .name("Scheduled Certificate")
-                .startsAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
-                .certificate(PEM_CERTIFICATE)
-                .build()
+            new ClientCertificate("Scheduled Certificate", PEM_CERTIFICATE, Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), null)
         );
 
-        assertThat(created.getStatus()).isEqualTo(ClientCertificateStatus.SCHEDULED);
+        assertThat(created.status()).isEqualTo(ClientCertificateStatus.SCHEDULED);
     }
 
     @Test
@@ -204,14 +200,10 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate created = clientCertificateCrudService.create(
             APPLICATION_ID,
-            ClientCertificate.builder()
-                .name("Certificate with end date")
-                .endsAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
-                .certificate(PEM_CERTIFICATE)
-                .build()
+            new ClientCertificate("Certificate with end date", PEM_CERTIFICATE, null, Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
         );
 
-        assertThat(created.getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE_WITH_END);
+        assertThat(created.status()).isEqualTo(ClientCertificateStatus.ACTIVE_WITH_END);
     }
 
     @Test
@@ -221,20 +213,16 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate created = clientCertificateCrudService.create(
             APPLICATION_ID,
-            ClientCertificate.builder()
-                .name("Revoked Certificate")
-                .endsAt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)))
-                .certificate(PEM_CERTIFICATE)
-                .build()
+            new ClientCertificate("Revoked Certificate", PEM_CERTIFICATE, null, Date.from(Instant.now().minus(1, ChronoUnit.DAYS)))
         );
 
-        assertThat(created.getStatus()).isEqualTo(ClientCertificateStatus.REVOKED);
+        assertThat(created.status()).isEqualTo(ClientCertificateStatus.REVOKED);
     }
 
     @Test
     void should_raise_error_when_certificate_already_exists() throws TechnicalException {
         when(clientCertificateRepository.existsByFingerprintAndActiveApplication(any(), eq(ENVIRONMENT_ID))).thenReturn(true);
-        ClientCertificate toCreate = ClientCertificate.builder().name("Certificate").certificate(PEM_CERTIFICATE).build();
+        ClientCertificate toCreate = new ClientCertificate("Certificate", PEM_CERTIFICATE, null, null);
         assertThatCode(() -> clientCertificateCrudService.create(APPLICATION_ID, toCreate)).isInstanceOf(
             ClientCertificateAlreadyUsedException.class
         );
@@ -250,14 +238,11 @@ class ClientCertificateCrudServiceImplTest {
         when(clientCertificateRepository.findById(CERTIFICATE_ID)).thenReturn(Optional.of(existingCert));
         when(clientCertificateRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        ClientCertificate updated = clientCertificateCrudService.update(
-            CERTIFICATE_ID,
-            ClientCertificate.builder().name("Updated Name").build()
-        );
+        ClientCertificate updated = clientCertificateCrudService.update(CERTIFICATE_ID, new ClientCertificate("Updated Name", null, null));
 
-        assertThat(updated.getName()).isEqualTo("Updated Name");
-        assertThat(updated.getUpdatedAt()).isNotNull();
-        assertThat(updated.getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE);
+        assertThat(updated.name()).isEqualTo("Updated Name");
+        assertThat(updated.updatedAt()).isNotNull();
+        assertThat(updated.status()).isEqualTo(ClientCertificateStatus.ACTIVE);
     }
 
     @Test
@@ -272,10 +257,10 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate updated = clientCertificateCrudService.update(
             CERTIFICATE_ID,
-            ClientCertificate.builder().name("Updated Name").startsAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS))).build()
+            new ClientCertificate("Updated Name", Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), null)
         );
 
-        assertThat(updated.getStatus()).isEqualTo(ClientCertificateStatus.SCHEDULED);
+        assertThat(updated.status()).isEqualTo(ClientCertificateStatus.SCHEDULED);
     }
 
     @Test
@@ -290,10 +275,10 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate updated = clientCertificateCrudService.update(
             CERTIFICATE_ID,
-            ClientCertificate.builder().name("Updated Name").endsAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS))).build()
+            new ClientCertificate("Updated Name", null, Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
         );
 
-        assertThat(updated.getStatus()).isEqualTo(ClientCertificateStatus.ACTIVE_WITH_END);
+        assertThat(updated.status()).isEqualTo(ClientCertificateStatus.ACTIVE_WITH_END);
     }
 
     @Test
@@ -308,17 +293,17 @@ class ClientCertificateCrudServiceImplTest {
 
         ClientCertificate updated = clientCertificateCrudService.update(
             CERTIFICATE_ID,
-            ClientCertificate.builder().name("Updated Name").endsAt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS))).build()
+            new ClientCertificate("Updated Name", null, Date.from(Instant.now().minus(1, ChronoUnit.DAYS)))
         );
 
-        assertThat(updated.getStatus()).isEqualTo(ClientCertificateStatus.REVOKED);
+        assertThat(updated.status()).isEqualTo(ClientCertificateStatus.REVOKED);
     }
 
     @Test
     void should_throw_not_found_when_updating_non_existing_certificate() throws TechnicalException {
         when(clientCertificateRepository.findById(CERTIFICATE_ID)).thenReturn(Optional.empty());
 
-        ClientCertificate udpatedName = ClientCertificate.builder().name("Udpated Name").build();
+        ClientCertificate udpatedName = new ClientCertificate("Udpated Name", null, null);
         assertThatThrownBy(() -> clientCertificateCrudService.update(CERTIFICATE_ID, udpatedName)).isInstanceOf(
             ClientCertificateNotFoundException.class
         );
@@ -400,7 +385,7 @@ class ClientCertificateCrudServiceImplTest {
         );
 
         assertThat(result).hasSize(1);
-        assertThat(result.iterator().next().getId()).isEqualTo(CERTIFICATE_ID);
+        assertThat(result.iterator().next().id()).isEqualTo(CERTIFICATE_ID);
     }
 
     @Test
@@ -431,7 +416,7 @@ class ClientCertificateCrudServiceImplTest {
         );
 
         assertThat(result).hasSize(2);
-        assertThat(result).extracting(ClientCertificate::getId).containsExactlyInAnyOrder(CERTIFICATE_ID, certificateId2);
+        assertThat(result).extracting(ClientCertificate::id).containsExactlyInAnyOrder(CERTIFICATE_ID, certificateId2);
     }
 
     @Test
@@ -470,7 +455,7 @@ class ClientCertificateCrudServiceImplTest {
         var result = clientCertificateCrudService.findByStatuses(ClientCertificateStatus.ACTIVE);
 
         assertThat(result).hasSize(2);
-        assertThat(result).extracting(ClientCertificate::getId).containsExactlyInAnyOrder(CERTIFICATE_ID, "cert-id-2");
+        assertThat(result).extracting(ClientCertificate::id).containsExactlyInAnyOrder(CERTIFICATE_ID, "cert-id-2");
     }
 
     @Test
@@ -492,7 +477,7 @@ class ClientCertificateCrudServiceImplTest {
             -----END CERTIFICATE-----
             """;
 
-        ClientCertificate toCreate = ClientCertificate.builder().name("Invalid Certificate").certificate(invalidCertificate).build();
+        ClientCertificate toCreate = new ClientCertificate("Invalid Certificate", invalidCertificate, null, null);
         assertThatThrownBy(() -> {
             clientCertificateCrudService.create(APPLICATION_ID, toCreate);
         }).isInstanceOf(ClientCertificateInvalidException.class);
@@ -503,7 +488,7 @@ class ClientCertificateCrudServiceImplTest {
         String noCertificate = """
             no certificate header, so not parsed as an exception by the library.
             """;
-        ClientCertificate toCreate = ClientCertificate.builder().name("Empty Certificate").certificate(noCertificate).build();
+        ClientCertificate toCreate = new ClientCertificate("Empty Certificate", noCertificate, null, null);
         assertThatThrownBy(() -> clientCertificateCrudService.create(APPLICATION_ID, toCreate)).isInstanceOf(
             ClientCertificateEmptyException.class
         );
@@ -547,7 +532,7 @@ class ClientCertificateCrudServiceImplTest {
             P5EfACFOUJGjCiuDC02wG2mO44Y98bT3oIMdjH9haMd5eoEAxmFy+M4UVTa2YK6u
             Q6teMha+jg==
             -----END CERTIFICATE-----""";
-        ClientCertificate createDto = ClientCertificate.builder().name("CA Certificate").certificate(caCertificate).build();
+        ClientCertificate createDto = new ClientCertificate("CA Certificate", caCertificate, null, null);
 
         assertThatThrownBy(() -> clientCertificateCrudService.create(APPLICATION_ID, createDto)).isInstanceOf(
             ClientCertificateAuthorityException.class
@@ -556,18 +541,18 @@ class ClientCertificateCrudServiceImplTest {
 
     @Test
     void should_create_certificate_with_scheduled_status_when_starts_at_and_ends_at_in_future() throws TechnicalException {
-        ClientCertificate domainCertificate = ClientCertificate.builder()
-            .name("Scheduled Certificate")
-            .startsAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
-            .endsAt(Date.from(Instant.now().plus(2, ChronoUnit.DAYS)))
-            .certificate(PEM_CERTIFICATE)
-            .build();
+        ClientCertificate domainCertificate = new ClientCertificate(
+            "Scheduled Certificate",
+            PEM_CERTIFICATE,
+            Date.from(Instant.now().plus(1, ChronoUnit.DAYS)),
+            Date.from(Instant.now().plus(2, ChronoUnit.DAYS))
+        );
         when(clientCertificateRepository.existsByFingerprintAndActiveApplication(any(), eq(ENVIRONMENT_ID))).thenReturn(false);
         when(clientCertificateRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         ClientCertificate created = clientCertificateCrudService.create(APPLICATION_ID, domainCertificate);
 
-        assertThat(created.getStatus()).isEqualTo(ClientCertificateStatus.SCHEDULED);
+        assertThat(created.status()).isEqualTo(ClientCertificateStatus.SCHEDULED);
 
         ArgumentCaptor<io.gravitee.repository.management.model.ClientCertificate> captor = ArgumentCaptor.forClass(
             io.gravitee.repository.management.model.ClientCertificate.class
@@ -605,7 +590,7 @@ class ClientCertificateCrudServiceImplTest {
         Optional<ClientCertificate> result = clientCertificateCrudService.findMostRecentActiveByApplicationId(APPLICATION_ID);
 
         assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(recentCertificateId);
+        assertThat(result.get().id()).isEqualTo(recentCertificateId);
     }
 
     @Test
@@ -643,12 +628,7 @@ class ClientCertificateCrudServiceImplTest {
         when(clientCertificateRepository.findById(any())).thenReturn(
             Optional.of(io.gravitee.repository.management.model.ClientCertificate.builder().build())
         );
-        ClientCertificate clientCertificate = ClientCertificate.builder()
-            .name("With dates")
-            .startsAt(startDate)
-            .endsAt(endDate)
-            .certificate(PEM_CERTIFICATE)
-            .build();
+        ClientCertificate clientCertificate = new ClientCertificate("With dates", PEM_CERTIFICATE, startDate, endDate);
         if (valid) {
             assertThatCode(() -> clientCertificateCrudService.create(APPLICATION_ID, clientCertificate)).doesNotThrowAnyException();
             assertThatCode(() -> clientCertificateCrudService.update(APPLICATION_ID, clientCertificate)).doesNotThrowAnyException();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class ValidateApplicationSettingsDomainServiceImplTest {
+class ValidateApplicationSettingsDomainServiceImplTest {
 
     private final ApplicationRepository applicationRepository = mock(ApplicationRepository.class);
 
@@ -315,8 +315,10 @@ public class ValidateApplicationSettingsDomainServiceImplTest {
 
             var result = cut.validateAndSanitize(inputWithTls(tls));
 
-            assertThat(result.severe()).isEmpty();
-            assertThat(result.warning()).isEmpty();
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e ->
+                e.getMessage().contains("tls configuration must contain either clientCertificate or clientCertificates")
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.infra.domain_service.application;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
@@ -24,13 +24,18 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
+import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
+import io.gravitee.rest.api.model.application.TlsSettings;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
+import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -102,5 +107,216 @@ public class ValidateApplicationSettingsDomainServiceImplTest {
         var result = cut.validateAndSanitize(input);
 
         assertThat(result.value()).isNotEmpty().hasValue(input.sanitized(expectedSettings));
+    }
+
+    @Nested
+    class TlsValidation {
+
+        private static final String VALID_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIFxjCCA64CCQD9kAnHVVL02TANBgkqhkiG9w0BAQsFADCBozEsMCoGCSqGSIb3
+            DQEJARYddW5pdC50ZXN0c0BncmF2aXRlZXNvdXJjZS5jb20xEzARBgNVBAMMCnVu
+            aXQtdGVzdHMxFzAVBgNVBAsMDkdyYXZpdGVlU291cmNlMRcwFQYDVQQKDA5HcmF2
+            aXRlZVNvdXJjZTEOMAwGA1UEBwwFTGlsbGUxDzANBgNVBAgMBkZyYW5jZTELMAkG
+            A1UEBhMCRlIwIBcNMjExMDE5MTUyMDQxWhgPMjEyMTA5MjUxNTIwNDFaMIGjMSww
+            KgYJKoZIhvcNAQkBFh11bml0LnRlc3RzQGdyYXZpdGVlc291cmNlLmNvbTETMBEG
+            A1UEAwwKdW5pdC10ZXN0czEXMBUGA1UECwwOR3Jhdml0ZWVTb3VyY2UxFzAVBgNV
+            BAoMDkdyYXZpdGVlU291cmNlMQ4wDAYDVQQHDAVMaWxsZTEPMA0GA1UECAwGRnJh
+            bmNlMQswCQYDVQQGEwJGUjCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+            AOKxBeF33XOd5sVaHbavIGFU+DMTX+cqTbRiJQJqAlrrDeuPQ3YEfga7hpHHB3ev
+            OjunNCBJp4p/6VsBhylqcqd8KU+xqQ/wvNsqzp/50ssMkud+0sbPFjjjxM1rDI9X
+            JVCqGqa15jlKfylcOOggH6KAOugM4BquBjeTRH0mGv2MBgZvtKHAieW0gzPslXxp
+            UZZZ+gvvSSLo7NkAv7awWKSoV+yMlXma0yX0ygAj14EK1AxhFLZFgWDm8Ex919ry
+            rbcPV6tqUHjw7Us8cy8p/pqftOUnwyRQ4LmaSdqwESZmdU+GXNXq22sAB6rX0G7u
+            tXmoXVwQVlD8kEb79JbbIEOfPvLATyr8VStCK5dSXyc/JuzDo7QCquQUdrGpWrSy
+            wdKKbCbOWDStakmBTEkgB0Bqg6yWFrHjgj+rzNeWFvIoZA+sLV2UCrlhDQ8BUV9O
+            PMdgGBMKu4TrdEezt1NqDHjvThC3c6quxixxmaO/K7YPncVzguypijw7U7yl8CkG
+            DlUJ+rPddEgsQCf+1E6z/xIeh8sCEdLm6TN80Dsw1yTdwzhRO9KvVY/gjE/ZaUYL
+            g8Z0Htjq6vvnMwvr4C/8ykRk9oMYlv3o52pXQEcsbiZYm7LCTwgCs6k7KEiaHUze
+            ySEqlkqFC8PG2GzCC6dM50xYktbcmwC+mep7c6bTAsexAgMBAAEwDQYJKoZIhvcN
+            AQELBQADggIBAIHpb9solYTIPszzgvw0S6BVBAGzARDNDSi/jj+4KXKlKxYvVvq+
+            bTX7YE6rC/wFGpyCjwfoWzzIrfLiIcmVTfu1o13Y/B8IEP4WyiAYrGszLqbjy1wM
+            cyfwaxYpP/XfIQgcP5idI6kAA7hbGrFrLijIcdfYhh4tr6dsjD81uNrsVhp+JcAV
+            CPv2o5YeRSMFUJrImAU5s73yX/x6fb2nCUR6PIMiPm9gveIAuY2+L12NzIJUugwN
+            EZjqCeOr52f/yDuA+pAvVCGnZSSdkVWUh02ZsPxM4TiRzmxSkM5ODb59XWHeoFT1
+            yvKA2F7+WFAL2R8BhBoVlBp1hug33Mrsix7L6yG4G9Ljss9Y0pzEd4B+IFGbpMZN
+            R4dqZGpKS0aiStnvnurXBVWwIcJ3kCaAl2OgXZO5ivi+iNIx8e5qtXqDCnnlpeGz
+            1KVhzZaqND1I+X1JS6I/V/HiTsnuVdg5aBZPYbQI0QLSgB+0SOjmTlWzjyJEt0PS
+            kyOEs4bB9CPf3JaWgB9aORczsgn/cz8S7kEc8JlXDflePiSl4QPWYbX05wY9l2lJ
+            yzuug/vKMCWUq0cU2i8WSA02N0+tEm4hCNol04KLKa3MRAa/yOSmDIJ4z+2D/BSD
+            FZHaYejhPQFZzv73SxOAu2QCaXH5vIBEDx4Mb+lvc4BukgeIT2Gyi2gg
+            -----END CERTIFICATE-----
+            """;
+
+        private static final String VALID_CA_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIGAzCCA+ugAwIBAgIUcso7he1LovzeKw5od1lZD3vlNOAwDQYJKoZIhvcNAQEL
+            BQAwgZAxKTAnBgkqhkiG9w0BCQEWGmNvbnRhY3RAZ3Jhdml0ZWVzb3VyY2UuY29t
+            MRAwDgYDVQQDDAdBUElNX0NOMQ0wCwYDVQQLDARBUElNMRQwEgYDVQQKDAtBUElN
+            X1Rlc3RlcjEOMAwGA1UEBwwFTGlsbGUxDzANBgNVBAgMBkZyYW5jZTELMAkGA1UE
+            BhMCRlIwHhcNMjQwODI4MDY0NzMzWhcNMzQwODI2MDY0NzMzWjCBkDEpMCcGCSqG
+            SIb3DQEJARYaY29udGFjdEBncmF2aXRlZXNvdXJjZS5jb20xEDAOBgNVBAMMB0FQ
+            SU1fQ04xDTALBgNVBAsMBEFQSU0xFDASBgNVBAoMC0FQSU1fVGVzdGVyMQ4wDAYD
+            VQQHDAVMaWxsZTEPMA0GA1UECAwGRnJhbmNlMQswCQYDVQQGEwJGUjCCAiIwDQYJ
+            KoZIhvcNAQEBBQADggIPADCCAgoCggIBAMOEVa4niB+yfSz9+cxoydZTMoHVPUEJ
+            6o4NT34pcGf4Q6+DwNmV3Lrk291rw4hhXnlzflw4AOEZEbbpVBCC304vfjSt+enE
+            MP8AtuIAsAJXjKMNBO3saD+6fhLdyIdz3rjq+fMcIAcjGFGQqgQJoniLnrnDU3ee
+            WX0XnRHFOB1iGfMZ2X+0PptKvKH8Pq33er6tCCCH2cA7Owc4+6herDtP4oQ+xSqY
+            spEORK37iRg7Pm8NgA/GsfjBIDjyjBsYN+waNGuS02MR8znQfgk+DjZlc4+e93vK
+            VJfTzgMdOG1a/imB1mdwZvO1l9nSlArJlfvItCzi+2dc6Us67Pp8XyCiHK/2I7nJ
+            DBDs84o3SA4uWe6SXfOGulTma6ENPsKC5Oh8VbbZvubbgNqFRCY19yz66zhq4wH4
+            7W90TGZelHez6Dk/cCnl3WRPljuEzRcqRiU8YWdMCVqAfjdgxdSiQCOWa+Ug7Hlz
+            LUvRcCAS2i20oGePKJ1Zl9IJuoik8QCovzjPP4bGgySTzvlhuKB7kyxJ6EDmo1Ic
+            k2HVr0VvLRV4O1gT2lGFSu2k0QquV6WeKoQni+/oZfMRv1LTc0m+r34PN+ZdL+01
+            2Bkcs2lmdp5oTwbSjw8w76Yf1vtz0SSwaQDgss8t0dJZNPECnHL+wki5byyrsdBM
+            bJbovk7g8HUJAgMBAAGjUzBRMB0GA1UdDgQWBBQ3IIhDN+2FihTlbDjDIPdXjIEz
+            GDAfBgNVHSMEGDAWgBQ3IIhDN+2FihTlbDjDIPdXjIEzGDAPBgNVHRMBAf8EBTAD
+            AQH/MA0GCSqGSIb3DQEBCwUAA4ICAQBCyUHgdsx5tG09ol5PoHULn7QpUNYqdRo2
+            Go3Qy+VTl1PngnKzWcpzFgc4zf+gaQG55KelulqOSAr13GBL2Wd9u7diM5OQQ6pK
+            dhxWu9i2U/7LMSASYpNgawHTVdZ6tLi5hPxL8WQxoEBtXGIynQNKI6z76AjZwRcr
+            fgq+CB2Ai8jcJxWCcMfbABPAPSwK9bRAmuP95+K7CXiCOvVnHQFQT3xMw4yyZ2Qq
+            HrAL42RGyiejAx8eraE8fH8Dq9iWn6q91WY60nesyOnZLkZz/c8mTvibCE97d767
+            rJUJREeS4MHFOw/wHXN/JeLryedUGSR4pEllBS/QjUhiUysvM+02a1XuwP0qD/5v
+            697tDuozn/i7N9O0ThbZNR9KlSSMqAJ1iWpijt7e7Rr/CqP/42HYOZSyuoYGiydA
+            P5TTsFBjbDTs2XtPEjPkoZ2vzegKLcT7H/pBtNHdwNnEcLbgDLwMGwxWI6urkjx4
+            uz/iY/SibzgTnuxgTjW03HFVOFq9w2Tv/4qFNJrCxt+aQwG4RjnS77zS4AFoJ6ZI
+            YQvqCvXVVosYZWLZGkbQSc2iNS2Wr5dFqngl3py6kps8BcUDzF/J/9QLMLI3ZTUt
+            P5EfACFOUJGjCiuDC02wG2mO44Y98bT3oIMdjH9haMd5eoEAxmFy+M4UVTa2YK6u
+            Q6teMha+jg==
+            -----END CERTIFICATE-----""";
+
+        private static final AuditInfo AUDIT_INFO = AuditInfo.builder().organizationId("test").environmentId("test").build();
+
+        private ValidateApplicationSettingsDomainService.Input inputWithTls(TlsSettings tls) {
+            var settings = ApplicationSettings.builder().app(new SimpleApplicationSettings()).tls(tls).build();
+            return new ValidateApplicationSettingsDomainService.Input(AUDIT_INFO, "app-id", settings);
+        }
+
+        @Test
+        void should_reject_when_both_single_and_list_certificates_are_set() {
+            var tls = TlsSettings.builder()
+                .clientCertificate(VALID_PEM)
+                .clientCertificates(List.of(new CreateClientCertificate("cert1", null, null, VALID_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("cannot set both"));
+        }
+
+        @Test
+        void should_warn_when_deprecated_single_certificate_is_used() {
+            var tls = TlsSettings.builder().clientCertificate(VALID_PEM).build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isEmpty();
+            assertThat(result.warning()).isPresent();
+            assertThat(result.warning().get()).anyMatch(e -> e.getMessage().contains("deprecated"));
+        }
+
+        @Test
+        void should_accept_valid_certificate_list() {
+            var tls = TlsSettings.builder()
+                .clientCertificates(
+                    List.of(
+                        new CreateClientCertificate("cert1", null, null, VALID_PEM),
+                        new CreateClientCertificate("cert2", null, null, VALID_PEM)
+                    )
+                )
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isEmpty();
+            assertThat(result.warning()).isEmpty();
+        }
+
+        @Test
+        void should_reject_unparsable_certificate_in_list() {
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("bad", null, null, "not-a-pem")))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("certificate is empty"));
+        }
+
+        @Test
+        void should_reject_invalid_pem_certificate_in_list() {
+            var tls = TlsSettings.builder()
+                .clientCertificates(
+                    List.of(
+                        new CreateClientCertificate(
+                            "bad-pem",
+                            null,
+                            null,
+                            "-----BEGIN CERTIFICATE-----\nYmFkLWRhdGE=\n-----END CERTIFICATE-----"
+                        )
+                    )
+                )
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("not a valid PEM"));
+        }
+
+        @Test
+        void should_reject_ca_certificate_in_list() {
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("ca-cert", null, null, VALID_CA_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("CA certificate"));
+        }
+
+        @Test
+        void should_reject_when_starts_at_is_after_ends_at() {
+            var startsAt = new Date(System.currentTimeMillis() + 86400000L); // tomorrow
+            var endsAt = new Date(System.currentTimeMillis() - 86400000L); // yesterday
+
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("bad-dates", startsAt, endsAt, VALID_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("startsAt must be before endsAt"));
+        }
+
+        @Test
+        void should_warn_when_ends_at_is_after_certificate_expiration() {
+            // The VALID_PEM cert expires at 2121-09-25, so set endsAt way past that
+            var endsAt = new Date(5000000000000L); // year 2128
+
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("late-end", null, endsAt, VALID_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isEmpty();
+            assertThat(result.warning()).isPresent();
+            assertThat(result.warning().get()).anyMatch(e -> e.getMessage().contains("endsAt is after certificate expiration"));
+        }
+
+        @Test
+        void should_accept_tls_settings_with_no_certificates() {
+            var tls = TlsSettings.builder().build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isEmpty();
+            assertThat(result.warning()).isEmpty();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.apim.infra.domain_service.application;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
@@ -317,6 +319,26 @@ class ValidateApplicationSettingsDomainServiceImplTest {
 
             assertThat(result.severe()).isEmpty();
             assertThat(result.warning()).isEmpty();
+        }
+
+        @Test
+        void should_reject_duplicated_certificate() {
+            var tls = TlsSettings.builder()
+                .clientCertificates(
+                    List.of(
+                        new CreateClientCertificate("cert1", null, null, VALID_PEM),
+                        new CreateClientCertificate("cert2", null, null, VALID_PEM)
+                    )
+                )
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe())
+                .get()
+                .asInstanceOf(LIST)
+                .anyMatch(e -> ((Validator.Error) e).getMessage().contains("client certificate content must be unique"));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -219,7 +219,7 @@ class ValidateApplicationSettingsDomainServiceImplTest {
         }
 
         @Test
-        void should_accept_valid_certificate_list() {
+        void should_reject_duplicated_certificate() {
             var tls = TlsSettings.builder()
                 .clientCertificates(
                     List.of(
@@ -231,8 +231,11 @@ class ValidateApplicationSettingsDomainServiceImplTest {
 
             var result = cut.validateAndSanitize(inputWithTls(tls));
 
-            assertThat(result.severe()).isEmpty();
-            assertThat(result.warning()).isEmpty();
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe())
+                .get()
+                .asInstanceOf(LIST)
+                .anyMatch(e -> ((Validator.Error) e).getMessage().contains("client certificate content must be unique"));
         }
 
         @Test
@@ -319,26 +322,6 @@ class ValidateApplicationSettingsDomainServiceImplTest {
 
             assertThat(result.severe()).isEmpty();
             assertThat(result.warning()).isEmpty();
-        }
-
-        @Test
-        void should_reject_duplicated_certificate() {
-            var tls = TlsSettings.builder()
-                .clientCertificates(
-                    List.of(
-                        new CreateClientCertificate("cert1", null, null, VALID_PEM),
-                        new CreateClientCertificate("cert2", null, null, VALID_PEM)
-                    )
-                )
-                .build();
-
-            var result = cut.validateAndSanitize(inputWithTls(tls));
-
-            assertThat(result.severe()).isPresent();
-            assertThat(result.severe())
-                .get()
-                .asInstanceOf(LIST)
-                .anyMatch(e -> ((Validator.Error) e).getMessage().contains("client certificate content must be unique"));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -315,10 +315,8 @@ class ValidateApplicationSettingsDomainServiceImplTest {
 
             var result = cut.validateAndSanitize(inputWithTls(tls));
 
-            assertThat(result.severe()).isPresent();
-            assertThat(result.severe().get()).anyMatch(e ->
-                e.getMessage().contains("tls configuration must contain either clientCertificate or clientCertificates")
-            );
+            assertThat(result.severe()).isEmpty();
+            assertThat(result.warning()).isEmpty();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.application_certificates;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
@@ -30,6 +31,7 @@ import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.time.Instant;
@@ -128,13 +130,13 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     @Test
     void should_not_update_ActiveMTLSSubscriptions_when_no_mtls_subscriptions() {
         // Given: an API key plan (not mTLS)
-        Plan apiKeyPlan = buildPlan(PLAN_ID, PlanSecurityType.API_KEY.getLabel());
+        Plan apiKeyPlan = buildPlan(PlanSecurityType.API_KEY.getLabel());
         planCrudService.initWith(List.of(apiKeyPlan));
 
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
         subscriptionCrudService.initWith(List.of(subscription));
 
-        ClientCertificate certificate = buildClientCertificate("cert-1", APPLICATION_ID, ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
         clientCertificateCrudService.initWith(List.of(certificate));
 
         // When
@@ -143,18 +145,19 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         // Then: subscription should not be updated
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
         assertThat(result.getClientCertificate()).isNull();
+        assertThat(result.getCreatedAt()).isSameAs(result.getUpdatedAt());
     }
 
     @Test
     void should_update_ActiveMTLSSubscriptions_subscription_with_single_certificate_as_base64_pem() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
         subscriptionCrudService.initWith(List.of(subscription));
 
-        ClientCertificate certificate = buildClientCertificate("cert-1", APPLICATION_ID, ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
         clientCertificateCrudService.initWith(List.of(certificate));
 
         // When
@@ -163,6 +166,7 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         // Then: subscription should be updated with base64 encoded PEM
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
         assertThat(result.getClientCertificate()).isNotNull();
+        assertThat(result.getCreatedAt()).isNotEqualTo(result.getUpdatedAt());
 
         String decodedCertificate = new String(Base64.getDecoder().decode(result.getClientCertificate()), StandardCharsets.UTF_8);
         assertThat(decodedCertificate).isEqualTo(PEM_CERTIFICATE_1);
@@ -171,24 +175,14 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     @Test
     void should_update_ActiveMTLSSubscriptions_subscription_with_pkcs7_bundle_when_multiple_certificates() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
         subscriptionCrudService.initWith(List.of(subscription));
 
-        ClientCertificate certificate1 = buildClientCertificate(
-            "cert-1",
-            APPLICATION_ID,
-            ClientCertificateStatus.ACTIVE,
-            PEM_CERTIFICATE_1
-        );
-        ClientCertificate certificate2 = buildClientCertificate(
-            "cert-2",
-            APPLICATION_ID,
-            ClientCertificateStatus.ACTIVE_WITH_END,
-            PEM_CERTIFICATE_2
-        );
+        ClientCertificate certificate1 = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate certificate2 = buildClientCertificate("cert-2", ClientCertificateStatus.ACTIVE_WITH_END, PEM_CERTIFICATE_2);
         clientCertificateCrudService.initWith(List.of(certificate1, certificate2));
 
         // When
@@ -197,6 +191,7 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         // Then: subscription should be updated with base64 encoded PKCS7 bundle
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
         assertThat(result.getClientCertificate()).isNotNull();
+        assertThat(result.getCreatedAt()).isNotEqualTo(result.getUpdatedAt());
 
         // Verify it's a valid base64 string and starts with PKCS7 signature
         byte[] decoded = Base64.getDecoder().decode(result.getClientCertificate());
@@ -208,14 +203,14 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     @Test
     void should_not_update_ActiveMTLSSubscriptions_subscription_when_certificate_unchanged() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         String existingEncodedCert = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_1.getBytes(StandardCharsets.UTF_8));
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, existingEncodedCert);
         subscriptionCrudService.initWith(List.of(subscription));
 
-        ClientCertificate certificate = buildClientCertificate("cert-1", APPLICATION_ID, ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
         clientCertificateCrudService.initWith(List.of(certificate));
 
         // When
@@ -224,12 +219,13 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         // Then: subscription should remain unchanged (same reference)
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
         assertThat(result.getClientCertificate()).isEqualTo(existingEncodedCert);
+        assertThat(result.getCreatedAt()).isSameAs(result.getUpdatedAt());
     }
 
     @Test
     void should_clear_certificate_when_no_active_certificates() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         String existingEncodedCert = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_1.getBytes(StandardCharsets.UTF_8));
@@ -237,33 +233,26 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         subscriptionCrudService.initWith(List.of(subscription));
 
         // No active certificates (only revoked)
-        ClientCertificate revokedCertificate = buildClientCertificate(
-            "cert-1",
-            APPLICATION_ID,
-            ClientCertificateStatus.REVOKED,
-            PEM_CERTIFICATE_1
-        );
+        ClientCertificate revokedCertificate = buildClientCertificate("cert-1", ClientCertificateStatus.REVOKED, PEM_CERTIFICATE_1);
         clientCertificateCrudService.initWith(List.of(revokedCertificate));
 
-        // When
-        service.updateActiveMTLSSubscriptions(APPLICATION_ID);
-
-        // Then: subscription should have null certificate
-        SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
-        assertThat(result.getClientCertificate()).isNull();
+        // When calling => error should be thrown
+        assertThatThrownBy(() -> service.updateActiveMTLSSubscriptions(APPLICATION_ID))
+            .isInstanceOf(ClientCertificateLastRemovalException.class)
+            .hasMessageContaining(APPLICATION_ID);
     }
 
     @Test
     void should_update_ActiveMTLSSubscriptions_multiple_subscriptions() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         SubscriptionEntity subscription1 = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID, null);
         SubscriptionEntity subscription2 = buildSubscription("sub-2", APPLICATION_ID, PLAN_ID, null);
         subscriptionCrudService.initWith(List.of(subscription1, subscription2));
 
-        ClientCertificate certificate = buildClientCertificate("cert-1", APPLICATION_ID, ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
         clientCertificateCrudService.initWith(List.of(certificate));
 
         // When
@@ -271,14 +260,18 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
 
         // Then: both subscriptions should be updated
         String expectedEncodedCert = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_1.getBytes(StandardCharsets.UTF_8));
-        assertThat(subscriptionCrudService.get("sub-1").getClientCertificate()).isEqualTo(expectedEncodedCert);
-        assertThat(subscriptionCrudService.get("sub-2").getClientCertificate()).isEqualTo(expectedEncodedCert);
+        SubscriptionEntity sub1 = subscriptionCrudService.get("sub-1");
+        assertThat(sub1.getClientCertificate()).isEqualTo(expectedEncodedCert);
+        assertThat(sub1.getCreatedAt()).isNotEqualTo(sub1.getUpdatedAt());
+        SubscriptionEntity sub2 = subscriptionCrudService.get("sub-2");
+        assertThat(sub2.getClientCertificate()).isEqualTo(expectedEncodedCert);
+        assertThat(sub2.getCreatedAt()).isNotEqualTo(sub2.getUpdatedAt());
     }
 
     @Test
     void should_order_certificates_by_created_at_when_creating_pkcs7_bundle() throws Exception {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
@@ -288,20 +281,8 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         Date olderDate = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
         Date newerDate = Date.from(Instant.now());
 
-        ClientCertificate certificate1 = buildClientCertificate(
-            "cert-1",
-            APPLICATION_ID,
-            ClientCertificateStatus.ACTIVE,
-            PEM_CERTIFICATE_1,
-            olderDate
-        );
-        ClientCertificate certificate2 = buildClientCertificate(
-            "cert-2",
-            APPLICATION_ID,
-            ClientCertificateStatus.ACTIVE,
-            PEM_CERTIFICATE_2,
-            newerDate
-        );
+        ClientCertificate certificate1 = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1, olderDate);
+        ClientCertificate certificate2 = buildClientCertificate("cert-2", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_2, newerDate);
         // Add in reverse order to ensure sorting is happening
         clientCertificateCrudService.initWith(List.of(certificate1, certificate2));
 
@@ -323,26 +304,16 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     @Test
     void should_only_consider_active_and_active_with_end_certificates() {
         // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PLAN_ID, PlanSecurityType.MTLS.getLabel());
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
 
         SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
         subscriptionCrudService.initWith(List.of(subscription));
 
         // Mix of certificate statuses
-        ClientCertificate activeCert = buildClientCertificate("cert-1", APPLICATION_ID, ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        ClientCertificate scheduledCert = buildClientCertificate(
-            "cert-2",
-            APPLICATION_ID,
-            ClientCertificateStatus.SCHEDULED,
-            PEM_CERTIFICATE_2
-        );
-        ClientCertificate revokedCert = buildClientCertificate(
-            "cert-3",
-            APPLICATION_ID,
-            ClientCertificateStatus.REVOKED,
-            PEM_CERTIFICATE_2
-        );
+        ClientCertificate activeCert = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
+        ClientCertificate scheduledCert = buildClientCertificate("cert-2", ClientCertificateStatus.SCHEDULED, PEM_CERTIFICATE_2);
+        ClientCertificate revokedCert = buildClientCertificate("cert-3", ClientCertificateStatus.REVOKED, PEM_CERTIFICATE_2);
         clientCertificateCrudService.initWith(List.of(activeCert, scheduledCert, revokedCert));
 
         // When
@@ -354,16 +325,22 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         assertThat(decodedCertificate).isEqualTo(PEM_CERTIFICATE_1);
     }
 
-    private Plan buildPlan(String planId, String securityType) {
+    private Plan buildPlan(String securityType) {
         io.gravitee.definition.model.v4.plan.Plan planDefinition = io.gravitee.definition.model.v4.plan.Plan.builder()
-            .id(planId)
+            .id(PLAN_ID)
             .security(PlanSecurity.builder().type(securityType).build())
             .build();
 
-        return Plan.builder().id(planId).apiId(API_ID).definitionVersion(DefinitionVersion.V4).planDefinitionHttpV4(planDefinition).build();
+        return Plan.builder()
+            .id(PLAN_ID)
+            .apiId(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
     }
 
     private SubscriptionEntity buildSubscription(String subscriptionId, String applicationId, String planId, String clientCertificate) {
+        ZonedDateTime now = ZonedDateTime.now();
         return SubscriptionEntity.builder()
             .id(subscriptionId)
             .applicationId(applicationId)
@@ -372,43 +349,32 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
             .environmentId(ENVIRONMENT_ID)
             .status(SubscriptionEntity.Status.ACCEPTED)
             .clientCertificate(clientCertificate)
-            .createdAt(ZonedDateTime.now())
-            .updatedAt(ZonedDateTime.now())
+            .createdAt(now)
+            .updatedAt(now)
             .build();
     }
 
-    private ClientCertificate buildClientCertificate(
-        String id,
-        String applicationId,
-        ClientCertificateStatus status,
-        String pemCertificate
-    ) {
-        return buildClientCertificate(id, applicationId, status, pemCertificate, new Date());
+    private ClientCertificate buildClientCertificate(String id, ClientCertificateStatus status, String pemCertificate) {
+        return buildClientCertificate(id, status, pemCertificate, new Date());
     }
 
-    private ClientCertificate buildClientCertificate(
-        String id,
-        String applicationId,
-        ClientCertificateStatus status,
-        String pemCertificate,
-        Date createdAt
-    ) {
-        return ClientCertificate.builder()
-            .id(id)
-            .crossId("cross-id-" + id)
-            .applicationId(applicationId)
-            .name("Test Certificate " + id)
-            .startsAt(null)
-            .endsAt(null)
-            .createdAt(createdAt)
-            .updatedAt(new Date())
-            .certificate(pemCertificate)
-            .certificateExpiration(Date.from(Instant.now().plus(365, ChronoUnit.DAYS)))
-            .subject("CN=localhost")
-            .issuer("CN=localhost")
-            .fingerprint("fingerprint-" + id)
-            .environmentId(ENVIRONMENT_ID)
-            .status(status)
-            .build();
+    private ClientCertificate buildClientCertificate(String id, ClientCertificateStatus status, String pemCertificate, Date createdAt) {
+        return new ClientCertificate(
+            id,
+            "cross-id-" + id,
+            APPLICATION_ID,
+            "Test Certificate " + id,
+            null,
+            null,
+            createdAt,
+            new Date(),
+            pemCertificate,
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            "CN=localhost",
+            "CN=localhost",
+            "fingerprint-" + id,
+            ENVIRONMENT_ID,
+            status
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdTest.java
@@ -15,9 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.model.ApiKeyMode;
@@ -30,7 +34,11 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,7 +74,7 @@ public class ApplicationService_FindByIdTest {
     private Application application;
 
     @Mock
-    private io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService clientCertificateCrudService;
+    private ClientCertificateCrudService clientCertificateCrudService;
 
     @Before
     public void setUp() {
@@ -86,9 +94,37 @@ public class ApplicationService_FindByIdTest {
         when(application.getType()).thenReturn(ApplicationType.SIMPLE);
         when(application.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
 
-        final ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
+        when(clientCertificateCrudService.findByApplicationIdAndStatuses(any(), any(), any())).thenReturn(
+            Set.of(
+                clientCertificate("old", Date.from(Instant.now().minus(1, ChronoUnit.DAYS))),
+                clientCertificate("most_recent", Date.from(Instant.now().plus(1, ChronoUnit.DAYS))),
+                clientCertificate("now", Date.from(Instant.now()))
+            )
+        );
 
+        final ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
         assertNotNull(applicationEntity);
+        assertThat(applicationEntity.getSettings().getTls().getClientCertificate()).isEqualTo("most_recent");
+    }
+
+    private static ClientCertificate clientCertificate(String cert, Date createdAt) {
+        return new ClientCertificate(
+            "id",
+            "crossId",
+            APPLICATION_ID,
+            "test",
+            null,
+            null,
+            createdAt,
+            null,
+            cert,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
     }
 
     @Test(expected = ApplicationNotFoundException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -86,9 +86,13 @@ import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeExcep
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionEndsAfterClientCertificateException;
 import jakarta.ws.rs.BadRequestException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1068,6 +1072,53 @@ public class ApplicationService_UpdateTest {
         verify(clientCertificateCrudService, never()).update(eq("kept-cert-id"), any());
         // No new certs to create
         verify(clientCertificateCrudService, never()).create(any(), any());
+    }
+
+    @Test
+    public void should_fail_updating_multiple_certificates_from_list() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setApp(new SimpleApplicationSettings());
+        Instant maxDate = Instant.now().plus(10, ChronoUnit.DAYS);
+        settings.setTls(
+            TlsSettings.builder()
+                .clientCertificates(
+                    java.util.List.of(
+                        new io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate(
+                            "cert-1",
+                            null,
+                            Date.from(Instant.now().plus(5, ChronoUnit.DAYS)),
+                            VALID_PEM_1
+                        ),
+                        new io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate(
+                            "cert-2",
+                            null,
+                            Date.from(maxDate),
+                            "another-pem-content"
+                        )
+                    )
+                )
+                .build()
+        );
+        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
+
+        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
+        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+
+        // Mocks subscription search returning active subscriptions for the application
+        when(subscriptionService.search(any(), any())).thenReturn(List.of(mock(SubscriptionEntity.class)));
+
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertThrows(SubscriptionEndsAfterClientCertificateException.class, () ->
+            applicationService.update(executionContext, APPLICATION_ID, updateApplication)
+        );
+
+        // Verify both certificates were created
+        verify(clientCertificateCrudService, never()).create(eq(APPLICATION_ID), any());
+        verify(clientCertificateCrudService, never()).update(any(), any());
     }
 
     private static @NotNull ConsoleConfigEntity getConsoleConfigEntity(boolean enabled) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -728,7 +728,7 @@ public class SubscriptionServiceTest {
 
         verify(subscriptionRepository, times(1)).update(any(Subscription.class));
         verify(apiKeyService, never()).findBySubscription(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
-        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), any(UpdateSubscriptionEntity.class));
+        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), any(UpdateSubscriptionEntity.class), eq(APPLICATION_ID));
     }
 
     @Test
@@ -1278,7 +1278,7 @@ public class SubscriptionServiceTest {
         // Verify
         verify(subscriptionRepository, times(1)).update(any(Subscription.class));
         verify(apiKeyService, never()).findBySubscription(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
-        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), any(UpdateSubscriptionEntity.class));
+        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), any(UpdateSubscriptionEntity.class), eq(APPLICATION_ID));
     }
 
     @Test
@@ -1304,7 +1304,7 @@ public class SubscriptionServiceTest {
         // Verify
         verify(subscriptionRepository, times(1)).update(any(Subscription.class));
         verify(apiKeyService, never()).findBySubscription(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
-        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), eq(updatedSubscription));
+        verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), eq(updatedSubscription), eq(APPLICATION_ID));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgraderTest.java
@@ -144,7 +144,7 @@ class ApplicationClientCertificateMigrationUpgraderTest {
         assertThat(result).isTrue();
         verify(clientCertificateCrudService).create(
             eq("app-1"),
-            argThat(createCert -> createCert.getName().equals("App 1") && createCert.getCertificate().equals(VALID_PEM_CERTIFICATE))
+            argThat(createCert -> createCert.name().equals("App 1") && createCert.certificate().equals(VALID_PEM_CERTIFICATE))
         );
         verify(applicationRepository).update(
             argThat(app -> app.getId().equals("app-1") && !app.getMetadata().containsKey(METADATA_CLIENT_CERTIFICATE))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -66,6 +66,7 @@ public class SubscriptionValidationServiceImplTest {
 
     @Mock
     private ClientCertificateCrudService clientCertificateCrudService;
+
     @Mock
     private SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
@@ -73,7 +74,11 @@ public class SubscriptionValidationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        cut = new SubscriptionValidationServiceImpl(entrypointConnectorPluginService, clientCertificateCrudService);
+        cut = new SubscriptionValidationServiceImpl(
+            entrypointConnectorPluginService,
+            subscriptionMetadataSanitizer,
+            clientCertificateCrudService
+        );
         lenient()
             .when(subscriptionMetadataSanitizer.sanitizeAndValidate(any()))
             .thenAnswer(invocation -> invocation.getArgument(0));
@@ -220,7 +225,7 @@ public class SubscriptionValidationServiceImplTest {
                     "cert-name",
                     null,
                     Date.from(now),
-                    Date.from(now.plus(30, ChronoUnit.DAYS))
+                    Date.from(now)
                 );
                 when(
                     clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
@@ -235,17 +240,42 @@ public class SubscriptionValidationServiceImplTest {
             void should_not_throw_when_subscription_ends_after_all_certificate_expirations() {
                 Instant now = Instant.now();
                 UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
-                updateSubscriptionEntity.setEndingAt(Date.from(now.plus(60, ChronoUnit.DAYS)));
+                updateSubscriptionEntity.setEndingAt(Date.from(now.plus(30, ChronoUnit.DAYS)));
 
                 var cert = new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
                     "cert-name",
                     null,
                     Date.from(now),
-                    Date.from(now.plus(30, ChronoUnit.DAYS))
+                    Date.from(now.plus(60, ChronoUnit.DAYS))
                 );
                 when(
                     clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
                 ).thenReturn(Set.of(cert));
+
+                assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).doesNotThrowAnyException();
+            }
+
+            @Test
+            void should_not_throw_when_subscription_ends_before_one_certificate_expirations() {
+                Instant now = Instant.now();
+                UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
+                updateSubscriptionEntity.setEndingAt(Date.from(now.plus(30, ChronoUnit.DAYS)));
+
+                var after = new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                    "cert-name",
+                    null,
+                    Date.from(now),
+                    Date.from(now.plus(60, ChronoUnit.DAYS))
+                );
+                var before = new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                    "cert-name",
+                    null,
+                    Date.from(now),
+                    Date.from(now.plus(20, ChronoUnit.DAYS))
+                );
+                when(
+                    clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
+                ).thenReturn(Set.of(before, after));
 
                 assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).doesNotThrowAnyException();
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.rest.api.service.v4.impl.validation;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
@@ -30,9 +33,14 @@ import io.gravitee.rest.api.model.UpdateSubscriptionEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionEndsAfterClientCertificateException;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionEntrypointIdMissingException;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionMetadataSanitizer;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -50,19 +58,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class SubscriptionValidationServiceImplTest {
 
+    public static final String APP_ID = "appId";
     private SubscriptionValidationService cut;
 
     @Mock
     private EntrypointConnectorPluginService entrypointConnectorPluginService;
 
     @Mock
+    private ClientCertificateCrudService clientCertificateCrudService;
+    @Mock
     private SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
     private PlanEntity planEntity;
 
     @BeforeEach
-    public void setUp() {
-        cut = new SubscriptionValidationServiceImpl(entrypointConnectorPluginService, subscriptionMetadataSanitizer);
+    void setUp() {
+        cut = new SubscriptionValidationServiceImpl(entrypointConnectorPluginService, clientCertificateCrudService);
         lenient()
             .when(subscriptionMetadataSanitizer.sanitizeAndValidate(any()))
             .thenAnswer(invocation -> invocation.getArgument(0));
@@ -73,10 +84,10 @@ public class SubscriptionValidationServiceImplTest {
     }
 
     @Nested
-    class SubscriptionType {
+    class PushType {
 
         @BeforeEach
-        public void beforeEach() {
+        void beforeEach() {
             planEntity.setMode(PlanMode.PUSH);
         }
 
@@ -87,9 +98,6 @@ public class SubscriptionValidationServiceImplTest {
             void should_throw_when_no_entrypointId_defined() {
                 NewSubscriptionEntity newSubscriptionEntity = new NewSubscriptionEntity();
                 newSubscriptionEntity.setConfiguration(new SubscriptionConfigurationEntity());
-
-                PlanEntity planEntity = new PlanEntity();
-                planEntity.setMode(PlanMode.PUSH);
 
                 assertThrows(SubscriptionEntrypointIdMissingException.class, () ->
                     cut.validateAndSanitize(planEntity, newSubscriptionEntity)
@@ -128,7 +136,7 @@ public class SubscriptionValidationServiceImplTest {
                 updateSubscriptionEntity.setConfiguration(configuration);
 
                 assertThrows(SubscriptionEntrypointIdMissingException.class, () ->
-                    cut.validateAndSanitize(planEntity, updateSubscriptionEntity)
+                    cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)
                 );
             }
 
@@ -148,7 +156,7 @@ public class SubscriptionValidationServiceImplTest {
                     )
                 ).thenReturn(sanitizedCfg);
 
-                cut.validateAndSanitize(planEntity, updateSubscriptionEntity);
+                cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID);
 
                 assertThat(updateSubscriptionEntity.getConfiguration().getEntrypointConfiguration()).isEqualTo(sanitizedCfg);
             }
@@ -192,10 +200,83 @@ public class SubscriptionValidationServiceImplTest {
     }
 
     @Nested
-    class OtherType {
+    class MTLSType {
 
         @BeforeEach
-        public void beforeEach() {
+        void beforeEach() {
+            planEntity.getSecurity().setType(PlanSecurityType.MTLS.name());
+        }
+
+        @Nested
+        class UpdateSubscription {
+
+            @Test
+            void should_throw_when_subscription_ends_before_certificate_expiration() {
+                Instant now = Instant.now();
+                UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
+                updateSubscriptionEntity.setEndingAt(Date.from(now.plus(10, ChronoUnit.DAYS)));
+
+                var cert = new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                    "cert-name",
+                    null,
+                    Date.from(now),
+                    Date.from(now.plus(30, ChronoUnit.DAYS))
+                );
+                when(
+                    clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
+                ).thenReturn(Set.of(cert));
+
+                assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).isInstanceOf(
+                    SubscriptionEndsAfterClientCertificateException.class
+                );
+            }
+
+            @Test
+            void should_not_throw_when_subscription_ends_after_all_certificate_expirations() {
+                Instant now = Instant.now();
+                UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
+                updateSubscriptionEntity.setEndingAt(Date.from(now.plus(60, ChronoUnit.DAYS)));
+
+                var cert = new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                    "cert-name",
+                    null,
+                    Date.from(now),
+                    Date.from(now.plus(30, ChronoUnit.DAYS))
+                );
+                when(
+                    clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
+                ).thenReturn(Set.of(cert));
+
+                assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).doesNotThrowAnyException();
+            }
+
+            @Test
+            void should_not_throw_when_no_ending_date_on_subscription() {
+                UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
+                updateSubscriptionEntity.setEndingAt(null);
+
+                assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).doesNotThrowAnyException();
+            }
+
+            @Test
+            void should_not_throw_when_no_active_certificates() {
+                UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
+                updateSubscriptionEntity.setEndingAt(Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
+
+                when(
+                    clientCertificateCrudService.findByApplicationIdAndStatuses(APP_ID, ClientCertificateStatus.ACTIVE_WITH_END)
+                ).thenReturn(Set.of());
+
+                assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID)).doesNotThrowAnyException();
+            }
+        }
+    }
+
+    @Nested
+    class JWTType {
+
+        @BeforeEach
+        void beforeEach() {
             planEntity.getSecurity().setType(PlanSecurityType.JWT.getLabel());
         }
 
@@ -203,7 +284,7 @@ public class SubscriptionValidationServiceImplTest {
         class NewSubscription {
 
             @Test
-            public void should_do_nothing() {
+            void should_do_nothing() {
                 NewSubscriptionEntity newSubscriptionEntity = new NewSubscriptionEntity();
                 newSubscriptionEntity.setConfiguration(null);
                 planEntity.setSecurity(new PlanSecurity());
@@ -218,12 +299,12 @@ public class SubscriptionValidationServiceImplTest {
         class UpdateSubscription {
 
             @Test
-            public void should_do_nothing() {
+            void should_do_nothing() {
                 UpdateSubscriptionEntity updateSubscriptionEntity = new UpdateSubscriptionEntity();
                 updateSubscriptionEntity.setConfiguration(null);
                 planEntity.setSecurity(new PlanSecurity());
 
-                cut.validateAndSanitize(planEntity, updateSubscriptionEntity);
+                cut.validateAndSanitize(planEntity, updateSubscriptionEntity, APP_ID);
 
                 assertThat(updateSubscriptionEntity.getConfiguration()).isNull();
             }
@@ -233,7 +314,7 @@ public class SubscriptionValidationServiceImplTest {
         class UpdateSubscriptionConfiguration {
 
             @Test
-            public void should_do_nothing() {
+            void should_do_nothing() {
                 UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
                 updateSubscriptionConfigurationEntity.setConfiguration(null);
                 planEntity.setSecurity(new PlanSecurity());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2002
https://gravitee.atlassian.net/browse/GKO-2003

## Description

* Add a list of certificates at the API level for GKO
* Apply the logic so that several certs can be managed
* Update subscription outside ApplicationService
* Refactor domain client cert to be a record
* Fix faulty behaviour of subscription truststore loader in multi server env
* Fix GKO-2003
   * Change cardinality in subscription trustore loader and manager to work at the certificate level
   * Adjust register/unregister order to avoid connection cuts
   * Rewrite test to be more functional 
     * Less introspection to check internal states 
     * Less mock to use lower level layer

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

