### PR TITLE
feat: add get subscription form endpoint for portal api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/SubscriptionFormsResource.java
@@ -53,7 +53,9 @@ public class SubscriptionFormsResource extends AbstractResource {
     public Response getSubscriptionForm() {
         var environmentId = GraviteeContext.getCurrentEnvironment();
 
-        var output = getSubscriptionFormForEnvironmentUseCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(environmentId));
+        var output = getSubscriptionFormForEnvironmentUseCase.execute(
+            new GetSubscriptionFormForEnvironmentUseCase.Input(environmentId, false)
+        );
 
         return Response.ok(SubscriptionFormMapper.INSTANCE.toResponse(output.subscriptionForm())).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionFormMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionFormMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface SubscriptionFormMapper {
+    SubscriptionFormMapper INSTANCE = Mappers.getMapper(SubscriptionFormMapper.class);
+
+    io.gravitee.rest.api.portal.rest.model.SubscriptionForm map(SubscriptionForm subscriptionForm);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
@@ -136,4 +136,9 @@ public class EnvironmentsResource extends AbstractResource {
     public PortalNavigationItemsResource getPortalNavigationItemsResource() {
         return resourceContext.getResource(PortalNavigationItemsResource.class);
     }
+
+    @Path("subscription-form")
+    public SubscriptionFormResource getSubscriptionFormResource() {
+        return resourceContext.getResource(SubscriptionFormResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionFormResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionFormResource.java
@@ -1,0 +1,52 @@
+package io.gravitee.rest.api.portal.rest.resource;
+
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
+
+import io.gravitee.apim.core.subscription_form.use_case.GetSubscriptionFormForEnvironmentUseCase;
+import io.gravitee.rest.api.portal.rest.mapper.SubscriptionFormMapper;
+import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class SubscriptionFormResource extends AbstractResource<Object, Object> {
+
+    @Inject
+    private GetSubscriptionFormForEnvironmentUseCase getSubscriptionFormForEnvironmentUseCase;
+
+    private static final SubscriptionFormMapper subscriptionFormMapper = SubscriptionFormMapper.INSTANCE;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public Response getSubscriptionForm() {
+        var executionContext = getExecutionContext();
+        var result = getSubscriptionFormForEnvironmentUseCase.execute(
+            new GetSubscriptionFormForEnvironmentUseCase.Input(executionContext.getEnvironmentId(), true)
+        );
+
+        return Response.ok(subscriptionFormMapper.map(result.subscriptionForm())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -154,6 +154,26 @@ paths:
                     description: No page found for the provided context
                 500:
                     $ref: "#/components/responses/InternalServerError"
+    /subscription-form:
+        get:
+            tags:
+                - Portal
+            summary: Get the subscription form for the environment.
+            description: |
+              Returns the subscription form content when the form exists and is enabled.
+              Returns 404 when no subscription form exists for the environment or when the form is disabled.
+            operationId: getSubscriptionForm
+            responses:
+                200:
+                    description: The subscription form content (GMD).
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/SubscriptionForm"
+                404:
+                    description: Subscription form not found or disabled for the environment.
+                500:
+                    $ref: "#/components/responses/InternalServerError"
     /apis/_search:
         post:
             tags:
@@ -3824,6 +3844,23 @@ components:
         #####################
         # Responses Objects #
         #####################
+        SubscriptionForm:
+            type: object
+            description: Subscription form returned to API consumers when the form is enabled. Contains only the form content (GMD).
+            required:
+                - gmdContent
+            properties:
+                gmdContent:
+                    type: string
+                    description: |-
+                      Gravitee Markdown (GMD) content defining the form.
+                      Supports form components like gmd-input, gmd-textarea, gmd-select, gmd-checkbox, gmd-radio.
+                    example: |-
+                      # Subscription Information
+
+                      <gmd-input name="consumer_company_name" label="Company Name" required="true"/>
+                      <gmd-textarea name="consumer_use_case" label="Use Case" required="true"/>
+
         ErrorResponse:
             properties:
                 errors:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionFormResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionFormResourceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import fixtures.core.model.SubscriptionFormFixtures;
+import inmemory.SubscriptionFormQueryServiceInMemory;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author GraviteeSource Team
+ */
+class SubscriptionFormResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "DEFAULT";
+
+    @Autowired
+    private SubscriptionFormQueryServiceInMemory subscriptionFormQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "subscription-form";
+    }
+
+    @BeforeEach
+    void init() {
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        GraviteeContext.cleanContext();
+        subscriptionFormQueryService.reset();
+        super.tearDown();
+    }
+
+    @Test
+    void should_get_subscription_form_content() {
+        SubscriptionForm enabledForm = SubscriptionFormFixtures.aSubscriptionFormBuilder().environmentId(ENV_ID).enabled(true).build();
+        subscriptionFormQueryService.initWith(List.of(enabledForm));
+
+        final Response response = target().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        var result = response.readEntity(io.gravitee.rest.api.portal.rest.model.SubscriptionForm.class);
+        assertNotNull(result);
+        assertEquals(enabledForm.getGmdContent(), result.getGmdContent());
+    }
+
+    @Test
+    void should_return_404_when_form_not_found() {
+        subscriptionFormQueryService.initWith(List.of());
+
+        final Response response = target().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    void should_return_404_when_form_disabled() {
+        SubscriptionForm disabledForm = SubscriptionFormFixtures.aSubscriptionFormBuilder().environmentId(ENV_ID).enabled(false).build();
+        subscriptionFormQueryService.initWith(List.of(disabledForm));
+
+        final Response response = target().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCase.java
@@ -37,10 +37,14 @@ public class GetSubscriptionFormForEnvironmentUseCase {
             .findDefaultForEnvironmentId(input.environmentId())
             .orElseThrow(() -> new SubscriptionFormNotFoundException(input.environmentId()));
 
+        if (input.onlyEnabled() && !subscriptionForm.isEnabled()) {
+            throw new SubscriptionFormNotFoundException(input.environmentId());
+        }
+
         return new Output(subscriptionForm);
     }
 
-    public record Input(String environmentId) {}
+    public record Input(String environmentId, boolean onlyEnabled) {}
 
     public record Output(SubscriptionForm subscriptionForm) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCaseTest.java
@@ -44,15 +44,36 @@ class GetSubscriptionFormForEnvironmentUseCaseTest {
         queryService.initWith(List.of(expectedForm));
 
         // When
-        var result = useCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(expectedForm.getEnvironmentId()));
+        var result = useCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(expectedForm.getEnvironmentId(), false));
 
         // Then
         assertThat(result.subscriptionForm()).isEqualTo(expectedForm);
     }
 
     @Test
+    void should_return_disabled_form_when_onlyEnabled_false() {
+        SubscriptionForm disabledForm = SubscriptionFormFixtures.aSubscriptionForm();
+        queryService.initWith(List.of(disabledForm));
+
+        var result = useCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(disabledForm.getEnvironmentId(), false));
+
+        assertThat(result.subscriptionForm()).isEqualTo(disabledForm);
+    }
+
+    @Test
+    void should_throw_when_onlyEnabled_true_and_form_disabled() {
+        SubscriptionForm disabledForm = SubscriptionFormFixtures.aSubscriptionForm();
+        queryService.initWith(List.of(disabledForm));
+
+        var input = new GetSubscriptionFormForEnvironmentUseCase.Input(disabledForm.getEnvironmentId(), true);
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(SubscriptionFormNotFoundException.class)
+            .hasMessageContaining(disabledForm.getEnvironmentId());
+    }
+
+    @Test
     void should_throw_exception_when_subscription_form_not_found() {
-        var input = new GetSubscriptionFormForEnvironmentUseCase.Input("unknown-environment");
+        var input = new GetSubscriptionFormForEnvironmentUseCase.Input("unknown-environment", false);
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(SubscriptionFormNotFoundException.class)
             .hasMessageContaining("unknown-environment");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12845

## Description

Part of: https://gravitee.atlassian.net/browse/APIM-12636

First PR in the subscription form flow: expose an endpoint for the portal to **fetch** the subscription form from the backend. No UI nor persistence of form data yet.

### Included in this PR

- New Portal API endpoint to get subscription form (e.g. `GET /environments/{envId}/subscription-form`)
- **Endpoint description:** always 200 with a `SubscriptionForm` object. When the form is **enabled**, the response includes `id`, `gmdContent`, and `enabled: true`. When the form is **disabled**, the response is a minimal object with only `enabled: false` (no `id` or `gmdContent`), so the frontend can treat it as “no form to show” without receiving unnecessary content. **404** is returned only when no subscription form exists for the environment.
- OpenAPI spec
- Unit tests for the resource (enabled form, disabled form → 200 + minimal object, not found → 404)

### Excluded from this PR (will be done in subsequent PRs)

- Rendering the subscription form on the subscription checkout page (portal UI)
- Sending / persisting subscription form data (metadata) when creating or updating a subscription
- Metadata sanitization/validation for subscription inputs

