### PR TITLE
Apim 12791 portal api add subscribe button

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -225,7 +225,7 @@ export class SubscribeToApiComponent implements OnInit {
       )
       .subscribe({
         next: ({ id }) => {
-          this.router.navigate(['../', 'subscriptions', id], { relativeTo: this.activatedRoute });
+          this.router.navigate(['/dashboard', 'subscriptions', id], { relativeTo: this.activatedRoute });
         },
         error: err => {
           this.hasSubscriptionError = true;

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -27,6 +27,12 @@ import { ApiTabSubscriptionsComponent } from './api/api-details/api-tab-subscrip
 import { SubscriptionsDetailsComponent } from './api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
 import { SubscriptionsTableComponent } from './api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component';
 import { ApiComponent } from './api/api.component';
+import { ConfigureConsumerComponent } from '../components/subscription/webhook/configure-consumer/configure-consumer.component';
+import { anonymousGuard } from '../guards/anonymous.guard';
+import { authGuard } from '../guards/auth.guard';
+import { catalogCategoriesViewGuard } from '../guards/catalog-categories-view.guard';
+import { pagesResolver } from '../resolvers/pages.resolver';
+import { ApiTabToolsComponent } from './api/api-details/api-tab-tools/api-tab-tools.component';
 import { SubscribeToApiComponent } from './api/subscribe-to-api/subscribe-to-api.component';
 import { ApplicationLogComponent } from './applications/application/application-tab-logs/application-log/application-log.component';
 import { ApplicationLogTableComponent } from './applications/application/application-tab-logs/application-log-table/application-log-table.component';
@@ -34,10 +40,21 @@ import { ApplicationTabLogsComponent } from './applications/application/applicat
 import { ApplicationTabSettingsComponent } from './applications/application/application-tab-settings/application-tab-settings.component';
 import { ApplicationComponent } from './applications/application/application.component';
 import { ApplicationsComponent } from './applications/applications.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
+import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
+import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
+import { catalogTabsViewGuard } from '../guards/catalog-tabs-view.guard';
+import { redirectGuard } from '../guards/redirect.guard';
+import { apiResolver } from '../resolvers/api.resolver';
+import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
+import { categoriesResolver } from '../resolvers/categories.resolver';
+import { homepageContentResolver } from '../resolvers/homepage-content.resolver';
 import { CreateApplicationComponent } from './applications/create-application/create-application.component';
 import { CategoriesViewComponent } from './catalog/categories-view/categories-view.component';
 import { CategoryApisComponent } from './catalog/categories-view/category-apis/category-apis.component';
 import { TabsViewComponent } from './catalog/tabs-view/tabs-view.component';
+import { DocumentationSubscribeComponent } from './documentation/components/documentation-subscribe/documentation-subscribe.component';
 import { DocumentationComponent } from './documentation/components/documentation.component';
 import { documentationResolver } from './documentation/resolvers/documentation.resolver';
 import { LogInComponent } from './log-in/log-in.component';
@@ -45,22 +62,6 @@ import { ResetPasswordConfirmationComponent } from './log-in/reset-password/rese
 import { ResetPasswordComponent } from './log-in/reset-password/reset-password.component';
 import { LogOutComponent } from './log-out/log-out.component';
 import { NotFoundComponent } from './not-found/not-found.component';
-import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
-import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
-import { ConfigureConsumerComponent } from '../components/subscription/webhook/configure-consumer/configure-consumer.component';
-import { anonymousGuard } from '../guards/anonymous.guard';
-import { authGuard } from '../guards/auth.guard';
-import { catalogCategoriesViewGuard } from '../guards/catalog-categories-view.guard';
-import { catalogTabsViewGuard } from '../guards/catalog-tabs-view.guard';
-import { redirectGuard } from '../guards/redirect.guard';
-import { apiResolver } from '../resolvers/api.resolver';
-import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
-import { categoriesResolver } from '../resolvers/categories.resolver';
-import { homepageContentResolver } from '../resolvers/homepage-content.resolver';
-import { pagesResolver } from '../resolvers/pages.resolver';
-import { ApiTabToolsComponent } from './api/api-details/api-tab-tools/api-tab-tools.component';
-import { DashboardComponent } from './dashboard/dashboard.component';
-import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
 import { RegistrationComponent } from './registration/registration.component';
 
 const apiRoutes: Routes = [
@@ -263,7 +264,17 @@ export const routes: Routes = [
       {
         path: ':navId',
         resolve: { navItem: documentationResolver },
-        component: DocumentationComponent,
+        children: [
+          {
+            path: '',
+            component: DocumentationComponent,
+          },
+          {
+            path: 'api/:apiId/subscribe',
+            resolve: { api: apiResolver },
+            component: DocumentationSubscribeComponent,
+          },
+        ],
       },
     ],
   },

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
@@ -36,7 +36,7 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
   );
   private readonly getNavigationItemContentViewerHarness = this.locatorForOptional(NavigationItemContentViewerHarness);
   private readonly getGraviteeMarkdownViewer = this.locatorForOptional(GraviteeMarkdownViewerHarness);
-  private readonly getSubscribeMatButton = this.locatorForOptional(MatButtonHarness.with({ text: 'Subscribe' }));
+  private readonly getSubscribeMatButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="subscribe-button"]' }));
 
   async getSidenavToggleButton(): Promise<SidenavToggleButtonComponentHarness | null> {
     const sidenav = await this.getSidenavLayoutHarness();

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { GraviteeMarkdownViewerHarness } from '@gravitee/gravitee-markdown';
 
@@ -35,6 +36,7 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
   );
   private readonly getNavigationItemContentViewerHarness = this.locatorForOptional(NavigationItemContentViewerHarness);
   private readonly getGraviteeMarkdownViewer = this.locatorForOptional(GraviteeMarkdownViewerHarness);
+  private readonly getSubscribeMatButton = this.locatorForOptional(MatButtonHarness.with({ text: 'Subscribe' }));
 
   async getSidenavToggleButton(): Promise<SidenavToggleButtonComponentHarness | null> {
     const sidenav = await this.getSidenavLayoutHarness();
@@ -60,5 +62,9 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
 
   async getGmdViewer(): Promise<GraviteeMarkdownViewerHarness | null> {
     return this.getGraviteeMarkdownViewer();
+  }
+
+  async getSubscribeButton(): Promise<MatButtonHarness | null> {
+    return this.getSubscribeMatButton();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -18,7 +18,13 @@
 <app-sidenav-layout [breadcrumbs]="breadcrumbs()">
   @if (subscribeApiId()) {
     <div breadcrumbActions>
-      <button mat-stroked-button>Subscribe</button>
+      <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
+        @if (currentUser()) {
+          <span i18n="@@subscribeToApiButton">Subscribe</span>
+        } @else {
+          <span i18n="@@signInToSubscribeButton">Sign in to subscribe</span>
+        }
+      </button>
     </div>
   }
   <div sidenavContent class="documentation-folder__sidenav__content">

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -16,6 +16,11 @@
 
 -->
 <app-sidenav-layout [breadcrumbs]="breadcrumbs()">
+  @if (subscribeApiId()) {
+    <div breadcrumbActions>
+      <button mat-stroked-button>Subscribe</button>
+    </div>
+  }
   <div sidenavContent class="documentation-folder__sidenav__content">
     @if (tree() && tree()!.length > 0) {
       <app-tree-component

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -126,6 +126,13 @@ describe('DocumentationFolderComponent', () => {
         expect(await breadcrumbs?.getText()).toEqual('Test item/Folder 1/Page 2');
       });
 
+      it('should not show subscribe button when selected page has no API ancestor', async () => {
+        await init({ items: MOCK_CHILDREN, queryParams: { pageId: 'p2' }, content: MOCK_CONTENT });
+
+        const subscribeButton = await harness.getSubscribeButton();
+        expect(subscribeButton).toBeNull();
+      });
+
       it('should not select if no pages exist', async () => {
         const items = [
           makeItem('f1', 'FOLDER', 'Folder 1', 0),
@@ -204,6 +211,16 @@ describe('DocumentationFolderComponent', () => {
 
       const breadcrumbs = await harness.getBreadcrumbs();
       expect(await breadcrumbs?.getText()).toEqual('Test item/Folder 1/Page 2');
+    });
+  });
+
+  describe('api', () => {
+    it('should show subscribe button when api documentation is clicked', async () => {
+      const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
+      const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
+      await init({ items: [apiItem, apiPage], queryParams: { pageId: 'p-api1' }, content: MOCK_CONTENT });
+
+      expect(await harness.getSubscribeButton()).not.toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -16,6 +16,7 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, input, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, debounceTime, map, merge, Observable, switchMap, tap, withLatestFrom } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
@@ -43,7 +44,14 @@ enum NavParamsChange {
 
 @Component({
   selector: 'app-documentation-folder',
-  imports: [SidenavLayoutComponent, TreeComponent, GraviteeMarkdownViewerModule, NavigationItemContentViewerComponent, AsyncPipe],
+  imports: [
+    SidenavLayoutComponent,
+    TreeComponent,
+    GraviteeMarkdownViewerModule,
+    NavigationItemContentViewerComponent,
+    AsyncPipe,
+    MatButtonModule,
+  ],
   standalone: true,
   templateUrl: './documentation-folder.component.html',
   styleUrl: './documentation-folder.component.scss',
@@ -56,6 +64,7 @@ export class DocumentationFolderComponent {
   folderData = toSignal<FolderData | undefined>(this.loadFolderData());
   tree = signal<TreeNode[]>([]);
   breadcrumbs = signal<Breadcrumb[]>([]);
+  subscribeApiId = signal<string | null>(null);
 
   constructor(
     private readonly router: Router,
@@ -98,6 +107,7 @@ export class DocumentationFolderComponent {
     if (!pageId) {
       return of({ children, selectedPageContent: null }).pipe(
         tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByDefault())),
+        tap(() => this.subscribeApiId.set(null)),
         tap(() => this.navigateToFirstPage()),
       );
     }
@@ -108,6 +118,7 @@ export class DocumentationFolderComponent {
 
     return this.itemsService.getNavigationItemContent(pageId).pipe(
       tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByNodeId(pageId))),
+      tap(() => this.subscribeApiId.set(this.treeService.getAncestorApiId(pageId))),
       map(selectedPageContent => ({ children, selectedPageContent })),
     );
   }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, input, signal } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -29,6 +29,7 @@ import { NavigationItemContentViewerComponent } from '../../../../components/nav
 import { SidenavLayoutComponent } from '../../../../components/sidenav-layout/sidenav-layout.component';
 import { PortalNavigationItem } from '../../../../entities/portal-navigation/portal-navigation-item';
 import { PortalPageContent } from '../../../../entities/portal-navigation/portal-page-content';
+import { CurrentUserService } from '../../../../services/current-user.service';
 import { PortalNavigationItemsService } from '../../../../services/portal-navigation-items.service';
 import { TreeNode, TreeService } from '../../services/tree.service';
 
@@ -65,6 +66,7 @@ export class DocumentationFolderComponent {
   tree = signal<TreeNode[]>([]);
   breadcrumbs = signal<Breadcrumb[]>([]);
   subscribeApiId = signal<string | null>(null);
+  readonly currentUser = inject(CurrentUserService).isUserAuthenticated;
 
   constructor(
     private readonly router: Router,
@@ -75,6 +77,16 @@ export class DocumentationFolderComponent {
 
   onSelect(selectedPageId: string) {
     this.navigateToPage(selectedPageId);
+  }
+
+  onSubscribe() {
+    const apiId = this.subscribeApiId();
+    if (apiId) {
+      this.router.navigate(['api', apiId, 'subscribe'], {
+        relativeTo: this.activatedRoute,
+        queryParamsHandling: 'preserve',
+      });
+    }
   }
 
   private loadFolderData(): Observable<FolderData | undefined> {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
@@ -34,22 +34,25 @@
     <span class="material-icons tree__link__icon" aria-hidden="true">open_in_new</span>
   </a>
 } @else {
+  @let isContainer = node().type === 'FOLDER' || node().type === 'API';
+
   <button
     class="tree__row nav-button"
     role="treeitem"
     mat-stroked-button
     [class.m3-selected-nav-item]="isSelected()"
     [class.folder]="node().type === 'FOLDER'"
+    [class.api]="node().type === 'API'"
     [class.child]="level() > 0"
     [style.--level]="level()"
     [attr.aria-level]="level() + 1"
     [attr.aria-selected]="isSelected()"
-    [attr.aria-expanded]="node().type === 'FOLDER' ? isExpanded() : null"
+    [attr.aria-expanded]="isContainer ? isExpanded() : null"
     (click)="onClick()"
-    (keydown.arrowright)="node().type === 'FOLDER' && isExpanded.set(true)"
-    (keydown.arrowleft)="node().type === 'FOLDER' && isExpanded.set(false)"
+    (keydown.arrowright)="isContainer && isExpanded.set(true)"
+    (keydown.arrowleft)="isContainer && isExpanded.set(false)"
   >
-    @if (node().type === 'FOLDER') {
+    @if (isContainer) {
       <span class="material-icons tree__icon" [class.expanded]="isExpanded()" [attr.data-test-icon]="'toggle'" aria-hidden="true">{{
         'keyboard_arrow_down'
       }}</span>

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
@@ -40,7 +40,7 @@ $indent-step: 26px;
     background: none;
     cursor: pointer;
 
-    &.folder {
+    &.folder, &.api {
       padding-left: calc(#{$indent-base} + (var(--level) * #{$indent-step}));
 
       &.child {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
@@ -40,7 +40,8 @@ $indent-step: 26px;
     background: none;
     cursor: pointer;
 
-    &.folder, &.api {
+    &.folder,
+    &.api {
       padding-left: calc(#{$indent-base} + (var(--level) * #{$indent-step}));
 
       &.child {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
@@ -68,6 +68,7 @@ export class TreeNodeComponent {
   onClick(): void {
     switch (this.node().type) {
       case 'FOLDER':
+      case 'API':
         this.toggleNode();
         break;
       case 'PAGE':

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.harness.ts
@@ -56,6 +56,26 @@ export class TreeComponentHarness extends ComponentHarness {
     throw new Error(`No item found with title: ${title}`);
   }
 
+  async getApiByTitle(title: string): Promise<{
+    label: string;
+    expanded: boolean;
+  } | null> {
+    const buttons = await this.locatorForAll(TreeRowHarness.with({ selector: '.tree__row.api' }))();
+
+    for (const button of buttons) {
+      const text = await button.getText();
+
+      if (text?.trim() === title.trim()) {
+        return {
+          label: text,
+          expanded: await button.isExpanded(),
+        };
+      }
+    }
+
+    throw new Error(`No item found with title: ${title}`);
+  }
+
   async clickItemByTitle(title: string): Promise<void> {
     const buttons = await this.getTreeLabelButtons();
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.spec.ts
@@ -49,6 +49,8 @@ describe('TreeComponent', () => {
      *      - Page 2
      *      - Folder 3
      *      - External Link 2
+     *  - API 1
+     *      - Page 3
      */
     documentationTreeService.init(parentItem, [
       makeItem('p1', 'PAGE', 'Page 1', 0),
@@ -58,6 +60,8 @@ describe('TreeComponent', () => {
       makeItem('p2', 'PAGE', 'Page 2', 0, 'f2'),
       makeItem('f3', 'FOLDER', 'Folder 3', 1, 'f2'),
       makeItem('l2', 'LINK', 'External Link 2', 2, 'f2'),
+      makeItem('a1', 'API', 'API 1', 4),
+      makeItem('p3', 'PAGE', 'Page 3', 5, 'a1'),
     ]);
     itemsTree = documentationTreeService.getTree();
     fixture = TestBed.createComponent(TreeComponent);
@@ -69,10 +73,10 @@ describe('TreeComponent', () => {
 
   it('should build tree', async () => {
     const topLevelItems = await harness.getTopLevelNodes();
-    expect(topLevelItems.length).toBe(4);
+    expect(topLevelItems.length).toBe(5);
 
     const topLevelLabels = await Promise.all(topLevelItems?.map(node => node.getText()) || []);
-    expect(topLevelLabels).toEqual(['Page 1', 'Folder 1', 'open_in_new External Link 1', 'Folder 2']);
+    expect(topLevelLabels).toEqual(['Page 1', 'Folder 1', 'open_in_new External Link 1', 'Folder 2', 'API 1']);
 
     expect(await topLevelItems[0].getChildren()).toHaveLength(0);
     expect(await topLevelItems[1].getChildren()).toHaveLength(0);
@@ -120,6 +124,20 @@ describe('TreeComponent', () => {
 
       folder = await harness.getFolderByTitle('Folder 1');
       expect(folder?.expanded).toEqual(false);
+    });
+
+    it('should collapse api on click', async () => {
+      const selectSpy = jest.fn();
+      component.selectNode.subscribe(selectSpy);
+
+      let api = await harness.getApiByTitle('API 1');
+      expect(api?.expanded).toEqual(true);
+
+      await harness.clickItemByTitle('API 1');
+      expect(selectSpy).not.toHaveBeenCalledWith('a1');
+
+      api = await harness.getApiByTitle('API 1');
+      expect(api?.expanded).toEqual(false);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="content">
+  <a [routerLink]="['/documentation', navId()]" [queryParams]="{ pageId: pageId() }" class="documentation-subscribe__back-link">
+    <span class="material-icons">arrow_back</span>
+    <span i18n="@@documentationSubscribeBack">Back to Documentation</span>
+  </a>
+  <div class="next-gen-h3"><span i18n="@@documentationSubscribeCTA">Subscribe to an API:</span> {{ api().name }}</div>
+  <app-subscribe-to-api [api]="api()" />
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
@@ -1,0 +1,28 @@
+@use '../../../../scss/layout' as layout;
+@use '../../../../scss/theme' as app-theme;
+
+:host {
+  @include layout.medium-container();
+  padding-top: layout.$container-padding-vertical;
+}
+
+.content {
+  flex-direction: column;
+  gap: 24px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  max-width: app-theme.$inner-content-width;
+}
+
+.documentation-subscribe__back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: app-theme.$default-text-color;
+}

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { Router } from '@angular/router';
+
+import { DocumentationSubscribeComponent } from './documentation-subscribe.component';
+import { fakeApi } from '../../../../entities/api/api.fixtures';
+import { AppTestingModule } from '../../../../testing/app-testing.module';
+
+describe('DocumentationSubscribeComponent', () => {
+  let fixture: ComponentFixture<DocumentationSubscribeComponent>;
+  let component: DocumentationSubscribeComponent;
+  let routerSpy: jest.Mocked<Router>;
+
+  const MOCK_API = fakeApi({ id: 'api-1', name: 'Test API' });
+
+  const init = async () => {
+    routerSpy = { navigate: jest.fn().mockReturnValue(Promise.resolve(true)) } as unknown as jest.Mocked<Router>;
+
+    await TestBed.configureTestingModule({
+      imports: [DocumentationSubscribeComponent, MatIconTestingModule, AppTestingModule],
+      providers: [{ provide: Router, useValue: routerSpy }],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(DocumentationSubscribeComponent, {
+        set: { imports: [MatIconTestingModule], schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(DocumentationSubscribeComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('api', MOCK_API);
+    fixture.componentRef.setInput('navId', 'nav-1');
+    fixture.detectChanges();
+  };
+
+  it('should create', async () => {
+    await init();
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { Api } from '../../../../entities/api/api';
+import { SubscribeToApiComponent } from '../../../api/subscribe-to-api/subscribe-to-api.component';
+
+@Component({
+  selector: 'app-documentation-subscribe',
+  imports: [RouterModule, SubscribeToApiComponent],
+  templateUrl: './documentation-subscribe.component.html',
+  styleUrls: ['./documentation-subscribe.component.scss'],
+})
+export class DocumentationSubscribeComponent {
+  api = input.required<Api>();
+  navId = input.required<string>();
+  pageId = input<string>();
+}

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
@@ -59,6 +59,17 @@ export class TreeService {
     return this.parentItemBreadcrumb ? [this.parentItemBreadcrumb] : [];
   }
 
+  getAncestorApiId(nodeId: string): string | null {
+    let node = this.treeNodesById.get(nodeId);
+    while (node) {
+      if (node.type === 'API' && node.data?.type === 'API') {
+        return node.data.apiId;
+      }
+      node = node.__parentId ? this.treeNodesById.get(node.__parentId) : undefined;
+    }
+    return null;
+  }
+
   findFirstPageId(): string | null {
     return this.findFirstPageIdRecursively(this.treeNodes);
   }

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
@@ -25,6 +25,9 @@ export class SidenavLayoutComponentHarness extends ComponentHarness {
   private readonly getSidenavHarness = this.locatorFor(DivHarness.with({ selector: '.sidenav-layout__sidenav' }));
   private readonly getSidenavToggleButtonHarness = this.locatorFor(SidenavToggleButtonComponentHarness);
   private readonly getBreadcrumbsHarness = this.locatorForOptional(BreadcrumbsComponentHarness);
+  private readonly getBreadcrumbActionsHarness = this.locatorForOptional(
+    DivHarness.with({ selector: '.sidenav-layout__container__breadcrumbs__actions' }),
+  );
 
   public async getBreadcrumbs(): Promise<BreadcrumbsComponentHarness | null> {
     return this.getBreadcrumbsHarness();
@@ -36,6 +39,10 @@ export class SidenavLayoutComponentHarness extends ComponentHarness {
 
   public async getSidenavToggleButton(): Promise<SidenavToggleButtonComponentHarness | null> {
     return this.getSidenavToggleButtonHarness();
+  }
+
+  public async getBreadcrumbActions(): Promise<DivHarness | null> {
+    return this.getBreadcrumbActionsHarness();
   }
 
   public async toggleSidenav(): Promise<void> {

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
@@ -30,6 +30,9 @@
   <div class="sidenav-layout__container__breadcrumbs">
     <app-sidenav-toggle-button-component [collapsed]="sidenavCollapsed()" (toggleState)="onToggleSidenav()" />
     <app-breadcrumbs-component [breadcrumbs]="breadcrumbs()" />
+    <div class="sidenav-layout__container__breadcrumbs__actions">
+      <ng-content select="[breadcrumbActions]" />
+    </div>
   </div>
   <div class="sidenav-layout__container__content">
     <ng-content select="[mainContent]" />

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
@@ -87,9 +87,15 @@ $transition-base: 300ms cubic-bezier(0.4, 0, 0.2, 1);
       display: flex;
       min-height: 55px;
       align-items: center;
-      padding: 0 20px;
+      padding: 0 16px;
       border-bottom: 1px solid app-theme.$border-color;
       gap: 10px;
+
+      &__actions {
+        display: flex;
+        justify-content: flex-end;
+        flex: 1;
+      }
     }
 
     &__content {

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
@@ -30,6 +30,7 @@ import { Breadcrumb } from '../breadcrumbs/breadcrumbs.component';
   template: `
     <app-sidenav-layout [breadcrumbs]="breadcrumbs">
       <div sidenavContent>Sidenav Content</div>
+      <div breadcrumbActions>Breadcrumb Actions</div>
       <div mainContent>Main Content</div>
     </app-sidenav-layout>
   `,
@@ -68,5 +69,10 @@ describe('SidenavLayoutComponent', () => {
   it('should display breadcrumbs', async () => {
     const breadcrumbs = await harness.getBreadcrumbs();
     expect(await breadcrumbs?.getText()).toContain('Parent/Child/Grandchild');
+  });
+
+  it('should display breadcrumb actions', async () => {
+    const breadcrumbActions = await harness.getBreadcrumbActions();
+    expect(await breadcrumbActions?.getText()).toBe('Breadcrumb Actions');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
@@ -15,7 +15,7 @@
  */
 import { isFunction } from 'lodash';
 
-import { PortalNavigationPage, PortalNavigationFolder, PortalNavigationLink } from './portal-navigation-item';
+import { PortalNavigationPage, PortalNavigationFolder, PortalNavigationLink, PortalNavigationApi } from './portal-navigation-item';
 
 export function fakePortalNavigationPage(overrides?: Partial<PortalNavigationPage>): PortalNavigationPage {
   const base: PortalNavigationPage = {
@@ -72,6 +72,29 @@ export function fakePortalNavigationLink(overrides?: Partial<PortalNavigationLin
     order: 1,
     area: 'HOMEPAGE',
     url: 'https://example.com',
+    published: true,
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakePortalNavigationApi(overrides?: Partial<PortalNavigationApi>): PortalNavigationApi {
+  const base: PortalNavigationApi = {
+    id: 'nav-api-1',
+    organizationId: 'org-1',
+    environmentId: 'env-1',
+    title: 'API 1',
+    type: 'API',
+    order: 1,
+    area: 'HOMEPAGE',
+    apiId: 'api-1',
     published: true,
   };
 

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
@@ -16,7 +16,7 @@
 
 export type PortalArea = 'HOMEPAGE' | 'TOP_NAVBAR';
 
-export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK';
+export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API';
 
 export interface BasePortalNavigationItem {
   id: string;
@@ -44,4 +44,9 @@ export interface PortalNavigationLink extends BasePortalNavigationItem {
   url: string;
 }
 
-export type PortalNavigationItem = PortalNavigationPage | PortalNavigationFolder | PortalNavigationLink;
+export interface PortalNavigationApi extends BasePortalNavigationItem {
+  type: 'API';
+  apiId: string;
+}
+
+export type PortalNavigationItem = PortalNavigationPage | PortalNavigationFolder | PortalNavigationLink | PortalNavigationApi;

--- a/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
+++ b/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
@@ -15,6 +15,7 @@
  */
 import { PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
 import {
+  fakePortalNavigationApi,
   fakePortalNavigationFolder,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
@@ -22,7 +23,7 @@ import {
 
 export const makeItem = (
   id: string,
-  type: 'PAGE' | 'FOLDER' | 'LINK',
+  type: PortalNavigationItem['type'],
   title: string,
   order?: number,
   parentId?: string | null,
@@ -32,6 +33,8 @@ export const makeItem = (
       return fakePortalNavigationFolder({ id, title, order, parentId });
     case 'LINK':
       return fakePortalNavigationLink({ id, title, order, parentId });
+    case 'API':
+      return fakePortalNavigationApi({ id, title, order, parentId, apiId: `api-${id}` });
     case 'PAGE':
     default:
       return fakePortalNavigationPage({ id, title, order, parentId });

--- a/gravitee-apim-portal-webui-next/src/scss/layout.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/layout.scss
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+@use './theme' as app-theme;
+
 $container-padding-vertical-legacy: 2rem;
 $container-padding-horizontal: 16px;
+$container-padding-vertical: 16px;
 
 /**
   * Mixins for containers
@@ -25,6 +28,10 @@ $container-padding-horizontal: 16px;
 
 @mixin full-width-container {
   @include -container(100%);
+}
+
+@mixin medium-container {
+  @include -container(app-theme.$inner-content-width);
 }
 
 @mixin large-container-legacy {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12791

## Description

This Pull Request introduces a new feature allowing users to subscribe to APIs directly from the documentation folder. It includes modifications to components, routes, services, and associated tests, along with the addition of a new DocumentationSubscribeComponent.

**Main changes:**

Subscription Feature:
- Added DocumentationSubscribeComponent along with its HTML, SCSS, TypeScript, and test files for enabling direct API subscription.
- Added a new button and navigation logic for API subscription in the documentation-folder component and its corresponding tree UI.

Route Updates:
- Updated application routing to include API subscription navigation under documentation.

Component Enhancements:
- Refactored subscribe-to-api component to use required inputs instead of optional ones.

Service Updates:
- Extended tree.service.ts to fetch the parent API ID for new subscribe functionality.

UI and Styling:
- Included new breadcrumb actions in the sidenav layout for better usability.

Test Updates:
- Expanded test coverage for new subscription functionality in various components and services.

This PR ensures smoother user migration between documentation and API subscriptions while maintaining backward compatibility.


https://github.com/user-attachments/assets/dbe3363b-4707-40f5-bf8a-3d5949140906


When a user is not logged in:

<img width="2059" height="1084" alt="Screenshot 2026-02-20 at 17 10 17" src="https://github.com/user-attachments/assets/4bd425f9-059b-4589-90be-236d4f68e3e5" />

**Next PRs:**
- User can add gmd page via Console
- Subscribe button in portal is disabled when no api plans are available

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

