### PR TITLE
feat: add skipResponsePayloadFiltering for streaming support & include payload origin in pii warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>
         <gravitee-policy-token-ratelimit.version>1.0.0</gravitee-policy-token-ratelimit.version>
         <gravitee-policy-mcp-acl.version>1.0.2</gravitee-policy-mcp-acl.version>
-        <gravitee-policy-pii-filtering.version>1.0.0-alpha.4</gravitee-policy-pii-filtering.version>
+        <gravitee-policy-pii-filtering.version>1.0.0-alpha.6</gravitee-policy-pii-filtering.version>
         <gravitee-resource-ai-model-token-classification.version>1.0.0-alpha.2</gravitee-resource-ai-model-token-classification.version>
     </properties>
 


### PR DESCRIPTION
**Issues**
https://gravitee.atlassian.net/browse/APIM-12708
https://gravitee.atlassian.net/browse/APIM-12709


**Description**
This PR introduces enhancements to the PII Filtering Policy to support streaming scenarios and provide better observability regarding the origin of detected sensitive data.

_**_1. Streaming Support & Bypass (APIM-12709)_**_
_Streaming Detection:_ The policy now inspects the request body for the "stream": true parameter.
_Skip Response Toggle:_ Added a skipResponsePayloadFiltering configuration option. When enabled, it allows request redaction while bypassing response analysis, enabling compatibility with LLM streaming.

_**_2. Payload Origin Tracking (APIM-12708)_**_
_Contextual Warnings:_ Execution warnings for PII detection now include the origin of the payload