### PR TITLE
fix: api field should not be reflecting api-product value

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -2160,7 +2160,11 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         entity.setId(subscription.getId());
         entity.setReferenceId(subscription.getReferenceId());
         entity.setReferenceType(subscription.getReferenceType() != null ? subscription.getReferenceType().name() : null);
-        entity.setApi(subscription.getApi() != null ? subscription.getApi() : subscription.getReferenceId());
+        entity.setApi(
+            subscription.getReferenceType() != SubscriptionReferenceType.API_PRODUCT
+                ? (subscription.getApi() != null ? subscription.getApi() : subscription.getReferenceId())
+                : null
+        );
         entity.setPlan(subscription.getPlan());
         entity.setProcessedAt(subscription.getProcessedAt());
         entity.setStatus(SubscriptionStatus.valueOf(subscription.getStatus().name()));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12802

## Description

api should only have API ID till we remove it completely for subscription but not API Product value

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

