### PR TITLE
fix: add query param in api-product subscription get call

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -36,6 +36,7 @@ import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
+import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.FilterPreProcessor;
@@ -141,6 +142,7 @@ import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -363,6 +365,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionService subscriptionService() {
         return mock(SubscriptionService.class);
+    }
+
+    @Bean
+    public SubscriptionSearchQueryService subscriptionSearchQueryService() {
+        return new SubscriptionSearchQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -25,9 +25,12 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
+import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -61,5 +64,14 @@ public class RestManagementConfiguration {
     @Bean
     public UserContextLoader userContextLoader(ApiAuthorizationService apiAuthorizationService, @Lazy ApiRepository apiRepository) {
         return new UserContextLoaderImpl(apiAuthorizationService, apiRepository);
+    }
+
+    @Bean
+    public SubscriptionExpandHelper subscriptionExpandHelper(
+        PlanSearchService planSearchService,
+        ApplicationService applicationService,
+        UserService userService
+    ) {
+        return new SubscriptionExpandHelper(planSearchService, applicationService, userService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/utils/SubscriptionExpandHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/utils/SubscriptionExpandHelper.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.utils;
+
+import io.gravitee.rest.api.management.v2.rest.mapper.ApplicationMapper;
+import io.gravitee.rest.api.management.v2.rest.mapper.PlanMapper;
+import io.gravitee.rest.api.management.v2.rest.mapper.UserMapper;
+import io.gravitee.rest.api.management.v2.rest.model.BaseApplication;
+import io.gravitee.rest.api.management.v2.rest.model.BasePlan;
+import io.gravitee.rest.api.management.v2.rest.model.BaseUser;
+import io.gravitee.rest.api.management.v2.rest.model.Subscription;
+import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SubscriptionExpandHelper {
+
+    public static final String EXPAND_PLAN = "plan";
+    public static final String EXPAND_APPLICATION = "application";
+    public static final String EXPAND_SUBSCRIBED_BY = "subscribedBy";
+
+    private static final PlanMapper planMapper = PlanMapper.INSTANCE;
+    private static final ApplicationMapper applicationMapper = ApplicationMapper.INSTANCE;
+    private static final UserMapper userMapper = UserMapper.INSTANCE;
+
+    private final PlanSearchService planSearchService;
+    private final ApplicationService applicationService;
+    private final UserService userService;
+
+    public SubscriptionExpandHelper(PlanSearchService planSearchService, ApplicationService applicationService, UserService userService) {
+        this.planSearchService = planSearchService;
+        this.applicationService = applicationService;
+        this.userService = userService;
+    }
+
+    public void expandForApiProduct(
+        ExecutionContext executionContext,
+        String apiProductId,
+        List<Subscription> subscriptions,
+        Set<String> expands
+    ) {
+        if (expands == null || expands.isEmpty()) {
+            return;
+        }
+        if (expands.contains(EXPAND_PLAN)) {
+            final Set<String> planIds = subscriptions
+                .stream()
+                .map(sub -> sub.getPlan().getId())
+                .collect(Collectors.toSet());
+            final Collection<BasePlan> plans = planMapper.mapToBasePlans(planSearchService.findByIdIn(executionContext, planIds));
+            plans.forEach(plan -> {
+                plan.setApiId(null);
+                plan.setApiProductId(apiProductId);
+                subscriptions
+                    .stream()
+                    .filter(sub -> sub.getPlan().getId().equals(plan.getId()))
+                    .forEach(sub -> sub.setPlan(plan));
+            });
+        }
+        if (expands.contains(EXPAND_APPLICATION)) {
+            final Set<String> applicationIds = subscriptions
+                .stream()
+                .map(sub -> sub.getApplication().getId())
+                .collect(Collectors.toSet());
+            final Collection<BaseApplication> applications = applicationMapper.mapToBaseApplicationList(
+                applicationService.findByIds(executionContext, applicationIds)
+            );
+            applications.forEach(application ->
+                subscriptions
+                    .stream()
+                    .filter(sub -> sub.getApplication().getId().equals(application.getId()))
+                    .forEach(sub -> sub.setApplication(application))
+            );
+        }
+        if (expands.contains(EXPAND_SUBSCRIBED_BY)) {
+            final Set<String> userIds = subscriptions
+                .stream()
+                .map(sub -> sub.getSubscribedBy().getId())
+                .collect(Collectors.toSet());
+            final Collection<BaseUser> users = userMapper.mapToBaseUserList(userService.findByIds(executionContext, userIds));
+            users.forEach(user ->
+                subscriptions
+                    .stream()
+                    .filter(sub -> sub.getSubscribedBy().getId().equals(user.getId()))
+                    .forEach(sub -> sub.setSubscribedBy(user))
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -667,9 +667,58 @@ paths:
       tags:
         - API Product Subscriptions
       summary: List subscriptions for the API Product
-      description: List all subscriptions for the specified API Product. User must have API_PRODUCT_SUBSCRIPTION[READ] permission.
+      description: |
+        List subscriptions for the specified API Product, with optional filters and expand options.
+        Same query parameters and expands as the API subscriptions endpoint.
+
+        User must have API_PRODUCT_SUBSCRIPTION[READ] permission.
       operationId: getApiProductSubscriptions
       parameters:
+        - name: applicationIds
+          in: query
+          description: List of application ids to filter on.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          explode: false
+        - name: planIds
+          in: query
+          description: List of plan ids to filter on.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          explode: false
+        - name: statuses
+          in: query
+          description: List of status filters.
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SubscriptionStatus"
+          explode: false
+        - name: apiKey
+          in: query
+          description: API Key associated to the subscription to filter on.
+          schema:
+            type: string
+        - name: expands
+          in: query
+          description: Expansion of data to return in subscriptions (plan, application, subscribedBy).
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - application
+                - plan
+                - subscribedBy
+          explode: false
         - name: page
           in: query
           description: Page number (starting from 1)
@@ -832,6 +881,20 @@ paths:
       summary: Get an API Product subscription by ID
       description: User must have API_PRODUCT_SUBSCRIPTION[READ] permission.
       operationId: getApiProductSubscription
+      parameters:
+        - name: expands
+          in: query
+          description: Expansion of data to return in the subscription (plan, application, subscribedBy).
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - application
+                - plan
+                - subscribedBy
+          explode: false
       responses:
         '200':
           description: The API Product subscription
@@ -1934,6 +1997,18 @@ components:
         next:
           type: string
           description: In a paginated response, link to the next page. Maybe null if current is the last page
+
+    SubscriptionStatus:
+      type: string
+      description: The status of the subscription manageable by the api publisher.
+      example: ACCEPTED
+      enum:
+        - PENDING
+        - REJECTED
+        - ACCEPTED
+        - CLOSED
+        - PAUSED
+        - RESUMED
 
     Subscription:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3126,6 +3126,21 @@ components:
                     type: string
                     description: API's description. A short description of your API.
                     example: I can use many characters to describe this API.
+        BaseApiProduct:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: API Product's uuid.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                name:
+                    type: string
+                    description: API Product's name.
+                    example: My API Product
+                description:
+                    type: string
+                    description: API Product's description.
+                    example: A bundle of public APIs.
         GenericApi:
             type: object
             allOf:
@@ -4872,6 +4887,10 @@ components:
                     type: string
                     description: Id of the API owning the plan.
                     example: 6c530064-0b2c-4004-9300-640b2ce0047b
+                apiProductId:
+                    type: string
+                    description: Id of the API Product owning the plan. Present only when the plan belongs to an API Product (omitted for API plans).
+                    example: 6c530064-0b2c-4004-9300-640b2ce0047b
                 security:
                     $ref: "#/components/schemas/PlanSecurity"
                 mode:
@@ -5365,6 +5384,8 @@ components:
                 - properties:
                       api:
                           $ref: "#/components/schemas/BaseApi"
+                      apiProduct:
+                          $ref: "#/components/schemas/BaseApiProduct"
                       plan:
                           $ref: "#/components/schemas/BasePlan"
                       application:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -31,24 +32,30 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import assertions.MAPIAssertions;
+import fixtures.PlanFixtures;
 import fixtures.SubscriptionFixtures;
-import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
-import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.VerifySubscription;
 import io.gravitee.rest.api.management.v2.rest.model.VerifySubscriptionResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,13 +69,16 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
     private static final String API_PRODUCT_ID = "c45b8e66-4d2a-47ad-9b8e-664d2a97ad88";
 
     @Inject
-    private GetSubscriptionsUseCase getSubscriptionsUseCase;
-
-    @Inject
     private CreateSubscriptionUseCase createSubscriptionUseCase;
 
     @Inject
+    private SubscriptionService subscriptionService;
+
+    @Inject
     private ApiKeyService apiKeyService;
+
+    @Inject
+    private PlanSearchService planSearchService;
 
     @Override
     protected String contextPath() {
@@ -94,7 +104,7 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
     public void tearDown() {
         super.tearDown();
         GraviteeContext.cleanContext();
-        reset(getSubscriptionsUseCase, createSubscriptionUseCase, apiKeyService);
+        reset(createSubscriptionUseCase, subscriptionService, apiKeyService, planSearchService);
     }
 
     @Nested
@@ -286,41 +296,100 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_empty_list_when_no_subscriptions() {
-            when(getSubscriptionsUseCase.execute(any())).thenReturn(GetSubscriptionsUseCase.Output.multiple(List.of()));
+            when(
+                subscriptionService.search(
+                    eq(GraviteeContext.getExecutionContext()),
+                    argThat(
+                        (SubscriptionQuery q) ->
+                            API_PRODUCT_ID.equals(q.getReferenceId()) && q.getReferenceType() == GenericPlanEntity.ReferenceType.API_PRODUCT
+                    ),
+                    any(),
+                    eq(false),
+                    eq(false)
+                )
+            ).thenReturn(new Page<>(List.of(), 1, 10, 0));
 
             Response response = rootTarget().request().get();
 
             assertThat(response.getStatus()).isEqualTo(OK_200);
             var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.SubscriptionsResponse.class);
             assertThat(body.getData()).isEmpty();
-
-            var captor = ArgumentCaptor.forClass(GetSubscriptionsUseCase.Input.class);
-            verify(getSubscriptionsUseCase).execute(captor.capture());
-            assertThat(captor.getValue().referenceId()).isEqualTo(API_PRODUCT_ID);
-            assertThat(captor.getValue().referenceType()).isEqualTo(SubscriptionReferenceType.API_PRODUCT);
         }
 
         @Test
         void should_return_subscriptions_list() {
-            SubscriptionEntity sub = SubscriptionEntity.builder()
+            SubscriptionEntity sub = SubscriptionFixtures.aSubscriptionEntity()
+                .toBuilder()
                 .id("sub-1")
-                .apiId(null)
                 .referenceId(API_PRODUCT_ID)
-                .referenceType(SubscriptionReferenceType.API_PRODUCT)
-                .planId("plan-1")
-                .applicationId("app-1")
-                .status(SubscriptionEntity.Status.ACCEPTED)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
+                .referenceType("API_PRODUCT")
+                .plan("plan-1")
+                .application("app-1")
                 .build();
-            when(getSubscriptionsUseCase.execute(any())).thenReturn(GetSubscriptionsUseCase.Output.multiple(List.of(sub)));
+            when(
+                subscriptionService.search(
+                    eq(GraviteeContext.getExecutionContext()),
+                    argThat(
+                        (SubscriptionQuery q) ->
+                            API_PRODUCT_ID.equals(q.getReferenceId()) && q.getReferenceType() == GenericPlanEntity.ReferenceType.API_PRODUCT
+                    ),
+                    any(),
+                    eq(false),
+                    eq(false)
+                )
+            ).thenReturn(new Page<>(List.of(sub), 1, 10, 1));
 
             Response response = rootTarget().request().get();
 
             assertThat(response.getStatus()).isEqualTo(OK_200);
             var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.SubscriptionsResponse.class);
             assertThat(body.getData()).hasSize(1);
-            assertThat(body.getData().get(0).getId()).isEqualTo("sub-1");
+            var subscription = body.getData().get(0);
+            assertThat(subscription.getId()).isEqualTo("sub-1");
+            assertThat(subscription.getApiProduct()).isNotNull();
+            assertThat(subscription.getApiProduct().getId()).isEqualTo(API_PRODUCT_ID);
+            assertThat(subscription.getApi()).isNull();
+        }
+
+        @Test
+        void should_return_plan_with_apiProduct_and_no_apiId_when_expand_plan() {
+            String planId = "plan-1";
+            SubscriptionEntity sub = SubscriptionFixtures.aSubscriptionEntity()
+                .toBuilder()
+                .id("sub-1")
+                .referenceId(API_PRODUCT_ID)
+                .referenceType("API_PRODUCT")
+                .plan(planId)
+                .application("app-1")
+                .build();
+            when(
+                subscriptionService.search(
+                    eq(GraviteeContext.getExecutionContext()),
+                    argThat(
+                        (SubscriptionQuery q) ->
+                            API_PRODUCT_ID.equals(q.getReferenceId()) && q.getReferenceType() == GenericPlanEntity.ReferenceType.API_PRODUCT
+                    ),
+                    any(),
+                    eq(false),
+                    eq(false)
+                )
+            ).thenReturn(new Page<>(List.of(sub), 1, 10, 1));
+
+            var planEntity = PlanFixtures.aPlanEntityV4().toBuilder().id(planId).referenceId(API_PRODUCT_ID).build();
+            when(planSearchService.findByIdIn(eq(GraviteeContext.getExecutionContext()), eq(Set.of(planId)))).thenReturn(
+                Set.of(planEntity)
+            );
+
+            Response response = rootTarget().queryParam("expands", "plan").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.SubscriptionsResponse.class);
+            assertThat(body.getData()).hasSize(1);
+            var subscription = body.getData().get(0);
+            assertThat(subscription.getPlan()).isNotNull();
+            assertThat(subscription.getPlan().getId()).isEqualTo(planId);
+            assertThat(subscription.getPlan().getApiId()).isNull();
+            assertThat(subscription.getPlan().getApiProductId()).isEqualTo(API_PRODUCT_ID);
         }
 
         @Test
@@ -336,17 +405,18 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_create_subscription() {
-            SubscriptionEntity created = SubscriptionEntity.builder()
-                .id("new-sub-id")
-                .apiId(null)
-                .referenceId(API_PRODUCT_ID)
-                .referenceType(SubscriptionReferenceType.API_PRODUCT)
-                .planId("plan-1")
-                .applicationId("app-1")
-                .status(SubscriptionEntity.Status.PENDING)
-                .createdAt(ZonedDateTime.now())
-                .updatedAt(ZonedDateTime.now())
-                .build();
+            io.gravitee.apim.core.subscription.model.SubscriptionEntity created =
+                io.gravitee.apim.core.subscription.model.SubscriptionEntity.builder()
+                    .id("new-sub-id")
+                    .apiId(null)
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                    .planId("plan-1")
+                    .applicationId("app-1")
+                    .status(io.gravitee.apim.core.subscription.model.SubscriptionEntity.Status.PENDING)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build();
             when(createSubscriptionUseCase.execute(any())).thenReturn(new CreateSubscriptionUseCase.Output(created));
 
             var createPayload = new io.gravitee.rest.api.management.v2.rest.model.CreateSubscription();
@@ -357,6 +427,11 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
 
             MAPIAssertions.assertThat(response).hasStatus(CREATED_201);
             assertThat(response.getLocation().getPath()).contains("new-sub-id");
+
+            var subscription = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Subscription.class);
+            assertThat(subscription.getApi()).isNull();
+            assertThat(subscription.getApiProduct()).isNotNull();
+            assertThat(subscription.getApiProduct().getId()).isEqualTo(API_PRODUCT_ID);
 
             var captor = ArgumentCaptor.forClass(CreateSubscriptionUseCase.Input.class);
             verify(createSubscriptionUseCase).execute(captor.capture());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -166,6 +166,7 @@ import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -188,6 +189,7 @@ import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.query_service.analytics_engine.HTTPDataPlaneAnalyticsQueryService;
 import io.gravitee.apim.infra.query_service.analytics_engine.MessageDataPlaneQueryService;
 import io.gravitee.apim.infra.query_service.gateway.InstanceQueryServiceLegacyWrapper;
+import io.gravitee.apim.infra.query_service.subscription.SubscriptionSearchQueryServiceImpl;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
@@ -195,6 +197,7 @@ import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApiDuplicatorService;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -379,6 +382,11 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public SubscriptionSearchQueryService subscriptionSearchQueryService(SubscriptionService subscriptionService) {
+        return new SubscriptionSearchQueryServiceImpl(subscriptionService);
+    }
+
+    @Bean
     public ApplicationService applicationService() {
         return mock(ApplicationService.class);
     }
@@ -391,6 +399,15 @@ public class ResourceContextConfiguration {
     @Bean
     public UserService userService() {
         return mock(UserService.class);
+    }
+
+    @Bean
+    public SubscriptionExpandHelper subscriptionExpandHelper(
+        PlanSearchService planSearchService,
+        ApplicationService applicationService,
+        UserService userService
+    ) {
+        return new SubscriptionExpandHelper(planSearchService, applicationService, userService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -30,6 +30,7 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
@@ -129,6 +130,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGrou
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -504,6 +506,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionService subscriptionService() {
         return mock(SubscriptionService.class);
+    }
+
+    @Bean
+    public SubscriptionSearchQueryService subscriptionSearchQueryService() {
+        return new SubscriptionSearchQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -28,6 +28,7 @@ import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
@@ -120,6 +121,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGrou
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.DeleteSubscriptionSpecUseCase;
@@ -400,6 +402,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionService subscriptionService() {
         return mock(SubscriptionService.class);
+    }
+
+    @Bean
+    public SubscriptionSearchQueryService subscriptionSearchQueryService() {
+        return new SubscriptionSearchQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionSearchQueryService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.query_service;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+
+public interface SubscriptionSearchQueryService {
+    Page<SubscriptionEntity> search(
+        ExecutionContext executionContext,
+        String referenceId,
+        SubscriptionReferenceType referenceType,
+        Set<String> applicationIds,
+        Set<String> planIds,
+        Set<SubscriptionStatus> statuses,
+        String apiKey,
+        Pageable pageable
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/SearchSubscriptionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/SearchSubscriptionsUseCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class SearchSubscriptionsUseCase {
+
+    private final SubscriptionSearchQueryService subscriptionSearchQueryService;
+
+    public Output execute(Input input) {
+        Page<SubscriptionEntity> page = subscriptionSearchQueryService.search(
+            input.executionContext,
+            input.referenceId,
+            input.referenceType,
+            input.applicationIds,
+            input.planIds,
+            input.statuses,
+            input.apiKey,
+            input.pageable
+        );
+        return new Output(page);
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String referenceId,
+        SubscriptionReferenceType referenceType,
+        Set<String> applicationIds,
+        Set<String> planIds,
+        Set<SubscriptionStatus> statuses,
+        String apiKey,
+        Pageable pageable
+    ) {}
+
+    public record Output(Page<SubscriptionEntity> page) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.subscription;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionSearchQueryServiceImpl implements SubscriptionSearchQueryService {
+
+    private final SubscriptionService subscriptionService;
+
+    @Override
+    public Page<SubscriptionEntity> search(
+        ExecutionContext executionContext,
+        String referenceId,
+        SubscriptionReferenceType referenceType,
+        Set<String> applicationIds,
+        Set<String> planIds,
+        Set<SubscriptionStatus> statuses,
+        String apiKey,
+        Pageable pageable
+    ) {
+        GenericPlanEntity.ReferenceType queryReferenceType = GenericPlanEntity.ReferenceType.valueOf(referenceType.name());
+        SubscriptionQuery query = SubscriptionQuery.builder()
+            .referenceId(referenceId)
+            .referenceType(queryReferenceType)
+            .applications(applicationIds)
+            .plans(planIds)
+            .statuses(statuses)
+            .apiKey(apiKey)
+            .build();
+
+        return subscriptionService.search(executionContext, query, pageable, false, false);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionSearchQueryServiceInMemory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Collections;
+import java.util.Set;
+
+public class SubscriptionSearchQueryServiceInMemory implements SubscriptionSearchQueryService {
+
+    @Override
+    public Page<SubscriptionEntity> search(
+        ExecutionContext executionContext,
+        String referenceId,
+        SubscriptionReferenceType referenceType,
+        Set<String> applicationIds,
+        Set<String> planIds,
+        Set<SubscriptionStatus> statuses,
+        String apiKey,
+        Pageable pageable
+    ) {
+        int pageNumber = pageable != null ? pageable.getPageNumber() : 0;
+        int pageSize = pageable != null ? pageable.getPageSize() : 10;
+        return new Page<>(Collections.emptyList(), pageNumber + 1, pageSize, 0);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/SearchSubscriptionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/SearchSubscriptionsUseCaseTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class SearchSubscriptionsUseCaseTest {
+
+    private static final String REFERENCE_ID = "ref-id";
+    private static final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
+    private static final PageableImpl PAGEABLE = new PageableImpl(1, 10);
+
+    @Mock
+    private SubscriptionSearchQueryService subscriptionSearchQueryService;
+
+    @Captor
+    private ArgumentCaptor<SubscriptionReferenceType> referenceTypeCaptor;
+
+    private AutoCloseable mocks;
+    private SearchSubscriptionsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        useCase = new SearchSubscriptionsUseCase(subscriptionSearchQueryService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(SubscriptionReferenceType.class)
+    void should_call_query_service_with_reference_type_and_id(SubscriptionReferenceType referenceType) {
+        Page<SubscriptionEntity> expectedPage = new Page<>(List.of(), 1, 10, 0);
+        when(
+            subscriptionSearchQueryService.search(
+                eq(EXECUTION_CONTEXT),
+                eq(REFERENCE_ID),
+                eq(referenceType),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(PAGEABLE)
+            )
+        ).thenReturn(expectedPage);
+
+        var input = new SearchSubscriptionsUseCase.Input(EXECUTION_CONTEXT, REFERENCE_ID, referenceType, null, null, null, null, PAGEABLE);
+
+        SearchSubscriptionsUseCase.Output output = useCase.execute(input);
+
+        assertThat(output.page()).isSameAs(expectedPage);
+        verify(subscriptionSearchQueryService).search(
+            eq(EXECUTION_CONTEXT),
+            eq(REFERENCE_ID),
+            referenceTypeCaptor.capture(),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(PAGEABLE)
+        );
+        assertThat(referenceTypeCaptor.getValue()).isEqualTo(referenceType);
+    }
+
+    @Test
+    void should_pass_filters_to_query_service() {
+        Set<String> applicationIds = Set.of("app-1");
+        Set<String> planIds = Set.of("plan-1");
+        Set<SubscriptionStatus> statuses = Set.of(SubscriptionStatus.ACCEPTED);
+        String apiKey = "api-key-1";
+        Page<SubscriptionEntity> expectedPage = new Page<>(List.of(), 1, 10, 0);
+        when(
+            subscriptionSearchQueryService.search(
+                eq(EXECUTION_CONTEXT),
+                eq(REFERENCE_ID),
+                eq(SubscriptionReferenceType.API_PRODUCT),
+                eq(applicationIds),
+                eq(planIds),
+                eq(statuses),
+                eq(apiKey),
+                eq(PAGEABLE)
+            )
+        ).thenReturn(expectedPage);
+
+        var input = new SearchSubscriptionsUseCase.Input(
+            EXECUTION_CONTEXT,
+            REFERENCE_ID,
+            SubscriptionReferenceType.API_PRODUCT,
+            applicationIds,
+            planIds,
+            statuses,
+            apiKey,
+            PAGEABLE
+        );
+
+        useCase.execute(input);
+
+        verify(subscriptionSearchQueryService).search(
+            eq(EXECUTION_CONTEXT),
+            eq(REFERENCE_ID),
+            eq(SubscriptionReferenceType.API_PRODUCT),
+            eq(applicationIds),
+            eq(planIds),
+            eq(statuses),
+            eq(apiKey),
+            eq(PAGEABLE)
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12915

## Description

This PR improves the API Product subscription endpoints by adding **filtering**, **pagination**, and **expand** support. The list endpoint now goes through a dedicated UseCase and a core query service so the implementation stays aligned with architecture rules (core independent from rest-api services).

---

## User Stories & Acceptance Criteria

### US1: Filter and paginate API Product subscriptions (list)

> As an API Product Owner, I want to filter and paginate subscriptions when listing them, so that I can find specific subscriptions efficiently.

| Criteria | Implementation |
| --- | --- |
| Filter by application IDs, plan IDs, statuses, API key | Query params `applicationIds`, `planIds`, `statuses`, `apiKey` on `GET .../api-products/{id}/subscriptions` |
| Pagination | Existing `PaginationParam` / `page` & `size` (or equivalent) on list endpoint |
| List implemented via UseCase | `SearchSubscriptionsUseCase` → `SubscriptionSearchQueryService` (core); infra impl delegates to `SubscriptionService` |

### US2: Expand related data on subscriptions

> As an API Product Owner, I want to optionally load plan, application, and subscriber details with each subscription, so that I can avoid extra round-trips.

| Criteria | Implementation |
| --- | --- |
| Expand plan, application, subscribedBy | Query param `expands` with values e.g. `plan`, `application`, `subscribedBy` on list and single subscription GET |
| API Product context in response | Subscriptions have `apiProduct` set and `api` null where appropriate; OpenAPI includes `BaseApiProduct` / `apiProductId` where relevant |

---

## File References

### Backend (changes in this PR)

| Area | Path |
| --- | --- |
| API Product subscriptions list resource | `gravitee-apim-rest-api-management-v2/.../api_product/ApiProductSubscriptionsResource.java` |
| API Product single subscription resource | `gravitee-apim-rest-api-management-v2/.../api_product/ApiProductSubscriptionResource.java` |
| Search subscriptions UseCase | `gravitee-apim-rest-api-service/.../subscription/use_case/SearchSubscriptionsUseCase.java` |
| Subscription search query service (core) | `gravitee-apim-rest-api-service/.../subscription/query_service/SubscriptionSearchQueryService.java` |
| Subscription search query impl (infra) | `gravitee-apim-rest-api-service/.../infra/query_service/subscription/SubscriptionSearchQueryServiceImpl.java` |
| OpenAPI API Products | `gravitee-apim-rest-api-management-v2/.../openapi/openapi-api-products.yaml` |
| OpenAPI APIs (subscription schemas) | `gravitee-apim-rest-api-management-v2/.../openapi/openapi-apis.yaml` |

---

## Test Cases

### `SearchSubscriptionsUseCaseTest`

| Test | Description |
| --- | --- |
| `should_call_query_service_with_reference_type_and_id` | UseCase calls `SubscriptionSearchQueryService.search` with correct `referenceId` and `referenceType` (API / API_PRODUCT) |
| `should_pass_filters_to_query_service` | UseCase passes `applicationIds`, `planIds`, `statuses`, `apiKey` and `pageable` to query service |

### `ApiProductSubscriptionsResourceTest`

| Test | Description |
| --- | --- |
| `should_return_empty_list_when_no_subscriptions` | List returns 200 and empty data when no subscriptions |
| `should_return_subscriptions_list` | List returns subscriptions with `apiProduct` set and `api` null |
| `should_return_plan_with_apiProduct_and_no_apiId_when_expand_plan` | With `expands=plan`, plan is populated and has API Product context |

### `ApiProductSubscriptionResourceTest`

| Test | Description |
| --- | --- |
| `should_return_plan_with_apiProduct_and_no_apiId_when_expand_plan` | Single subscription GET with `expands=plan` returns plan with API Product context |

---

