### PR TITLE
fix: revert reporter elasticsearch 7.4.3 update and safely bump to 6.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>7.4.3</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>6.0.9</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.5.6</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.6.5</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.5.6</gravitee-reporter-cloud.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12887

## Description

The previous bump to 7.4.3 introduced e2e failures and bumping reporter api might have broken other reporters. Updating to stable one.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

