### PR TITLE
fix: bump LDAP resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <gravitee-policy-javascript.version>1.3.3</gravitee-policy-javascript.version>
         <gravitee-resource-auth-provider-http.version>1.4.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
-        <gravitee-resource-auth-provider-ldap.version>2.0.0</gravitee-resource-auth-provider-ldap.version>
+        <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>4.0.3</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12443

## Description
Removed default value of User search base field so that
The UI does not force a default value of "ou=users" into the field whenever the resource is loaded for editing,
It was resulting in failed authentication if the user doesn't catch it before saving.
Merged gravitee-resource-auth-provider-ldap changes(https://github.com/gravitee-io/gravitee-resource-auth-provider-ldap/pull/43) with above changes & updated it's version in APIM
