### PR TITLE
fix: return a bad request when parameters cannot be parsed

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ConstraintValidat
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.JsonMappingExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ManagementExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.NotFoundExceptionMapper;
+import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ParamExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.PreconditionFailedExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ThrowableMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.UnrecognizedPropertyExceptionMapper;
@@ -104,6 +105,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(PreconditionFailedExceptionMapper.class);
         register(ValidationExceptionMapper.class);
         register(JsonMappingExceptionMapper.class);
+        register(ParamExceptionMapper.class);
 
         register(ValidationDomainExceptionMapper.class);
         register(TechnicalDomainExceptionMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ParamExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ParamExceptionMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ErrorDetailsInner;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.glassfish.jersey.server.ParamException;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ParamExceptionMapper extends AbstractExceptionMapper<ParamException> {
+
+    @Override
+    public Response toResponse(ParamException e) {
+        return Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON_TYPE).entity(paramError(e)).build();
+    }
+
+    private static Error paramError(ParamException e) {
+        return new Error().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).details(details(e)).message(errorMessage(e));
+    }
+
+    private static List<ErrorDetailsInner> details(ParamException e) {
+        if (e.getCause() == null) {
+            return List.of();
+        }
+        return List.of(new ErrorDetailsInner().message(e.getCause().getMessage()).location(e.getParameterName()));
+    }
+
+    private static String errorMessage(ParamException e) {
+        return paramType(e) + " " + e.getParameterName() + " does not have a valid format";
+    }
+
+    private static String paramType(ParamException e) {
+        return switch (e) {
+            case ParamException.QueryParamException q -> "Query parameter";
+            case ParamException.PathParamException p -> "Path parameter";
+            case ParamException.FormParamException f -> "Form value";
+            case ParamException.HeaderParamException h -> "Header";
+            default -> "Parameter";
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/dashboards/DashboardsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/dashboards/DashboardsResource.java
@@ -15,9 +15,6 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.analytics.dashboards;
 
-import io.gravitee.apim.core.audit.model.AuditActor;
-import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.dashboard.model.Dashboard;
 import io.gravitee.apim.core.dashboard.use_case.CreateDashboardUseCase;
 import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
 import io.gravitee.common.http.MediaType;
@@ -31,7 +28,6 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ParamExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ParamExceptionMapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import jakarta.ws.rs.core.Response;
+import java.util.stream.Stream;
+import org.glassfish.jersey.server.ParamException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ParamExceptionMapperTest {
+
+    private final ParamExceptionMapper mapper = new ParamExceptionMapper();
+
+    @ParameterizedTest(name = "Exception [{0}] should map to message [{1}]")
+    @MethodSource("paramExceptions")
+    void should_return_proper_error_message(ParamException exception, String expectedMessage) {
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(((Error) response.getEntity()).getMessage()).isEqualTo(expectedMessage);
+        }
+    }
+
+    private static Stream<Arguments> paramExceptions() {
+        var cause = new RuntimeException("invalid");
+        return Stream.of(
+            Arguments.of(new ParamException.QueryParamException(cause, "page", null), "Query parameter page does not have a valid format"),
+            Arguments.of(new ParamException.PathParamException(cause, "apiId", null), "Path parameter apiId does not have a valid format"),
+            Arguments.of(new ParamException.FormParamException(cause, "field", null), "Form value field does not have a valid format"),
+            Arguments.of(new ParamException.HeaderParamException(cause, "Accept", null), "Header Accept does not have a valid format"),
+            Arguments.of(new ParamException.MatrixParamException(cause, "matrix", null), "Parameter matrix does not have a valid format")
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/dashboards/DashboardsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/dashboards/DashboardsResourceTest.java
@@ -151,7 +151,7 @@ class DashboardsResourceTest extends AbstractResourceTest {
         @Test
         void should_return_403_if_incorrect_permissions() {
             shouldReturn403(RolePermission.ORGANIZATION_DASHBOARD, ORGANIZATION, RolePermissionAction.CREATE, () ->
-                rootTarget().request().post(json(new CreateDashboard()))
+                rootTarget().request().post(json(DashboardFixtures.aCreateDashboard()))
             );
         }
     }
@@ -292,6 +292,12 @@ class DashboardsResourceTest extends AbstractResourceTest {
             var body = response.readEntity(DashboardsResponse.class);
             assertThat(body.getData()).isEmpty();
             assertThat(body.getPagination()).isNotNull();
+        }
+
+        @Test
+        void should_return_400_when_page_is_not_a_number() {
+            var response = rootTarget().queryParam("page", "a").request().get();
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
         }
 
         @Test


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-2396

This is to avoid this very weird 500 error with a "404 not found" message when parameters cannot be parsed.