### PR TITLE
feat: add API Product APIs list and add API dialog

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/apiSearchQuery.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/apiSearchQuery.ts
@@ -32,4 +32,8 @@ export interface ApiSearchQuery {
   categories?: string[];
   published?: string[];
   visibilities?: string[];
+  /**
+   * When true, only returns APIs that are allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.
+   */
+  allowedInApiProducts?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -49,6 +49,10 @@ export const API_PRODUCTS_ROUTES: Routes = [
         path: 'configuration',
         loadComponent: () => import('./configuration/api-product-configuration.component').then(m => m.ApiProductConfigurationComponent),
       },
+      {
+        path: 'apis',
+        loadComponent: () => import('./apis/api-product-apis.component').then(m => m.ApiProductApisComponent),
+      },
     ],
   },
 ];

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
-    
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
@@ -1,0 +1,115 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<h2 mat-dialog-title>Add API</h2>
+
+<form autocomplete="off" (ngSubmit)="submit()">
+  <mat-dialog-content class="dialog-content">
+    <gio-banner-info>
+      Can't see all your APIs?
+      <span gioBannerBody>APIs must have API products enabled before they appear in the list.</span>
+    </gio-banner-info>
+
+    @if (selectedApis.length > 0) {
+      <div class="selected-apis-section">
+        <h3 class="selected-apis-section__header">APIs added to this product</h3>
+        <mat-chip-set class="selected-apis-section__chips">
+          @for (api of selectedApis; track api.id) {
+            <mat-chip
+              class="selected-apis-section__chip"
+              [removable]="true"
+              (removed)="removeApi(api)"
+              [attr.aria-label]="'Remove ' + api.name"
+              [attr.data-testid]="'selected-api-chip'"
+            >
+              <span class="selected-apis-section__chip-name">{{ api.name }}</span>
+              @if (getContextPath(api); as contextPath) {
+                <span class="selected-apis-section__chip-path">{{ contextPath }}</span>
+              }
+              @if (api.lifecycleState === 'DEPRECATED') {
+                <span class="gio-badge-error">Deprecated</span>
+              }
+              <mat-icon matChipRemove>cancel</mat-icon>
+            </mat-chip>
+          }
+        </mat-chip-set>
+      </div>
+    }
+
+    <mat-form-field appearance="outline" class="form-field">
+      <mat-label>Add APIs</mat-label>
+      <input matInput type="search" [matAutocomplete]="auto" [formControl]="searchApiControl" [attr.data-testid]="'api-select-input'" />
+      @if (searchApiControl.value) {
+        <button matSuffix mat-icon-button aria-label="Clear input" (click)="resetSearchTerm()">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+      <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selectAPI()" [displayWith]="displayFn">
+        @if (filteredOptions$ | async; as filteredOptions) {
+          @if (filteredOptions.length > 0) {
+            @for (option of filteredOptions; track option.id) {
+              <mat-option [value]="option" [attr.data-testid]="'api-select-option'">
+                <span class="autocompleteRow">
+                  <gio-avatar
+                    class="autocompleteRow__avatar"
+                    [src]="option._links?.pictureUrl"
+                    [name]="option.name + ' ' + option.apiVersion"
+                    [size]="28"
+                    [roundedBorder]="true"
+                  ></gio-avatar>
+                  <span class="autocompleteRow__content">
+                    <span class="autocompleteRow__name">{{ option.name }}</span>
+                    @if (getContextPath(option); as contextPath) {
+                      <span class="autocompleteRow__path">{{ contextPath }}</span>
+                    }
+                  </span>
+                  @if (option.lifecycleState === 'DEPRECATED') {
+                    <span class="autocompleteRow__badge gio-badge-error">Deprecated</span>
+                  }
+                </span>
+              </mat-option>
+            }
+          } @else {
+            @if (hasNonEmptySearchTerm) {
+              <mat-option disabled>No APIs matching search criteria</mat-option>
+            }
+          }
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button type="button" mat-button (click)="onCancelClick()" [disabled]="isSubmitting" [attr.data-testid]="'cancel-button'">
+      Cancel
+    </button>
+    <button
+      type="submit"
+      [disabled]="selectedApis.length === 0 || isSubmitting"
+      mat-raised-button
+      color="primary"
+      [attr.data-testid]="'submit-button'"
+    >
+      @if (isSubmitting) {
+        Adding...
+      } @else {
+        Add API
+      }
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
@@ -25,21 +25,25 @@
       <span gioBannerBody>APIs must have API products enabled before they appear in the list.</span>
     </gio-banner-info>
 
-    @if (selectedApis.length > 0) {
+    @if (validationError(); as error) {
+      <gio-banner-error>{{ error }}</gio-banner-error>
+    }
+
+    @if (selectedApisWithContext().length > 0) {
       <div class="selected-apis-section">
         <h3 class="selected-apis-section__header">APIs added to this product</h3>
         <mat-chip-set class="selected-apis-section__chips">
-          @for (api of selectedApis; track api.id) {
+          @for (api of selectedApisWithContext(); track api.id) {
             <mat-chip
               class="selected-apis-section__chip"
               [removable]="true"
               (removed)="removeApi(api)"
               [attr.aria-label]="'Remove ' + api.name"
-              [attr.data-testid]="'selected-api-chip'"
+              [attr.data-testid]="'selected-api-chip-' + api.id"
             >
               <span class="selected-apis-section__chip-name">{{ api.name }}</span>
-              @if (getContextPath(api); as contextPath) {
-                <span class="selected-apis-section__chip-path">{{ contextPath }}</span>
+              @if (api.contextPath) {
+                <span class="selected-apis-section__chip-path">{{ api.contextPath }}</span>
               }
               @if (api.lifecycleState === 'DEPRECATED') {
                 <span class="gio-badge-error">Deprecated</span>
@@ -61,30 +65,28 @@
       }
       <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selectAPI()" [displayWith]="displayFn">
         @if (filteredOptions$ | async; as filteredOptions) {
-          @if (filteredOptions.length > 0) {
-            @for (option of filteredOptions; track option.id) {
-              <mat-option [value]="option" [attr.data-testid]="'api-select-option'">
-                <span class="autocompleteRow">
-                  <gio-avatar
-                    class="autocompleteRow__avatar"
-                    [src]="option._links?.pictureUrl"
-                    [name]="option.name + ' ' + option.apiVersion"
-                    [size]="28"
-                    [roundedBorder]="true"
-                  ></gio-avatar>
-                  <span class="autocompleteRow__content">
-                    <span class="autocompleteRow__name">{{ option.name }}</span>
-                    @if (getContextPath(option); as contextPath) {
-                      <span class="autocompleteRow__path">{{ contextPath }}</span>
-                    }
-                  </span>
-                  @if (option.lifecycleState === 'DEPRECATED') {
-                    <span class="autocompleteRow__badge gio-badge-error">Deprecated</span>
+          @for (option of filteredOptions; track option.id) {
+            <mat-option [value]="option" [attr.data-testid]="'api-select-option-' + option.id">
+              <span class="autocompleteRow">
+                <gio-avatar
+                  class="autocompleteRow__avatar"
+                  [src]="option._links?.pictureUrl"
+                  [name]="option.name + ' ' + option.apiVersion"
+                  [size]="28"
+                  [roundedBorder]="true"
+                ></gio-avatar>
+                <span class="autocompleteRow__content">
+                  <span class="autocompleteRow__name">{{ option.name }}</span>
+                  @if (option.contextPath) {
+                    <span class="autocompleteRow__path">{{ option.contextPath }}</span>
                   }
                 </span>
-              </mat-option>
-            }
-          } @else {
+                @if (option.lifecycleState === 'DEPRECATED') {
+                  <span class="autocompleteRow__badge gio-badge-error">Deprecated</span>
+                }
+              </span>
+            </mat-option>
+          } @empty {
             @if (hasNonEmptySearchTerm) {
               <mat-option disabled>No APIs matching search criteria</mat-option>
             }
@@ -95,21 +97,9 @@
   </mat-dialog-content>
 
   <mat-dialog-actions class="actions">
-    <button type="button" mat-button (click)="onCancelClick()" [disabled]="isSubmitting" [attr.data-testid]="'cancel-button'">
-      Cancel
-    </button>
-    <button
-      type="submit"
-      [disabled]="selectedApis.length === 0 || isSubmitting"
-      mat-raised-button
-      color="primary"
-      [attr.data-testid]="'submit-button'"
-    >
-      @if (isSubmitting) {
-        Adding...
-      } @else {
-        Add API
-      }
+    <button type="button" mat-button (click)="onCancelClick()" [attr.data-testid]="'cancel-button'">Cancel</button>
+    <button type="submit" [disabled]="selectedApis().length === 0" mat-raised-button color="primary" [attr.data-testid]="'submit-button'">
+      Add API
     </button>
   </mat-dialog-actions>
 </form>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.html
@@ -87,7 +87,7 @@
               </span>
             </mat-option>
           } @empty {
-            @if (hasNonEmptySearchTerm) {
+            @if (hasNonEmptySearchTerm()) {
               <mat-option disabled>No APIs matching search criteria</mat-option>
             }
           }

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.scss
@@ -1,0 +1,115 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  gio-banner-info {
+    margin-bottom: 24px;
+  }
+}
+
+.dialog-content {
+  overflow: visible;
+  max-height: none;
+  padding: 0 24px 8px 24px;
+}
+
+.selected-apis-section {
+  margin-bottom: 24px;
+
+  &__header {
+    @include mat.m2-typography-level($typography, subtitle-2);
+    margin: 0 0 12px 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'darker20');
+  }
+
+  &__chips {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  &__chip {
+    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, darker10);
+    color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, darker10-contrast);
+    min-height: 1.5rem;
+    height: fit-content;
+    padding: 0 4px 0 12px;
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+
+    &-avatar {
+      flex-shrink: 0;
+      margin-right: 4px;
+    }
+
+    &-name {
+      @include mat.m2-typography-level($typography, body-2);
+    }
+
+    &-path {
+      @include mat.m2-typography-level($typography, caption);
+      margin-left: 2px;
+      opacity: 0.9;
+      font-style: italic;
+      white-space: nowrap;
+    }
+
+    .gio-badge-error {
+      padding: 2px 8px;
+      line-height: 1.25;
+    }
+  }
+}
+
+.form-field {
+  width: 100%;
+}
+
+.autocompleteRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  &__avatar {
+    flex-shrink: 0;
+  }
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__name {
+    @include mat.m2-typography-level($typography, body-2);
+  }
+
+  &__path {
+    @include mat.m2-typography-level($typography, caption);
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'darker20');
+  }
+
+  &__badge {
+    flex-shrink: 0;
+    margin-left: auto;
+    padding: 2px 8px;
+    line-height: 1.25;
+  }
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px 24px 24px;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.scss
@@ -57,7 +57,6 @@ $typography: map.get(gio.$mat-theme, typography);
       @include mat.m2-typography-level($typography, caption);
       margin-left: 2px;
       opacity: 0.9;
-      font-style: italic;
       white-space: nowrap;
     }
 

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { ApiProductAddApiDialogComponent, ApiProductAddApiDialogData } from './api-product-add-api-dialog.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { fakeProxyApiV4 } from '../../../../entities/management-api-v2';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+describe('ApiProductAddApiDialogComponent', () => {
+  let fixture: ComponentFixture<ApiProductAddApiDialogComponent>;
+  let _loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: MatDialogRef<ApiProductAddApiDialogComponent>;
+
+  const API_PRODUCT_ID = 'product-1';
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  const dialogData: ApiProductAddApiDialogData = {
+    apiProductId: API_PRODUCT_ID,
+    existingApiIds: ['api-1'],
+  };
+
+  const fakeApi = fakeProxyApiV4({
+    id: 'api-2',
+    name: 'New API',
+    apiVersion: '1.0',
+    listeners: [
+      {
+        type: 'HTTP',
+        paths: [{ path: '/new-api' }],
+        entrypoints: [{ type: 'http-proxy' }],
+      },
+    ] as any,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ApiProductAddApiDialogComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductAddApiDialogComponent);
+    _loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    dialogRef = TestBed.inject(MatDialogRef);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should close dialog on cancel', () => {
+    fixture.detectChanges();
+    const cancelButton = fixture.nativeElement.querySelector('[data-testid="cancel-button"]');
+    cancelButton?.dispatchEvent(new Event('click'));
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should disable submit when no APIs selected', () => {
+    fixture.detectChanges();
+    const submitButton = fixture.nativeElement.querySelector('[data-testid="submit-button"]');
+    expect(submitButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('should call close with true on successful submit', async () => {
+    fixture.componentInstance.selectedApis = [fakeApi];
+    fixture.detectChanges();
+
+    const submitButton = fixture.nativeElement.querySelector('[data-testid="submit-button"]');
+    (submitButton as HTMLButtonElement)?.click();
+    fixture.detectChanges();
+
+    const productReq = httpTestingController.expectOne(req => req.url.includes('/api-products/') && req.method === 'GET');
+    productReq.flush({ id: API_PRODUCT_ID, apiIds: ['api-1'] });
+
+    const updateReq = httpTestingController.expectOne(req => req.url.includes('/api-products/') && req.method === 'PUT');
+    updateReq.flush({});
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should show error when API already in product', async () => {
+    fixture.componentInstance.selectedApis = [fakeProxyApiV4({ id: 'api-1', name: 'Existing API' }) as any];
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const submitButton = fixture.nativeElement.querySelector('[data-testid="submit-button"]');
+    (submitButton as HTMLButtonElement)?.click();
+    fixture.detectChanges();
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush({ id: API_PRODUCT_ID, apiIds: ['api-1'] });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalledWith(expect.stringContaining('already in this API Product'));
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -98,12 +99,19 @@ describe('ApiProductAddApiDialogComponent', () => {
   });
 
   it('should show validation error when API already in product', async () => {
-    fixture.componentInstance.selectedApis.set([fakeProxyApiV4({ id: 'api-1', name: 'Existing API' }) as any]);
+    const existingApi = fakeProxyApiV4({
+      id: 'api-1',
+      name: 'Existing API',
+      apiVersion: '1.0',
+      listeners: [{ type: 'HTTP', paths: [{ path: '/existing-api' }], entrypoints: [{ type: 'http-proxy' }] }] as any,
+    });
+    fixture.componentInstance.selectedApis.set([existingApi]);
     fixture.detectChanges();
 
     const submitButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="submit-button"]' }));
     await submitButton.click();
     fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.componentInstance.validationError()).toContain('already in this API Product');
     expect(dialogRef.close).not.toHaveBeenCalled();

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { AsyncPipe } from '@angular/common';
+import { GioAvatarModule, GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+
+import { Api } from '../../../../entities/management-api-v2';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { getApiContextPath } from '../../../../shared/utils/api.util';
+
+export interface ApiProductAddApiDialogData {
+  apiProductId: string;
+  existingApiIds?: string[];
+}
+
+export type ApiProductAddApiDialogResult = boolean;
+
+@Component({
+  selector: 'api-product-add-api-dialog',
+  templateUrl: './api-product-add-api-dialog.component.html',
+  styleUrls: ['./api-product-add-api-dialog.component.scss'],
+  imports: [
+    AsyncPipe,
+    FormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    ReactiveFormsModule,
+    GioAvatarModule,
+    GioBannerModule,
+    GioIconsModule,
+  ],
+  standalone: true,
+})
+export class ApiProductAddApiDialogComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApiProductAddApiDialogComponent>);
+  private readonly apiService = inject(ApiV2Service);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  readonly data = inject<ApiProductAddApiDialogData>(MAT_DIALOG_DATA);
+  readonly getContextPath = getApiContextPath;
+
+  get hasNonEmptySearchTerm(): boolean {
+    const v = this.searchApiControl.value;
+    return typeof v === 'string' && v.trim().length > 0;
+  }
+
+  readonly searchApiControl = new FormControl<string | Api>('');
+  filteredOptions$!: Observable<Api[]>;
+  selectedApis: Api[] = [];
+  private readonly selectedApis$ = new BehaviorSubject<Api[]>([]);
+  isApiSelected = false;
+  isSubmitting = false;
+
+  ngOnInit(): void {
+    this.filteredOptions$ = combineLatest([
+      this.searchApiControl.valueChanges.pipe(
+        filter((v): v is string => typeof v === 'string'),
+        debounceTime(300),
+        distinctUntilChanged(),
+        startWith(''),
+      ),
+      this.selectedApis$.asObservable().pipe(startWith([])),
+    ]).pipe(
+      switchMap(([term, selectedApis]) => {
+        if (!term || term.trim() === '') {
+          return of([]);
+        }
+        return this.apiService.search({ query: term, apiTypes: ['V4_HTTP_PROXY'], allowedInApiProducts: true }).pipe(
+          map(apisResponse => {
+            const existingIds = this.data.existingApiIds || [];
+            const selectedIds = selectedApis.map(api => api.id);
+            const apis = apisResponse.data || [];
+            return apis.filter(api => !existingIds.includes(api.id) && !selectedIds.includes(api.id));
+          }),
+        );
+      }),
+      tap(() => (this.isApiSelected = false)),
+      takeUntilDestroyed(this.destroyRef),
+    );
+  }
+
+  readonly displayFn = (option: Api): string => (option?.name && option?.apiVersion ? `${option.name} - ${option.apiVersion}` : '');
+
+  resetSearchTerm(): void {
+    this.searchApiControl.setValue('');
+  }
+
+  onCancelClick(): void {
+    this.dialogRef.close();
+  }
+
+  selectAPI(): void {
+    const selectedApi = this.searchApiControl.getRawValue();
+    if (selectedApi && typeof selectedApi !== 'string') {
+      if (!this.selectedApis.find(api => api.id === selectedApi.id)) {
+        this.selectedApis.push(selectedApi);
+        this.selectedApis$.next(this.selectedApis);
+        this.isApiSelected = true;
+      }
+      this.searchApiControl.setValue('');
+    }
+  }
+
+  submit(): void {
+    if (this.selectedApis.length === 0) return;
+
+    this.isSubmitting = true;
+
+    this.apiProductV2Service
+      .get(this.data.apiProductId)
+      .pipe(
+        switchMap(apiProduct => this.buildUpdateRequest(apiProduct)),
+        catchError(error => {
+          this.snackBarService.error(error.error?.message || 'An error occurred while adding the APIs');
+          this.isSubmitting = false;
+          return of(null);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(result => {
+        if (!result) {
+          this.isSubmitting = false;
+          return;
+        }
+        const apiNames = this.selectedApis.map(api => api.name).join(', ');
+        this.snackBarService.success(
+          this.selectedApis.length === 1
+            ? `API "${apiNames}" has been added to the API Product`
+            : `${this.selectedApis.length} APIs have been added to the API Product`,
+        );
+        this.dialogRef.close(true);
+      });
+  }
+
+  private buildUpdateRequest(apiProduct: { apiIds?: string[] }) {
+    const currentApiIds = apiProduct.apiIds || [];
+    const { newApiIds, errors } = this.selectedApis.reduce(
+      (acc, api) => {
+        if (currentApiIds.includes(api.id)) {
+          acc.errors.push(`API "${api.name}" is already in this API Product`);
+        } else {
+          acc.newApiIds.push(api.id);
+        }
+        return acc;
+      },
+      { newApiIds: [] as string[], errors: [] as string[] },
+    );
+
+    if (errors.length > 0) {
+      this.snackBarService.error(errors.join(', '));
+      this.isSubmitting = false;
+      return of(null);
+    }
+
+    const updatedApiIds = [...currentApiIds, ...newApiIds];
+    return this.apiProductV2Service.updateApiProductApis(this.data.apiProductId, updatedApiIds);
+  }
+
+  removeApi(apiToRemove: Api): void {
+    this.selectedApis = this.selectedApis.filter(api => api.id !== apiToRemove.id);
+    this.selectedApis$.next(this.selectedApis);
+    this.isApiSelected = this.selectedApis.length > 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/add-api-dialog/api-product-add-api-dialog.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component, computed, inject, Injector, OnInit, signal } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { combineLatest, Observable, of } from 'rxjs';
@@ -31,7 +31,7 @@ import { GioAvatarModule, GioBannerModule, GioIconsModule } from '@gravitee/ui-p
 
 import { Api } from '../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
-import { getApiContextPath } from '../../../../shared/utils/api.util';
+import { getApiContextPath } from '../../../../shared/utils/api-access.util';
 
 export type ApiWithContextPath = Api & { contextPath: string | null };
 
@@ -69,12 +69,15 @@ export class ApiProductAddApiDialogComponent implements OnInit {
   private readonly apiService = inject(ApiV2Service);
   readonly data = inject<ApiProductAddApiDialogData>(MAT_DIALOG_DATA);
 
-  get hasNonEmptySearchTerm(): boolean {
-    const v = this.searchApiControl.value;
-    return typeof v === 'string' && v.trim().length > 0;
-  }
-
   readonly searchApiControl = new FormControl<string | Api>('');
+  readonly searchTermValue = toSignal(
+    this.searchApiControl.valueChanges.pipe(
+      startWith(this.searchApiControl.value ?? ''),
+      map(v => (typeof v === 'string' ? v : '')),
+    ),
+    { initialValue: '' },
+  );
+  readonly hasNonEmptySearchTerm = computed(() => this.searchTermValue().trim().length > 0);
   filteredOptions$!: Observable<ApiWithContextPath[]>;
 
   readonly selectedApis = signal<Api[]>([]);

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
-    
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -21,8 +21,8 @@
       <h1>APIs</h1>
       <p class="subtitle">Manage APIs grouped together in your API Product.</p>
     </div>
-    <button mat-raised-button color="primary" (click)="onAddApi()" class="add-api-button" data-testid="add-api-button" aria-label="Add API">
-      Add API
+    <button mat-raised-button color="primary" (click)="onAddApi()" data-testid="add-api-button" aria-label="Add API">
+      <mat-icon svgIcon="gio:plus"></mat-icon> Add API
     </button>
   </div>
 
@@ -60,7 +60,7 @@
       <ng-container matColumnDef="version">
         <th mat-header-cell *matHeaderCellDef>Version</th>
         <td mat-cell *matCellDef="let element">
-          v{{ element.version }}
+          {{ element.version }}
           @if (element.lifecycleState === 'DEPRECATED') {
             <span class="gio-badge-error">Deprecated</span>
           }
@@ -73,7 +73,7 @@
             mat-icon-button
             [matTooltip]="'Remove from API Product'"
             (click)="onDeleteApi(element)"
-            data-testid="delete-api-button"
+            [attr.data-testid]="'delete-api-button-' + element.id"
             aria-label="Remove API"
           >
             <mat-icon svgIcon="gio:trash"></mat-icon>
@@ -86,13 +86,13 @@
 
       <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
         <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
-          @if (!isLoadingData && apisTableDS.length === 0) {
-            <div class="api-product-apis-empty-state">
-              <p>There are no APIs in this API Product (yet).</p>
-            </div>
-          } @else if (isLoadingData) {
+          @if (isLoadingData) {
             <div class="api-product-apis-empty-state">
               <p>Loading...</p>
+            </div>
+          } @else {
+            <div class="api-product-apis-empty-state">
+              <p>There are no APIs in this API Product (yet).</p>
             </div>
           }
         </td>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -1,0 +1,102 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="api-product-apis">
+  <div class="api-product-apis__header">
+    <div>
+      <h1>APIs</h1>
+      <p class="subtitle">Manage APIs grouped together in your API Product.</p>
+    </div>
+    <button mat-raised-button color="primary" (click)="onAddApi()" class="add-api-button" data-testid="add-api-button" aria-label="Add API">
+      Add API
+    </button>
+  </div>
+
+  <gio-table-wrapper
+    [filters]="filters"
+    [length]="apisTableDSUnpaginatedLength"
+    [searchLabel]="searchLabel"
+    (filtersChange)="onFiltersChanged($event)"
+  >
+    <table mat-table [dataSource]="apisTableDS">
+      <ng-container matColumnDef="picture">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <gio-avatar
+            class="api-product-apis__avatar"
+            [src]="element.picture"
+            [name]="element.name + ' ' + element.version"
+            [size]="32"
+            [roundedBorder]="true"
+          ></gio-avatar>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+      </ng-container>
+      <ng-container matColumnDef="contextPath">
+        <th mat-header-cell *matHeaderCellDef>Context Path</th>
+        <td mat-cell *matCellDef="let element">{{ element.contextPath }}</td>
+      </ng-container>
+      <ng-container matColumnDef="definition">
+        <th mat-header-cell *matHeaderCellDef>Definition</th>
+        <td mat-cell *matCellDef="let element">{{ element.definition }}</td>
+      </ng-container>
+      <ng-container matColumnDef="version">
+        <th mat-header-cell *matHeaderCellDef>Version</th>
+        <td mat-cell *matCellDef="let element">
+          v{{ element.version }}
+          @if (element.lifecycleState === 'DEPRECATED') {
+            <span class="gio-badge-error">Deprecated</span>
+          }
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <button
+            mat-icon-button
+            [matTooltip]="'Remove from API Product'"
+            (click)="onDeleteApi(element)"
+            data-testid="delete-api-button"
+            aria-label="Remove API"
+          >
+            <mat-icon svgIcon="gio:trash"></mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+          @if (!isLoadingData && apisTableDS.length === 0) {
+            <div class="api-product-apis-empty-state">
+              <p>There are no APIs in this API Product (yet).</p>
+            </div>
+          } @else if (isLoadingData) {
+            <div class="api-product-apis-empty-state">
+              <p>Loading...</p>
+            </div>
+          }
+        </td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -27,7 +27,7 @@
   </div>
 
   <gio-table-wrapper
-    [filters]="filters"
+    [filters]="filters()"
     [length]="apisTableDSUnpaginatedLength"
     [searchLabel]="searchLabel"
     (filtersChange)="onFiltersChanged($event)"

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
@@ -1,0 +1,100 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.api-product-apis {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 32px;
+
+    h1 {
+      @include mat.m2-typography-level($typography, headline-6);
+      margin: 0;
+    }
+
+    .subtitle {
+      @include mat.m2-typography-level($typography, body-2);
+      margin-top: 8px;
+      margin-bottom: 0;
+      color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    }
+  }
+
+  .add-api-button {
+    flex-shrink: 0;
+  }
+
+  &__content-card {
+    flex: 1;
+    min-height: 400px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  &__avatar {
+    height: 32px;
+    width: 32px;
+  }
+}
+
+.api-product-apis-empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  padding: 48px 24px;
+}
+
+.mat-column-picture,
+.mat-column-name,
+.mat-column-contextPath,
+.mat-column-definition,
+.mat-column-version {
+  text-align: left;
+}
+
+.mat-column-picture {
+  padding: 0 8px;
+  width: 3rem;
+  min-width: 3rem;
+}
+
+.mat-column-version,
+.mat-column-actions {
+  padding: 0 8px;
+}
+
+.mat-column-name,
+.mat-column-contextPath,
+.mat-column-definition {
+  padding: 0 8px;
+  width: auto;
+}
+
+.mat-column-version {
+  .version__badge {
+    cursor: default;
+    margin-right: 8px;
+  }
+}
+
+.mat-column-actions {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
@@ -85,6 +85,7 @@ $typography: map.get(gio.$mat-theme, typography);
 }
 
 .mat-column-version {
+  white-space: nowrap;
   .version__badge {
     cursor: default;
     margin-right: 8px;

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.scss
@@ -35,28 +35,26 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 
-  .add-api-button {
-    flex-shrink: 0;
-  }
-
   &__content-card {
     flex: 1;
-    min-height: 400px;
+    min-height: 25rem;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   &__avatar {
-    height: 32px;
-    width: 32px;
+    height: 2rem;
+    width: 2rem;
   }
 }
 
 .api-product-apis-empty-state {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 300px;
+  gap: 16px;
+  min-height: 18.75rem;
   padding: 48px 24px;
 }
 

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { ApiProductApisComponent } from './api-product-apis.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { Api, fakeProxyApiV4 } from '../../../entities/management-api-v2';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../entities/Constants';
+
+describe('ApiProductApisComponent', () => {
+  let fixture: ComponentFixture<ApiProductApisComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let _router: Router;
+  let queryParams$: BehaviorSubject<Record<string, string>>;
+
+  const API_PRODUCT_ID = 'product-1';
+  const fakeSnackBarService = {
+    error: jest.fn(),
+    success: jest.fn(),
+  };
+
+  const fakeApiProduct: ApiProduct = {
+    id: API_PRODUCT_ID,
+    name: 'Test API Product',
+    version: '1.0',
+    apiIds: ['api-1', 'api-2'],
+  };
+
+  const fakeApi1 = fakeProxyApiV4({
+    id: 'api-1',
+    name: 'Payments API',
+    apiVersion: '1.0',
+    listeners: [
+      {
+        type: 'HTTP',
+        paths: [{ path: '/payments' }],
+        entrypoints: [{ type: 'http-proxy' }],
+      },
+    ] as any,
+  }) as Api;
+
+  const fakeApi2 = fakeProxyApiV4({
+    id: 'api-2',
+    name: 'Orders API',
+    apiVersion: '2.0',
+    listeners: [
+      {
+        type: 'HTTP',
+        paths: [{ path: '/orders' }],
+        entrypoints: [{ type: 'http-proxy' }],
+      },
+    ] as any,
+  }) as Api;
+
+  beforeEach(() => {
+    queryParams$ = new BehaviorSubject<Record<string, string>>({});
+
+    TestBed.configureTestingModule({
+      imports: [ApiProductApisComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: {}, queryParams: {} },
+            params: new BehaviorSubject({}),
+            queryParams: queryParams$.asObservable(),
+            parent: {
+              snapshot: { params: { apiProductId: API_PRODUCT_ID }, queryParams: {} },
+              params: new BehaviorSubject({ apiProductId: API_PRODUCT_ID }),
+              queryParams: queryParams$.asObservable(),
+            } as any,
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductApisComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    _router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should display empty state when no APIs in product', async () => {
+    await initComponent({ ...fakeApiProduct, apiIds: [] });
+
+    const emptyState = fixture.nativeElement.querySelector('.api-product-apis-empty-state');
+    expect(emptyState).toBeTruthy();
+    expect(emptyState?.textContent).toContain('There are no APIs in this API Product (yet).');
+  });
+
+  it('should display table with API rows when product has APIs', async () => {
+    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(2);
+
+    const rowCells0 = await rows[0].getCellTextByIndex();
+    expect(rowCells0[1]).toContain('Payments API');
+    expect(rowCells0[2]).toContain('/payments');
+
+    const rowCells1 = await rows[1].getCellTextByIndex();
+    expect(rowCells1[1]).toContain('Orders API');
+    expect(rowCells1[2]).toContain('/orders');
+  });
+
+  it('should display Loading... then data', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const emptyState = fixture.nativeElement.querySelector('.api-product-apis-empty-state');
+    expect(emptyState?.textContent).toContain('Loading...');
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush(fakeApiProduct);
+
+    await fixture.whenStable();
+
+    const api1Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`);
+    api1Req.flush(fakeApi1);
+    const api2Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`);
+    api2Req.flush(fakeApi2);
+
+    await new Promise(r => setTimeout(r, 50));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(2);
+  });
+
+  it('should handle error when loading API product', async () => {
+    fixture.detectChanges();
+    await new Promise(r => setTimeout(r, 150));
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+
+  it('should have Add API button', async () => {
+    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+
+    const addButton = fixture.nativeElement.querySelector('[data-testid="add-api-button"]');
+    expect(addButton).toBeTruthy();
+    expect(addButton?.textContent?.trim()).toContain('Add API');
+  });
+
+  it('should open Add API dialog when Add API clicked', async () => {
+    const matDialog = TestBed.inject(MatDialog);
+    const dialogOpenSpy = jest.spyOn(matDialog, 'open');
+    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+
+    const addButton = fixture.nativeElement.querySelector('[data-testid="add-api-button"]');
+    addButton?.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush({ ...fakeApiProduct, apiIds: ['api-1'] });
+    await fixture.whenStable();
+
+    expect(dialogOpenSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          apiProductId: API_PRODUCT_ID,
+          existingApiIds: ['api-1'],
+        }),
+      }),
+    );
+  });
+
+  it('should filter APIs by search term', async () => {
+    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+
+    fixture.componentInstance.onFiltersChanged({
+      searchTerm: 'Orders',
+      pagination: { index: 1, size: 10 },
+    });
+    await new Promise(r => setTimeout(r, 150));
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush(fakeApiProduct);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`).flush(fakeApi1);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`).flush(fakeApi2);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.apisTableDS.length).toBe(1);
+    expect(fixture.componentInstance.apisTableDS[0].name).toBe('Orders API');
+  });
+
+  async function initComponent(apiProduct: ApiProduct, apis: Api[] = []) {
+    fixture.detectChanges();
+    await new Promise(r => setTimeout(r, 150));
+
+    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    productReq.flush(apiProduct);
+
+    for (const api of apis) {
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`);
+      req.flush(api);
+    }
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -109,6 +109,19 @@ describe('ApiProductApisComponent', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
     _router = TestBed.inject(Router);
+
+    // Simulate router.navigate updating query params (Router is source of truth)
+    jest.spyOn(_router, 'navigate').mockImplementation((_commands, extras) => {
+      if (extras?.['queryParams']) {
+        const merged = { ...queryParams$.value, ...extras['queryParams'] };
+        const filtered: Record<string, string> = {};
+        for (const [k, v] of Object.entries(merged)) {
+          if (v != null) filtered[k] = String(v);
+        }
+        queryParams$.next(filtered);
+      }
+      return Promise.resolve(true);
+    });
   });
 
   afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, inject, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, inject, Injector, OnInit } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 import {
   GIO_DIALOG_WIDTH,
@@ -33,12 +33,17 @@ import {
   GioIconsModule,
 } from '@gravitee/ui-particles-angular';
 
-import { ApiProductAddApiDialogComponent, ApiProductAddApiDialogData } from './add-api-dialog/api-product-add-api-dialog.component';
+import {
+  ApiProductAddApiDialogComponent,
+  ApiProductAddApiDialogData,
+  ApiProductAddApiDialogResult,
+} from './add-api-dialog/api-product-add-api-dialog.component';
 
 import { Api } from '../../../entities/management-api-v2';
 import { getApiContextPath } from '../../../shared/utils/api.util';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { filtersToQueryParams } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -64,6 +69,7 @@ interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
 })
 export class ApiProductApisComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
+  private readonly injector = inject(Injector);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
@@ -80,43 +86,59 @@ export class ApiProductApisComponent implements OnInit {
   };
   searchLabel = 'Search APIs...';
   isLoadingData = true;
-  apiProductId = '';
+  readonly apiProductId = toSignal((this.activatedRoute.parent?.params ?? of({})).pipe(map(p => p['apiProductId'] ?? '')), {
+    initialValue: '',
+  });
   private readonly filters$ = new BehaviorSubject(this.filters);
 
-  ngOnInit(): void {
-    const getApiProductId = (route: ActivatedRoute): string | null => {
-      if (route.snapshot.params['apiProductId']) {
-        return route.snapshot.params['apiProductId'];
-      }
-      if (route.parent) {
-        return getApiProductId(route.parent);
-      }
-      return null;
+  private static readonly LOAD_API_PRODUCT_ERROR = 'An error occurred while loading the API Product';
+
+  private handleError<T>(message: string, fallback: Observable<T>): (error: unknown) => Observable<T> {
+    return (error: unknown) => {
+      this.snackBarService.error((error as { error?: { message?: string } })?.error?.message || message);
+      return fallback;
     };
+  }
 
-    this.apiProductId = getApiProductId(this.activatedRoute) || '';
-    this.initFilters();
-
-    this.filters$
+  private subscribeWithSuccessReload<T>(observable$: Observable<T>, successMessage: string | ((value: T) => string)): void {
+    observable$
       .pipe(
-        debounceTime(100),
-        distinctUntilChanged(isEqual),
-        tap((filters: ApiProductApisTableWrapperFilters) => {
-          this.router.navigate([], {
-            relativeTo: this.activatedRoute,
-            queryParams: {
-              q: filters.searchTerm,
-              page: filters.pagination.index,
-              size: filters.pagination.size,
-            },
-            queryParamsHandling: 'merge',
-          });
+        tap(value => {
+          const message = typeof successMessage === 'function' ? successMessage(value) : successMessage;
+          this.snackBarService.success(message);
+          this.reloadTable();
         }),
-        switchMap(() => this.loadApisForProduct()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  ngOnInit(): void {
+    this.initFilters();
+    this.initApisTableSubscription();
+  }
+
+  private initApisTableSubscription(): void {
+    combineLatest([
+      this.filters$.pipe(debounceTime(100), distinctUntilChanged(isEqual)),
+      toObservable(this.apiProductId, { injector: this.injector }).pipe(filter(id => !!id)),
+    ])
+      .pipe(
+        map(([filters, apiProductId]) => ({ filters, apiProductId })),
+        tap(({ filters }) => this.syncFiltersToUrl(filters)),
+        switchMap(({ apiProductId }) => this.loadApisForProduct(apiProductId)),
         tap(apis => this.processAndDisplayApis(apis)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  private syncFiltersToUrl(filters: ApiProductApisTableWrapperFilters): void {
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParams: filtersToQueryParams(filters),
+      queryParamsHandling: 'merge',
+    });
   }
 
   private initFilters(): void {
@@ -138,24 +160,16 @@ export class ApiProductApisComponent implements OnInit {
     this.filters$.next(this.filters);
   }
 
-  private loadApisForProduct(): Observable<(Api | null)[]> {
+  private loadApisForProduct(apiProductId: string): Observable<(Api | null)[]> {
     this.isLoadingData = true;
-    return this.apiProductV2Service.get(this.apiProductId).pipe(
-      catchError(error => {
-        this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
-        return of(null);
-      }),
+    return this.apiProductV2Service.get(apiProductId).pipe(
+      catchError(this.handleError(ApiProductApisComponent.LOAD_API_PRODUCT_ERROR, of(null))),
       switchMap(apiProduct => {
         if (!apiProduct?.apiIds?.length) {
           return of([]);
         }
         const apiObservables = apiProduct.apiIds.map(apiId => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
-        return forkJoin(apiObservables).pipe(
-          catchError(error => {
-            this.snackBarService.error(error.error?.message || 'An error occurred while loading APIs');
-            return of([]);
-          }),
-        );
+        return forkJoin(apiObservables).pipe(catchError(this.handleError('An error occurred while loading APIs', of([]))));
       }),
     );
   }
@@ -202,7 +216,7 @@ export class ApiProductApisComponent implements OnInit {
   }
 
   private reloadTable(): void {
-    this.loadApisForProduct()
+    this.loadApisForProduct(this.apiProductId())
       .pipe(
         tap(apis => this.processAndDisplayApis(apis)),
         takeUntilDestroyed(this.destroyRef),
@@ -211,36 +225,56 @@ export class ApiProductApisComponent implements OnInit {
   }
 
   onAddApi(): void {
-    this.apiProductV2Service
-      .get(this.apiProductId)
-      .pipe(
-        catchError(error => {
-          this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
-          return of(null);
-        }),
-        filter((apiProduct): apiProduct is NonNullable<typeof apiProduct> => apiProduct != null),
-        switchMap(apiProduct =>
-          this.matDialog
-            .open<ApiProductAddApiDialogComponent, ApiProductAddApiDialogData, boolean>(ApiProductAddApiDialogComponent, {
+    const apiProductId = this.apiProductId();
+    const addApis$ = this.apiProductV2Service.get(apiProductId).pipe(
+      catchError(this.handleError(ApiProductApisComponent.LOAD_API_PRODUCT_ERROR, EMPTY)),
+      switchMap(apiProduct =>
+        this.matDialog
+          .open<ApiProductAddApiDialogComponent, ApiProductAddApiDialogData, ApiProductAddApiDialogResult>(
+            ApiProductAddApiDialogComponent,
+            {
               width: GIO_DIALOG_WIDTH.MEDIUM,
               data: {
-                apiProductId: this.apiProductId,
+                apiProductId,
                 existingApiIds: apiProduct.apiIds || [],
               },
               role: 'dialog',
               id: 'addApiDialog',
-            })
-            .afterClosed(),
-        ),
-        filter((success): success is true => success === true),
-        tap(() => this.reloadTable()),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+            },
+          )
+          .afterClosed()
+          .pipe(map(selectedApis => ({ apiProduct, selectedApis }))),
+      ),
+      filter(
+        (ctx): ctx is { apiProduct: NonNullable<typeof ctx.apiProduct>; selectedApis: ApiProductAddApiDialogResult } =>
+          (ctx.selectedApis?.length ?? 0) > 0,
+      ),
+      switchMap(({ apiProduct, selectedApis }) => this.addApisToProduct(selectedApis, apiProductId, apiProduct.apiIds || [])),
+    );
+    this.subscribeWithSuccessReload(addApis$, selectedApis => {
+      const apiNames = selectedApis.map(api => api.name).join(', ');
+      return selectedApis.length === 1
+        ? `API "${apiNames}" has been added to the API Product`
+        : `${selectedApis.length} APIs have been added to the API Product`;
+    });
+  }
+
+  private addApisToProduct(
+    selectedApis: ApiProductAddApiDialogResult,
+    apiProductId: string,
+    currentApiIds: string[],
+  ): Observable<ApiProductAddApiDialogResult> {
+    const newApiIds = selectedApis.map(api => api.id);
+    const updatedApiIds = [...currentApiIds, ...newApiIds];
+    return this.apiProductV2Service.updateApiProductApis(apiProductId, updatedApiIds).pipe(
+      map(() => selectedApis),
+      catchError(this.handleError('An error occurred while adding the APIs', EMPTY)),
+    );
   }
 
   onDeleteApi(api: ApiProductApiTableDS[0]): void {
-    this.matDialog
+    const apiProductId = this.apiProductId();
+    const removeApi$ = this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         width: GIO_DIALOG_WIDTH.SMALL,
         data: {
@@ -254,33 +288,22 @@ export class ApiProductApisComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter((result): result is true => result === true),
-        switchMap(() =>
-          this.apiProductV2Service.get(this.apiProductId).pipe(
-            catchError(error => {
-              this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
-              return of(null);
-            }),
-          ),
-        ),
-        filter((apiProduct): apiProduct is NonNullable<typeof apiProduct> => apiProduct != null),
-        switchMap(apiProduct => {
-          const currentApiIds = apiProduct.apiIds || [];
-          const updatedApiIds = currentApiIds.filter(id => id !== api.id);
-          return this.apiProductV2Service.updateApiProductApis(this.apiProductId, updatedApiIds).pipe(
-            catchError(error => {
-              this.snackBarService.error(error.error?.message || 'An error occurred while removing the API');
-              return of(null);
-            }),
-          );
-        }),
-        filter((result): result is NonNullable<typeof result> => result !== null),
-        tap(() => {
-          this.snackBarService.success(`API "${api.name}" has been removed from the API Product`);
-          this.reloadTable();
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+        switchMap(() => this.removeApiFromProduct(api, apiProductId)),
+      );
+    this.subscribeWithSuccessReload(removeApi$, `API "${api.name}" has been removed from the API Product`);
+  }
+
+  private removeApiFromProduct(api: ApiProductApiTableDS[0], apiProductId: string): Observable<void> {
+    return this.apiProductV2Service.get(apiProductId).pipe(
+      catchError(this.handleError(ApiProductApisComponent.LOAD_API_PRODUCT_ERROR, EMPTY)),
+      switchMap(apiProduct => {
+        const updatedApiIds = (apiProduct.apiIds || []).filter(id => id !== api.id);
+        return this.apiProductV2Service.updateApiProductApis(apiProductId, updatedApiIds).pipe(
+          catchError(this.handleError('An error occurred while removing the API', EMPTY)),
+          map(() => undefined),
+        );
+      }),
+    );
   }
 
   get hasApis(): boolean {

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog } from '@angular/material/dialog';
+import { Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
+import { isEqual } from 'lodash';
+import {
+  GIO_DIALOG_WIDTH,
+  GioAvatarModule,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioIconsModule,
+} from '@gravitee/ui-particles-angular';
+
+import { ApiProductAddApiDialogComponent, ApiProductAddApiDialogData } from './add-api-dialog/api-product-add-api-dialog.component';
+
+import { Api } from '../../../entities/management-api-v2';
+import { getApiContextPath } from '../../../shared/utils/api.util';
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+export type ApiProductApiTableDS = {
+  id: string;
+  name: string;
+  picture?: string;
+  contextPath: string;
+  definition: string;
+  version: string;
+  lifecycleState?: string;
+}[];
+
+interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
+
+@Component({
+  selector: 'api-product-apis',
+  templateUrl: './api-product-apis.component.html',
+  styleUrls: ['./api-product-apis.component.scss'],
+  imports: [MatButtonModule, MatIconModule, MatTableModule, MatTooltipModule, GioAvatarModule, GioIconsModule, GioTableWrapperModule],
+  standalone: true,
+})
+export class ApiProductApisComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly apiV2Service = inject(ApiV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly matDialog = inject(MatDialog);
+
+  readonly displayedColumns = ['picture', 'name', 'contextPath', 'definition', 'version', 'actions'] as const;
+  apisTableDS: ApiProductApiTableDS = [];
+  apisTableDSUnpaginatedLength = 0;
+  filters: ApiProductApisTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+  searchLabel = 'Search APIs...';
+  isLoadingData = true;
+  apiProductId = '';
+  private readonly filters$ = new BehaviorSubject(this.filters);
+
+  ngOnInit(): void {
+    const getApiProductId = (route: ActivatedRoute): string | null => {
+      if (route.snapshot.params['apiProductId']) {
+        return route.snapshot.params['apiProductId'];
+      }
+      if (route.parent) {
+        return getApiProductId(route.parent);
+      }
+      return null;
+    };
+
+    this.apiProductId = getApiProductId(this.activatedRoute) || '';
+    this.initFilters();
+
+    this.filters$
+      .pipe(
+        debounceTime(100),
+        distinctUntilChanged(isEqual),
+        tap((filters: ApiProductApisTableWrapperFilters) => {
+          this.router.navigate([], {
+            relativeTo: this.activatedRoute,
+            queryParams: {
+              q: filters.searchTerm,
+              page: filters.pagination.index,
+              size: filters.pagination.size,
+            },
+            queryParamsHandling: 'merge',
+          });
+        }),
+        switchMap(() => this.loadApisForProduct()),
+        tap(apis => this.processAndDisplayApis(apis)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private initFilters(): void {
+    const initialSearchValue = this.activatedRoute.snapshot.queryParams['q'] ?? this.filters.searchTerm;
+    const initialPageNumber = this.activatedRoute.snapshot.queryParams['page']
+      ? Number(this.activatedRoute.snapshot.queryParams['page'])
+      : this.filters.pagination.index;
+    const initialPageSize = this.activatedRoute.snapshot.queryParams['size']
+      ? Number(this.activatedRoute.snapshot.queryParams['size'])
+      : this.filters.pagination.size;
+
+    this.filters = {
+      searchTerm: initialSearchValue,
+      pagination: {
+        index: initialPageNumber,
+        size: initialPageSize,
+      },
+    };
+    this.filters$.next(this.filters);
+  }
+
+  private loadApisForProduct(): Observable<(Api | null)[]> {
+    this.isLoadingData = true;
+    return this.apiProductV2Service.get(this.apiProductId).pipe(
+      catchError(error => {
+        this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+        return of(null);
+      }),
+      switchMap(apiProduct => {
+        if (!apiProduct?.apiIds?.length) {
+          return of([]);
+        }
+        const apiObservables = apiProduct.apiIds.map(apiId => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
+        return forkJoin(apiObservables).pipe(
+          catchError(error => {
+            this.snackBarService.error(error.error?.message || 'An error occurred while loading APIs');
+            return of([]);
+          }),
+        );
+      }),
+    );
+  }
+
+  private processAndDisplayApis(apis: (Api | null)[]): void {
+    let filteredApis = apis.filter((api): api is Api => api !== null);
+    const searchTerm = this.filters.searchTerm?.toLowerCase() || '';
+
+    if (searchTerm) {
+      filteredApis = filteredApis.filter(
+        api =>
+          api.name?.toLowerCase().includes(searchTerm) ||
+          getApiContextPath(api)?.toLowerCase().includes(searchTerm) ||
+          api.apiVersion?.toLowerCase().includes(searchTerm),
+      );
+    }
+
+    const page = this.filters.pagination?.index || 1;
+    const perPage = this.filters.pagination?.size || 10;
+    const startIndex = (page - 1) * perPage;
+    const endIndex = startIndex + perPage;
+    const paginatedApis = filteredApis.slice(startIndex, endIndex);
+
+    this.apisTableDS = this.toApisTableDS(paginatedApis);
+    this.apisTableDSUnpaginatedLength = filteredApis.length;
+    this.isLoadingData = false;
+  }
+
+  private toApisTableDS(data: Api[]): ApiProductApiTableDS {
+    return data.map(api => ({
+      id: api.id,
+      name: api.name,
+      picture: api._links?.['pictureUrl'],
+      contextPath: getApiContextPath(api) || '-',
+      definition: 'HTTP Proxy Gravitee',
+      version: api.apiVersion || '-',
+      lifecycleState: api.lifecycleState,
+    }));
+  }
+
+  onFiltersChanged(filters: ApiProductApisTableWrapperFilters): void {
+    this.filters = { ...this.filters, ...filters };
+    this.filters$.next(this.filters);
+  }
+
+  private reloadTable(): void {
+    this.loadApisForProduct()
+      .pipe(
+        tap(apis => this.processAndDisplayApis(apis)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  onAddApi(): void {
+    this.apiProductV2Service
+      .get(this.apiProductId)
+      .pipe(
+        catchError(error => {
+          this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+          return of(null);
+        }),
+        filter((apiProduct): apiProduct is NonNullable<typeof apiProduct> => apiProduct != null),
+        switchMap(apiProduct =>
+          this.matDialog
+            .open<ApiProductAddApiDialogComponent, ApiProductAddApiDialogData, boolean>(ApiProductAddApiDialogComponent, {
+              width: GIO_DIALOG_WIDTH.MEDIUM,
+              data: {
+                apiProductId: this.apiProductId,
+                existingApiIds: apiProduct.apiIds || [],
+              },
+              role: 'dialog',
+              id: 'addApiDialog',
+            })
+            .afterClosed(),
+        ),
+        filter((success): success is true => success === true),
+        tap(() => this.reloadTable()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  onDeleteApi(api: ApiProductApiTableDS[0]): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: GIO_DIALOG_WIDTH.SMALL,
+        data: {
+          title: 'Remove API',
+          content: 'Please note that once your API is removed from this API Product, consumers will lose access to this API.',
+          confirmButton: 'Remove',
+        },
+        role: 'alertdialog',
+        id: 'removeApiDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((result): result is true => result === true),
+        switchMap(() =>
+          this.apiProductV2Service.get(this.apiProductId).pipe(
+            catchError(error => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+              return of(null);
+            }),
+          ),
+        ),
+        filter((apiProduct): apiProduct is NonNullable<typeof apiProduct> => apiProduct != null),
+        switchMap(apiProduct => {
+          const currentApiIds = apiProduct.apiIds || [];
+          const updatedApiIds = currentApiIds.filter(id => id !== api.id);
+          return this.apiProductV2Service.updateApiProductApis(this.apiProductId, updatedApiIds).pipe(
+            catchError(error => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while removing the API');
+              return of(null);
+            }),
+          );
+        }),
+        filter((result): result is NonNullable<typeof result> => result !== null),
+        tap(() => {
+          this.snackBarService.success(`API "${api.name}" has been removed from the API Product`);
+          this.reloadTable();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  get hasApis(): boolean {
+    return this.apisTableDS.length > 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -22,7 +22,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { combineLatest, EMPTY, Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
+import { combineLatest, EMPTY, Observable, forkJoin, of } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 import {
@@ -40,7 +40,7 @@ import {
 } from './add-api-dialog/api-product-add-api-dialog.component';
 
 import { Api } from '../../../entities/management-api-v2';
-import { getApiContextPath } from '../../../shared/utils/api.util';
+import { getApiContextPath } from '../../../shared/utils/api-access.util';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { filtersToQueryParams } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
@@ -59,6 +59,21 @@ export type ApiProductApiTableDS = {
 }[];
 
 interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
+
+const DEFAULT_FILTERS: ApiProductApisTableWrapperFilters = {
+  pagination: { index: 1, size: 10 },
+  searchTerm: '',
+};
+
+function queryParamsToFilters(queryParams: Record<string, string>): ApiProductApisTableWrapperFilters {
+  const searchTerm = queryParams['q'] ?? DEFAULT_FILTERS.searchTerm;
+  const index = queryParams['page'] ? Number(queryParams['page']) : DEFAULT_FILTERS.pagination.index;
+  const size = queryParams['size'] ? Number(queryParams['size']) : DEFAULT_FILTERS.pagination.size;
+  return {
+    searchTerm,
+    pagination: { index, size },
+  };
+}
 
 @Component({
   selector: 'api-product-apis',
@@ -80,16 +95,16 @@ export class ApiProductApisComponent implements OnInit {
   readonly displayedColumns = ['picture', 'name', 'contextPath', 'definition', 'version', 'actions'] as const;
   apisTableDS: ApiProductApiTableDS = [];
   apisTableDSUnpaginatedLength = 0;
-  filters: ApiProductApisTableWrapperFilters = {
-    pagination: { index: 1, size: 10 },
-    searchTerm: '',
-  };
   searchLabel = 'Search APIs...';
   isLoadingData = true;
   readonly apiProductId = toSignal((this.activatedRoute.parent?.params ?? of({})).pipe(map(p => p['apiProductId'] ?? '')), {
     initialValue: '',
   });
-  private readonly filters$ = new BehaviorSubject(this.filters);
+
+  /** Filters derived from router query params (single source of truth) */
+  readonly filters = toSignal(this.activatedRoute.queryParams.pipe(map(params => queryParamsToFilters(params as Record<string, string>))), {
+    initialValue: queryParamsToFilters(this.activatedRoute.snapshot.queryParams as Record<string, string>),
+  });
 
   private static readonly LOAD_API_PRODUCT_ERROR = 'An error occurred while loading the API Product';
 
@@ -114,50 +129,25 @@ export class ApiProductApisComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.initFilters();
     this.initApisTableSubscription();
   }
 
   private initApisTableSubscription(): void {
     combineLatest([
-      this.filters$.pipe(debounceTime(100), distinctUntilChanged(isEqual)),
+      this.activatedRoute.queryParams.pipe(
+        map(params => queryParamsToFilters(params as Record<string, string>)),
+        debounceTime(100),
+        distinctUntilChanged(isEqual),
+      ),
       toObservable(this.apiProductId, { injector: this.injector }).pipe(filter(id => !!id)),
     ])
       .pipe(
         map(([filters, apiProductId]) => ({ filters, apiProductId })),
-        tap(({ filters }) => this.syncFiltersToUrl(filters)),
-        switchMap(({ apiProductId }) => this.loadApisForProduct(apiProductId)),
-        tap(apis => this.processAndDisplayApis(apis)),
+        switchMap(({ filters, apiProductId }) => this.loadApisForProduct(apiProductId).pipe(map(apis => ({ filters, apis })))),
+        tap(({ filters, apis }) => this.processAndDisplayApis(filters, apis)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  private syncFiltersToUrl(filters: ApiProductApisTableWrapperFilters): void {
-    this.router.navigate([], {
-      relativeTo: this.activatedRoute,
-      queryParams: filtersToQueryParams(filters),
-      queryParamsHandling: 'merge',
-    });
-  }
-
-  private initFilters(): void {
-    const initialSearchValue = this.activatedRoute.snapshot.queryParams['q'] ?? this.filters.searchTerm;
-    const initialPageNumber = this.activatedRoute.snapshot.queryParams['page']
-      ? Number(this.activatedRoute.snapshot.queryParams['page'])
-      : this.filters.pagination.index;
-    const initialPageSize = this.activatedRoute.snapshot.queryParams['size']
-      ? Number(this.activatedRoute.snapshot.queryParams['size'])
-      : this.filters.pagination.size;
-
-    this.filters = {
-      searchTerm: initialSearchValue,
-      pagination: {
-        index: initialPageNumber,
-        size: initialPageSize,
-      },
-    };
-    this.filters$.next(this.filters);
   }
 
   private loadApisForProduct(apiProductId: string): Observable<(Api | null)[]> {
@@ -174,9 +164,9 @@ export class ApiProductApisComponent implements OnInit {
     );
   }
 
-  private processAndDisplayApis(apis: (Api | null)[]): void {
+  private processAndDisplayApis(filters: ApiProductApisTableWrapperFilters, apis: (Api | null)[]): void {
     let filteredApis = apis.filter((api): api is Api => api !== null);
-    const searchTerm = this.filters.searchTerm?.toLowerCase() || '';
+    const searchTerm = filters.searchTerm?.toLowerCase() || '';
 
     if (searchTerm) {
       filteredApis = filteredApis.filter(
@@ -187,8 +177,8 @@ export class ApiProductApisComponent implements OnInit {
       );
     }
 
-    const page = this.filters.pagination?.index || 1;
-    const perPage = this.filters.pagination?.size || 10;
+    const page = filters.pagination?.index || 1;
+    const perPage = filters.pagination?.size || 10;
     const startIndex = (page - 1) * perPage;
     const endIndex = startIndex + perPage;
     const paginatedApis = filteredApis.slice(startIndex, endIndex);
@@ -211,14 +201,21 @@ export class ApiProductApisComponent implements OnInit {
   }
 
   onFiltersChanged(filters: ApiProductApisTableWrapperFilters): void {
-    this.filters = { ...this.filters, ...filters };
-    this.filters$.next(this.filters);
+    const mergedFilters: ApiProductApisTableWrapperFilters = {
+      ...this.filters(),
+      ...filters,
+    };
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParams: filtersToQueryParams(mergedFilters),
+      queryParamsHandling: 'merge',
+    });
   }
 
   private reloadTable(): void {
     this.loadApisForProduct(this.apiProductId())
       .pipe(
-        tap(apis => this.processAndDisplayApis(apis)),
+        tap(apis => this.processAndDisplayApis(this.filters(), apis)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -56,27 +56,6 @@
       </mat-card-content>
     </mat-card>
 
-    @if (apiIds().length) {
-      <mat-card class="configuration-card">
-        <mat-card-header>
-          <mat-card-title>APIs in this Product</mat-card-title>
-          <mat-card-subtitle>Remove individual APIs from the product</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <div class="apis-list">
-            @for (apiId of apiIds(); track apiId) {
-              <div class="apis-list__item">
-                <span class="apis-list__item-id">{{ apiId }}</span>
-                <button mat-icon-button color="warn" (click)="onDeleteApi(apiId)" aria-label="Remove API">
-                  <mat-icon>delete</mat-icon>
-                </button>
-              </div>
-            }
-          </div>
-        </mat-card-content>
-      </mat-card>
-    }
-
     @if (product) {
       <api-product-danger-zone
         [apiProduct]="product"

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -172,12 +172,12 @@ describe('ApiProductConfigurationComponent', () => {
     const dialog = await rootLoader.getHarness(GioConfirmDialogHarness);
     await dialog.confirm();
 
-    const deleteReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`);
-    expect(deleteReq.request.method).toBe('DELETE');
-    deleteReq.flush({});
+    const putReq = httpTestingController.expectOne(req => req.url.includes(`/api-products/${API_PRODUCT_ID}`) && req.method === 'PUT');
+    expect(putReq.request.body).toEqual({ apiIds: [] });
+    putReq.flush({ ...fakeApiProduct, apiIds: [] });
     await fixture.whenStable();
 
-    const reloadReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    const reloadReq = httpTestingController.expectOne(req => req.url.includes(`/api-products/${API_PRODUCT_ID}`) && req.method === 'GET');
     reloadReq.flush({ ...fakeApiProduct, apiIds: [] });
     await fixture.whenStable();
 
@@ -190,7 +190,7 @@ describe('ApiProductConfigurationComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }));
     await deleteButton.click();
 
     const dialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -204,7 +204,7 @@ export class ApiProductConfigurationComponent {
           title: 'Delete API Product',
           content: 'Are you sure you want to delete this API Product?',
           confirmButton: 'Yes, delete it',
-          validationMessage: `Please, type in the name of the API Product ${product.name} to confirm.`,
+          validationMessage: `Please, type in the name of the API Product <code>${product.name}</code> to confirm.`,
           validationValue: product.name,
           warning: 'This operation is irreversible.',
         },

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -21,6 +21,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { EMPTY, merge, of, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { MatCardModule } from '@angular/material/card';
+import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
@@ -55,6 +56,7 @@ interface ConfigForm {
   templateUrl: './api-product-configuration.component.html',
   styleUrls: ['./api-product-configuration.component.scss'],
   standalone: true,
+  providers: [{ provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher }],
   imports: [
     ReactiveFormsModule,
     MatCardModule,
@@ -265,7 +267,6 @@ export class ApiProductConfigurationComponent {
         nonNullable: true,
         validators: [Validators.required, Validators.maxLength(this.nameMaxLength), Validators.minLength(1)],
         asyncValidators: [apiProductNameUniqueAsyncValidator(this.apiProductV2Service, () => this.currentApiProduct?.name)],
-        updateOn: 'blur',
       }),
       version: new FormControl('', {
         nonNullable: true,

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -178,7 +178,7 @@ export class ApiProductConfigurationComponent {
       .afterClosed()
       .pipe(
         filter((confirm): confirm is true => confirm === true),
-        switchMap(() => this.apiProductV2Service.deleteAllApisFromApiProduct(apiProductId)),
+        switchMap(() => this.apiProductV2Service.updateApiProductApis(apiProductId, [])),
         tap(() => {
           this.snackBarService.success('All APIs have been removed from the API Product.');
           this.onReloadDetails();

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -21,19 +21,31 @@
     <h3 class="danger-card__title">Danger Zone</h3>
     <div class="danger-card__actions">
       <div class="danger-card__actions__action">
-        <span>Remove all the APIs of this API Product.</span>
+        <span>
+          Remove all the APIs of this API Product.
+          @if (!apiProduct().apiIds?.length) {
+            <span>No APIs in this product.</span>
+          }
+        </span>
         <button mat-button color="warn" [disabled]="isReadOnly() || !apiProduct().apiIds?.length" (click)="onRemoveApis()">
           Remove APIs
         </button>
       </div>
 
       <div class="danger-card__actions__action">
-        <span>Delete this API Product. This won't delete APIs associated to it.</span>
+        <span class="gv-form-danger-text">
+          Delete this API Product.
+          @if (isReadOnly()) {
+            <span>This API Product cannot be deleted</span>
+          } @else {
+            <span>This won't delete APIs associated to it.</span>
+          }
+        </span>
         <button
           mat-button
           color="warn"
           [disabled]="isReadOnly()"
-          data-testid="api_product_dangerzone_delete"
+          [attr.data-testid]="'api_product_dangerzone_delete'"
           (click)="onDeleteApiProduct()"
         >
           Delete API Product

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -21,26 +21,14 @@
     <h3 class="danger-card__title">Danger Zone</h3>
     <div class="danger-card__actions">
       <div class="danger-card__actions__action">
-        <span>
-          Remove all the APIs of this API Product.
-          @if (!apiProduct().apiIds?.length) {
-            <span>No APIs in this product.</span>
-          }
-        </span>
+        <span> Remove all the APIs of this API Product. </span>
         <button mat-button color="warn" [disabled]="isReadOnly() || !apiProduct().apiIds?.length" (click)="onRemoveApis()">
           Remove APIs
         </button>
       </div>
 
       <div class="danger-card__actions__action">
-        <span class="gv-form-danger-text">
-          Delete this API Product.
-          @if (isReadOnly()) {
-            <span>This API Product cannot be deleted</span>
-          } @else {
-            <span>This won't delete APIs associated to it.</span>
-          }
-        </span>
+        <span class="gv-form-danger-text"> Delete this API Product. </span>
         <button
           mat-button
           color="warn"

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@use 'sass:map';
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
-
-$typography: map.get(gio.$mat-theme, typography);
 
 :host {
   display: block;
@@ -34,20 +31,13 @@ $typography: map.get(gio.$mat-theme, typography);
   &__actions {
     display: flex;
     flex-direction: column;
-    gap: 16px;
 
     &__action {
       display: flex;
       align-items: center;
       flex-direction: row;
       justify-content: space-between;
-      min-height: 3rem;
-
-      span {
-        @include mat.m2-typography-level($typography, caption);
-        display: block;
-        color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
-      }
+      height: 48px;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.scss
@@ -37,7 +37,7 @@
       align-items: center;
       flex-direction: row;
       justify-content: space-between;
-      height: 48px;
+      height: 3rem;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
@@ -83,8 +83,8 @@ describe('ApiProductDangerZoneComponent', () => {
     expect(hostComponent.removeApisEmitted).toBe(true);
   });
 
-  it('should emit deleteApiProductClick when Delete API Product button is clicked', async () => {
-    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: /Delete API Product/i }));
+  it('should emit deleteApiProductClick when Delete button is clicked', async () => {
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }));
     await deleteButton.click();
 
     expect(hostComponent.deleteApiProductEmitted).toBe(true);

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -102,7 +102,7 @@
         <ng-container matColumnDef="version">
           <th mat-header-cell *matHeaderCellDef mat-sort-header id="version">Version</th>
           <td mat-cell *matCellDef="let element">
-            <span class="version__badge gio-badge-neutral">v{{ element.version }}</span>
+            <span class="version__badge gio-badge-neutral">{{ element.version }}</span>
           </td>
         </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -107,6 +107,7 @@ export class ApiProductListComponent implements OnInit {
   private readonly snackBarService = inject(SnackBarService);
   private readonly permissionService = inject(GioPermissionService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly cdr = inject(ChangeDetectorRef);
 
   displayedColumns = ['picture', 'name', 'apis', 'version', 'owner', 'actions'];
   apiProductsTableDS: ApiProductTableDS = [];
@@ -135,6 +136,7 @@ export class ApiProductListComponent implements OnInit {
           return this.apiProductV2Service.list(page, perPage).pipe(
             catchError(error => {
               this.isLoadingData = false;
+              this.cdr.markForCheck();
               this.snackBarService.error(this.getErrorMessage(error, 'An error occurred while loading API Products'));
               return of(EMPTY_API_PRODUCTS_RESPONSE);
             }),
@@ -144,6 +146,7 @@ export class ApiProductListComponent implements OnInit {
           this.apiProductsTableDS = this.toApiProductsTableDS(response.data || []);
           this.apiProductsTableDSUnpaginatedLength = response.pagination?.totalCount || 0;
           this.isLoadingData = false;
+          this.cdr.markForCheck();
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -15,8 +15,8 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -26,13 +26,13 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioAvatarModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators';
 import { isObject } from 'angular';
 import { isEqual } from 'lodash';
 
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
-import { toSort, toOrder } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
+import { filtersToQueryParams, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -60,15 +60,6 @@ function queryParamsToFilters(queryParams: Record<string, string>): ApiProductLi
   };
 }
 
-function filtersToQueryParams(filters: ApiProductListTableWrapperFilters): Record<string, string | number | null> {
-  return {
-    q: filters.searchTerm || null,
-    page: filters.pagination?.index ?? 1,
-    size: filters.pagination?.size ?? 10,
-    order: filters.sort ? toOrder(filters.sort) : null,
-  };
-}
-
 export type ApiProductTableDS = {
   id: string;
   name: string;
@@ -80,12 +71,23 @@ export type ApiProductTableDS = {
 
 type ApiProductListTableWrapperFilters = GioTableWrapperFilters;
 
+type ApiProductsState = {
+  tableDS: ApiProductTableDS;
+  totalCount: number;
+  isLoading: boolean;
+};
+
+const INITIAL_API_PRODUCTS_STATE: ApiProductsState = {
+  tableDS: [],
+  totalCount: 0,
+  isLoading: true,
+};
+
 @Component({
   selector: 'api-product-list',
   templateUrl: './api-product-list.component.html',
   styleUrls: ['./api-product-list.component.scss'],
   standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CommonModule,
     MatButtonModule,
@@ -100,20 +102,15 @@ type ApiProductListTableWrapperFilters = GioTableWrapperFilters;
     RouterModule,
   ],
 })
-export class ApiProductListComponent implements OnInit {
+export class ApiProductListComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly snackBarService = inject(SnackBarService);
   private readonly permissionService = inject(GioPermissionService);
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly cdr = inject(ChangeDetectorRef);
 
   displayedColumns = ['picture', 'name', 'apis', 'version', 'owner', 'actions'];
-  apiProductsTableDS: ApiProductTableDS = [];
-  apiProductsTableDSUnpaginatedLength = 0;
   searchLabel = 'Search';
-  isLoadingData = true;
   canCreateApiProduct = this.permissionService.hasAnyMatching(['environment-api_product-c']);
 
   /** Filters derived from router query params (single source of truth) */
@@ -121,36 +118,42 @@ export class ApiProductListComponent implements OnInit {
     initialValue: queryParamsToFilters(this.activatedRoute.snapshot.queryParams as Record<string, string>),
   });
 
-  ngOnInit(): void {
-    this.activatedRoute.queryParams
-      .pipe(
-        debounceTime(FILTERS_DEBOUNCE_MS),
-        map(params => queryParamsToFilters(params)),
-        distinctUntilChanged(isEqual),
-        tap(() => {
-          this.isLoadingData = true;
-        }),
-        switchMap((filters: ApiProductListTableWrapperFilters) => {
-          const page = filters.pagination?.index || 1;
-          const perPage = filters.pagination?.size || 10;
-          return this.apiProductV2Service.list(page, perPage).pipe(
-            catchError(error => {
-              this.isLoadingData = false;
-              this.cdr.markForCheck();
-              this.snackBarService.error(this.getErrorMessage(error, 'An error occurred while loading API Products'));
-              return of(EMPTY_API_PRODUCTS_RESPONSE);
-            }),
-          );
-        }),
-        tap((response: ApiProductsResponse) => {
-          this.apiProductsTableDS = this.toApiProductsTableDS(response.data || []);
-          this.apiProductsTableDSUnpaginatedLength = response.pagination?.totalCount || 0;
-          this.isLoadingData = false;
-          this.cdr.markForCheck();
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+  /** API products data stream - toSignal triggers change detection when the stream emits */
+  readonly apiProductsState = toSignal(
+    this.activatedRoute.queryParams.pipe(
+      debounceTime(FILTERS_DEBOUNCE_MS),
+      map(params => queryParamsToFilters(params)),
+      distinctUntilChanged(isEqual),
+      switchMap((filters: ApiProductListTableWrapperFilters) => {
+        const page = filters.pagination?.index || 1;
+        const perPage = filters.pagination?.size || 10;
+        return this.apiProductV2Service.list(page, perPage).pipe(
+          catchError(error => {
+            this.snackBarService.error(this.getErrorMessage(error, 'An error occurred while loading API Products'));
+            return of(EMPTY_API_PRODUCTS_RESPONSE);
+          }),
+          map((response: ApiProductsResponse) => ({
+            tableDS: this.toApiProductsTableDS(response.data || []),
+            totalCount: response.pagination?.totalCount || 0,
+            isLoading: false,
+          })),
+          startWith(INITIAL_API_PRODUCTS_STATE),
+        );
+      }),
+    ),
+    { initialValue: INITIAL_API_PRODUCTS_STATE },
+  );
+
+  get apiProductsTableDS(): ApiProductTableDS {
+    return this.apiProductsState().tableDS;
+  }
+
+  get apiProductsTableDSUnpaginatedLength(): number {
+    return this.apiProductsState().totalCount;
+  }
+
+  get isLoadingData(): boolean {
+    return this.apiProductsState().isLoading;
   }
 
   private getErrorMessage(error: unknown, fallback: string): string {

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -49,6 +49,9 @@ $textColor: map.get(gio.$mat-dove-palette, default);
         @include mat.m2-typography-level($typography, subtitle-1);
         margin: 0;
         padding: 16px 20px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -46,7 +46,10 @@ export class ApiProductNavigationComponent {
   private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly snackBarService = inject(SnackBarService);
 
-  readonly subMenuItems: MenuItem[] = [{ displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' }];
+  readonly subMenuItems: MenuItem[] = [
+    { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
+    { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
+  ];
   readonly hasBreadcrumb = toSignal(this.gioMenuService.reduced$, { initialValue: false });
 
   private readonly navTrigger = toSignal(

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-included-in-dialog/api-general-info-included-in-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-included-in-dialog/api-general-info-included-in-dialog.component.spec.ts
@@ -91,12 +91,6 @@ describe('ApiGeneralInfoIncludedInDialogComponent', () => {
       expect(names).toEqual(['Product Alpha']);
     });
 
-    it('should filter products by search term (description)', async () => {
-      await harness.setSearchTerm('Gamma description');
-      const names = await harness.getProductNames();
-      expect(names).toEqual(['Gamma API']);
-    });
-
     it('should show no products when search has no matches', async () => {
       await harness.setSearchTerm('nonexistent');
       const names = await harness.getProductNames();

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-included-in-dialog/api-general-info-included-in-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-included-in-dialog/api-general-info-included-in-dialog.component.ts
@@ -61,6 +61,6 @@ export class ApiGeneralInfoIncludedInDialogComponent {
     if (!term) {
       return products;
     }
-    return products.filter(p => p.name?.toLowerCase().includes(term) || p.description?.toLowerCase().includes(term));
+    return products.filter(p => p.name?.toLowerCase().includes(term));
   });
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.util.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.util.ts
@@ -73,3 +73,12 @@ export const toOrder = (sort: Sort): string => {
   }
   return 'desc' === sort.direction ? `-${sort.active}` : sort.active;
 };
+
+export function filtersToQueryParams(filters: Partial<GioTableWrapperFilters>): Record<string, string | number | null> {
+  return {
+    q: filters.searchTerm || null,
+    page: filters.pagination?.index ?? 1,
+    size: filters.pagination?.size ?? 10,
+    order: filters.sort ? toOrder(filters.sort) : null,
+  };
+}

--- a/gravitee-apim-console-webui/src/shared/utils/api-access.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api-access.util.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getApiAccess } from './api-access.util';
+import { getApiAccess, getApiContextPath } from './api-access.util';
 
 import { fakeApiV2, fakeApiV4, fakeNativeKafkaApiV4 } from '../../entities/management-api-v2';
 
@@ -100,5 +100,43 @@ describe('getApiAccess', () => {
     const api = fakeApiV4({ type: 'PROXY', listeners: [] });
 
     expect(getApiAccess(api)).toEqual(null);
+  });
+});
+
+describe('getApiContextPath', () => {
+  it('should return first access when getApiAccess returns multiple', () => {
+    const api = fakeApiV2({
+      proxy: {
+        ...fakeApiV2().proxy,
+        virtualHosts: [
+          { host: 'example.com', path: '/planets', overrideEntrypoint: true },
+          { host: 'api.example.com', path: '/v2', overrideEntrypoint: true },
+        ],
+      },
+    });
+
+    expect(getApiContextPath(api)).toBe('example.com/planets');
+  });
+
+  it('should return single access when getApiAccess returns one', () => {
+    const api = fakeApiV2({ proxy: { ...fakeApiV2().proxy, virtualHosts: [] }, contextPath: '/ctx' });
+
+    expect(getApiContextPath(api)).toBe('/ctx');
+  });
+
+  it('should return null when getApiAccess returns null', () => {
+    const api = fakeApiV4({ type: 'PROXY', listeners: [] });
+
+    expect(getApiContextPath(api)).toBe(null);
+  });
+
+  it('should return null for null or undefined api', () => {
+    expect(getApiContextPath(null)).toBe(null);
+    expect(getApiContextPath(undefined)).toBe(null);
+  });
+
+  it('should return null for unsupported definition version', () => {
+    const api = { definitionVersion: 'V1' } as Parameters<typeof getApiContextPath>[0];
+    expect(getApiContextPath(api)).toBe(null);
   });
 });

--- a/gravitee-apim-console-webui/src/shared/utils/api-access.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api-access.util.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiV2, ApiV4, HttpListener, KafkaListener, TcpListener } from '../../entities/management-api-v2';
+import { Api, ApiV2, ApiV4, HttpListener, KafkaListener, TcpListener } from '../../entities/management-api-v2';
 
 export const getApiAccess = (api: ApiV4 | ApiV2): string[] | null => {
   if (api.definitionVersion === 'V2') {
@@ -42,3 +42,13 @@ export const getApiAccess = (api: ApiV4 | ApiV2): string[] | null => {
 
   return tcpListenerHosts.length > 0 ? tcpListenerHosts : httpListenerPaths.length > 0 ? httpListenerPaths : null;
 };
+
+/**
+ * Returns the first access path for display (e.g. context path, primary path).
+ * Complementary to getApiAccess - use when you need a single value for UI display.
+ */
+export function getApiContextPath(api: Api | null | undefined): string | null {
+  if (!api || (api.definitionVersion !== 'V2' && api.definitionVersion !== 'V4')) return null;
+  const access = getApiAccess(api as ApiV4 | ApiV2);
+  return access?.[0] ?? null;
+}

--- a/gravitee-apim-console-webui/src/shared/utils/api.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api.util.ts
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+import { Api, ApiV4, HttpListener } from '../../entities/management-api-v2';
+
+/** Extracts the context path from V4 HTTP Proxy APIs (HTTP listener's first path). */
+export function getApiContextPath(api: Api | null | undefined): string | null {
+  if (!api || api.definitionVersion !== 'V4') return null;
+  const httpListener = (api as ApiV4).listeners?.find(l => l.type === 'HTTP') as HttpListener | undefined;
+  return httpListener?.paths?.[0]?.path ?? null;
+}
+
 export const mapDefinitionVersionToLabel = (definitionVersion: string): string => {
   switch (definitionVersion) {
     case 'V1':

--- a/gravitee-apim-console-webui/src/shared/utils/api.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api.util.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { Api, ApiV4, HttpListener } from '../../entities/management-api-v2';
+import { getApiAccess } from './api-access.util';
 
-/** Extracts the context path from V4 HTTP Proxy APIs (HTTP listener's first path). */
+import { Api, ApiV2, ApiV4 } from '../../entities/management-api-v2';
+
 export function getApiContextPath(api: Api | null | undefined): string | null {
-  if (!api || api.definitionVersion !== 'V4') return null;
-  const httpListener = (api as ApiV4).listeners?.find(l => l.type === 'HTTP') as HttpListener | undefined;
-  return httpListener?.paths?.[0]?.path ?? null;
+  if (!api || (api.definitionVersion !== 'V2' && api.definitionVersion !== 'V4')) return null;
+  const access = getApiAccess(api as ApiV4 | ApiV2);
+  return access?.[0] ?? null;
 }
 
 export const mapDefinitionVersionToLabel = (definitionVersion: string): string => {

--- a/gravitee-apim-console-webui/src/shared/utils/api.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api.util.ts
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-import { getApiAccess } from './api-access.util';
-
-import { Api, ApiV2, ApiV4 } from '../../entities/management-api-v2';
-
-export function getApiContextPath(api: Api | null | undefined): string | null {
-  if (!api || (api.definitionVersion !== 'V2' && api.definitionVersion !== 'V4')) return null;
-  const access = getApiAccess(api as ApiV4 | ApiV2);
-  return access?.[0] ?? null;
-}
-
 export const mapDefinitionVersionToLabel = (definitionVersion: string): string => {
   switch (definitionVersion) {
     case 'V1':

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCTS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
@@ -321,12 +322,12 @@ public class ApisResource extends AbstractResource {
             apiQueryBuilder.addFilter(FIELD_PORTAL_STATUS, apiSearchQuery.getPublished());
         }
 
-        if (apiSearchQuery.getPublished() != null && !apiSearchQuery.getPublished().isEmpty()) {
-            apiQueryBuilder.addFilter(FIELD_PORTAL_STATUS, apiSearchQuery.getPublished());
-        }
-
         if (CollectionUtils.isNotEmpty(apiSearchQuery.getVisibilities())) {
             apiQueryBuilder.addFilter(FIELD_VISIBILITY, apiSearchQuery.getVisibilities());
+        }
+
+        if (apiSearchQuery.getAllowedInApiProducts() != null) {
+            apiQueryBuilder.addFilter(FIELD_ALLOW_IN_API_PRODUCTS, apiSearchQuery.getAllowedInApiProducts());
         }
 
         var selectedDefinitions = Stream.concat(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4038,6 +4038,10 @@ components:
                   type: array
                   items:
                     type: string
+                allowedInApiProducts:
+                  type: boolean
+                  description: When set, filters results to only APIs with this allowedInApiProducts value. When true, only returns APIs allowed in API Products. When false, only returns APIs not allowed in API Products. Only applicable for V4 HTTP Proxy APIs.
+                  example: true
         ApiType:
             type: string
             description: API's type.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -181,6 +181,8 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
             }
         } else if (values instanceof String value) {
             return Stream.of(new TermQuery(new Term(remapFields.getOrDefault(field, field), QueryParserBase.escape(value))));
+        } else if (values instanceof Boolean bool) {
+            return Stream.of(new TermQuery(new Term(remapFields.getOrDefault(field, field), Boolean.toString(bool))));
         }
         return Stream.empty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -17,16 +17,13 @@ package io.gravitee.rest.api.service.v4.impl;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCTS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.IntegrationRepository;
@@ -299,13 +296,6 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
             return new Page<>(List.of(), 0, 0, 0);
         }
 
-        // Filter by allowedInApiProducts when requested (source of truth from DB, handles index staleness)
-        apis = filterApisByAllowedInApiProducts(apis, apiQuery);
-
-        if (apis.isEmpty()) {
-            return new Page<>(List.of(), 0, 0, 0);
-        }
-
         Map<String, PrimaryOwnerEntity> primaryOwners = primaryOwnerService.getPrimaryOwners(
             executionContext,
             apis.stream().map(Api::getId).toList()
@@ -334,69 +324,9 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
             .sorted((o1, o2) -> orderingComparator.compare(o1.getId(), o2.getId()))
             .collect(
                 Collectors.collectingAndThen(Collectors.toList(), apiEntityList ->
-                    new Page<>(apiEntityList, pageable.getPageNumber(), apiEntityList.size(), apiIds.size())
+                    new Page<>(apiEntityList, pageable.getPageNumber(), apis.size(), apiIds.size())
                 )
             );
-    }
-
-    private List<Api> filterApisByAllowedInApiProducts(List<Api> apis, io.gravitee.rest.api.service.search.query.Query<?> apiQuery) {
-        if (apiQuery.getFilters() == null) {
-            return apis;
-        }
-        Object filterValue = apiQuery.getFilters().get(FIELD_ALLOW_IN_API_PRODUCTS);
-        if (filterValue == null) {
-            return apis;
-        }
-        Boolean expectedValue;
-        if (filterValue instanceof Boolean b) {
-            expectedValue = b;
-        } else if (filterValue instanceof Collection<?> coll && !coll.isEmpty()) {
-            String first = coll.iterator().next().toString();
-            expectedValue = "true".equalsIgnoreCase(first) ? Boolean.TRUE : Boolean.FALSE;
-        } else {
-            String filterStr = filterValue != null ? filterValue.toString() : "";
-            expectedValue = "true".equalsIgnoreCase(filterStr) ? Boolean.TRUE : Boolean.FALSE;
-        }
-
-        var objectMapper = new ObjectMapper();
-        List<Api> filtered = apis
-            .stream()
-            .filter(api -> {
-                if (api.getDefinition() == null) {
-                    return false;
-                }
-                if (!isV4ProxyApi(api, objectMapper)) {
-                    return false;
-                }
-                try {
-                    var tree = objectMapper.readTree(api.getDefinition());
-                    if (!tree.has("allowedInApiProducts")) {
-                        return !expectedValue;
-                    }
-                    boolean actualValue = tree.get("allowedInApiProducts").asBoolean();
-                    return Objects.equals(actualValue, expectedValue);
-                } catch (Exception e) {
-                    log.warn("Failed to parse allowedInApiProducts from API {} definition", api.getId(), e);
-                    return false;
-                }
-            })
-            .toList();
-        return filtered;
-    }
-
-    private static boolean isV4ProxyApi(Api api, ObjectMapper objectMapper) {
-        if (api.getType() == ApiType.PROXY) {
-            return true;
-        }
-        if (api.getDefinition() == null) {
-            return false;
-        }
-        try {
-            var tree = objectMapper.readTree(api.getDefinition());
-            return "PROXY".equals(tree.path("type").asText(null));
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private List<String> getApiIdPageSubset(Collection<String> ids, Pageable pageable) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12361
https://gravitee.atlassian.net/browse/APIM-12365

## Description

This PR adds the **APIs** page within the API Product detail flow, allowing API Product Managers to view all associated APIs and search for/add eligible APIs. The page integrates with existing navigation and reuses the v2 APIs `_search` endpoint with V4 HTTP Proxy and `allowedInApiProducts` filtering.

---

## User Stories & Acceptance Criteria

### US1: View APIs in a Product
> As an API Product Manager, I want to see all APIs included in a product, so that I can verify product composition.

| Criteria | Implementation |
|----------|----------------|
| APIs page lists all associated APIs | Table populated from product `apiIds` via `ApiProductV2Service` + `ApiV2Service.get()` |
| API name, version, and status shown | Columns: Name, Context Path, Definition, Version; "Deprecated" badge when applicable |
| Navigation consistent with Console UX | APIs tab added to submenu alongside Configuration; uses `gio-table-wrapper` and `gio-submenu` |

### US2: Search When Adding APIs
> As an API Product Manager, I want to search for APIs when adding them to a product, so that I can easily find eligible APIs.

| Criteria | Implementation |
|----------|----------------|
| Search UI available when adding APIs | Autocomplete search in Add API dialog |
| Reuses existing API `_search` endpoint | `ApiV2Service.search()` → `POST /environments/{envId}/apis/_search` |
| Only V4 HTTP Proxy APIs returned | Search params: `apiTypes: ['V4_HTTP_PROXY']`, `allowedInApiProducts: true` |
| Supports filtering and selection | Client-side filtering of already-selected and existing product APIs; multi-select with chips |
| UI and backend validation aligned | UI validates duplicates; backend `ValidateApiProductService` enforces `allowedInApiProducts` |

---

## File References

### Backend (Reference – No Changes in This PR)

| Area | Path |
|------|------|
| API Products OpenAPI | `gravitee-apim-rest-api-management-v2/.../openapi-api-products.yaml` |
| APIs search OpenAPI | `gravitee-apim-rest-api-management-v2/.../openapi-apis.yaml` |
| Validate API Product | `gravitee-apim-rest-api-service/.../ValidateApiProductService.java` |

---

## Test Cases

### `ApiProductApisComponent` (`api-product-apis.component.spec.ts`)

| Test | Description |
|------|-------------|
| `should create` | Component initializes |
| `should display empty state when no APIs in product` | Shows empty state when `apiIds` is empty |
| `should display table with API rows when product has APIs` | Table shows name, context path for each API |
| `should display Loading... then data` | Loading state, then table after API fetch |
| `should handle error when loading API product` | SnackBar error on failed load |
| `should have Add API button` | Add API button present |
| `should open Add API dialog when Add API clicked` | Dialog opens with `apiProductId`, `existingApiIds` |
| `should filter APIs by search term` | Client-side filter updates table (e.g. "Orders") |

### `ApiProductAddApiDialogComponent` (`add-api-dialog/api-product-add-api-dialog.component.spec.ts`)

| Test | Description |
|------|-------------|
| `should create` | Dialog initializes |
| `should close dialog on cancel` | Cancel closes dialog |
| `should disable submit when no APIs selected` | Submit disabled when selection is empty |
| `should call close with true on successful submit` | Success flow: GET product → PUT update → snackbar → close |
| `should show error when API already in product` | SnackBar error and no close when API already in product |


---
https://github.com/user-attachments/assets/d95556eb-ea3f-4a9f-8d82-7599631ac1d8
