### PR TITLE
chore: align copyright years per project and add per-project license emplates

### DIFF
--- a/gravitee-apim-console-webui/LICENSE_TEMPLATE.txt
+++ b/gravitee-apim-console-webui/LICENSE_TEMPLATE.txt
@@ -1,4 +1,4 @@
-Copyright (C) @@@[0-9]{4}@@@ The Gravitee team (http://gravitee.io)
+Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/license-check-config.json
+++ b/gravitee-apim-console-webui/license-check-config.json
@@ -40,7 +40,7 @@
     "wc/**",
     "yarn.lock"
   ],
-  "license": "../LICENSE_TEMPLATE.txt",
+  "license": "LICENSE_TEMPLATE.txt",
   "licenseFormats": {
     "js|ts|scss|less|php|as|c|java|cpp|go|cto|acl": {
       "prepend": "/*",
@@ -71,6 +71,5 @@
     "eachLine": {
       "prepend": " * "
     }
-  },
-  "regexIdentifier": "@@@"
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/management/api-products/validators/api-product-name-unique-async.validator.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/validators/api-product-name-unique-async.validator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/LICENSE_TEMPLATE.txt
+++ b/gravitee-apim-portal-webui-next/LICENSE_TEMPLATE.txt
@@ -1,0 +1,13 @@
+Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gravitee-apim-portal-webui-next/__mocks__/chartjs-adapter-date-fns.js
+++ b/gravitee-apim-portal-webui-next/__mocks__/chartjs-adapter-date-fns.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/license-check-config.json
+++ b/gravitee-apim-portal-webui-next/license-check-config.json
@@ -40,7 +40,7 @@
     "wc/**",
     "yarn.lock"
   ],
-  "license": "../LICENSE_TEMPLATE.txt",
+  "license": "LICENSE_TEMPLATE.txt",
   "licenseFormats": {
     "js|ts|scss|less|php|as|c|java|cpp|go|cto|acl": {
       "prepend": "/*",
@@ -71,6 +71,5 @@
     "eachLine": {
       "prepend": " * "
     }
-  },
-  "regexIdentifier": "@@@"
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/index.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscription-consumer-configuration/subscription-consumer-configuration.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-messages/application-log-messages.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-request-response/application-log-request-response.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-settings/delete-confirm-dialog/delete-confirm-dialog.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/categories-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/categories-view/category-apis/category-apis.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/apis-list/apis-list.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/components/catalog-banner/catalog-banner.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/tabs-view/tabs-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/close-subscription-dialog/close-subscription-dialog.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/resolvers/documentation.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/resolvers/documentation.resolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/helpers/yaml-parser.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/helpers/yaml-parser.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/helpers/yaml-parser.ts
+++ b/gravitee-apim-portal-webui-next/src/app/helpers/yaml-parser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/log-in/reset-password/reset-password-confirmation/reset-password-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/reset-password/reset-password-confirmation/reset-password-confirmation.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/log-in/reset-password/reset-password.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/reset-password/reset-password.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/validators/password-match.validator.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/validators/password-match.validator.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/app/validators/password-match.validator.ts
+++ b/gravitee-apim-portal-webui-next/src/app/validators/password-match.validator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/accordion/accordion-title.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/accordion/accordion-title.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/accordion/accordion.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/accordion/accordion.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/accordion/accordion.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/accordion/accordion.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/accordion/accordion.module.ts
+++ b/gravitee-apim-portal-webui-next/src/components/accordion/accordion.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/accordion/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/accordion/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-navigation/breadcrumb-navigation.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-navigation/breadcrumb-navigation.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/category-card/category-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/category-card/category-card.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.types.ts
+++ b/gravitee-apim-portal-webui-next/src/components/dropdown-search/dropdown-search.types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/form-key-value-pairs/form-key-value-pairs.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/mcp-tool/mcp-tool.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/navigation-page-full-width/navigation-page-full-width.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-page-full-width/navigation-page-full-width.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/pipe/markdown-description.pipe.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pipe/markdown-description.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-toggle-button/sidenav-toggle-button.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/consumer-configuration-headers.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-headers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/consumer-configuration-retry.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-retry/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-keystore/ssl-key-store.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/ssl-truststore/ssl-trust-store.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/validators/ssl-trust-store.validators.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/validators/ssl-trust-store.validators.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/validators/ssl-trust-store.validators.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/components/validators/ssl-trust-store.validators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/consumer-configuration-ssl.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/consumer-configuration-ssl.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/consumer-configuration-ssl.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/consumer-configuration-ssl.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-ssl/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.models.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/consumer-configuration.models.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/index.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/api/mcp.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/mcp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/connector/connector.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/connector/connector.fixture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/connector/connector.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/connector/connector.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/connector/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/connector/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/log/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/log/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/log/messageLog.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/log/messageLog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/portal/portal-page.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal/portal-page.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  * Licensed under the Apache License, Version 2.0
  */
 

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/keystore.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/keystore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/ssl/truststore.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/ssl/truststore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.fixture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/entities/user/custom-user-field.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/custom-user-field.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/guards/catalog-categories-view.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/catalog-categories-view.guard.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/guards/catalog-categories-view.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/catalog-categories-view.guard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/guards/catalog-tabs-view.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/catalog-tabs-view.guard.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/guards/catalog-tabs-view.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/catalog-tabs-view.guard.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/interceptors/csrf.interceptor.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/interceptors/csrf.interceptor.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/interceptors/csrf.interceptor.ts
+++ b/gravitee-apim-portal-webui-next/src/interceptors/csrf.interceptor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
+++ b/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.ts
+++ b/gravitee-apim-portal-webui-next/src/pipe/application-type-translate.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/proxy.conf.mjs
+++ b/gravitee-apim-portal-webui-next/src/proxy.conf.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/resolvers/categories.resolver.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/categories.resolver.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/resolvers/categories.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/categories.resolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/resolvers/homepage-content.resolver.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/homepage-content.resolver.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/resolvers/homepage-content.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/homepage-content.resolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/connector.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/connector.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/connector.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/connector.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/token.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/token.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/services/users.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/testing/div.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/div.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
+++ b/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/utils/deep-equal-ignore-order.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/utils/deep-equal-ignore-order.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui-next/src/utils/deep-equal-ignore-order.ts
+++ b/gravitee-apim-portal-webui-next/src/utils/deep-equal-ignore-order.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-dashboard/LICENSE_TEMPLATE.txt
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/LICENSE_TEMPLATE.txt
@@ -1,0 +1,13 @@
+Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gravitee-apim-webui-libs/gravitee-dashboard/license-check-config.json
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/license-check-config.json
@@ -40,7 +40,7 @@
     "wc/**",
     "yarn.lock"
   ],
-  "license": "../../LICENSE_TEMPLATE.txt",
+  "license": "LICENSE_TEMPLATE.txt",
   "licenseFormats": {
     "js|ts|scss|less|php|as|c|java|cpp|go|cto|acl": {
       "prepend": "/*",
@@ -71,6 +71,5 @@
     "eachLine": {
       "prepend": " * "
     }
-  },
-  "regexIdentifier": "@@@"
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dropdown-search/dropdown-search-overlay/dropdown-search-overlay.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dropdown-search/dropdown-search.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dropdown-search/dropdown-search.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/models/dashboard.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/models/dashboard.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/test-setup.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/test-setup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/LICENSE_TEMPLATE.txt
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/LICENSE_TEMPLATE.txt
@@ -1,0 +1,13 @@
+Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/license-check-config.json
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/license-check-config.json
@@ -40,7 +40,7 @@
     "wc/**",
     "yarn.lock"
   ],
-  "license": "../../LICENSE_TEMPLATE.txt",
+  "license": "LICENSE_TEMPLATE.txt",
   "licenseFormats": {
     "js|ts|scss|less|php|as|c|java|cpp|go|cto|acl": {
       "prepend": "/*",
@@ -71,6 +71,5 @@
     "eachLine": {
       "prepend": " * "
     }
-  },
-  "regexIdentifier": "@@@"
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-markdown/LICENSE_TEMPLATE.txt
+++ b/gravitee-apim-webui-libs/gravitee-markdown/LICENSE_TEMPLATE.txt
@@ -1,0 +1,13 @@
+Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/license-check-config.json
+++ b/gravitee-apim-webui-libs/gravitee-markdown/license-check-config.json
@@ -40,7 +40,7 @@
     "wc/**",
     "yarn.lock"
   ],
-  "license": "../../LICENSE_TEMPLATE.txt",
+  "license": "LICENSE_TEMPLATE.txt",
   "licenseFormats": {
     "js|ts|scss|less|php|as|c|java|cpp|go|cto|acl": {
       "prepend": "/*",
@@ -71,6 +71,5 @@
     "eachLine": {
       "prepend": " * "
     }
-  },
-  "regexIdentifier": "@@@"
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/card/gmd-card.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox/gmd-checkbox.suggestions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-field-base/gmd-form-field-base.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-field-base/gmd-form-field-base.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/input/gmd-input.suggestions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.suggestions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.suggestions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.suggestions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.module.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/tokens/gmd-config.token.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/tokens/gmd-config.token.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.harness.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.test.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/gmd-form-editor.test.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-editor/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/gmd-form-host.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-host/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/gmd-form-validation-panel.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-form-validation-panel/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/gravitee-markdown-viewer.stories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-viewer/public-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/formField.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/formField.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/services/gmd-form-state.store.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/test-setup.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/test-setup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nx.json
+++ b/nx.json
@@ -40,7 +40,7 @@
             "options": {
                 "fix": false,
                 "cwd": "{projectRoot}",
-                "command": "sh -c 'case \"$*\" in *--fix*) license-check-and-add add -r $(date +%Y) -f license-check-config.json ;; *) license-check-and-add check -f license-check-config.json ;; esac' _"
+                "command": "sh -c 'case \"$*\" in *--fix*) license-check-and-add add -f license-check-config.json ;; *) license-check-and-add check -f license-check-config.json ;; esac' _"
             },
             "cache": true
         },


### PR DESCRIPTION

Each Nx project now has its own LICENSE_TEMPLATE.txt with the correct
   copyright year matching when the project was created:
   - console-webui: 2015
   - portal-next: 2024
   - dashboard: 2025
   - markdown: 2025
   - kafka-explorer: 2026

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

