### PR TITLE
feat: add support for configuring defaultFilters for API alerts

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -32,3 +32,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: 'Allow configuration of ECS logging'
+    - kind: added
+      description: 'Add parameter to enable or disable Alert Engine default filters (enabled by default) through the APIM Rest API.'

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -553,6 +553,8 @@ data:
             username: {{ .Values.alerts.security.username }}
             password: {{ .Values.alerts.security.password }}
           {{- end }}
+          defaultFilters:
+            enabled: {{ .Values.alerts.api.ws.defaultFilters.enabled }}
     {{- else }}
     alerts:
       alert-engine-connector-ws:

--- a/helm/tests/api/configmap_alert_test.yaml
+++ b/helm/tests/api/configmap_alert_test.yaml
@@ -36,6 +36,38 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: "[ ]{6}- http://localhost:8072/"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "defaultFilters:"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: true"
+
+  - it: should set defaultFilters enabled to true when explicitly set
+    set:
+      alerts.enabled: true
+      alerts.security.enabled: false
+      alerts.api.ws.defaultFilters.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "defaultFilters:"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: true"
+
+  - it: should set defaultFilters enabled to false when explicitly set
+    set:
+      alerts.enabled: true
+      alerts.security.enabled: false
+      alerts.api.ws.defaultFilters.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "defaultFilters:"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "[ ]{6}enabled: false"
 
   - it: should set alert engine values enabled
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -414,6 +414,10 @@ alerts:
     enabled: false
     username: admin
     password: adminadmin
+  api:
+    ws:
+      defaultFilters:
+        enabled: true
 
 management:
   type: mongodb


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-4045

## Description

Add Helm chart support for configuring Alert Engine default filters via the `alerts.ws.defaultFilters.enabled` parameter (enabled by default).

### Changes

- Add `alerts.ws.defaultFilters.enabled` configuration in Helm chart templates
- Default value is `true` when not specified
- Update related Helm chart tests


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

