### PR TITLE
feat: added permission & deploy banner changes for API product

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
@@ -26,11 +26,14 @@ import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApiProductPlan
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.factory.Mappers;
@@ -102,4 +105,16 @@ public interface ApiProductPlanMapper {
 
     @Mapping(target = "securityConfiguration", source = "security.configuration", qualifiedByName = "serializeConfiguration")
     PlanUpdates mapToPlanUpdates(UpdateGenericApiProductPlan updatePlanV4);
+
+    /**
+     * API Products don't send tags in update requests. Set tags to empty set so PlanUpdates.applyTo()
+     * receives non-null and sets result to empty (matching DB), avoiding false deploy banner on cosmetic changes.
+     */
+    @AfterMapping
+    @SuppressWarnings("unused")
+    default void setEmptyTagsForApiProductUpdate(UpdateGenericApiProductPlan source, @MappingTarget PlanUpdates target) {
+        if (target.getTags() == null) {
+            target.setTags(Collections.emptySet());
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api_product;
+
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.CustomLog;
+
+@CustomLog
+public class ApiProductMembersResource extends AbstractResource {
+
+    @PathParam("apiProductId")
+    private String apiProductId;
+
+    @GET
+    @Path("/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getApiProductMemberPermissions() {
+        Map<String, char[]> permissions = new HashMap<>();
+        if (isAuthenticated()) {
+            final String userId = getAuthenticatedUser();
+            if (isAdmin()) {
+                final char[] rights = new char[] {
+                    RolePermissionAction.CREATE.getId(),
+                    RolePermissionAction.READ.getId(),
+                    RolePermissionAction.UPDATE.getId(),
+                    RolePermissionAction.DELETE.getId(),
+                };
+                for (ApiProductPermission perm : ApiProductPermission.values()) {
+                    permissions.put(perm.getName(), rights);
+                }
+            } else {
+                permissions = membershipService.getUserMemberPermissions(
+                    GraviteeContext.getExecutionContext(),
+                    MembershipReferenceType.API_PRODUCT,
+                    apiProductId,
+                    userId
+                );
+            }
+        }
+        return Response.ok(permissions).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -30,6 +30,8 @@ servers:
 tags:
   - name: API Product
     description: API Product lifecycle - create, read, update, delete, verify, deploy
+  - name: API Product Members
+    description: Manage API Product members and their permissions
   - name: API Product Subscriptions
     description: Subscribe applications to API Product plans and manage subscriptions
   - name: API Product Plans
@@ -442,6 +444,69 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  /environments/{envId}/api-products/{apiProductId}/members/permissions:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    get:
+      tags:
+        - API Product Members
+      summary: Get API Product member permissions
+      description: |-
+        Get the permissions of the current user for the API Product.
+        Returns a map of permission names to allowed actions (CRUD) for the authenticated user.
+        Admins receive all permissions; other users receive their membership-based permissions.
+      operationId: getApiProductMemberPermissions
+      responses:
+        '200':
+          description: Map of permission names to allowed actions (e.g. CREATE, READ, UPDATE, DELETE)
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                  description: Allowed action IDs as a string (e.g. "CRUD" for Create, Read, Update, Delete)
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /environments/{envId}/api-products/{apiProductId}/deployments/_verify:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    get:
+      tags:
+        - API Product
+      summary: Check if a deployment is possible
+      description: |-
+        Verifies whether the API Product can be deployed to gateway instances, based on the current license.
+
+        User must have the API_PRODUCT_DEFINITION[READ] permission.
+      operationId: verifyApiProductDeployment
+      responses:
+        "200":
+          description: Verification successfully performed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyApiProductDeploymentResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        default:
+          $ref: '#/components/responses/Error'
 
   /environments/{envId}/api-products/{apiProductId}/deployments:
     parameters:
@@ -1732,6 +1797,25 @@ components:
           example: "2025-01-01T10:15:30Z"
         primaryOwner:
           $ref: '#/components/schemas/PrimaryOwner'
+        deploymentState:
+          $ref: '#/components/schemas/ApiProductDeploymentState'
+
+    ApiProductDeploymentState:
+      type: string
+      description: Indicates whether the API Product is in sync with the latest deployment.
+      enum:
+        - DEPLOYED
+        - NEED_REDEPLOY
+
+    VerifyApiProductDeploymentResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          description: Indicates whether the deployment can be done or not.
+        reason:
+          type: string
+          description: An optional reason giving details about the result.
 
     PrimaryOwner:
       type: object
@@ -2080,6 +2164,9 @@ components:
           type: integer
           description: Simple order that could be used by a front end to display plans in a certain order. To highlight a plan on the portal for instance.
           example: 0
+        selectionRule:
+          type: string
+          description: An optional EL expression that will be evaluated at request time to select this plan.
         security:
           type: object
           properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.plan.model.PlanUpdates;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApiProductPlan;
+import org.junit.jupiter.api.Test;
+
+class ApiProductPlanMapperTest {
+
+    private final ApiProductPlanMapper apiProductPlanMapper = ApiProductPlanMapper.INSTANCE;
+
+    @Test
+    void mapToPlanUpdates_should_set_empty_tags_when_source_has_null_tags() {
+        // API Products don't send tags in update requests - tags are null after mapping.
+        // @AfterMapping sets tags to empty set so PlanUpdates.applyTo() matches DB and deploy banner is correct.
+        var updatePlan = new UpdateGenericApiProductPlan();
+        updatePlan.setName("Updated Plan");
+        updatePlan.setDescription("Updated description");
+
+        PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTags()).isNotNull();
+        assertThat(result.getTags()).isEmpty();
+        assertThat(result.getName()).isEqualTo("Updated Plan");
+        assertThat(result.getDescription()).isEqualTo("Updated description");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api_product;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiProductMembersResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "my-env";
+    private static final String API_PRODUCT_ID = "c45b8e66-4d2a-47ad-9b8e-664d2a97ad88";
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENV_ID + "/api-products/" + API_PRODUCT_ID + "/members";
+    }
+
+    @BeforeEach
+    void init() {
+        super.setUp();
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENV_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        when(environmentService.findById(ENV_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENV_ID)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        reset(membershipService);
+    }
+
+    @Nested
+    class GetApiProductMemberPermissionsTest {
+
+        /**
+         * JerseySpringTest.AuthenticationFilter always returns {@code true} for {@code isUserInRole},
+         * so {@code isAdmin()} is {@code true} in all tests — only the admin branch of
+         * {@link io.gravitee.rest.api.management.v2.rest.resource.api_product.ApiProductMembersResource#getApiProductMemberPermissions()}
+         * can be exercised here. The non-admin branch (which delegates to
+         * {@code membershipService.getUserMemberPermissions}) cannot be reached through this framework
+         * without replacing the underlying JAX-RS security filter.
+         */
+        @Test
+        void should_return_200_with_all_api_product_permissions_for_admin() {
+            Response response = rootTarget("permissions").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+
+            @SuppressWarnings("unchecked")
+            Map<String, String> permissions = response.readEntity(Map.class);
+
+            assertThat(permissions).isNotNull().hasSize(ApiProductPermission.values().length);
+
+            // Each permission key maps to a string serialised from char[] — verify CRUD chars present
+            final String expectedRights = new String(
+                new char[] {
+                    RolePermissionAction.CREATE.getId(),
+                    RolePermissionAction.READ.getId(),
+                    RolePermissionAction.UPDATE.getId(),
+                    RolePermissionAction.DELETE.getId(),
+                }
+            );
+
+            Arrays.stream(ApiProductPermission.values()).forEach(perm ->
+                assertThat(permissions)
+                    .as("Permission map should contain '%s' with full CRUD rights", perm.getName())
+                    .containsEntry(perm.getName(), expectedRights)
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -31,6 +31,11 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 public class ApiProduct {
 
+    public enum DeploymentState {
+        DEPLOYED,
+        NEED_REDEPLOY,
+    }
+
     private String id;
     private String environmentId;
     private String name;
@@ -40,6 +45,7 @@ public class ApiProduct {
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
     private PrimaryOwnerEntity primaryOwner;
+    private DeploymentState deploymentState;
 
     public void update(UpdateApiProduct updateApiProduct) {
         this.updatedAt = ZonedDateTime.now(TimeProvider.clock());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductDeployUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductDeployUseCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Verifies whether an API Product can be deployed based on the current organization license.
+ * API Product deployment requires the "universe" license tier.
+ */
+@UseCase
+@RequiredArgsConstructor
+public class VerifyApiProductDeployUseCase {
+
+    private final LicenseDomainService licenseDomainService;
+
+    public Output execute(Input input) {
+        boolean ok = licenseDomainService.isApiProductDeploymentAllowed(input.organizationId());
+        String reason = ok ? null : "API Product deployment requires a universe license.";
+        return new Output(ok, reason);
+    }
+
+    public record Input(String organizationId) {}
+
+    public record Output(boolean ok, String reason) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/event/query_service/EventLatestQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/event/query_service/EventLatestQueryService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.event.query_service;
+
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.rest.api.model.EventType;
+import java.util.Optional;
+
+/**
+ * Port for querying the event_latest store, which holds exactly one
+ * "current" event per entity (keyed by entity ID).
+ */
+public interface EventLatestQueryService {
+    /**
+     * Returns the latest event of the given type recorded for the specified entity.
+     *
+     * @param entityId     the entity ID (e.g. an API Product ID)
+     * @param eventType    the event type to filter on
+     * @param propertyKey  the event property that holds the entity ID
+     * @return the single latest event, or empty if none has been recorded yet
+     */
+    Optional<Event> findLatestByEntityId(String entityId, EventType eventType, Event.EventProperties propertyKey);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -294,6 +294,10 @@ public class UpdatePlanDomainService {
         Plan existingPlan = planCrudService.getById(planToUpdate.getId());
         Plan updatePlan = existingPlan.update(planToUpdate);
 
+        if (!planSynchronizationService.checkSynchronized(existingPlan, List.of(), updatePlan, List.of())) {
+            updatePlan.setNeedRedeployAt(Date.from(updatePlan.getUpdatedAt().toInstant()));
+        }
+
         Plan updated = orderAwareUpdateForApiProduct(existingPlan, updatePlan);
 
         createApiProductAuditLog(existingPlan, updated, auditInfo);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plan/PublishPlanDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plan/PublishPlanDomainServiceImpl.java
@@ -115,17 +115,19 @@ public class PublishPlanDomainServiceImpl implements PublishPlanDomainService {
             plan = planRepository.update(plan);
 
             // Audit
-            auditService.createApiAuditLog(
-                executionContext,
-                AuditService.AuditLogData.builder()
-                    .properties(Collections.singletonMap(Audit.AuditProperties.PLAN, plan.getId()))
-                    .event(PLAN_PUBLISHED)
-                    .createdAt(plan.getUpdatedAt())
-                    .oldValue(previousPlan)
-                    .newValue(plan)
-                    .build(),
-                plan.getReferenceId()
-            );
+            AuditService.AuditLogData auditLogData = AuditService.AuditLogData.builder()
+                .properties(Collections.singletonMap(Audit.AuditProperties.PLAN, plan.getId()))
+                .event(PLAN_PUBLISHED)
+                .createdAt(plan.getUpdatedAt())
+                .oldValue(previousPlan)
+                .newValue(plan)
+                .build();
+
+            if (plan.getReferenceType() == io.gravitee.repository.management.model.Plan.PlanReferenceType.API_PRODUCT) {
+                auditService.createApiProductAuditLog(executionContext, auditLogData, plan.getReferenceId());
+            } else {
+                auditService.createApiAuditLog(executionContext, auditLogData, plan.getReferenceId());
+            }
 
             return PlanAdapter.INSTANCE.fromRepository(plan);
         } catch (TechnicalException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/event/EventLatestQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/event/EventLatestQueryServiceImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.event;
+
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
+import io.gravitee.apim.infra.adapter.EventAdapter;
+import io.gravitee.repository.management.api.EventLatestRepository;
+import io.gravitee.repository.management.api.search.EventCriteria;
+import io.gravitee.repository.management.model.EventType;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EventLatestQueryServiceImpl implements EventLatestQueryService {
+
+    private final EventLatestRepository eventLatestRepository;
+
+    public EventLatestQueryServiceImpl(@Lazy EventLatestRepository eventLatestRepository) {
+        this.eventLatestRepository = eventLatestRepository;
+    }
+
+    @Override
+    public Optional<Event> findLatestByEntityId(
+        String entityId,
+        io.gravitee.rest.api.model.EventType eventType,
+        Event.EventProperties propertyKey
+    ) {
+        try {
+            List<io.gravitee.repository.management.model.Event> events = eventLatestRepository.search(
+                EventCriteria.builder()
+                    .types(List.of(EventType.valueOf(eventType.name())))
+                    .properties(Map.of(propertyKey.getLabel(), entityId))
+                    .build(),
+                io.gravitee.repository.management.model.Event.EventProperties.valueOf(propertyKey.name()),
+                0L,
+                1L
+            );
+            return events.stream().findFirst().map(EventAdapter.INSTANCE::map);
+        } catch (Exception e) {
+            throw new TechnicalManagementException(
+                "An error occurs while trying to find latest event for entity [" + entityId + "]: " + e.getMessage(),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventLatestQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventLatestQueryServiceInMemory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
+import io.gravitee.rest.api.model.EventType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class EventLatestQueryServiceInMemory implements EventLatestQueryService, InMemoryAlternative<Event> {
+
+    private final List<Event> storage;
+
+    public EventLatestQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    @Override
+    public Optional<Event> findLatestByEntityId(String entityId, EventType eventType, Event.EventProperties propertyKey) {
+        return storage
+            .stream()
+            .filter(event -> eventType.name().equals(event.getType() != null ? event.getType().name() : null))
+            .filter(event -> entityId.equals(event.getProperties().getOrDefault(propertyKey, null)))
+            .max(Comparator.comparing(event -> event.getUpdatedAt() != null ? event.getUpdatedAt() : event.getCreatedAt()));
+    }
+
+    @Override
+    public void initWith(List<Event> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Event> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -17,6 +17,7 @@ package inmemory.spring;
 
 import inmemory.*;
 import io.gravitee.apim.core.api.domain_service.NotificationCRDDomainService;
+import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
 import io.gravitee.apim.core.integration.service_provider.A2aAgentFetcher;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
@@ -182,6 +183,11 @@ public class InMemoryConfiguration {
     @Bean
     public EventLatestCrudInMemory eventLatestCrudService() {
         return new EventLatestCrudInMemory();
+    }
+
+    @Bean
+    public EventLatestQueryService eventLatestQueryService() {
+        return new EventLatestQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -19,29 +19,54 @@ import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.EventLatestQueryServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.infra.adapter.GraviteeJacksonMapper;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
 
+    private static final Instant DEPLOYED_AT = Instant.parse("2024-01-10T10:00:00Z");
+    private static final Instant BEFORE_DEPLOY = Instant.parse("2024-01-09T10:00:00Z");
+    private static final Instant AFTER_DEPLOY = Instant.parse("2024-01-11T10:00:00Z");
+
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final EventLatestQueryServiceInMemory eventLatestQueryService = new EventLatestQueryServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
     private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    private final ObjectMapper objectMapper = GraviteeJacksonMapper.getInstance();
 
     private GetApiProductsUseCase getApiProductsUseCase;
 
@@ -70,7 +95,22 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             userCrudService
         );
 
-        getApiProductsUseCase = new GetApiProductsUseCase(apiProductQueryService, apiProductPrimaryOwnerDomainService);
+        getApiProductsUseCase = new GetApiProductsUseCase(
+            apiProductQueryService,
+            apiProductPrimaryOwnerDomainService,
+            eventLatestQueryService,
+            planQueryService,
+            objectMapper
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        apiProductQueryService.reset();
+        eventLatestQueryService.reset();
+        planQueryService.reset();
+        membershipCrudService.reset();
+        userCrudService.reset();
     }
 
     @Test
@@ -147,5 +187,202 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> getApiProductsUseCase.execute(input))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("environmentId must be provided");
+    }
+
+    @Nested
+    class DeploymentState {
+
+        private static final String API_PRODUCT_ID = "api-product-id";
+
+        @Test
+        void should_be_need_redeploy_when_never_deployed() {
+            apiProductQueryService.initWith(List.of(ApiProduct.builder().id(API_PRODUCT_ID).name("Product").environmentId(ENV_ID).build()));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
+        void should_be_deployed_when_product_not_modified_after_last_deploy_and_no_plan_changes() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, BEFORE_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.DEPLOYED);
+        }
+
+        @Test
+        void should_be_need_redeploy_when_list_of_apis_in_product_changed() throws Exception {
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1", "api-2"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+            ApiProduct deployedProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, deployedProduct)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
+        void should_be_need_redeploy_when_plan_published_after_last_deploy() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, AFTER_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
+        void should_be_deployed_when_only_staging_plan_modified_after_last_deploy() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(List.of(aStagingApiProductPlan(API_PRODUCT_ID, AFTER_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.DEPLOYED);
+        }
+
+        @Test
+        void should_compute_deployment_state_when_listing_products_by_environment() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, BEFORE_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID));
+
+            assertThat(output.apiProducts())
+                .extracting(ApiProduct::getDeploymentState)
+                .containsExactly(ApiProduct.DeploymentState.DEPLOYED);
+        }
+
+        @Test
+        void should_be_need_redeploy_for_listed_product_when_plan_published_after_last_deploy() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, AFTER_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID));
+
+            assertThat(output.apiProducts())
+                .extracting(ApiProduct::getDeploymentState)
+                .containsExactly(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
+        void should_be_deployed_when_only_name_description_version_changed() throws Exception {
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product v2")
+                .description("New description")
+                .version("2.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .updatedAt(DEPLOYED_AT.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+            ApiProduct deployedProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product v1")
+                .description("Old description")
+                .version("1.0")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, deployedProduct)));
+            planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, BEFORE_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.DEPLOYED);
+        }
+
+        private Event aDeployApiProductEvent(String apiProductId, Instant updatedAt, ApiProduct deployedPayload) throws Exception {
+            Event.EventBuilder builder = Event.builder()
+                .id("event-" + apiProductId)
+                .type(EventType.DEPLOY_API_PRODUCT)
+                .properties(
+                    new EnumMap<>(Map.of(Event.EventProperties.API_PRODUCT_ID, apiProductId, Event.EventProperties.USER, "user-id"))
+                )
+                .createdAt(updatedAt.atZone(ZoneId.systemDefault()))
+                .updatedAt(updatedAt.atZone(ZoneId.systemDefault()));
+            if (deployedPayload != null) {
+                builder.payload(objectMapper.writeValueAsString(deployedPayload));
+            }
+            return builder.build();
+        }
+
+        private Plan aPublishedApiProductPlan(String apiProductId, Instant needRedeployAt) {
+            return Plan.builder()
+                .id("plan-" + apiProductId)
+                .referenceId(apiProductId)
+                .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                .definitionVersion(DefinitionVersion.V4)
+                .apiType(ApiType.PROXY)
+                .planDefinitionHttpV4(
+                    fixtures.definition.PlanFixtures.HttpV4Definition.anApiKeyV4().toBuilder().status(PlanStatus.PUBLISHED).build()
+                )
+                .needRedeployAt(Date.from(needRedeployAt))
+                .build();
+        }
+
+        private Plan aStagingApiProductPlan(String apiProductId, Instant needRedeployAt) {
+            return Plan.builder()
+                .id("plan-staging-" + apiProductId)
+                .referenceId(apiProductId)
+                .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                .definitionVersion(DefinitionVersion.V4)
+                .apiType(ApiType.PROXY)
+                .planDefinitionHttpV4(
+                    fixtures.definition.PlanFixtures.HttpV4Definition.anApiKeyV4().toBuilder().status(PlanStatus.STAGING).build()
+                )
+                .needRedeployAt(Date.from(needRedeployAt))
+                .build();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/plan/PlanOperationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/plan/PlanOperationsDomainServiceTest.java
@@ -205,7 +205,7 @@ class PlanOperationsDomainServiceTest {
 
         assertThat(result.getId()).isEqualTo(PLAN_ID);
         assertThat(result.getOrder()).isEqualTo(1);
-        verify(auditService).createApiAuditLog(eq(executionContext), any(AuditService.AuditLogData.class), eq(API_PRODUCT_ID));
+        verify(auditService).createApiProductAuditLog(eq(executionContext), any(AuditService.AuditLogData.class), eq(API_PRODUCT_ID));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12796

Title: feat(api-product): permission endpoint and deploy banner backend (APIM-12796)

Description:

- Permissions: New endpoint GET .../api-products/{id}/members/permissions so the console can show/hide actions (e.g. Edit, Deploy) based on the current user’s API Product permissions (admins get all; others get membership-based permissions).
- Deploy verification: New endpoint GET .../api-products/{id}/deployments/_verify that checks whether deployment is allowed (e.g. universe license). Used by the console to show a deploy banner or disable deploy with a clear reason.
- Deployment state: API Products now expose deploymentState (DEPLOYED | NEED_REDEPLOY) in list/detail. State is derived from last deploy event and product/plan changes so the console can show “Deployed” vs “Redeploy needed.”
- Event latest: New EventLatestQueryService (and impl + in-memory for tests) to fetch the latest deploy event per API Product for deployment-state computation.
- Plan updates: When an API Product plan is updated in a way that affects sync, needRedeployAt is set so deployment state becomes NEED_REDEPLOY; cosmetic updates do not set it.
- Audit: Plan publish for API Product plans is now audited via createApiProductAuditLog so it appears in API Product audit history.

