### PR TITLE
feat: debug mode enhancement by increasing timeout & implement long-poll

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.html
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.html
@@ -16,93 +16,75 @@
 
 -->
 <div class="debug-mode-response">
-  <ng-container *ngIf="!debugResponse; then emptyResponse"></ng-container>
-  <ng-container *ngIf="!!debugResponse && debugResponse.isLoading; then loadingResponse"></ng-container>
-  <ng-container *ngIf="!!debugResponse && !debugResponse.isLoading && !debugResponse.reachedTimeout; then displayResponse"></ng-container>
-  <ng-container
-    *ngIf="!!debugResponse && !debugResponse.isLoading && !debugResponse.reachedTimeout && !inspectorVM; then inspectorHelper"
-  ></ng-container>
-  <ng-container *ngIf="!!debugResponse && !debugResponse.isLoading && debugResponse.reachedTimeout; then reachedTimeout"></ng-container>
+  @if (!debugResponse) {
+    <!-- Empty Response -->
+    <div class="debug-mode-response__empty-response">
+      <gv-icon class="debug-mode-response__empty-response__icon" shape="editor:format_align_left"></gv-icon>
+      <h5>Define and run the request you want to test!</h5>
+    </div>
+  } @else if (debugResponse.isLoading) {
+    <!-- Loading Response -->
+    <div class="debug-mode-response__loading-response">
+      <gv-icon class="debug-mode-response__loading-response__icon" shape="communication:sending"></gv-icon>
+      <h5>Request in progress!</h5>
+      <p *ngIf="showLongRequestWarning" class="debug-mode-response__loading-response__long-request-warning">
+        The debug request has taken more than 20 seconds. It is unlikely that a response will be received, but we will continue waiting.
+      </p>
+    </div>
+  } @else {
+    <!-- Display Response -->
+    <div class="debug-mode-response__display-response__header">
+      <div>Response</div>
+      <div
+        class="debug-mode-response__display-response__header__status"
+        [class.status-success]="responseDisplayableVM.successfulRequest"
+        [class.status-error]="responseDisplayableVM.errorRequest"
+      >
+        {{ responseDisplayableVM.statusCode }} - {{ responseDisplayableVM.statusCodeDescription }}
+      </div>
+      <div class="debug-mode-response__display-response__header__method" [ngClass]="responseDisplayableVM.methodBadgeCSSClass">
+        {{ debugResponse.request.method }}
+      </div>
+      <div class="debug-mode-response__display-response__header__path">{{ debugResponse.request.path }}</div>
+    </div>
+    <div>
+      <debug-mode-timeline
+        [nbPoliciesRequest]="debugResponse.requestPolicyDebugSteps.length"
+        [nbPoliciesResponse]="debugResponse.responsePolicyDebugSteps.length"
+        [metrics]="debugResponse.metrics"
+      >
+        <debug-mode-timeline-card
+          *ngFor="let timelineStep of responseDisplayableVM.timelineSteps"
+          [id]="'card_' + timelineStep.id"
+          [timelineStep]="timelineStep"
+          (click)="onSelectTimelineStep(timelineStep)"
+        ></debug-mode-timeline-card>
+      </debug-mode-timeline>
+    </div>
+    <div>
+      <debug-mode-timeline-overview
+        [timelineSteps]="responseDisplayableVM.timelineSteps"
+        (selected)="onSelectTimelineStepOverview($event)"
+      ></debug-mode-timeline-overview>
+    </div>
+    <div>
+      <debug-mode-timeline-legend></debug-mode-timeline-legend>
+    </div>
+
+    <debug-mode-inspector
+      class="debug-mode-response__display-response__inspector"
+      *ngIf="inspectorVM"
+      [inputDebugStep]="inspectorVM.input"
+      [outputDebugStep]="inspectorVM.output"
+      [executionStatus]="inspectorVM.executionStatus"
+    >
+    </debug-mode-inspector>
+    @if (inspectorVM == null) {
+      <!-- Display timeline helper text -->
+      <div class="debug-mode-response__inspector-helper">
+        <gv-icon class="debug-mode-response__inspector-helper__icon" shape="general:search"></gv-icon>
+        <h5>Select a step in the timeline to compare its inputs and outputs</h5>
+      </div>
+    }
+  }
 </div>
-
-<!-- Empty Response -->
-<ng-template #emptyResponse>
-  <div class="debug-mode-response__empty-response">
-    <gv-icon class="debug-mode-response__empty-response__icon" shape="editor:format_align_left"></gv-icon>
-    <h5>Define and run the request you want to test!</h5>
-  </div>
-</ng-template>
-
-<!-- Loading Response -->
-<ng-template #loadingResponse>
-  <div class="debug-mode-response__loading-response">
-    <gv-icon class="debug-mode-response__loading-response__icon" shape="communication:sending"></gv-icon>
-    <h5>Request in progress!</h5>
-  </div>
-</ng-template>
-
-<!-- Debug request ended in timeout -->
-<ng-template #reachedTimeout>
-  <div class="debug-mode-response__reached-timeout">
-    <gv-icon class="debug-mode-response__reached-timeout__icon" shape="devices:lte#2"></gv-icon>
-    <h5>Bad news, it looks like your request was lost in space. Please try again.</h5>
-  </div>
-</ng-template>
-
-<!-- Display timeline helper text -->
-<ng-template #inspectorHelper>
-  <div class="debug-mode-response__inspector-helper">
-    <gv-icon class="debug-mode-response__inspector-helper__icon" shape="general:search"></gv-icon>
-    <h5>Select a step in the timeline to compare its inputs and outputs</h5>
-  </div>
-</ng-template>
-
-<!-- Display Response -->
-<ng-template #displayResponse>
-  <div class="debug-mode-response__display-response__header">
-    <div>Response</div>
-    <div
-      class="debug-mode-response__display-response__header__status"
-      [class.status-success]="responseDisplayableVM.successfulRequest"
-      [class.status-error]="responseDisplayableVM.errorRequest"
-    >
-      {{ responseDisplayableVM.statusCode }} - {{ responseDisplayableVM.statusCodeDescription }}
-    </div>
-    <div class="debug-mode-response__display-response__header__method" [ngClass]="responseDisplayableVM.methodBadgeCSSClass">
-      {{ debugResponse.request.method }}
-    </div>
-    <div class="debug-mode-response__display-response__header__path">{{ debugResponse.request.path }}</div>
-  </div>
-  <div>
-    <debug-mode-timeline
-      [nbPoliciesRequest]="debugResponse.requestPolicyDebugSteps.length"
-      [nbPoliciesResponse]="debugResponse.responsePolicyDebugSteps.length"
-      [metrics]="debugResponse.metrics"
-    >
-      <debug-mode-timeline-card
-        *ngFor="let timelineStep of responseDisplayableVM.timelineSteps"
-        [id]="'card_' + timelineStep.id"
-        [timelineStep]="timelineStep"
-        (click)="onSelectTimelineStep(timelineStep)"
-      ></debug-mode-timeline-card>
-    </debug-mode-timeline>
-  </div>
-  <div>
-    <debug-mode-timeline-overview
-      [timelineSteps]="responseDisplayableVM.timelineSteps"
-      (selected)="onSelectTimelineStepOverview($event)"
-    ></debug-mode-timeline-overview>
-  </div>
-  <div>
-    <debug-mode-timeline-legend></debug-mode-timeline-legend>
-  </div>
-
-  <debug-mode-inspector
-    class="debug-mode-response__display-response__inspector"
-    *ngIf="inspectorVM"
-    [inputDebugStep]="inspectorVM.input"
-    [outputDebugStep]="inspectorVM.output"
-    [executionStatus]="inspectorVM.executionStatus"
-  >
-  </debug-mode-inspector>
-</ng-template>

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.scss
@@ -12,7 +12,6 @@ $typography: map.get(gio.$mat-theme, typography);
 
   &__empty-response,
   &__loading-response,
-  &__reached-timeout,
   &__inspector-helper {
     display: flex;
     flex-direction: column;
@@ -36,6 +35,12 @@ $typography: map.get(gio.$mat-theme, typography);
       animation-iteration-count: infinite;
       animation-fill-mode: both;
       animation-play-state: running;
+    }
+
+    &__long-request-warning {
+      margin: 8px 48px 0;
+      max-width: 560px;
+      text-align: center;
     }
   }
 

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/components/debug-mode-response/debug-mode-response.component.ts
@@ -45,6 +45,9 @@ export class DebugModeResponseComponent implements OnChanges {
   @Input()
   public listPolicies?: PolicyListItem[];
 
+  @Input()
+  public showLongRequestWarning = false;
+
   public responseDisplayableVM: ResponseDisplayableVM;
 
   public inspectorVM: {

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.component.html
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.component.html
@@ -27,7 +27,11 @@
 
     <div class="debug-mode__response">
       <div class="debug-mode__response__container">
-        <debug-mode-response [debugResponse]="debugResponse" [listPolicies]="listPolicies"></debug-mode-response>
+        <debug-mode-response
+          [debugResponse]="debugResponse"
+          [listPolicies]="listPolicies"
+          [showLongRequestWarning]="showLongRequestWarning"
+        ></debug-mode-response>
       </div>
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.component.spec.ts
@@ -29,18 +29,23 @@ import { DebugModeModule } from './debug-mode.module';
 import { fakeDebugEvent } from './models/DebugEvent.fixture';
 import { DebugModeV2Service } from './v2-wrapper/debug-mode-v2.service';
 import { DebugModeV4Service } from './v4-wrapper/debug-mode-v4.service';
-import { DebugModeService } from './debug-mode.service';
+import { DEBUG_EVENT_FAILED_MESSAGE, DebugModeService } from './debug-mode.service';
 
 import { PolicyStudioService } from '../policy-studio-v2/policy-studio.service';
 import { fakePolicyListItem } from '../../../entities/policy';
 import { fakeApiV2, fakeApiV4 } from '../../../entities/management-api-v2';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { toApiDefinition } from '../policy-studio-v2/models/ApiDefinition';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+const LONG_REQUEST_WARNING_TEXT =
+  'The debug request has taken more than 20 seconds. It is unlikely that a response will be received, but we will continue waiting.';
 
 describe('DebugModeComponent with DebugModeV2Service', () => {
   let fixture: ComponentFixture<DebugModeComponent>;
   let httpTestingController: HttpTestingController;
   let policyStudioService: PolicyStudioService;
+  let snackBarService: SnackBarService;
   let loader: HarnessLoader;
 
   const policies = [
@@ -83,6 +88,7 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
 
     httpTestingController = TestBed.inject(HttpTestingController);
+    snackBarService = TestBed.inject(SnackBarService);
 
     policyStudioService = TestBed.inject(PolicyStudioService);
     policyStudioService.setApiDefinition(toApiDefinition(api));
@@ -106,15 +112,180 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
 
     expectSendDebugEvent(eventId);
     tick(1000);
-    expectGetDebugEvent(eventId, false);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
     tick(1000);
-    expectGetDebugEvent(eventId, true);
+    expectGetDebugEvent(eventId, 'SUCCESS');
 
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.debug-mode-response__display-response__header').textContent).toContain(
       'Response 200 - OK  GET /',
     );
+  }));
+
+  it('should display a warning only after 20 seconds while request is still loading', fakeAsync(async () => {
+    const eventId = 'eventId';
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+    const cancelButton = await loader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+
+    for (let i = 0; i < 19; i++) {
+      tick(1000);
+      expectGetDebugEvent(eventId, 'DEBUGGING');
+    }
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).not.toContain(LONG_REQUEST_WARNING_TEXT);
+
+    tick(1000);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain(LONG_REQUEST_WARNING_TEXT);
+
+    await cancelButton.click();
+    tick();
+  }));
+
+  it('should display late success response and clear the warning state', fakeAsync(async () => {
+    const eventId = 'eventId';
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+
+    for (let i = 0; i < 30; i++) {
+      tick(1000);
+      expectGetDebugEvent(eventId, 'DEBUGGING');
+    }
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain(LONG_REQUEST_WARNING_TEXT);
+
+    for (let i = 0; i < 14; i++) {
+      tick(1000);
+      expectGetDebugEvent(eventId, 'DEBUGGING');
+    }
+
+    tick(1000);
+    expectGetDebugEvent(eventId, 'SUCCESS');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.debug-mode-response__display-response__header').textContent).toContain(
+      'Response 200 - OK  GET /',
+    );
+    expect(fixture.nativeElement.textContent).not.toContain(LONG_REQUEST_WARNING_TEXT);
+  }));
+
+  it('should stop polling when component is destroyed', fakeAsync(async () => {
+    const eventId = 'eventId';
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+
+    tick(1000);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
+
+    fixture.destroy();
+    tick(5000);
+
+    httpTestingController.expectNone({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/events/${eventId}`,
+    });
+  }));
+
+  it('should stop polling and clear warning when request is cancelled', fakeAsync(async () => {
+    const eventId = 'eventId';
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+    const cancelButton = await loader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+
+    for (let i = 0; i < 30; i++) {
+      tick(1000);
+      expectGetDebugEvent(eventId, 'DEBUGGING');
+    }
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain(LONG_REQUEST_WARNING_TEXT);
+
+    await cancelButton.click();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Define and run the request you want to test!');
+    expect(fixture.nativeElement.textContent).not.toContain(LONG_REQUEST_WARNING_TEXT);
+
+    tick(5000);
+    httpTestingController.expectNone({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/events/${eventId}`,
+    });
+  }));
+
+  it('should allow a new request to be sent after a previous one was cancelled', fakeAsync(async () => {
+    const eventId = 'eventId';
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+    const cancelButton = await loader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+
+    // First request — cancel it
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+    tick(1000);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
+
+    await cancelButton.click();
+    tick();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Define and run the request you want to test!');
+
+    // Second request — must not be immediately cancelled by the old Subject emission
+    await sendButton.click();
+    tick();
+    expectSendDebugEvent(eventId);
+    tick(1000);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
+    tick(1000);
+    expectGetDebugEvent(eventId, 'SUCCESS');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.debug-mode-response__display-response__header').textContent).toContain(
+      'Response 200 - OK  GET /',
+    );
+  }));
+
+  it('should stop polling and display an error message when debug event status is error', fakeAsync(async () => {
+    const eventId = 'eventId';
+    const snackBarErrorSpy = jest.spyOn(snackBarService, 'error').mockImplementation();
+
+    const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+    await sendButton.click();
+
+    tick();
+    expectSendDebugEvent(eventId);
+    tick(1000);
+    expectGetDebugEvent(eventId, 'ERROR');
+    tick();
+
+    expect(snackBarErrorSpy).toHaveBeenCalledWith(DEBUG_EVENT_FAILED_MESSAGE);
+    tick(5000);
+    httpTestingController.expectNone({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/events/${eventId}`,
+    });
   }));
 
   describe('when debug response is success', () => {
@@ -127,7 +298,7 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
       tick();
       expectSendDebugEvent(EVENT_ID);
       tick(1000);
-      expectGetDebugEvent(EVENT_ID, true);
+      expectGetDebugEvent(EVENT_ID, 'SUCCESS');
 
       fixture.detectChanges();
     }));
@@ -227,7 +398,7 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
       tick();
       expectSendDebugEvent(EVENT_ID);
       tick(1000);
-      expectGetDebugEvent(EVENT_ID, true);
+      expectGetDebugEvent(EVENT_ID, 'SUCCESS');
       fixture.detectChanges();
 
       expect(getInspectorContent()).toEqual(null);
@@ -245,7 +416,7 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
       .flush({ id: eventId });
   }
 
-  function expectGetDebugEvent(eventId: string, success: boolean) {
+  function expectGetDebugEvent(eventId: string, status: 'SUCCESS' | 'ERROR' | 'DEBUGGING') {
     httpTestingController
       .expectOne({
         method: 'GET',
@@ -254,7 +425,7 @@ describe('DebugModeComponent with DebugModeV2Service', () => {
       .flush({
         type: 'DEBUG_API',
         properties: {
-          api_debug_status: success ? 'SUCCESS' : 'FAILED',
+          api_debug_status: status,
         },
         payload: JSON.stringify(fakeDebugEvent().payload),
       });
@@ -327,9 +498,9 @@ describe('DebugModeComponent with DebugModeV4Service', () => {
 
     expectSendDebugEvent(eventId);
     tick(1000);
-    expectGetDebugEvent(eventId, false);
+    expectGetDebugEvent(eventId, 'DEBUGGING');
     tick(1000);
-    expectGetDebugEvent(eventId, true);
+    expectGetDebugEvent(eventId, 'SUCCESS');
 
     fixture.detectChanges();
 
@@ -348,7 +519,7 @@ describe('DebugModeComponent with DebugModeV4Service', () => {
       tick();
       expectSendDebugEvent(EVENT_ID);
       tick(1000);
-      expectGetDebugEvent(EVENT_ID, true);
+      expectGetDebugEvent(EVENT_ID, 'SUCCESS');
 
       fixture.detectChanges();
     }));
@@ -448,7 +619,7 @@ describe('DebugModeComponent with DebugModeV4Service', () => {
       tick();
       expectSendDebugEvent(EVENT_ID);
       tick(1000);
-      expectGetDebugEvent(EVENT_ID, true);
+      expectGetDebugEvent(EVENT_ID, 'SUCCESS');
       fixture.detectChanges();
 
       expect(getInspectorContent()).toEqual(null);
@@ -464,7 +635,7 @@ describe('DebugModeComponent with DebugModeV4Service', () => {
       .flush({ id: eventId });
   }
 
-  function expectGetDebugEvent(eventId: string, success: boolean) {
+  function expectGetDebugEvent(eventId: string, status: 'SUCCESS' | 'ERROR' | 'DEBUGGING') {
     httpTestingController
       .expectOne({
         method: 'GET',
@@ -473,7 +644,7 @@ describe('DebugModeComponent with DebugModeV4Service', () => {
       .flush({
         type: 'DEBUG_API',
         properties: {
-          API_DEBUG_STATUS: success ? 'SUCCESS' : 'FAILED',
+          API_DEBUG_STATUS: status,
         },
         payload: JSON.stringify(fakeDebugEvent().payload),
       });

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/debug-mode.service.ts
@@ -22,6 +22,9 @@ import { DebugRequest } from './models/DebugRequest';
 import { PolicyListItem } from '../../../entities/policy';
 import { PolicyService } from '../../../services-ngx/policy.service';
 
+export const DEBUG_EVENT_FAILED_ERROR = 'DEBUG_EVENT_FAILED_ERROR';
+export const DEBUG_EVENT_FAILED_MESSAGE = 'Debug request failed. Please try again.';
+
 @Injectable()
 export abstract class DebugModeService {
   protected constructor(protected readonly policyService: PolicyService) {}

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugEvent.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugEvent.ts
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type DebugStatus = 'TO_DEBUG' | 'DEBUGGING' | 'SUCCESS' | 'ERROR';
+
+export const debugStatus = (status: string): DebugStatus => {
+  if (status === 'TO_DEBUG' || status === 'DEBUGGING' || status === 'SUCCESS' || status === 'ERROR') {
+    return status;
+  }
+  throw new Error(`Invalid debug status: ${status}`);
+};
+
 export interface DebugEvent {
   id: string;
   payload: DebugEventPayload;
-  status: 'SUCCESS' | 'FAILED';
+  status: DebugStatus;
 }
 
 interface DebugEventPayload {

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugResponse.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugResponse.ts
@@ -20,7 +20,6 @@ import { DebugEvent, DebugEventMetrics } from './DebugEvent';
 
 export type DebugResponse = {
   isLoading: boolean;
-  reachedTimeout?: boolean;
   executionMode: string;
 
   request: {

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/v2-wrapper/debug-mode-v2.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/v2-wrapper/debug-mode-v2.service.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { interval, Observable, race, timer } from 'rxjs';
+import { EMPTY, interval, Observable, of, throwError } from 'rxjs';
 import { filter, map, switchMap, take } from 'rxjs/operators';
 
-import { DebugModeService } from '../debug-mode.service';
+import { DEBUG_EVENT_FAILED_ERROR, DebugModeService } from '../debug-mode.service';
 import { convertDebugEventToDebugResponse, DebugResponse } from '../models/DebugResponse';
 import { DebugRequest } from '../models/DebugRequest';
 import { EventService } from '../../../../services-ngx/event.service';
 import { DebugApiService } from '../../../../services-ngx/debug-api.service';
-import { DebugEvent } from '../models/DebugEvent';
+import { DebugEvent, debugStatus } from '../models/DebugEvent';
 import { ApiService } from '../../../../services-ngx/api.service';
 import { PolicyStudioService } from '../../policy-studio-v2/policy-studio.service';
 import { PolicyService } from '../../../../services-ngx/policy.service';
@@ -42,31 +42,21 @@ export class DebugModeV2Service extends DebugModeService {
   }
 
   public debug(debugRequest: DebugRequest): Observable<DebugResponse> {
-    const maxPollingTime$ = timer(10000).pipe(
-      map<number, DebugResponse>(() => ({
-        isLoading: false,
-        reachedTimeout: true,
-        executionMode: null,
-        request: {},
-        response: {},
-        responsePolicyDebugSteps: [],
-        backendResponse: {},
-        requestPolicyDebugSteps: [],
-        preprocessorStep: {},
-        requestDebugSteps: {},
-        responseDebugSteps: {},
-      })),
-    );
-
-    const pollingEvent$ = this.sendDebugEvent(debugRequest).pipe(
-      // Poll each 1s to find success event. Stops after 10 seconds
+    return this.sendDebugEvent(debugRequest).pipe(
+      // Poll each 1s to find success event.
       switchMap(({ apiId, debugEventId }) => interval(1000).pipe(switchMap(() => this.getDebugEvent(apiId, debugEventId)))),
-      filter((event) => event.status === 'SUCCESS'),
+      switchMap((event) => {
+        if (event.status === 'ERROR') {
+          return throwError(() => new Error(DEBUG_EVENT_FAILED_ERROR));
+        }
+        if (event.status === 'SUCCESS') {
+          return of(event);
+        }
+        return EMPTY;
+      }),
       take(1),
       map((event: DebugEvent) => convertDebugEventToDebugResponse(event)),
     );
-
-    return race(maxPollingTime$, pollingEvent$);
   }
 
   private sendDebugEvent(request: DebugRequest): Observable<{ apiId: string; debugEventId: string }> {
@@ -99,7 +89,7 @@ export class DebugModeV2Service extends DebugModeService {
       map((event) => ({
         id: event.id,
         payload: JSON.parse(event.payload),
-        status: event.properties.api_debug_status === 'SUCCESS' ? 'SUCCESS' : 'FAILED',
+        status: debugStatus(event.properties.api_debug_status),
       })),
     );
   }

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/v4-wrapper/debug-mode-v4.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/v4-wrapper/debug-mode-v4.service.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 
 import { DebugModeV4Service } from './debug-mode-v4.service';
@@ -23,6 +23,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing'
 import { RequestPolicyDebugStep, ResponsePolicyDebugStep } from '../models/DebugStep';
 import { fakeDebugEvent } from '../models/DebugEvent.fixture';
 import { fakeApiV4 } from '../../../../entities/management-api-v2';
+import { DEBUG_EVENT_FAILED_ERROR } from '../debug-mode.service';
 
 describe('DebugModeV4Service', () => {
   let httpTestingController: HttpTestingController;
@@ -302,15 +303,16 @@ describe('DebugModeV4Service', () => {
 
       expectSendDebugEvent(eventId);
       tick(1000);
-      expectGetDebugEvent(eventId, false);
+      expectGetDebugEvent(eventId, 'DEBUGGING');
       tick(1000);
-      expectGetDebugEvent(eventId, true);
+      expectGetDebugEvent(eventId, 'SUCCESS');
       tick(1000);
 
       expect(done).toEqual(true);
     }));
 
-    it('should return some empty data when timeout is reached', fakeAsync(() => {
+    it('should keep polling beyond 10 seconds and not auto-complete', fakeAsync(() => {
+      const eventId = 'eventId';
       let done = false;
       debugModeV4Service
         .debug({
@@ -319,31 +321,50 @@ describe('DebugModeV4Service', () => {
           headers: [],
           path: '',
         })
-        .subscribe((response) => {
-          expect(response).toStrictEqual({
-            isLoading: false,
-            executionMode: null,
-            reachedTimeout: true,
-            request: {},
-            response: {},
-            responsePolicyDebugSteps: [],
-            backendResponse: {},
-            requestPolicyDebugSteps: [],
-            preprocessorStep: {},
-            requestDebugSteps: {},
-            responseDebugSteps: {},
-          });
+        .subscribe(() => {
           done = true;
         });
 
-      // Expect without flushing to wait for the timeout
-      httpTestingController.expectOne({
-        method: 'POST',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/debug`,
-      });
+      expectSendDebugEvent(eventId);
 
-      tick(10000);
-      expect(done).toEqual(true);
+      for (let i = 0; i < 11; i++) {
+        tick(1000);
+        expectGetDebugEvent(eventId, 'DEBUGGING');
+      }
+
+      expect(done).toEqual(false);
+      discardPeriodicTasks();
+    }));
+
+    it('should stop polling and throw an error when debug event status is error', fakeAsync(() => {
+      const eventId = 'eventId';
+      let error: Error;
+
+      debugModeV4Service
+        .debug({
+          method: 'GET',
+          body: '',
+          headers: [],
+          path: '',
+        })
+        .subscribe({
+          error: (err) => {
+            error = err;
+          },
+        });
+
+      expectSendDebugEvent(eventId);
+      tick(1000);
+      expectGetDebugEvent(eventId, 'ERROR');
+      tick();
+
+      expect(error.message).toEqual(DEBUG_EVENT_FAILED_ERROR);
+
+      tick(5000);
+      httpTestingController.expectNone({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/events/${eventId}`,
+      });
     }));
   });
 
@@ -356,7 +377,7 @@ describe('DebugModeV4Service', () => {
       .flush({ id: eventId });
   }
 
-  function expectGetDebugEvent(eventId: string, success: boolean) {
+  function expectGetDebugEvent(eventId: string, status: 'SUCCESS' | 'ERROR' | 'DEBUGGING') {
     httpTestingController
       .expectOne({
         method: 'GET',
@@ -365,7 +386,7 @@ describe('DebugModeV4Service', () => {
       .flush({
         type: 'DEBUG_API',
         properties: {
-          API_DEBUG_STATUS: success ? 'SUCCESS' : 'FAILED',
+          API_DEBUG_STATUS: status,
         },
         payload: JSON.stringify(fakeDebugEvent().payload),
       });

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/v4-wrapper/debug-mode-v4.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/v4-wrapper/debug-mode-v4.service.ts
@@ -15,7 +15,7 @@
  */
 import { Injectable } from '@angular/core';
 import { filter, map, switchMap, take } from 'rxjs/operators';
-import { interval, Observable, race, timer } from 'rxjs';
+import { EMPTY, interval, Observable, of, throwError } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 
 import { ApiEventsV2Service } from '../../../../services-ngx/api-events-v2.service';
@@ -23,8 +23,8 @@ import { PolicyService } from '../../../../services-ngx/policy.service';
 import { DebugRequest } from '../models/DebugRequest';
 import { convertDebugEventToDebugResponse, DebugResponse } from '../models/DebugResponse';
 import { DebugApiV2Service } from '../../../../services-ngx/debug-api-v2.service';
-import { DebugModeService } from '../debug-mode.service';
-import { DebugEvent } from '../models/DebugEvent';
+import { DEBUG_EVENT_FAILED_ERROR, DebugModeService } from '../debug-mode.service';
+import { DebugEvent, debugStatus } from '../models/DebugEvent';
 
 @Injectable({
   providedIn: 'root',
@@ -40,31 +40,21 @@ export class DebugModeV4Service extends DebugModeService {
   }
 
   public debug(debugRequest: DebugRequest): Observable<DebugResponse> {
-    const maxPollingTime$ = timer(10000).pipe(
-      map<number, DebugResponse>(() => ({
-        isLoading: false,
-        reachedTimeout: true,
-        executionMode: null,
-        request: {},
-        response: {},
-        responsePolicyDebugSteps: [],
-        backendResponse: {},
-        requestPolicyDebugSteps: [],
-        preprocessorStep: {},
-        requestDebugSteps: {},
-        responseDebugSteps: {},
-      })),
-    );
-
-    const pollingEvent$ = this.sendDebugEvent(debugRequest).pipe(
-      // Poll each 1s to find success event. Stops after 10 seconds
+    return this.sendDebugEvent(debugRequest).pipe(
+      // Poll each 1s to find success event.
       switchMap(({ apiId, debugEventId }) => interval(1000).pipe(switchMap(() => this.getDebugEvent(apiId, debugEventId)))),
-      filter((event) => event.status === 'SUCCESS'),
+      switchMap((event) => {
+        if (event.status === 'ERROR') {
+          return throwError(() => new Error(DEBUG_EVENT_FAILED_ERROR));
+        }
+        if (event.status === 'SUCCESS') {
+          return of(event);
+        }
+        return EMPTY;
+      }),
       take(1),
       map((event: DebugEvent) => convertDebugEventToDebugResponse(event)),
     );
-
-    return race(maxPollingTime$, pollingEvent$);
   }
 
   private sendDebugEvent(request: DebugRequest): Observable<{ apiId: string; debugEventId: string }> {
@@ -97,7 +87,7 @@ export class DebugModeV4Service extends DebugModeService {
       map((event) => ({
         id: event.id,
         payload: JSON.parse(event.payload),
-        status: event.properties.API_DEBUG_STATUS === 'SUCCESS' ? 'SUCCESS' : 'FAILED',
+        status: debugStatus(event.properties.API_DEBUG_STATUS),
       })),
     );
   }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
@@ -73,9 +73,7 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
             try {
                 event = eventRepository.findById(debugApiComponent.getEventId()).orElseThrow(TechnicalException::new);
                 final io.gravitee.definition.model.debug.DebugApiV2 debugApi = computeDebugApiEventPayload(debugContext, debugApiComponent);
-
-                event.setPayload(objectMapper.writeValueAsString(debugApi));
-                updateEvent(event, ApiDebugStatus.SUCCESS);
+                updateEvent(event.updatePayload(objectMapper.writeValueAsString(debugApi)),ApiDebugStatus.SUCCESS);
             } catch (JsonProcessingException | TechnicalException e) {
                 LOGGER.error("Error occurs while saving debug event", e);
                 failEvent(event);
@@ -88,8 +86,8 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
     }
 
     private io.gravitee.definition.model.debug.DebugApiV2 computeDebugApiEventPayload(
-        DebugExecutionContext debugContext,
-        DebugApiV2 debugApiComponent
+            DebugExecutionContext debugContext,
+            DebugApiV2 debugApiComponent
     ) {
         final io.gravitee.definition.model.debug.DebugApiV2 debugApi = convert(debugApiComponent);
         PreprocessorStep preprocessorStep = createPreprocessorStep(debugContext);
@@ -97,16 +95,16 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         debugApi.setDebugSteps(convert(debugContext.getDebugSteps()));
 
         HttpResponse response = createResponse(
-            debugContext.response().headers(),
-            debugContext.response().status(),
-            getResponseBuffer(debugContext)
+                debugContext.response().headers(),
+                debugContext.response().status(),
+                getResponseBuffer(debugContext)
         );
         debugApi.setResponse(response);
 
         HttpResponse invokerResponse = createResponse(
-            debugContext.getInvokerResponse().getHeaders(),
-            debugContext.getInvokerResponse().getStatus(),
-            debugContext.getInvokerResponse().getBuffer()
+                debugContext.getInvokerResponse().getHeaders(),
+                debugContext.getInvokerResponse().getStatus(),
+                debugContext.getInvokerResponse().getBuffer()
         );
         debugApi.setBackendResponse(invokerResponse);
 
@@ -168,11 +166,9 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
     }
 
     private void updateEvent(io.gravitee.repository.management.model.Event debugEvent, ApiDebugStatus apiDebugStatus)
-        throws TechnicalException {
-        debugEvent
-            .getProperties()
-            .put(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name());
-        eventRepository.update(debugEvent);
+            throws TechnicalException {
+        eventRepository.update(debugEvent
+                .updateProperties(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name()));
     }
 
     protected io.gravitee.definition.model.debug.DebugApiV2 convert(DebugApiV2 content) {
@@ -186,12 +182,12 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         debugAPI.setFlows(content.getDefinition().getFlows());
         debugAPI.setPathMappings(content.getDefinition().getPathMappings());
         debugAPI.setPlans(
-            content
-                .getDefinition()
-                .getPlans()
-                .stream()
-                .filter(plan -> !PlanStatus.CLOSED.getLabel().equalsIgnoreCase(plan.getStatus()))
-                .collect(Collectors.toList())
+                content
+                        .getDefinition()
+                        .getPlans()
+                        .stream()
+                        .filter(plan -> !PlanStatus.CLOSED.getLabel().equalsIgnoreCase(plan.getStatus()))
+                        .collect(Collectors.toList())
         );
         debugAPI.setPaths(content.getDefinition().getPaths());
         debugAPI.setServices(content.getDefinition().getServices());
@@ -220,19 +216,19 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
 
         Map<String, Object> result = new HashMap<>();
         ds
-            .getDebugDiffContent()
-            .forEach((key, value) -> {
-                if (DebugStep.DIFF_KEY_HEADERS.equals(key)) {
-                    // Headers are converted to Map<String, List<String>>
-                    result.put(DebugStep.DIFF_KEY_HEADERS, convertHeaders((HttpHeaders) value));
-                } else if (DebugStep.DIFF_KEY_BODY_BUFFER.equals(key)) {
-                    // Body is converted from Buffer to String
-                    result.put(DebugStep.DIFF_KEY_BODY, value.toString());
-                } else {
-                    // Everything else is kept as is
-                    result.put(key, value);
-                }
-            });
+                .getDebugDiffContent()
+                .forEach((key, value) -> {
+                    if (DebugStep.DIFF_KEY_HEADERS.equals(key)) {
+                        // Headers are converted to Map<String, List<String>>
+                        result.put(DebugStep.DIFF_KEY_HEADERS, convertHeaders((HttpHeaders) value));
+                    } else if (DebugStep.DIFF_KEY_BODY_BUFFER.equals(key)) {
+                        // Body is converted from Buffer to String
+                        result.put(DebugStep.DIFF_KEY_BODY, value.toString());
+                    } else {
+                        // Everything else is kept as is
+                        result.put(key, value);
+                    }
+                });
 
         debugStep.setResult(result);
         return debugStep;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
@@ -73,7 +73,7 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
             try {
                 event = eventRepository.findById(debugApiComponent.getEventId()).orElseThrow(TechnicalException::new);
                 final io.gravitee.definition.model.debug.DebugApiV2 debugApi = computeDebugApiEventPayload(debugContext, debugApiComponent);
-                updateEvent(event.updatePayload(objectMapper.writeValueAsString(debugApi)),ApiDebugStatus.SUCCESS);
+                updateEvent(event.updatePayload(objectMapper.writeValueAsString(debugApi)), ApiDebugStatus.SUCCESS);
             } catch (JsonProcessingException | TechnicalException e) {
                 LOGGER.error("Error occurs while saving debug event", e);
                 failEvent(event);
@@ -86,8 +86,8 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
     }
 
     private io.gravitee.definition.model.debug.DebugApiV2 computeDebugApiEventPayload(
-            DebugExecutionContext debugContext,
-            DebugApiV2 debugApiComponent
+        DebugExecutionContext debugContext,
+        DebugApiV2 debugApiComponent
     ) {
         final io.gravitee.definition.model.debug.DebugApiV2 debugApi = convert(debugApiComponent);
         PreprocessorStep preprocessorStep = createPreprocessorStep(debugContext);
@@ -95,16 +95,16 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         debugApi.setDebugSteps(convert(debugContext.getDebugSteps()));
 
         HttpResponse response = createResponse(
-                debugContext.response().headers(),
-                debugContext.response().status(),
-                getResponseBuffer(debugContext)
+            debugContext.response().headers(),
+            debugContext.response().status(),
+            getResponseBuffer(debugContext)
         );
         debugApi.setResponse(response);
 
         HttpResponse invokerResponse = createResponse(
-                debugContext.getInvokerResponse().getHeaders(),
-                debugContext.getInvokerResponse().getStatus(),
-                debugContext.getInvokerResponse().getBuffer()
+            debugContext.getInvokerResponse().getHeaders(),
+            debugContext.getInvokerResponse().getStatus(),
+            debugContext.getInvokerResponse().getBuffer()
         );
         debugApi.setBackendResponse(invokerResponse);
 
@@ -166,9 +166,13 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
     }
 
     private void updateEvent(io.gravitee.repository.management.model.Event debugEvent, ApiDebugStatus apiDebugStatus)
-            throws TechnicalException {
-        eventRepository.update(debugEvent
-                .updateProperties(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name()));
+        throws TechnicalException {
+        eventRepository.update(
+            debugEvent.updateProperties(
+                io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(),
+                apiDebugStatus.name()
+            )
+        );
     }
 
     protected io.gravitee.definition.model.debug.DebugApiV2 convert(DebugApiV2 content) {
@@ -182,12 +186,12 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         debugAPI.setFlows(content.getDefinition().getFlows());
         debugAPI.setPathMappings(content.getDefinition().getPathMappings());
         debugAPI.setPlans(
-                content
-                        .getDefinition()
-                        .getPlans()
-                        .stream()
-                        .filter(plan -> !PlanStatus.CLOSED.getLabel().equalsIgnoreCase(plan.getStatus()))
-                        .collect(Collectors.toList())
+            content
+                .getDefinition()
+                .getPlans()
+                .stream()
+                .filter(plan -> !PlanStatus.CLOSED.getLabel().equalsIgnoreCase(plan.getStatus()))
+                .collect(Collectors.toList())
         );
         debugAPI.setPaths(content.getDefinition().getPaths());
         debugAPI.setServices(content.getDefinition().getServices());
@@ -216,19 +220,19 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
 
         Map<String, Object> result = new HashMap<>();
         ds
-                .getDebugDiffContent()
-                .forEach((key, value) -> {
-                    if (DebugStep.DIFF_KEY_HEADERS.equals(key)) {
-                        // Headers are converted to Map<String, List<String>>
-                        result.put(DebugStep.DIFF_KEY_HEADERS, convertHeaders((HttpHeaders) value));
-                    } else if (DebugStep.DIFF_KEY_BODY_BUFFER.equals(key)) {
-                        // Body is converted from Buffer to String
-                        result.put(DebugStep.DIFF_KEY_BODY, value.toString());
-                    } else {
-                        // Everything else is kept as is
-                        result.put(key, value);
-                    }
-                });
+            .getDebugDiffContent()
+            .forEach((key, value) -> {
+                if (DebugStep.DIFF_KEY_HEADERS.equals(key)) {
+                    // Headers are converted to Map<String, List<String>>
+                    result.put(DebugStep.DIFF_KEY_HEADERS, convertHeaders((HttpHeaders) value));
+                } else if (DebugStep.DIFF_KEY_BODY_BUFFER.equals(key)) {
+                    // Body is converted from Buffer to String
+                    result.put(DebugStep.DIFF_KEY_BODY, value.toString());
+                } else {
+                    // Everything else is kept as is
+                    result.put(key, value);
+                }
+            });
 
         debugStep.setResult(result);
         return debugStep;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugHttpClientConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugHttpClientConfiguration.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.gateway.debug.vertx;
 
-import io.vertx.core.http.HttpServerOptions;
 import lombok.Builder;
-import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Guillaume Cusnieux (guillaume.cusnieux at graviteesource.com)
@@ -27,7 +25,7 @@ import org.springframework.beans.factory.annotation.Value;
 public class VertxDebugHttpClientConfiguration {
 
     public static final int MAX_CONNECTION_TIMEOUT = 5000;
-    public static final int MAX_REQUEST_TIMEOUT = 10000;
+    public static final int MAX_REQUEST_TIMEOUT = 30000;
 
     private boolean compressionSupported;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -294,10 +294,8 @@ public class DebugReactorEventListener extends ReactorEventListener {
 
     private Completable updateEvent(io.gravitee.repository.management.model.Event debugEvent, ApiDebugStatus apiDebugStatus) {
         return Completable.fromAction(() -> {
-            debugEvent
-                .getProperties()
-                .put(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name());
-            eventRepository.update(debugEvent);
+            eventRepository.update(debugEvent
+                    .updateProperties(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name()));
         });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
@@ -80,8 +80,7 @@ public class DebugCompletionProcessor implements Processor {
                     final Event event = eventOptional.get();
                     return computeDebugApiEventPayload(debugContext, debugApi)
                         .doOnSuccess(definitionDebugApi -> {
-                            event.setPayload(objectMapper.writeValueAsString(definitionDebugApi));
-                            updateEvent(event, ApiDebugStatus.SUCCESS);
+                            updateEvent(event.updatePayload(objectMapper.writeValueAsString(definitionDebugApi)), ApiDebugStatus.SUCCESS);
                         })
                         .ignoreElement()
                         .onErrorResumeNext(throwable -> {
@@ -171,8 +170,7 @@ public class DebugCompletionProcessor implements Processor {
     }
 
     private void updateEvent(@NonNull Event debugEvent, ApiDebugStatus apiDebugStatus) throws TechnicalException {
-        debugEvent.getProperties().put(Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name());
-        eventRepository.update(debugEvent);
+        eventRepository.update(debugEvent.updateProperties(Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name()));
     }
 
     private io.gravitee.definition.model.debug.DebugApiProxy convert(ReactableDebugApi<?> content) {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Event.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Event.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.management.model;
 
+import io.gravitee.common.utils.TimeProvider;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
@@ -103,5 +104,17 @@ public class Event implements Serializable {
         GATEWAY_ID("gateway_id");
 
         private final String value;
+    }
+
+    public Event updatePayload(String payload) {
+        this.payload = payload;
+        this.updatedAt = Date.from(TimeProvider.instantNow());
+        return this;
+    }
+
+    public Event updateProperties(String key, String value) {
+        properties.put(key, value);
+        this.updatedAt = Date.from(TimeProvider.instantNow());
+        return this;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
@@ -92,7 +92,7 @@ public class MongoEventRepository implements EventRepository {
             eventMongo.setType(event.getType().toString());
             eventMongo.setPayload(event.getPayload());
             eventMongo.setParentId(event.getParentId());
-            eventMongo.setCreatedAt(event.getUpdatedAt());
+            eventMongo.setCreatedAt(event.getCreatedAt());
             eventMongo.setUpdatedAt(event.getUpdatedAt());
             eventMongo.setEnvironments(event.getEnvironments());
             eventMongo.setOrganizations(event.getOrganizations());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
@@ -510,6 +510,72 @@ public class EventRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void updateShouldUpdateEvent() throws TechnicalException {
+        LocalDateTime localDate = LocalDateTime.now().minusMinutes(1);
+        var createdDate = Date.from(localDate.atZone(ZoneId.systemDefault()).toInstant());
+        Event event = Event.builder()
+            .id(UUID.toString(UUID.random()))
+            .createdAt(createdDate)
+            .updatedAt(createdDate)
+            .environments(singleton("DEFAULT"))
+            .organizations(singleton("DEFAULT"))
+            .type(EventType.DEBUG_API)
+            .payload("{}")
+            .properties(
+                Map.ofEntries(
+                    Map.entry("to_update", "property_to_update"),
+                    Map.entry("to_update_with_null", "property_to_update_with_null"),
+                    Map.entry("not_updated", "will_not_change")
+                )
+            )
+            .build();
+
+        // Should create the event
+        Event createdEvent = eventRepository.create(event);
+
+        assertThat(createdEvent).isEqualTo(
+            Event.builder()
+                .id(event.getId())
+                .organizations(Set.of("DEFAULT"))
+                .environments(Set.of("DEFAULT"))
+                .type(EventType.DEBUG_API)
+                .payload("{}")
+                .properties(
+                    Map.ofEntries(
+                        Map.entry("to_update", "property_to_update"),
+                        Map.entry("to_update_with_null", "property_to_update_with_null"),
+                        Map.entry("not_updated", "will_not_change")
+                    )
+                )
+                .createdAt(createdDate)
+                .updatedAt(createdDate)
+                .build()
+        );
+
+        Date updateDate = new Date();
+        var updatedProperties = new HashMap<String, String>();
+        updatedProperties.put("to_update", "updated_property");
+        updatedProperties.put("to_update_with_null", null);
+
+        // Should update the event with the new type and properties.
+        var toUpdate = event.toBuilder().updatedAt(updateDate).properties(updatedProperties).build();
+        Event updatedEvent = eventRepository.update(toUpdate);
+
+        assertThat(updatedEvent).isEqualTo(
+            Event.builder()
+                .id(event.getId())
+                .organizations(Set.of("DEFAULT"))
+                .environments(Set.of("DEFAULT"))
+                .type(EventType.DEBUG_API)
+                .payload("{}")
+                .properties(updatedProperties)
+                .createdAt(createdDate)
+                .updatedAt(updateDate)
+                .build()
+        );
+    }
+
+    @Test
     public void should_find_by_environment_id() {
         List<Event> events = eventRepository.findByEnvironmentId("DEFAULT");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cors/AbstractGraviteeUrlBasedCorsConfigurationSourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cors/AbstractGraviteeUrlBasedCorsConfigurationSourceTest.java
@@ -86,7 +86,7 @@ class AbstractGraviteeUrlBasedCorsConfigurationSourceTest {
     @Test
     void should_evict_from_cache_and_unregister_from_event_manager_when_entry_expires() {
         // Expires after 50ms.
-        fakeEnvironment.setProperty("cors.cache.ttl", "50");
+        fakeEnvironment.setProperty("cors.cache.ttl", "250");
 
         cut = buildCut();
 
@@ -97,7 +97,7 @@ class AbstractGraviteeUrlBasedCorsConfigurationSourceTest {
         assertThat(cut.getCorsConfiguration(buildRequest("other.gravitee.dev", null, null))).isNotSameAs(corsConfiguration);
 
         Awaitility.waitAtMost(2000, TimeUnit.MILLISECONDS)
-            .pollDelay(50, TimeUnit.MILLISECONDS)
+            .pollInterval(50, TimeUnit.MILLISECONDS)
             .untilAsserted(() -> {
                 // Eviction only occurs on next access after TTL, so we need to call getCorsConfiguration again to trigger eviction of the expired entry.
                 cut.getCorsConfiguration(request);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12870
https://gravitee.atlassian.net/browse/APIM-12898

## Description

- Removed 10-second timeout for polling debug events.
- Introduced a long-request warning after 20 seconds of no response.
- Ensured proper cleanup of polling on request cancellation or component destruction.

## Additional context
<img width="1014" height="425" alt="image" src="https://github.com/user-attachments/assets/24123190-cb74-4448-b25f-f38c119d75e0" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

