### PR TITLE
feat: store subscription form metadata

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -219,12 +219,15 @@ export class SubscribeToApiComponent implements OnInit {
     }
 
     const apiKeyMode = this.applicationApiKeyMode();
+    const hasSubscriptionForm = !!this.subscriptionForm()?.gmdContent && this.currentPlan()?.security !== 'KEY_LESS';
+    const metadata = this.filterEmptyMetadata(this.formValues());
 
     const createSubscription: CreateSubscription = {
       application,
       plan,
       ...this.toConsumerConfiguration(),
       ...(apiKeyMode ? { api_key_mode: apiKeyMode } : {}),
+      ...(hasSubscriptionForm && Object.keys(metadata).length > 0 ? { metadata } : {}),
     };
 
     this.handleTermsAndConditions$(createSubscription)
@@ -248,6 +251,10 @@ export class SubscribeToApiComponent implements OnInit {
           this.subscriptionInProgress.set(false);
         },
       });
+  }
+
+  private filterEmptyMetadata(metadata: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(Object.entries(metadata).filter(([_, value]) => value != null && value.trim() !== ''));
   }
 
   private toConsumerConfiguration(): SubscriptionConsumerConfiguration | Record<string, never> {

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -70,6 +70,7 @@ export interface CreateSubscription {
   plan: string;
   request?: string;
   configuration?: SubscriptionConsumerConfiguration;
+  metadata?: Record<string, string>;
 }
 
 export interface UpdateSubscription extends Omit<Subscription, 'consumerConfiguration'> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.InlinePictureEntity;
@@ -32,6 +34,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
@@ -122,6 +125,16 @@ public abstract class AbstractResource<T, K> {
 
     protected UserDetails getAuthenticatedUserDetails() {
         return (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+
+    protected AuditInfo getAuditInfo() {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var user = getAuthenticatedUserDetails();
+        return AuditInfo.builder()
+            .organizationId(executionContext.getOrganizationId())
+            .environmentId(executionContext.getEnvironmentId())
+            .actor(AuditActor.builder().userId(user.getUsername()).userSource(user.getSource()).userSourceId(user.getSourceId()).build())
+            .build();
     }
 
     protected boolean isAuthenticated() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationKeysResource.java
@@ -16,8 +16,6 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import io.gravitee.apim.core.api_key.use_case.RevokeApplicationApiKeyUseCase;
-import io.gravitee.apim.core.audit.model.AuditActor;
-import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -80,26 +78,7 @@ public class ApplicationKeysResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_SUBSCRIPTION, acls = RolePermissionAction.UPDATE) })
     public Response revokeKeySubscription(@PathParam("apiKey") String apiKey) {
-        final var executionContext = GraviteeContext.getExecutionContext();
-        final var user = getAuthenticatedUserDetails();
-
-        revokeApplicationApiKeyUsecase.execute(
-            new RevokeApplicationApiKeyUseCase.Input(
-                apiKey,
-                applicationId,
-                AuditInfo.builder()
-                    .organizationId(executionContext.getOrganizationId())
-                    .environmentId(executionContext.getEnvironmentId())
-                    .actor(
-                        AuditActor.builder()
-                            .userId(user.getUsername())
-                            .userSource(user.getSource())
-                            .userSourceId(user.getSourceId())
-                            .build()
-                    )
-                    .build()
-            )
-        );
+        revokeApplicationApiKeyUsecase.execute(new RevokeApplicationApiKeyUseCase.Input(apiKey, applicationId, getAuditInfo()));
 
         return Response.noContent().build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResource.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
-import io.gravitee.apim.core.api_key.use_case.RevokeApplicationApiKeyUseCase;
 import io.gravitee.apim.core.api_key.use_case.RevokeSubscriptionApiKeyUseCase;
-import io.gravitee.apim.core.audit.model.AuditActor;
-import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -98,29 +95,12 @@ public class SubscriptionKeysResource extends AbstractResource {
             ) ||
             hasPermission(executionContext, RolePermission.API_SUBSCRIPTION, subscriptionEntity.getApi(), RolePermissionAction.UPDATE)
         ) {
-            final var user = getAuthenticatedUserDetails();
             final String referenceId = subscriptionEntity.getReferenceId() != null
                 ? subscriptionEntity.getReferenceId()
                 : subscriptionEntity.getApi();
             final String referenceType = subscriptionEntity.getReferenceType() != null ? subscriptionEntity.getReferenceType() : "API";
             revokeSubscriptionApiKeyUsecase.execute(
-                new RevokeSubscriptionApiKeyUseCase.Input(
-                    subscriptionId,
-                    apiKey,
-                    referenceId,
-                    referenceType,
-                    AuditInfo.builder()
-                        .organizationId(executionContext.getOrganizationId())
-                        .environmentId(executionContext.getEnvironmentId())
-                        .actor(
-                            AuditActor.builder()
-                                .userId(user.getUsername())
-                                .userSource(user.getSource())
-                                .userSourceId(user.getSourceId())
-                                .build()
-                        )
-                        .build()
-                )
+                new RevokeSubscriptionApiKeyUseCase.Input(subscriptionId, apiKey, referenceId, referenceType, getAuditInfo())
             );
 
             return Response.noContent().build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
@@ -155,8 +155,11 @@ public class SubscriptionResource extends AbstractResource {
 
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(subscriptionId);
-        updateSubscriptionConfigurationEntity.setMetadata(updateSubscriptionInput.getMetadata());
         SubscriptionConfigurationInput subscriptionConfigurationInput = updateSubscriptionInput.getConfiguration();
+
+        if (updateSubscriptionInput.getMetadata() != null) {
+            updateSubscriptionConfigurationEntity.setMetadata(updateSubscriptionInput.getMetadata());
+        }
         if (subscriptionConfigurationInput != null) {
             SubscriptionConfigurationEntity subscriptionConfigurationEntity = new SubscriptionConfigurationEntity();
             subscriptionConfigurationEntity.setChannel(subscriptionConfigurationInput.getChannel());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
@@ -18,8 +18,6 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_SUBSCRIPTION;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 
-import io.gravitee.apim.core.audit.model.AuditActor;
-import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -115,24 +113,7 @@ public class SubscriptionResource extends AbstractResource {
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), RolePermissionAction.DELETE)) {
-            final var user = getAuthenticatedUserDetails();
-
-            closeSubscriptionUsecase.execute(
-                new CloseSubscriptionUseCase.Input(
-                    subscriptionId,
-                    AuditInfo.builder()
-                        .organizationId(executionContext.getOrganizationId())
-                        .environmentId(executionContext.getEnvironmentId())
-                        .actor(
-                            AuditActor.builder()
-                                .userId(user.getUsername())
-                                .userSource(user.getSource())
-                                .userSourceId(user.getSourceId())
-                                .build()
-                        )
-                        .build()
-                )
-            );
+            closeSubscriptionUsecase.execute(new CloseSubscriptionUseCase.Input(subscriptionId, getAuditInfo()));
             return Response.noContent().build();
         }
         throw new ForbiddenAccessException();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -18,13 +18,14 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.rest.api.model.ApiKeyMode;
-import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.PageEntity.PageRevisionId;
-import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
@@ -51,6 +52,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -69,6 +71,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -78,6 +81,12 @@ public class SubscriptionsResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
+
+    @Inject
+    private CreateSubscriptionUseCase createSubscriptionUseCase;
+
+    @Inject
+    private PlanSearchService planSearchService;
 
     @Inject
     private SubscriptionService subscriptionService;
@@ -104,46 +113,36 @@ public class SubscriptionsResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         String applicationId = subscriptionInput.getApplication();
         if (hasPermission(executionContext, RolePermission.APPLICATION_SUBSCRIPTION, applicationId, RolePermissionAction.CREATE)) {
-            NewSubscriptionEntity newSubscriptionEntity = new NewSubscriptionEntity();
-            newSubscriptionEntity.setApplication(applicationId);
-            newSubscriptionEntity.setPlan(subscriptionInput.getPlan());
-            newSubscriptionEntity.setRequest(subscriptionInput.getRequest());
-            newSubscriptionEntity.setGeneralConditionsAccepted(subscriptionInput.getGeneralConditionsAccepted());
-            if (subscriptionInput.getGeneralConditionsContentRevision() != null) {
-                final PageRevisionId generalConditionsContentRevision = new PageRevisionId(
-                    subscriptionInput.getGeneralConditionsContentRevision().getPageId(),
-                    subscriptionInput.getGeneralConditionsContentRevision().getRevision()
-                );
-                newSubscriptionEntity.setGeneralConditionsContentRevision(generalConditionsContentRevision);
-            }
-            if (subscriptionInput.getMetadata() != null) {
-                newSubscriptionEntity.setMetadata(subscriptionInput.getMetadata());
-            }
-            SubscriptionConfigurationInput inputConfiguration = subscriptionInput.getConfiguration();
-            if (inputConfiguration != null) {
-                SubscriptionConfigurationEntity subscriptionConfigurationEntity = new SubscriptionConfigurationEntity();
-                subscriptionConfigurationEntity.setEntrypointId(inputConfiguration.getEntrypointId());
-                subscriptionConfigurationEntity.setChannel(inputConfiguration.getChannel());
-                if (inputConfiguration.getEntrypointConfiguration() != null) {
-                    subscriptionConfigurationEntity.setEntrypointConfiguration(
-                        graviteeMapper.valueToTree(inputConfiguration.getEntrypointConfiguration())
-                    );
-                }
-                newSubscriptionEntity.setConfiguration(subscriptionConfigurationEntity);
-            }
-            if (subscriptionInput.getApiKeyMode() != null) {
-                newSubscriptionEntity.setApiKeyMode(ApiKeyMode.valueOf(subscriptionInput.getApiKeyMode().name()));
-            }
-            SubscriptionEntity createdSubscription = subscriptionService.create(executionContext, newSubscriptionEntity);
+            GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionInput.getPlan());
 
-            // For consumer convenience, fetch the keys just after the subscription has been
-            // created.
+            var auditInfo = getAuditInfo();
+
+            CreateSubscriptionUseCase.Output output = createSubscriptionUseCase.execute(
+                CreateSubscriptionUseCase.Input.builder()
+                    .referenceId(plan.getReferenceId())
+                    .referenceType(SubscriptionReferenceType.valueOf(plan.getReferenceType().name()))
+                    .planId(subscriptionInput.getPlan())
+                    .applicationId(applicationId)
+                    .requestMessage(subscriptionInput.getRequest())
+                    .metadata(subscriptionInput.getMetadata())
+                    .configuration(getSubscriptionConfiguration(subscriptionInput))
+                    .apiKeyMode(getApiKeyMode(subscriptionInput))
+                    .generalConditionsAccepted(subscriptionInput.getGeneralConditionsAccepted())
+                    .generalConditionsContentRevision(getPageRevisionId(subscriptionInput))
+                    .auditInfo(auditInfo)
+                    .build()
+            );
+
+            // Fetch legacy subscription entity for response mapping
+            SubscriptionEntity createdSubscription = subscriptionService.findById(output.subscription().getId());
+
+            // For consumer convenience, fetch the keys just after the subscription has been created.
             List<Key> keys = apiKeyService
                 .findBySubscription(executionContext, createdSubscription.getId())
                 .stream()
                 .sorted((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt()))
                 .map(keyMapper::convert)
-                .collect(Collectors.toList());
+                .toList();
 
             final Subscription subscription = SubscriptionMapper.INSTANCE.map(createdSubscription);
             subscription.setKeys(keys);
@@ -151,6 +150,39 @@ public class SubscriptionsResource extends AbstractResource {
             return Response.ok(subscription).build();
         }
         throw new ForbiddenAccessException();
+    }
+
+    private SubscriptionConfiguration getSubscriptionConfiguration(SubscriptionInput subscriptionInput) {
+        SubscriptionConfiguration configuration = null;
+        SubscriptionConfigurationInput inputConfiguration = subscriptionInput.getConfiguration();
+        if (inputConfiguration != null) {
+            var entrypointConfigNode = graviteeMapper.valueToTree(inputConfiguration.getEntrypointConfiguration());
+            configuration = SubscriptionConfiguration.builder()
+                .entrypointId(inputConfiguration.getEntrypointId())
+                .channel(inputConfiguration.getChannel())
+                .entrypointConfiguration(
+                    entrypointConfigNode != null && !entrypointConfigNode.isNull() ? entrypointConfigNode.toString() : null
+                )
+                .build();
+        }
+        return configuration;
+    }
+
+    private static ApiKeyMode getApiKeyMode(SubscriptionInput subscriptionInput) {
+        return subscriptionInput.getApiKeyMode() != null ? ApiKeyMode.valueOf(subscriptionInput.getApiKeyMode().name()) : null;
+    }
+
+    private static PageRevisionId getPageRevisionId(SubscriptionInput subscriptionInput) {
+        PageRevisionId generalConditionsContentRevision = null;
+        if (subscriptionInput.getGeneralConditionsContentRevision() != null) {
+            var pageId = subscriptionInput.getGeneralConditionsContentRevision().getPageId();
+            var revision = subscriptionInput.getGeneralConditionsContentRevision().getRevision();
+            if (pageId == null || revision == null) {
+                throw new IllegalArgumentException("generalConditionsContentRevision must contain pageId and revision fields");
+            }
+            generalConditionsContentRevision = new PageRevisionId(pageId, revision);
+        }
+        return generalConditionsContentRevision;
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -116,7 +116,9 @@ public class SubscriptionsResource extends AbstractResource {
                 );
                 newSubscriptionEntity.setGeneralConditionsContentRevision(generalConditionsContentRevision);
             }
-            newSubscriptionEntity.setMetadata(subscriptionInput.getMetadata());
+            if (subscriptionInput.getMetadata() != null) {
+                newSubscriptionEntity.setMetadata(subscriptionInput.getMetadata());
+            }
             SubscriptionConfigurationInput inputConfiguration = subscriptionInput.getConfiguration();
             if (inputConfiguration != null) {
                 SubscriptionConfigurationEntity subscriptionConfigurationEntity = new SubscriptionConfigurationEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.mockito.Mockito.reset;
 
+import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApiMapper;
@@ -110,6 +111,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { ResourceContextConfiguration.class })
 public abstract class AbstractResourceTest extends JerseySpringTest {
+
+    @Autowired
+    protected CreateSubscriptionUseCase createSubscriptionUseCase;
 
     @Autowired
     protected CustomUserFieldService customUserFieldService;
@@ -334,6 +338,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     }
 
     protected void resetAllMocks() {
+        reset(createSubscriptionUseCase);
         reset(apiService);
         reset(apiSearchService);
         reset(apiAuthorizationService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -29,21 +29,23 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApiKeyMode;
-import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.PlanEntity;
-import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.portal.rest.model.ApiKeyModeEnum;
 import io.gravitee.rest.api.portal.rest.model.Key;
 import io.gravitee.rest.api.portal.rest.model.Links;
@@ -59,6 +61,7 @@ import java.util.Collections;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -85,29 +88,40 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     public void init() {
         resetAllMocks();
 
-        SubscriptionEntity subscriptionEntity1 = new SubscriptionEntity();
+        io.gravitee.rest.api.model.SubscriptionEntity subscriptionEntity1 = new io.gravitee.rest.api.model.SubscriptionEntity();
         subscriptionEntity1.setId(SUBSCRIPTION);
         subscriptionEntity1.setStatus(SubscriptionStatus.ACCEPTED);
-        SubscriptionEntity subscriptionEntity2 = new SubscriptionEntity();
+        io.gravitee.rest.api.model.SubscriptionEntity subscriptionEntity2 = new io.gravitee.rest.api.model.SubscriptionEntity();
         subscriptionEntity2.setId(ANOTHER_SUBSCRIPTION);
         subscriptionEntity2.setStatus(SubscriptionStatus.ACCEPTED);
-        final Page<SubscriptionEntity> subscriptionPage = new Page<>(asList(subscriptionEntity1, subscriptionEntity2), 0, 1, 2);
+        final Page<io.gravitee.rest.api.model.SubscriptionEntity> subscriptionPage = new Page<>(
+            asList(subscriptionEntity1, subscriptionEntity2),
+            0,
+            1,
+            2
+        );
         doReturn(subscriptionPage.getContent()).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(subscriptionPage).when(subscriptionService).search(any(), any(), any());
 
-        SubscriptionEntity createdSubscription = new SubscriptionEntity();
-        createdSubscription.setId(SUBSCRIPTION);
-        createdSubscription.setStatus(SubscriptionStatus.ACCEPTED);
-        doReturn(createdSubscription).when(subscriptionService).create(eq(GraviteeContext.getExecutionContext()), any());
+        // Core subscription entity returned by UseCase
+        SubscriptionEntity coreSubscriptionEntity = SubscriptionEntity.builder().id(SUBSCRIPTION).build();
+        doReturn(new CreateSubscriptionUseCase.Output(coreSubscriptionEntity))
+            .when(createSubscriptionUseCase)
+            .execute(any(CreateSubscriptionUseCase.Input.class));
 
-        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
-        subscriptionEntity.setApi(API);
+        io.gravitee.rest.api.model.SubscriptionEntity subscriptionEntity = new io.gravitee.rest.api.model.SubscriptionEntity();
+        subscriptionEntity.setId(SUBSCRIPTION);
+        subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
+        subscriptionEntity.setReferenceId(API);
+        subscriptionEntity.setReferenceType("API");
         subscriptionEntity.setApplication(APPLICATION);
         doReturn(subscriptionEntity).when(subscriptionService).findById(eq(SUBSCRIPTION));
         doReturn(true).when(permissionService).hasPermission(any(), any(), any(), any());
 
         PlanEntity planEntity = new PlanEntity();
         planEntity.setApi(API);
+        planEntity.setReferenceId(API);
+        planEntity.setReferenceType(GenericPlanEntity.ReferenceType.API);
         doReturn(planEntity).when(planSearchService).findById(GraviteeContext.getExecutionContext(), PLAN);
     }
 
@@ -140,7 +154,7 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoPublishedApiAndNoLink() {
-        final Page<SubscriptionEntity> subscriptionPage = new Page<>(emptyList(), 0, 1, 2);
+        final Page<io.gravitee.rest.api.model.SubscriptionEntity> subscriptionPage = new Page<>(emptyList(), 0, 1, 2);
         doReturn(subscriptionPage).when(subscriptionService).search(any(), any(), any());
 
         //Test with default limit
@@ -186,15 +200,16 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         final Response response = target().request().post(Entity.json(subscriptionInput));
         assertEquals(OK_200, response.getStatus());
 
-        ArgumentCaptor<NewSubscriptionEntity> argument = ArgumentCaptor.forClass(NewSubscriptionEntity.class);
-        Mockito.verify(subscriptionService).create(eq(GraviteeContext.getExecutionContext()), argument.capture());
-        NewSubscriptionEntity newSubscriptionEntity = argument.getValue();
-        assertEquals(APPLICATION, newSubscriptionEntity.getApplication());
-        assertEquals(PLAN, newSubscriptionEntity.getPlan());
-        assertEquals("request", newSubscriptionEntity.getRequest());
-        assertEquals(Map.of("my-metadata", "my-value"), newSubscriptionEntity.getMetadata());
-        assertEquals("{\"url\":\"my-url\"}", newSubscriptionEntity.getConfiguration().getEntrypointConfiguration());
-        assertEquals(ApiKeyMode.EXCLUSIVE, argument.getValue().getApiKeyMode());
+        ArgumentCaptor<CreateSubscriptionUseCase.Input> argument = ArgumentCaptor.forClass(CreateSubscriptionUseCase.Input.class);
+        verify(createSubscriptionUseCase).execute(argument.capture());
+        CreateSubscriptionUseCase.Input useCaseInput = argument.getValue();
+        assertEquals(APPLICATION, useCaseInput.applicationId());
+        assertEquals(PLAN, useCaseInput.planId());
+        assertEquals("request", useCaseInput.requestMessage());
+        assertEquals(Map.of("my-metadata", "my-value"), useCaseInput.metadata());
+        assertEquals("{\"url\":\"my-url\"}", useCaseInput.configuration().getEntrypointConfiguration());
+        assertEquals(ApiKeyMode.EXCLUSIVE, useCaseInput.apiKeyMode());
+        assertEquals(API, useCaseInput.referenceId());
 
         final Subscription subscriptionResponse = response.readEntity(Subscription.class);
         assertNotNull(subscriptionResponse);
@@ -205,13 +220,10 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldReturnBadRequestWhenMetadataKeyIsInvalid() {
+    void shouldReturnBadRequestWhenMetadataKeyIsInvalid() {
         doThrow(new SubscriptionMetadataInvalidException("Invalid metadata key."))
-            .when(subscriptionService)
-            .create(
-                eq(GraviteeContext.getExecutionContext()),
-                argThat(e -> e.getMetadata() != null && e.getMetadata().containsKey("bad key"))
-            );
+            .when(createSubscriptionUseCase)
+            .execute(argThat(input -> input.metadata() != null && input.metadata().containsKey("bad key")));
 
         SubscriptionInput subscriptionInput = new SubscriptionInput()
             .application(APPLICATION)
@@ -219,8 +231,8 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
             .metadata(Map.of("bad key", "value"));
 
         final Response response = target().request().post(Entity.json(subscriptionInput));
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
-        Mockito.verify(subscriptionService, times(1)).create(eq(GraviteeContext.getExecutionContext()), any());
+        Assertions.assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        verify(createSubscriptionUseCase, times(1)).execute(any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CreateSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CreateSubscriptionDomainService.java
@@ -35,6 +35,7 @@ public interface CreateSubscriptionDomainService {
      * @param customApiKey Optional custom API key
      * @param configuration Optional subscription configuration
      * @param metadata Optional metadata
+     * @param apiKeyMode Optional API key mode (SHARED or EXCLUSIVE)
      * @param generalConditionsAccepted Whether general conditions were accepted
      * @param generalConditionsContentRevision General conditions content revision
      * @return The created subscription entity (REST model, will be converted to core by caller)
@@ -47,6 +48,7 @@ public interface CreateSubscriptionDomainService {
         String customApiKey,
         io.gravitee.apim.core.subscription.model.SubscriptionConfiguration configuration,
         java.util.Map<String, String> metadata,
+        io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
         io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision
     );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CreateSubscriptionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CreateSubscriptionUseCase.java
@@ -69,6 +69,7 @@ public class CreateSubscriptionUseCase {
             input.customApiKey,
             input.configuration,
             input.metadata,
+            input.apiKeyMode,
             input.generalConditionsAccepted,
             input.generalConditionsContentRevision
         );
@@ -111,6 +112,7 @@ public class CreateSubscriptionUseCase {
         String customApiKey,
         io.gravitee.apim.core.subscription.model.SubscriptionConfiguration configuration,
         java.util.Map<String, String> metadata,
+        io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
         io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision,
         AuditInfo auditInfo

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImpl.java
@@ -44,6 +44,7 @@ public class CreateSubscriptionDomainServiceImpl implements CreateSubscriptionDo
         String customApiKey,
         io.gravitee.apim.core.subscription.model.SubscriptionConfiguration configuration,
         java.util.Map<String, String> metadata,
+        io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
         io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision
     ) {
@@ -63,6 +64,9 @@ public class CreateSubscriptionDomainServiceImpl implements CreateSubscriptionDo
         }
         if (metadata != null) {
             newSubscriptionEntity.setMetadata(metadata);
+        }
+        if (apiKeyMode != null) {
+            newSubscriptionEntity.setApiKeyMode(apiKeyMode);
         }
         if (generalConditionsAccepted != null) {
             newSubscriptionEntity.setGeneralConditionsAccepted(generalConditionsAccepted);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -912,12 +912,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             );
             subscription.setFailureCause(null);
             setSubscriptionConfig(subscriptionConfigEntity.getConfiguration(), subscription);
-            if (subscriptionConfigEntity.getMetadata() != null) {
-                subscription.setMetadata(subscriptionConfigEntity.getMetadata());
-            }
+            subscription.setMetadata(subscriptionConfigEntity.getMetadata());
 
             subscription = subscriptionRepository.update(subscription);
-
             String referenceId = planEntity.getReferenceId();
             createAudit(
                 executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -912,7 +912,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             );
             subscription.setFailureCause(null);
             setSubscriptionConfig(subscriptionConfigEntity.getConfiguration(), subscription);
-            subscription.setMetadata(subscriptionConfigEntity.getMetadata());
+            if (subscriptionConfigEntity.getMetadata() != null) {
+                subscription.setMetadata(subscriptionConfigEntity.getMetadata());
+            }
 
             subscription = subscriptionRepository.update(subscription);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/SubscriptionMetadataInvalidException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/SubscriptionMetadataInvalidException.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+public class SubscriptionMetadataInvalidException extends AbstractManagementException {
+
+    @Getter
+    public enum Reason {
+        INVALID("subscription.metadata.invalid"),
+        KEY_INVALID("subscription.metadata.key.invalid"),
+        VALUE_TOO_LONG("subscription.metadata.value.too_long"),
+        TOO_MANY("subscription.metadata.too_many");
+
+        private final String technicalCode;
+
+        Reason(String technicalCode) {
+            this.technicalCode = technicalCode;
+        }
+    }
+
+    private final Reason reason;
+    private final String message;
+
+    public SubscriptionMetadataInvalidException(String message) {
+        this(Reason.INVALID, message);
+    }
+
+    public SubscriptionMetadataInvalidException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+        this.message = message;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return reason.getTechnicalCode();
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.rest.api.service.v4.impl.validation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionEntrypointIdMissingException;
+import io.gravitee.rest.api.service.v4.validation.SubscriptionMetadataSanitizer;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -41,15 +40,22 @@ import org.springframework.stereotype.Component;
 public class SubscriptionValidationServiceImpl extends TransactionalService implements SubscriptionValidationService {
 
     private final EntrypointConnectorPluginService entrypointService;
+    private final SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
     @Override
     public void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final NewSubscriptionEntity subscription) {
         subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
+        if (subscription.getMetadata() != null) {
+            subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
+        }
     }
 
     @Override
     public void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription) {
         subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
+        if (subscription.getMetadata() != null) {
+            subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
+        }
     }
 
     @Override
@@ -60,6 +66,11 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
         subscriptionConfiguration.setConfiguration(
             validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscriptionConfiguration.getConfiguration())
         );
+        if (subscriptionConfiguration.getMetadata() != null) {
+            subscriptionConfiguration.setMetadata(
+                subscriptionMetadataSanitizer.sanitizeAndValidate(subscriptionConfiguration.getMetadata())
+            );
+        }
     }
 
     private SubscriptionConfigurationEntity validateAndSanitizeSubscriptionConfiguration(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import io.gravitee.rest.api.service.sanitizer.HtmlSanitizer;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates and sanitizes subscription form metadata (keys, value length, HTML).
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+public class SubscriptionMetadataSanitizer {
+
+    private static final Pattern KEY_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{1,100}$");
+    private static final int MAX_VALUE_LENGTH = 1024;
+    private static final int MAX_METADATA_COUNT = 25;
+
+    private final HtmlSanitizer htmlSanitizer;
+
+    public SubscriptionMetadataSanitizer(HtmlSanitizer htmlSanitizer) {
+        this.htmlSanitizer = htmlSanitizer;
+    }
+
+    /**
+     * Validates metadata keys and value lengths, then sanitizes each value with HTML sanitizer.
+     *
+     * @param metadata raw metadata from the client
+     * @return sanitized metadata, or empty map if input is null
+     * @throws SubscriptionMetadataInvalidException if a key is invalid or a value exceeds max length
+     */
+    public Map<String, String> sanitizeAndValidate(Map<String, String> metadata) {
+        if (metadata == null) {
+            return Collections.emptyMap();
+        }
+
+        if (metadata.size() > MAX_METADATA_COUNT) {
+            throw new SubscriptionMetadataInvalidException(
+                SubscriptionMetadataInvalidException.Reason.TOO_MANY,
+                "Too many metadata entries. Maximum is " + MAX_METADATA_COUNT + "."
+            );
+        }
+
+        Map<String, String> sanitizedMetadata = new HashMap<>();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || !KEY_PATTERN.matcher(key).matches()) {
+                throw new SubscriptionMetadataInvalidException(
+                    SubscriptionMetadataInvalidException.Reason.KEY_INVALID,
+                    "Invalid metadata key: " + key
+                );
+            }
+
+            String value = entry.getValue();
+            if (value != null && value.length() > MAX_VALUE_LENGTH) {
+                throw new SubscriptionMetadataInvalidException(
+                    SubscriptionMetadataInvalidException.Reason.VALUE_TOO_LONG,
+                    "Metadata value for key '" + key + "' is too long (max " + MAX_VALUE_LENGTH + " characters)."
+                );
+            }
+
+            String sanitizedValue = htmlSanitizer.sanitize(value);
+            if (sanitizedValue == null || sanitizedValue.isBlank()) {
+                continue;
+            }
+            sanitizedMetadata.put(key, sanitizedValue);
+        }
+
+        return sanitizedMetadata;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
+import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.SubscriptionService;
@@ -68,6 +69,7 @@ class CreateSubscriptionDomainServiceImplTest {
             null,
             null,
             Map.of("k", "v"),
+            ApiKeyMode.EXCLUSIVE,
             null,
             null
         );
@@ -82,6 +84,7 @@ class CreateSubscriptionDomainServiceImplTest {
         assertThat(entityCaptor.getValue().getApplication()).isEqualTo(APP_ID);
         assertThat(entityCaptor.getValue().getRequest()).isEqualTo("request-msg");
         assertThat(entityCaptor.getValue().getMetadata()).isEqualTo(Map.of("k", "v"));
+        assertThat(entityCaptor.getValue().getApiKeyMode()).isEqualTo(ApiKeyMode.EXCLUSIVE);
     }
 
     @Test
@@ -94,7 +97,7 @@ class CreateSubscriptionDomainServiceImplTest {
             .build();
         when(subscriptionService.create(any(), any(), any())).thenReturn(new SubscriptionEntity());
 
-        cut.create(auditInfo, PLAN_ID, APP_ID, null, null, config, null, null, null);
+        cut.create(auditInfo, PLAN_ID, APP_ID, null, null, config, null, null, null, null);
 
         ArgumentCaptor<NewSubscriptionEntity> entityCaptor = ArgumentCaptor.forClass(NewSubscriptionEntity.class);
         verify(subscriptionService).create(any(), entityCaptor.capture(), any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -17,9 +17,10 @@ package io.gravitee.rest.api.service.v4.impl.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
@@ -30,6 +31,7 @@ import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionEntrypointIdMissingException;
+import io.gravitee.rest.api.service.v4.validation.SubscriptionMetadataSanitizer;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -53,13 +55,17 @@ public class SubscriptionValidationServiceImplTest {
     @Mock
     private EntrypointConnectorPluginService entrypointConnectorPluginService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
     private PlanEntity planEntity;
 
     @BeforeEach
     public void setUp() {
-        cut = new SubscriptionValidationServiceImpl(entrypointConnectorPluginService);
+        cut = new SubscriptionValidationServiceImpl(entrypointConnectorPluginService, subscriptionMetadataSanitizer);
+        lenient()
+            .when(subscriptionMetadataSanitizer.sanitizeAndValidate(any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
 
         planEntity = new PlanEntity();
         PlanSecurity security = new PlanSecurity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.service.sanitizer.HtmlSanitizer;
+import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionMetadataSanitizerTest {
+
+    @Mock
+    private HtmlSanitizer htmlSanitizer;
+
+    private SubscriptionMetadataSanitizer cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new SubscriptionMetadataSanitizer(htmlSanitizer);
+    }
+
+    @Test
+    void should_return_empty_map_when_metadata_is_null() {
+        assertThat(cut.sanitizeAndValidate(null)).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_metadata_key_is_invalid() {
+        Map<String, String> invalidKeyMetadata = Map.of("bad key", "value");
+
+        var throwable = assertThrows(SubscriptionMetadataInvalidException.class, () -> cut.sanitizeAndValidate(invalidKeyMetadata));
+
+        assertThat(throwable.getTechnicalCode()).isEqualTo("subscription.metadata.key.invalid");
+        assertThat(throwable.getMessage()).isEqualTo("Invalid metadata key: bad key");
+    }
+
+    @Test
+    void should_throw_when_metadata_value_is_too_long() {
+        Map<String, String> tooLongValue = Map.of("valid_key", "a".repeat(1025));
+
+        var throwable = assertThrows(SubscriptionMetadataInvalidException.class, () -> cut.sanitizeAndValidate(tooLongValue));
+
+        assertThat(throwable.getTechnicalCode()).isEqualTo("subscription.metadata.value.too_long");
+        assertThat(throwable.getMessage()).isEqualTo("Metadata value for key 'valid_key' is too long (max 1024 characters).");
+    }
+
+    @Test
+    void should_throw_when_metadata_count_exceeds_maximum() {
+        Map<String, String> tooMany = new HashMap<>();
+        for (int i = 0; i < 26; i++) {
+            tooMany.put("key_" + i, "value");
+        }
+
+        var throwable = assertThrows(SubscriptionMetadataInvalidException.class, () -> cut.sanitizeAndValidate(tooMany));
+
+        assertThat(throwable.getTechnicalCode()).isEqualTo("subscription.metadata.too_many");
+        assertThat(throwable.getMessage()).isEqualTo("Too many metadata entries. Maximum is 25.");
+    }
+
+    @Test
+    void should_accept_metadata_at_maximum_count() {
+        when(htmlSanitizer.sanitize(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        Map<String, String> maxAllowed = new HashMap<>();
+        for (int i = 0; i < 25; i++) {
+            maxAllowed.put("key_" + i, "value");
+        }
+
+        var result = cut.sanitizeAndValidate(maxAllowed);
+
+        assertThat(result).hasSize(25);
+    }
+
+    @Test
+    void should_sanitize_values_and_omit_empty_values() {
+        when(htmlSanitizer.sanitize("<script>alert(1)</script>")).thenReturn("alert(1)");
+        when(htmlSanitizer.sanitize("   ")).thenReturn("   ");
+        when(htmlSanitizer.sanitize(isNull())).thenReturn(null);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("field_a", "<script>alert(1)</script>");
+        metadata.put("field_b", null);
+        metadata.put("field_c", "   ");
+
+        var result = cut.sanitizeAndValidate(metadata);
+
+        assertThat(result).containsEntry("field_a", "alert(1)").doesNotContainKeys("field_b", "field_c");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12636

## Description

This PR follows [PR 2 – render subscription form on checkout](https://github.com/gravitee-io/gravitee-api-management/pull/15329) and completes the subscription form flow by persisting subscription form data as metadata when creating or updating a subscription, with validation and sanitization to keep data safe and within limits.

### Included in this PR

- `SubscriptionMetadataSanitizer`: validation and sanitization of subscription metadata (e.g. invalid keys, excessively long values)
- Sanitization applied on subscription create and update (`SubscriptionResource`, `SubscriptionsResource`)
- Unit tests for sanitizer and for create/update with invalid or oversized metadata

