### PR TITLE
feat(console): Added deploy banner & permission changes for API product plan

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -16,6 +16,8 @@
 
 import { PrimaryOwner } from '../api';
 
+export type ApiProductDeploymentState = 'NEED_REDEPLOY' | 'DEPLOYED';
+
 export interface ApiProduct {
   /**
    * API Product's unique identifier.
@@ -49,5 +51,10 @@ export interface ApiProduct {
    * The primary owner of the API Product.
    */
   primaryOwner?: PrimaryOwner;
+  /**
+   * Indicates whether the API Product is in sync with the latest deployment.
+   */
+  deploymentState?: ApiProductDeploymentState;
+
   _links?: { [key: string]: string };
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/verifyApiProductDeploy.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/verifyApiProductDeploy.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
-export * from './verifyApiProductDeploy';
+export interface VerifyApiProductDeployResponse {
+  ok: boolean;
+  reason?: string;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.guard.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.guard.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
+
+import { ApiProductsGuard } from './api-products.guard';
+
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { CONSTANTS_TESTING } from '../../shared/testing';
+import { Constants } from '../../entities/Constants';
+
+describe('ApiProductsGuard', () => {
+  const API_PRODUCT_ID = 'product-guard-test';
+
+  let permissionService: GioPermissionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        GioPermissionService,
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    permissionService = TestBed.inject(GioPermissionService);
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
+    jest.clearAllMocks();
+  });
+
+  const fakeRoute = { params: { apiProductId: API_PRODUCT_ID } } as unknown as ActivatedRouteSnapshot;
+  const fakeState = {} as RouterStateSnapshot;
+
+  describe('loadPermissions', () => {
+    it('loads API product permissions and returns true', async () => {
+      const loadSpy = jest.spyOn(permissionService, 'loadApiProductPermissions').mockReturnValue(of(undefined));
+
+      const result = await TestBed.runInInjectionContext(() =>
+        firstValueFrom(ApiProductsGuard.loadPermissions(fakeRoute, fakeState) as Observable<boolean>),
+      );
+
+      expect(loadSpy).toHaveBeenCalledWith(API_PRODUCT_ID);
+      expect(result).toBe(true);
+    });
+
+    it('propagates error when permission load fails', async () => {
+      jest.spyOn(permissionService, 'loadApiProductPermissions').mockReturnValue(throwError(() => ({ error: { message: 'Forbidden' } })));
+
+      await expect(
+        TestBed.runInInjectionContext(() => firstValueFrom(ApiProductsGuard.loadPermissions(fakeRoute, fakeState) as Observable<boolean>)),
+      ).rejects.toEqual({ error: { message: 'Forbidden' } });
+    });
+  });
+
+  describe('clearPermissions', () => {
+    it('clears API product permissions on deactivation', () => {
+      const clearSpy = jest.spyOn(permissionService, 'clearApiProductPermissions');
+
+      TestBed.runInInjectionContext(() => {
+        ApiProductsGuard.clearPermissions(null, fakeRoute, fakeState, fakeState);
+      });
+
+      expect(clearSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.guard.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.guard.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateFn, CanDeactivateFn, RouterStateSnapshot } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+
+export const ApiProductsGuard: {
+  loadPermissions: CanActivateFn;
+  clearPermissions: CanDeactivateFn<unknown>;
+} = {
+  loadPermissions: (route: ActivatedRouteSnapshot) => {
+    return inject(GioPermissionService)
+      .loadApiProductPermissions(route.params['apiProductId'])
+      .pipe(map(() => true));
+  },
+
+  clearPermissions: (
+    _component: unknown,
+    _currentRoute: ActivatedRouteSnapshot,
+    _currentState: RouterStateSnapshot,
+    _nextState?: RouterStateSnapshot,
+  ) => {
+    inject(GioPermissionService).clearApiProductPermissions();
+    return true;
+  },
+};

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -16,6 +16,8 @@
 
 import { Routes } from '@angular/router';
 
+import { ApiProductsGuard } from './api-products.guard';
+
 export const API_PRODUCTS_ROUTES: Routes = [
   {
     path: '',
@@ -39,6 +41,8 @@ export const API_PRODUCTS_ROUTES: Routes = [
   {
     path: ':apiProductId',
     loadComponent: () => import('./navigation/api-product-navigation.component').then(m => m.ApiProductNavigationComponent),
+    canActivate: [ApiProductsGuard.loadPermissions],
+    canDeactivate: [ApiProductsGuard.clearPermissions],
     children: [
       {
         path: '',
@@ -52,6 +56,38 @@ export const API_PRODUCTS_ROUTES: Routes = [
       {
         path: 'apis',
         loadComponent: () => import('./apis/api-product-apis.component').then(m => m.ApiProductApisComponent),
+      },
+      {
+        path: 'consumers',
+        redirectTo: 'consumers/plans',
+        pathMatch: 'full',
+      },
+      {
+        path: 'consumers/plans',
+        loadComponent: () => import('./plans/list/api-product-plan-list.component').then(m => m.ApiProductPlanListComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-r'],
+          },
+        },
+      },
+      {
+        path: 'consumers/plans/new',
+        loadComponent: () => import('./plans/edit/api-product-plan-edit.component').then(m => m.ApiProductPlanEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-c'],
+          },
+        },
+      },
+      {
+        path: 'consumers/plans/:planId',
+        loadComponent: () => import('./plans/edit/api-product-plan-edit.component').then(m => m.ApiProductPlanEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-r'],
+          },
+        },
       },
     ],
   },

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.harness.ts
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
-export * from './verifyApiProductDeploy';
+export class ApiProductConfirmDeploymentDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'api-product-confirm-deployment-dialog';
+
+  async clickDeploy(): Promise<void> {
+    const btn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="deploy_button"]' }))();
+    return btn.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<span matDialogTitle>Deploy your API Product</span>
+
+<mat-dialog-content class="content">
+  <p class="mat-body-2">You are about to deploy your API Product to the gateway. All subscribed consumers will be affected.</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+  <button color="primary" mat-raised-button aria-label="Deploy the API Product" data-testid="deploy_button" (click)="onDeploy()">
+    Deploy
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { ApiProductConfirmDeploymentDialogComponent } from './api-product-confirm-deployment-dialog.component';
+import { ApiProductConfirmDeploymentDialogHarness } from './api-product-confirm-deployment-dialog.component.harness';
+
+import { GioTestingModule } from '../../../../shared/testing';
+
+describe('ApiProductConfirmDeploymentDialogComponent', () => {
+  const API_PRODUCT_ID = 'api-product-deploy-test';
+
+  let fixture: ComponentFixture<ApiProductConfirmDeploymentDialogComponent>;
+  let harness: ApiProductConfirmDeploymentDialogHarness;
+  let dialogRefClose: jest.Mock;
+
+  beforeEach(async () => {
+    dialogRefClose = jest.fn();
+    await TestBed.configureTestingModule({
+      imports: [ApiProductConfirmDeploymentDialogComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+        { provide: MAT_DIALOG_DATA, useValue: { apiProductId: API_PRODUCT_ID } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductConfirmDeploymentDialogComponent);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductConfirmDeploymentDialogHarness);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should close dialog with true when user confirms deploy', async () => {
+    await harness.clickDeploy();
+
+    expect(dialogRefClose).toHaveBeenCalledWith(true);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+
+export interface ApiProductConfirmDeploymentDialogData {
+  apiProductId: string;
+}
+
+export type ApiProductConfirmDeploymentDialogResult = true;
+
+@Component({
+  selector: 'api-product-confirm-deployment-dialog',
+  templateUrl: './api-product-confirm-deployment-dialog.component.html',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
+})
+export class ApiProductConfirmDeploymentDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<ApiProductConfirmDeploymentDialogComponent, ApiProductConfirmDeploymentDialogResult>>(MatDialogRef);
+
+  onDeploy(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MatTabsModule } from '@angular/material/tabs';
 
@@ -26,7 +26,6 @@ export interface ApiProductTabMenuItem {
   selector: 'api-product-navigation-tabs',
   templateUrl: './api-product-navigation-tabs.component.html',
   standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterModule, MatTabsModule],
 })
 export class ApiProductNavigationTabsComponent {

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -16,7 +16,7 @@
 
 -->
 
-@if (currentApiProduct$ | async; as currentApiProduct) {
+@if (currentApiProduct(); as currentApiProduct) {
   <div class="api-product-navigation">
     <div class="api-product-navigation__menu">
       <gio-submenu class="api-product-navigation__submenu">
@@ -47,7 +47,38 @@
       }
 
       <div class="api-product-navigation__content__view">
-        <router-outlet></router-outlet>
+        @if (banners().length > 0) {
+          <div class="api-product-navigation__content__view__banners">
+            @for (banner of banners(); track banner.title) {
+              <gio-banner [type]="banner.type">
+                {{ banner.title }}
+                @if (banner.action) {
+                  <div gioBannerAction>
+                    <button mat-stroked-button color="basic" (click)="banner.action.onClick()" [disabled]="isActionDisabled()">
+                      {{ banner.action.btnText }}
+                    </button>
+                  </div>
+                }
+                @if (banner.body) {
+                  <div gioBannerBody [innerHTML]="banner.body"></div>
+                }
+              </gio-banner>
+            }
+          </div>
+        }
+        @if (selectedItemHeader(); as header) {
+          <div class="api-product-navigation__content__view__section-header">
+            <div class="mat-h2">{{ header.title }}</div>
+            @if (header.subtitle) {
+              <div class="api-product-navigation__content__view__section-header__subtitle">{{ header.subtitle }}</div>
+            }
+          </div>
+        }
+        @if (selectedItemWithTabs(); as itemWithTabs) {
+          <api-product-navigation-tabs [tabMenuItems]="itemWithTabs.tabs"><router-outlet></router-outlet></api-product-navigation-tabs>
+        } @else {
+          <router-outlet></router-outlet>
+        }
       </div>
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -48,7 +48,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       &__name {
         @include mat.m2-typography-level($typography, subtitle-1);
         margin: 0;
-        padding: 16px 20px;
+        padding: 1rem 1.25rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -61,7 +61,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       align-items: center;
 
       &__icon {
-        margin-right: 8px;
+        margin-right: 0.5rem;
         color: $textColor;
         width: 1.25rem;
         height: 1.25rem;
@@ -70,7 +70,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
   }
 
   &__breadcrumb {
-    padding: 16px 32px 0 32px;
+    padding: 1rem 2rem 0 2rem;
 
     &__item {
       display: contents;
@@ -88,7 +88,19 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       flex-direction: column;
       flex: 1 1 auto;
       height: 100%;
-      margin: 12px 24px 0 24px;
+      margin: 0.75rem 1.5rem 0 1.5rem;
+
+      &__section-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-bottom: 1.5rem;
+
+        &__subtitle {
+          color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+          @include mat.m2-typography-level($typography, 'body-2');
+        }
+      }
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -23,11 +24,14 @@ import { ActivatedRoute, RouterOutlet } from '@angular/router';
 import { of } from 'rxjs';
 
 import { ApiProductNavigationComponent } from './api-product-navigation.component';
+import { ApiProductConfirmDeploymentDialogHarness } from './api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { Constants } from '../../../entities/Constants';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductNavigationComponent', () => {
   const API_PRODUCT_ID = 'product-1';
@@ -39,9 +43,25 @@ describe('ApiProductNavigationComponent', () => {
   };
 
   let fixture: ComponentFixture<ApiProductNavigationComponent>;
-  let _loader: HarnessLoader;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
   const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  function flushRequests(product: ApiProduct, verifyOk = true, verifyReason?: string): void {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`).flush(product);
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments/_verify`)
+      .flush({ ok: verifyOk, ...(verifyReason ? { reason: verifyReason } : {}) });
+  }
+
+  function createFixture(): void {
+    fixture = TestBed.createComponent(ApiProductNavigationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -49,6 +69,7 @@ describe('ApiProductNavigationComponent', () => {
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -59,11 +80,6 @@ describe('ApiProductNavigationComponent', () => {
         },
       ],
     }).compileComponents();
-
-    fixture = TestBed.createComponent(ApiProductNavigationComponent);
-    _loader = TestbedHarnessEnvironment.loader(fixture);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
   });
 
   afterEach(() => {
@@ -72,16 +88,15 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should create', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should display API product name when loaded', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    expect(req.request.method).toBe('GET');
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -89,8 +104,8 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should display Configuration menu item', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -98,10 +113,145 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should show snackbar on load error', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    createFixture();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`)
+      .flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
     await fixture.whenStable();
 
     expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+
+  it('should not show out-of-sync banner when API Product is deployed', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'DEPLOYED' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('out of sync');
+  });
+
+  it('should show out-of-sync banner with Deploy button when NEED_REDEPLOY and license ok', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+    const deployButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: /Deploy API Product/i }));
+    expect(deployButton).toBeTruthy();
+  });
+
+  it('should call deploy API and show success snackbar when user confirms deploy', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const deployButton = await loader.getHarness(MatButtonHarness.with({ text: /Deploy API Product/i }));
+    await deployButton.click();
+
+    const dialogHarness = await rootLoader.getHarness(ApiProductConfirmDeploymentDialogHarness);
+    await dialogHarness.clickDeploy();
+
+    const deployRequest = httpTestingController.expectOne(req => req.url.endsWith('/deployments') && req.method === 'POST', 'deploy POST');
+    deployRequest.flush({ id: API_PRODUCT_ID, name: 'Product', version: '1.0' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('API Product successfully deployed.');
+
+    const pending = httpTestingController.match(() => true);
+    pending.forEach(req => {
+      if (req.request.url.includes('_verify')) {
+        req.flush({ ok: true });
+      } else if (req.request.url.includes('/api-products/') && !req.request.url.includes('/deployments')) {
+        req.flush(fakeApiProduct);
+      }
+    });
+  });
+
+  it('should show error snackbar when deploy fails', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const deployButton = await loader.getHarness(MatButtonHarness.with({ text: /Deploy API Product/i }));
+    await deployButton.click();
+
+    const dialogHarness = await rootLoader.getHarness(ApiProductConfirmDeploymentDialogHarness);
+    await dialogHarness.clickDeploy();
+
+    const deployRequest = httpTestingController.expectOne(
+      `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments`,
+      'POST',
+    );
+    deployRequest.flush({ message: 'Deployment not allowed' }, { status: 400, statusText: 'Bad Request' });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalled();
+    expect(fakeSnackBarService.error.mock.calls[0][0]).toContain('Deployment not allowed');
+  });
+
+  it('should show out-of-sync banner without Deploy button when user lacks update permission', async () => {
+    TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: [] });
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+    const deployButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: /Deploy API Product/i }));
+    expect(deployButton).toBeNull();
+  });
+
+  it('should show cannot-be-deployed banner with body when license check fails', async () => {
+    createFixture();
+    flushRequests(fakeApiProduct, false, 'API Product deployment requires a universe license.');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product cannot be deployed.');
+    expect(fixture.nativeElement.textContent).toContain('API Product deployment requires a universe license.');
+  });
+
+  it('should re-fetch api product and show banner after planStateVersion changes', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'DEPLOYED' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('out of sync');
+
+    TestBed.inject(ApiProductV2Service).notifyPlanStateChanged();
+    fixture.detectChanges();
+
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+  });
+
+  describe('Consumers menu item visibility', () => {
+    it('should show consumers menu item when user has api product plan read permission', async () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-plan-r'] });
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Consumers');
+    });
+
+    it('should hide consumers menu item when user lacks api product plan read permission', async () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-definition-r'] });
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('Consumers');
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -14,30 +14,75 @@
  * limitations under the License.
  */
 
-import { AsyncPipe } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { GioBreadcrumbModule, GioIconsModule, GioMenuModule, GioMenuService, GioSubmenuModule } from '@gravitee/ui-particles-angular';
-import { catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+import {
+  GIO_DIALOG_WIDTH,
+  GioBannerModule,
+  GioBannerTypes,
+  GioBreadcrumbModule,
+  GioIconsModule,
+  GioMenuModule,
+  GioMenuService,
+  GioSubmenuModule,
+} from '@gravitee/ui-particles-angular';
+import { catchError, combineLatest, EMPTY, filter, map, Observable, of, startWith, switchMap, tap } from 'rxjs';
 
+import {
+  ApiProductConfirmDeploymentDialogComponent,
+  ApiProductConfirmDeploymentDialogData,
+  ApiProductConfirmDeploymentDialogResult,
+} from './api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component';
+import {
+  ApiProductNavigationTabsComponent,
+  ApiProductTabMenuItem,
+} from './api-product-navigation-tabs/api-product-navigation-tabs.component';
+
+import { ApiProduct, VerifyApiProductDeployResponse } from '../../../entities/management-api-v2/api-product';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 export interface MenuItem {
   displayName: string;
   routerLink: string;
   icon?: string;
+  tabs?: ApiProductTabMenuItem[];
+  header?: { title: string; subtitle?: string };
 }
+
+type TopBanner = {
+  title: string;
+  body?: string;
+  type: GioBannerTypes;
+  action?: {
+    btnText: string;
+    onClick: () => void;
+  };
+};
 
 @Component({
   selector: 'api-product-navigation',
   templateUrl: './api-product-navigation.component.html',
   styleUrls: ['./api-product-navigation.component.scss'],
   standalone: true,
-  imports: [AsyncPipe, RouterModule, GioSubmenuModule, GioIconsModule, GioBreadcrumbModule, GioMenuModule, MatIconModule, MatTooltipModule],
+  imports: [
+    RouterModule,
+    GioSubmenuModule,
+    GioIconsModule,
+    GioBreadcrumbModule,
+    GioMenuModule,
+    GioBannerModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    ApiProductNavigationTabsComponent,
+  ],
 })
 export class ApiProductNavigationComponent {
   private readonly router = inject(Router);
@@ -45,13 +90,14 @@ export class ApiProductNavigationComponent {
   private readonly gioMenuService = inject(GioMenuService);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
 
-  readonly subMenuItems: MenuItem[] = [
-    { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
-    { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
-  ];
+  readonly isActionDisabled = signal(false);
+  private readonly reloadCount = signal(0);
+
   readonly hasBreadcrumb = toSignal(this.gioMenuService.reduced$, { initialValue: false });
-
   private readonly navTrigger = toSignal(
     this.router.events.pipe(
       filter((event): event is NavigationEnd => event instanceof NavigationEnd),
@@ -59,28 +105,159 @@ export class ApiProductNavigationComponent {
     ),
     { initialValue: null },
   );
+
+  private readonly apiProductData = toSignal(
+    combineLatest([
+      this.activatedRoute.params.pipe(map(p => p['apiProductId'] ?? null)),
+      toObservable(this.reloadCount),
+      toObservable(this.apiProductV2Service.planStateVersion),
+    ]).pipe(switchMap(([apiProductId]) => this.loadApiProductWithVerify(apiProductId))),
+    { initialValue: [null, { ok: true }] as [null, VerifyApiProductDeployResponse] },
+  );
+
+  readonly subMenuItems = computed(() => {
+    this.navTrigger();
+    return this.buildSubMenuItems();
+  });
+
   readonly menuItemsWithActive = computed(() => {
     this.navTrigger();
-    return this.subMenuItems.map(item => ({
+    return this.subMenuItems().map(item => ({
       ...item,
       active: this.isItemActive(item),
     }));
   });
 
-  readonly currentApiProduct$ = this.activatedRoute.params.pipe(
-    map(p => p['apiProductId'] ?? null),
-    switchMap(apiProductId => {
-      if (apiProductId) {
-        return this.apiProductV2Service.get(apiProductId).pipe(
-          catchError(error => {
-            this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
-            return of(null);
-          }),
-        );
-      }
-      return of(null);
-    }),
-  );
+  readonly selectedItemWithTabs = computed(() => {
+    this.navTrigger();
+    return this.subMenuItems().find(item => this.isItemActive(item) && (item.tabs?.length ?? 0) > 0) ?? null;
+  });
+
+  readonly selectedItemHeader = computed(() => {
+    this.navTrigger();
+    return this.subMenuItems().find(item => this.isItemActive(item) && item.header)?.header ?? null;
+  });
+
+  readonly currentApiProduct = computed(() => this.apiProductData()[0]);
+
+  readonly banners = computed<TopBanner[]>(() => {
+    const [apiProduct, verifyDeployResponse] = this.apiProductData();
+    if (!apiProduct) {
+      return [];
+    }
+
+    const banners: TopBanner[] = [];
+    const canUpdateApiProduct = this.permissionService.hasAnyMatching(['api_product-definition-u']);
+
+    if (apiProduct.deploymentState === 'NEED_REDEPLOY' && verifyDeployResponse.ok) {
+      banners.push(
+        canUpdateApiProduct
+          ? {
+              title: 'This API Product is out of sync.',
+              type: 'warning',
+              action: {
+                btnText: 'Deploy API Product',
+                onClick: () => this.openDeployDialog(apiProduct.id),
+              },
+            }
+          : {
+              title: 'This API Product is out of sync.',
+              type: 'warning',
+            },
+      );
+    }
+
+    if (!verifyDeployResponse.ok) {
+      banners.push({
+        title: 'This API Product cannot be deployed.',
+        body: verifyDeployResponse.reason ?? 'Deployment is not allowed.',
+        type: 'error',
+      });
+    }
+
+    return banners;
+  });
+
+  private loadApiProductWithVerify(apiProductId: string | null): Observable<[ApiProduct | null, VerifyApiProductDeployResponse]> {
+    if (!apiProductId) {
+      return of([null, { ok: true }] as [null, VerifyApiProductDeployResponse]);
+    }
+    return this.apiProductV2Service.refreshLastApiProductFetch(apiProductId).pipe(
+      catchError(err =>
+        this.handleLoadError(err, 'An error occurred while loading the API Product').pipe(
+          map(() => [null, { ok: true }] as [null, VerifyApiProductDeployResponse]),
+        ),
+      ),
+      switchMap(result =>
+        Array.isArray(result)
+          ? of(result)
+          : combineLatest([
+              this.apiProductV2Service.getLastApiProductFetch(apiProductId),
+              this.apiProductV2Service
+                .verifyDeploy(apiProductId)
+                .pipe(catchError(() => of({ ok: false, reason: 'Could not verify deployment compatibility.' }))),
+            ]),
+      ),
+    );
+  }
+
+  private openDeployDialog(apiProductId: string): void {
+    this.isActionDisabled.set(true);
+    this.matDialog
+      .open<ApiProductConfirmDeploymentDialogComponent, ApiProductConfirmDeploymentDialogData, ApiProductConfirmDeploymentDialogResult>(
+        ApiProductConfirmDeploymentDialogComponent,
+        {
+          data: { apiProductId },
+          role: 'alertdialog',
+          id: 'gioApiProductConfirmDeploymentDialog',
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+        },
+      )
+      .afterClosed()
+      .pipe(
+        tap(() => this.isActionDisabled.set(false)),
+        filter((result): result is true => result === true),
+        switchMap(() => this.apiProductV2Service.deploy(apiProductId)),
+        tap(() => {
+          this.snackBarService.success('API Product successfully deployed.');
+          this.reloadCount.update(count => count + 1);
+        }),
+        catchError(err => {
+          const message =
+            (err as { error?: { message?: string }; message?: string })?.error?.message ??
+            (err as { message?: string })?.message ??
+            'Unknown error';
+          this.snackBarService.error(`An error occurred while deploying the API Product. ${message}`);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private handleLoadError(err: unknown, defaultMessage: string): Observable<null> {
+    const message = (err as { error?: { message?: string } })?.error?.message ?? defaultMessage;
+    this.snackBarService.error(message);
+    return of(null);
+  }
+
+  private buildSubMenuItems(): MenuItem[] {
+    const items: MenuItem[] = [
+      { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
+      { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
+    ];
+    if (this.permissionService.hasAnyMatching(['api_product-plan-r'])) {
+      items.push({
+        displayName: 'Consumers',
+        routerLink: 'consumers/plans',
+        icon: 'gio:cloud-consumers',
+        header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
+        tabs: [{ displayName: 'Plans', routerLink: 'consumers/plans' }],
+      });
+    }
+
+    return items;
+  }
 
   private isItemActive(item: MenuItem): boolean {
     if (!item.routerLink) {

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -29,6 +29,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing'
 import { fakePlanV4 } from '../../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductPlanEditComponent', () => {
   const API_PRODUCT_ID = 'product-xyz';
@@ -38,6 +39,7 @@ describe('ApiProductPlanEditComponent', () => {
   let harness: ApiProductPlanEditComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
+  let notifyPlanStateChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function setup(
@@ -71,6 +73,7 @@ describe('ApiProductPlanEditComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
+    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductPlanEditComponentHarness);
   }
@@ -285,6 +288,82 @@ describe('ApiProductPlanEditComponent', () => {
       fixture.detectChanges();
 
       expect(await harness.isSaveBarVisible()).toBe(false);
+    }));
+  });
+
+  describe('deploy banner notification', () => {
+    it('notifies plan state changed after creating a plan so deploy banner is triggered', fakeAsync(async () => {
+      await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
+      tick();
+      fixture.detectChanges();
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
+
+      const planValue = fakePlanV4({ name: 'New Plan', security: { type: 'JWT' }, status: 'STAGING' });
+      fixture.componentInstance['planForm'].patchValue({ plan: planValue });
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans` })
+        .flush(fakePlanV4({ id: 'new-plan', status: 'STAGING' }));
+      tick();
+      fixture.detectChanges();
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after updating a plan so deploy banner is triggered', fakeAsync(async () => {
+      await setup({ planId: PLAN_ID });
+      const plan = fakePlanV4({ id: PLAN_ID, name: 'Original', status: 'PUBLISHED', security: { type: 'API_KEY' } });
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}`).flush(plan);
+      tick();
+      fixture.detectChanges();
+
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}`).flush(plan);
+      tick();
+
+      httpTestingController
+        .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}` })
+        .flush({ ...plan });
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('does not notify plan state changed when save fails', fakeAsync(async () => {
+      await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
+      tick();
+      fixture.detectChanges();
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
+
+      const planValue = fakePlanV4({ name: 'New Plan', security: { type: 'JWT' }, status: 'STAGING' });
+      fixture.componentInstance['planForm'].patchValue({ plan: planValue });
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans` })
+        .flush({ message: 'Plan creation failed' }, { status: 500, statusText: 'Server Error' });
+      tick();
+
+      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
     }));
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
@@ -23,6 +23,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { GioFormFocusInvalidModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
 import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
@@ -52,6 +53,7 @@ export class ApiProductPlanEditComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
   private readonly planService = inject(ApiProductPlanV2Service);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly permissionService = inject(GioPermissionService);
   private readonly snackBarService = inject(SnackBarService);
 
@@ -76,7 +78,7 @@ export class ApiProductPlanEditComponent {
     combineLatest([toObservable(this.apiProductId), toObservable(this.planId)]).pipe(
       switchMap(([apiProductId, planId]) => {
         if (!planId) return of(undefined as Plan | undefined);
-        return this.planService.get(apiProductId, planId).pipe(catchError(err => this.handleError(err)));
+        return this.planService.get(apiProductId, planId).pipe(catchError(err => this.handleError(err, 'An error occurred.')));
       }),
     ),
     { initialValue: null as Plan | undefined | null },
@@ -114,7 +116,10 @@ export class ApiProductPlanEditComponent {
 
     savePlan$
       .pipe(
-        tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        tap(() => {
+          this.snackBarService.success('Configuration successfully saved!');
+          this.apiProductV2Service.notifyPlanStateChanged();
+        }),
         catchError(err => this.handleError(err, 'An error occurred while saving configuration.')),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
@@ -36,6 +36,7 @@ import { ApiPlansResponse, Plan, PLAN_STATUS, fakePlanV4 } from '../../../../ent
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { Constants } from '../../../../entities/Constants';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductPlanListComponent', () => {
   const API_PRODUCT_ID = 'product-abc';
@@ -46,6 +47,7 @@ describe('ApiProductPlanListComponent', () => {
   let planListHarness: PlanListComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
+  let notifyPlanStateChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function init(permissions: string[] = ['api_product-plan-u', 'api_product-plan-r', 'api_product-plan-c']) {
@@ -87,6 +89,7 @@ describe('ApiProductPlanListComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
+    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
     loader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     planListHarness = await loader.getHarness(PlanListComponentHarness);
@@ -397,31 +400,147 @@ describe('ApiProductPlanListComponent', () => {
     }));
   });
 
-  describe('clicking a plan navigates to edit route', () => {
-    it('navigates to plan edit route when plan name is clicked', fakeAsync(async () => {
+  describe('deploy banner notification', () => {
+    it('notifies plan state changed after publish so deploy banner is triggered', fakeAsync(async () => {
       await init();
       fixture.detectChanges();
-      const plan = fakePlanV4({ status: 'PUBLISHED', security: { type: 'JWT' } });
+
+      const plan = fakePlanV4({ name: 'New Plan', status: 'STAGING', security: { type: 'API_KEY' } });
       flushPlansList([plan]);
       tick();
       fixture.detectChanges();
 
-      await planListHarness.clickPlanName();
+      await planListHarness.selectStatusFilter(/STAGING/);
+      tick();
+      fixture.detectChanges();
 
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['./', plan.id], expect.objectContaining({ relativeTo: expect.anything() }));
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#publishPlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Publish' })).then(btn => btn.click());
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_publish`)
+        .flush({ ...plan, status: 'PUBLISHED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'PUBLISHED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
-    it('navigates to plan edit route when edit button is clicked', fakeAsync(async () => {
+    it('notifies plan state changed after deprecate so deploy banner is triggered', fakeAsync(async () => {
       await init();
       fixture.detectChanges();
-      const plan = fakePlanV4({ status: 'PUBLISHED', security: { type: 'JWT' } });
+
+      const plan = fakePlanV4({ name: 'Active Plan', status: 'PUBLISHED', security: { type: 'JWT' } });
       flushPlansList([plan]);
       tick();
       fixture.detectChanges();
 
-      await planListHarness.clickEditPlanButton();
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Deprecate the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#deprecatePlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Deprecate' })).then(btn => btn.click());
 
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['./', plan.id], expect.objectContaining({ relativeTo: expect.anything() }));
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_deprecate`)
+        .flush({ ...plan, status: 'DEPRECATED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'DEPRECATED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after close so deploy banner is triggered', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+
+      const plan = fakePlanV4({ name: 'Close Me', status: 'PUBLISHED', security: { type: 'API_KEY' } });
+      flushPlansList([plan]);
+      tick();
+      fixture.detectChanges();
+
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Close the plan"]' })).then(btn => btn.click());
+      const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+      await confirmDialog.confirm();
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_close`)
+        .flush({ ...plan, status: 'CLOSED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'CLOSED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after reorder so deploy banner is triggered', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+      const plan1 = fakePlanV4({ id: 'p1', name: 'First', order: 1, status: 'PUBLISHED', security: { type: 'API_KEY' } });
+      const plan2 = fakePlanV4({ id: 'p2', name: 'Second', order: 2, status: 'PUBLISHED', security: { type: 'JWT' } });
+      flushPlansList([plan1, plan2]);
+      tick();
+      fixture.detectChanges();
+
+      const dropEvent = { previousIndex: 0, currentIndex: 1 } as CdkDragDrop<string[]>;
+      fixture.componentInstance['onPlanReordered'](dropEvent);
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan1.id}` })
+        .flush({ ...plan1, order: 2 });
+      tick();
+      tick(); // allow reload() to schedule the list request
+      fixture.detectChanges();
+
+      // Reload is triggered by triggerReload(); flush the second (reload) list request
+      const listUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`;
+      const listReq = httpTestingController.expectOne(req => req.method === 'GET' && req.urlWithParams === listUrl);
+      listReq.flush({ data: [plan2, { ...plan1, order: 2 }] });
+      fixture.detectChanges();
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('does not notify plan state changed when publish fails', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+
+      const plan = fakePlanV4({ name: 'New Plan', status: 'STAGING', security: { type: 'API_KEY' } });
+      flushPlansList([plan]);
+      tick();
+      fixture.detectChanges();
+
+      await planListHarness.selectStatusFilter(/STAGING/);
+      tick();
+      fixture.detectChanges();
+
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#publishPlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Publish' })).then(btn => btn.click());
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_publish`)
+        .flush({ message: 'Publish failed' }, { status: 500, statusText: 'Server Error' });
+      fixture.detectChanges();
+
+      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('selecting a plan type navigates to create route', () => {
+    it('navigates to new plan route with selected plan type as query param', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+      flushPlansList([]);
+      tick();
+      fixture.detectChanges();
+
+      await planListHarness.clickAddPlanMenuItem('API Key');
+
+      expect(routerNavigateSpy).toHaveBeenCalledWith(
+        ['./new'],
+        expect.objectContaining({ queryParams: { selectedPlanMenuItem: 'API_KEY' } }),
+      );
     }));
   });
 
@@ -451,10 +570,11 @@ describe('ApiProductPlanListComponent', () => {
       tick(); // allow reload() to schedule the list request
       fixture.detectChanges();
 
-      // Reload is triggered by triggerReload(); flush the second (reload) list request
-      const listUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`;
-      const listReq = httpTestingController.expectOne(req => req.method === 'GET' && req.urlWithParams === listUrl);
-      listReq.flush({ data: [plan2, { ...plan1, order: 2 }] });
+      httpTestingController
+        .expectOne(
+          `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`,
+        )
+        .flush({ data: [plan2, { ...plan1, order: 2 }] });
       fixture.detectChanges();
 
       const rowCells = await planListHarness.getRowCells();

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
@@ -20,6 +20,7 @@ import { catchError, EMPTY, filter, map, of, switchMap } from 'rxjs';
 import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { orderBy } from 'lodash';
 import {
+  GIO_DIALOG_WIDTH,
   GioConfirmAndValidateDialogComponent,
   GioConfirmAndValidateDialogData,
   GioConfirmDialogComponent,
@@ -28,6 +29,7 @@ import {
 import { MatDialog } from '@angular/material/dialog';
 
 import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ConstantsService, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
@@ -49,6 +51,7 @@ export class ApiProductPlanListComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
   private readonly plansService = inject(ApiProductPlanV2Service);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly constantsService = inject(ConstantsService);
   private readonly permissionService = inject(GioPermissionService);
   private readonly matDialog = inject(MatDialog);
@@ -116,6 +119,11 @@ export class ApiProductPlanListComponent {
     this.plansResource.reload();
   }
 
+  private refreshPlansAfterStateChange(): void {
+    this.apiProductV2Service.notifyPlanStateChanged();
+    this.triggerReload();
+  }
+
   protected onStatusFilterChanged(status: PlanStatus): void {
     this.filterOverride.set(status);
   }
@@ -166,14 +174,14 @@ export class ApiProductPlanListComponent {
         }),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.triggerReload());
+      .subscribe(() => this.refreshPlansAfterStateChange());
   }
 
   protected onPublishPlan(plan: Plan): void {
     const apiProductId = this.apiProductId();
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
-        width: '500px',
+        width: GIO_DIALOG_WIDTH.SMALL,
         data: {
           title: 'Publish plan',
           content: `Are you sure you want to publish the plan ${plan.name}?`,
@@ -194,7 +202,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(published => {
         this.snackBarService.success(`The plan ${published.name} has been published with success.`);
-        this.triggerReload();
+        this.refreshPlansAfterStateChange();
       });
   }
 
@@ -223,7 +231,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(deprecated => {
         this.snackBarService.success(`The plan ${deprecated.name} has been deprecated with success.`);
-        this.triggerReload();
+        this.refreshPlansAfterStateChange();
       });
   }
 
@@ -255,7 +263,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(closed => {
         this.snackBarService.success(`The plan ${closed.name} has been closed with success.`);
-        this.triggerReload();
+        this.refreshPlansAfterStateChange();
       });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
@@ -49,6 +49,10 @@ describe('PlanListComponent', () => {
   async function create(
     inputs: Partial<{
       plans: PlanDS[];
+      isReadOnly: boolean;
+      showDeployOnColumn: boolean;
+      canAddPlan: boolean;
+      isV2Api: boolean;
       context: PlanListContext;
       filterState: PlanFilterState;
     }> = {},

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Inject, Injectable, signal } from '@angular/core';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { distinctUntilChanged, filter, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { isEqual } from 'lodash';
 
 import { Constants } from '../entities/Constants';
 import {
@@ -25,16 +27,31 @@ import {
   CreateApiProduct,
   toApiProductSortByParam,
   UpdateApiProduct,
+  VerifyApiProductDeployResponse,
 } from '../entities/management-api-v2/api-product';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ApiProductV2Service {
+  private readonly _planStateVersion = signal(0);
+  readonly planStateVersion = this._planStateVersion.asReadonly();
+
+  private readonly lastApiProductFetch$ = new BehaviorSubject<ApiProduct | null>(null);
+
   constructor(
     private readonly http: HttpClient,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
+
+  /**
+   * Notifies subscribers that plan state has changed. Must be called after any operation that
+   * modifies plans: create, update, publish, deprecate, close, reorder, or delete.
+   * Keeps the navigation banner (e.g. NEED_REDEPLOY) in sync with the latest plan state.
+   */
+  notifyPlanStateChanged(): void {
+    this._planStateVersion.update(v => v + 1);
+  }
 
   /**
    * Create a new API Product
@@ -85,7 +102,31 @@ export class ApiProductV2Service {
    * @returns Observable of the API Product
    */
   get(apiProductId: string): Observable<ApiProduct> {
-    return this.http.get<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`);
+    return this.http
+      .get<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`)
+      .pipe(tap(api => this.lastApiProductFetch$.next(api)));
+  }
+
+  /**
+   * Returns the last fetched API Product, refetching if the cache is empty or for a different ID.
+   * Subscribers receive updates when the product is refreshed (e.g. after deploy or plan changes).
+   */
+  getLastApiProductFetch(apiProductId: string): Observable<ApiProduct> {
+    const start = this.lastApiProductFetch$.value?.id === apiProductId ? of(this.lastApiProductFetch$.value) : this.get(apiProductId);
+    return start.pipe(
+      switchMap(() => this.lastApiProductFetch$.asObservable()),
+      filter((api): api is ApiProduct => api !== null && api.id === apiProductId),
+      distinctUntilChanged(isEqual),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+
+  /**
+   * Refreshes the cached API Product by re-fetching from the server.
+   * Use when plan state or deployment state may have changed (e.g. after plan publish, deploy).
+   */
+  refreshLastApiProductFetch(apiProductId: string): Observable<ApiProduct> {
+    return this.get(apiProductId);
   }
 
   /**
@@ -117,7 +158,9 @@ export class ApiProductV2Service {
    * @returns Observable of the updated API Product
    */
   update(apiProductId: string, updateApiProduct: UpdateApiProduct): Observable<ApiProduct> {
-    return this.http.put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, updateApiProduct);
+    return this.http
+      .put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, updateApiProduct)
+      .pipe(tap(api => this.lastApiProductFetch$.next(api)));
   }
 
   /**
@@ -128,9 +171,11 @@ export class ApiProductV2Service {
    * @returns Observable of the updated API Product
    */
   updateApiProductApis(apiProductId: string, apiIds: string[]): Observable<ApiProduct> {
-    return this.http.put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, {
-      apiIds,
-    });
+    return this.http
+      .put<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}`, {
+        apiIds,
+      })
+      .pipe(tap(api => this.lastApiProductFetch$.next(api)));
   }
 
   /**
@@ -144,6 +189,30 @@ export class ApiProductV2Service {
   }
 
   /**
+   * Deploy an API Product to gateway instances
+   * Calls POST /environments/{envId}/api-products/{apiProductId}/deployments
+   * @param apiProductId - The API Product ID
+   * @returns Observable of the deployed API Product
+   */
+  deploy(apiProductId: string): Observable<ApiProduct> {
+    return this.http
+      .post<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/deployments`, {})
+      .pipe(tap(api => this.lastApiProductFetch$.next(api)));
+  }
+
+  /**
+   * Check whether an API Product can be deployed (license check)
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/deployments/_verify
+   * @param apiProductId - The API Product ID
+   * @returns Observable with ok boolean and optional reason
+   */
+  verifyDeploy(apiProductId: string): Observable<VerifyApiProductDeployResponse> {
+    return this.http.get<VerifyApiProductDeployResponse>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/deployments/_verify`,
+    );
+  }
+
+  /**
    * Verify if an API Product name is unique
    * Calls POST /environments/{envId}/api-products/_verify
    * @param name - The API Product name to verify
@@ -153,5 +222,15 @@ export class ApiProductV2Service {
     return this.http.post<{ ok: boolean; reason?: string }>(`${this.constants.env.v2BaseURL}/api-products/_verify`, {
       name,
     });
+  }
+
+  /**
+   * Get the current user's permissions for a given API Product
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/members/permissions
+   * @param apiProductId - The API Product ID
+   * @returns Observable of permission map, where each value is a string of permission characters (e.g. { PLAN: 'CRUD' })
+   */
+  getPermissions(apiProductId: string): Observable<Record<string, string>> {
+    return this.http.get<Record<string, string>>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members/permissions`);
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
@@ -28,11 +28,12 @@ import { ApplicationService } from '../../../services-ngx/application.service';
 import { IntegrationsService } from '../../../services-ngx/integrations.service';
 import { GroupV2Service } from '../../../services-ngx/group-v2.service';
 import { ClusterService } from '../../../services-ngx/cluster.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 
 export type GioTestingPermission = string[];
 
 export type GioTestingRoleScopePermission = {
-  roleScope: 'API' | 'APPLICATION' | 'CLUSTER';
+  roleScope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT';
   id: string;
   permissions: string[];
 };
@@ -50,6 +51,7 @@ export class GioPermissionService {
   private currentApplicationPermissions: string[] = [];
   private currentIntegrationPermissions: string[] = [];
   private currentClusterPermissions: string[] = [];
+  private currentApiProductPermissions: string[] = [];
   private permissions: string[] = [];
   private roleScopePermissionsCache = new Map<string, Observable<string[]>>();
 
@@ -65,6 +67,7 @@ export class GioPermissionService {
     private readonly integrationService: IntegrationsService,
     private readonly clusterService: ClusterService,
     private readonly groupService: GroupV2Service,
+    private readonly apiProductV2Service: ApiProductV2Service,
   ) {
     if (this.gioTestingPermission) {
       this._setPermissions(this.gioTestingPermission);
@@ -171,6 +174,16 @@ export class GioPermissionService {
     );
   }
 
+  loadApiProductPermissions(apiProductId: string): Observable<void> {
+    return this.apiProductV2Service.getPermissions(apiProductId).pipe(
+      map(apiProductPermissions => {
+        this.currentApiProductPermissions = Object.entries(apiProductPermissions).flatMap(([key, crudValues]) =>
+          crudValues.split('').map(crudValue => toLower(`API_PRODUCT-${key}-${crudValue}`)),
+        );
+      }),
+    );
+  }
+
   public fetchGroupPermissions(groupId: string): Observable<string[]> {
     return this.groupService
       .getPermissions(groupId)
@@ -188,11 +201,11 @@ export class GioPermissionService {
    * A Cache is used to store previously fetched permissions to optimize performance and reduce redundant API calls.
    * The Cache is cleared with scope clear methods in the service.
    *
-   * @param {('API'|'APPLICATON'|'CLUSTER')} roleScope - The scope of the role.
+   * @param {('API'|'APPLICATION'|'CLUSTER'|'API_PRODUCT')} roleScope - The scope of the role.
    * @param {string} id - The unique identifier associated with the role.
    * @return {Observable<string[]>} An observable that emits an array of string permissions corresponding to the specified role and ID.
    */
-  getPermissionsByRoleScope(roleScope: 'API' | 'APPLICATION' | 'CLUSTER', id: string): Observable<string[]> {
+  getPermissionsByRoleScope(roleScope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT', id: string): Observable<string[]> {
     const cacheKey = `${roleScope}:${id}`;
 
     if (this.roleScopePermissionsCache.has(cacheKey)) {
@@ -216,6 +229,9 @@ export class GioPermissionService {
         break;
       case 'CLUSTER':
         permissions$ = this.clusterService.getPermissions(id).pipe(map(mapToStringPermissions));
+        break;
+      case 'API_PRODUCT':
+        permissions$ = this.apiProductV2Service.getPermissions(id).pipe(map(mapToStringPermissions));
         break;
       default:
         permissions$ = of([]);
@@ -243,6 +259,7 @@ export class GioPermissionService {
       intersection(this.currentApplicationPermissions, permissions).length > 0 ||
       intersection(this.currentIntegrationPermissions, permissions).length > 0 ||
       intersection(this.currentClusterPermissions, permissions).length > 0 ||
+      intersection(this.currentApiProductPermissions, permissions).length > 0 ||
       intersection(this.permissions, permissions).length > 0
     );
   }
@@ -254,6 +271,11 @@ export class GioPermissionService {
   clearApiPermissions() {
     this.currentApiPermissions = [];
     this.clearRoleScopePermissionsCache('API');
+  }
+
+  clearApiProductPermissions() {
+    this.currentApiProductPermissions = [];
+    this.clearRoleScopePermissionsCache('API_PRODUCT');
   }
 
   clearApplicationPermissions() {
@@ -270,7 +292,7 @@ export class GioPermissionService {
     this.clearRoleScopePermissionsCache('CLUSTER');
   }
 
-  clearRoleScopePermissionsCache(scope: 'API' | 'APPLICATION' | 'CLUSTER') {
+  clearRoleScopePermissionsCache(scope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT') {
     Array.from(this.roleScopePermissionsCache.keys())
       .filter(key => key.startsWith(`${scope}:`))
       .forEach(key => this.roleScopePermissionsCache.delete(key));
@@ -286,6 +308,7 @@ export class GioPermissionService {
       ...this.currentEnvironmentPermissions,
       ...this.currentApiPermissions,
       ...this.currentApplicationPermissions,
+      ...this.currentApiProductPermissions,
       ...this.permissions,
     ];
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12796

## Description

### feat: Added deploy banner changes for API product
- Deploy banner when API product is out of sync (NEED_REDEPLOY)
- planStateVersion signal for banner reactivity
- Deploy confirmation dialog

### feat: Added routes & permission changes for API product-plan
- Routes for API product plan management
- Guard loads permissions for navigation
- Permission-based menu items (Consumers/Plans)


https://github.com/user-attachments/assets/27135389-5460-46d0-acee-31e058407304
