### PR TITLE
fix: migration system proxy error

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -362,6 +362,16 @@ class ApiMigration {
                     response.put("assertion", StringUtils.appendCurlyBraces(assertionsNode.get(0).asText()));
                 }
             }
+            JsonNode httpProxyNode = root.path("proxy");
+            if (httpProxyNode.isObject()) {
+                ObjectNode proxyObject = (ObjectNode) httpProxyNode;
+                boolean enabled = proxyObject.path("enabled").asBoolean(false);
+                boolean useSystemProxy = proxyObject.path("useSystemProxy").asBoolean(false);
+                if (enabled && useSystemProxy) {
+                    proxyObject.remove("port");
+                    proxyObject.remove("type");
+                }
+            }
             return MigrationResult.value(jsonMapper.writeValueAsString(root));
         } catch (JsonProcessingException e) {
             log.error("Unable to map configuration for endpoint", e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
@@ -76,7 +76,20 @@ public class SharedConfigurationMigration {
             sharedConfiguration.set("headers", objectMapper.valueToTree(source.getHeaders()));
         }
         if (source.getHttpProxy() != null) {
-            sharedConfiguration.set("proxy", objectMapper.valueToTree((source.getHttpProxy())));
+            ObjectNode proxyNode = (ObjectNode) objectMapper.valueToTree(source.getHttpProxy());
+            if (source.getHttpProxy().isEnabled() && source.getHttpProxy().isUseSystemProxy()) {
+                proxyNode.remove("host");
+                proxyNode.remove("port");
+                proxyNode.remove("type");
+                proxyNode.put("useSystemProxy", true);
+                proxyNode.remove("enabled");
+            } else {
+                String host = source.getHttpProxy().getHost();
+                if (host == null || host.isEmpty()) {
+                    proxyNode.put("host", "/");
+                }
+            }
+            sharedConfiguration.set("proxy", proxyNode);
         }
         return objectMapper.writeValueAsString(sharedConfiguration);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12621

## Description


Fixed a silent bug where proxy node mutations (system proxy stripping and null host fallback) were applied to a local `ObjectNode` but then discarded — the final serialization was re-using the original unmodified `HttpProxy` object. The mutated proxyNode is now correctly persisted to the output.


## Additional context


### Pre fix: 


https://github.com/user-attachments/assets/af460269-b831-442c-a074-9ce5c5f015f4



### Post fix: 


https://github.com/user-attachments/assets/732b83d5-289e-4c44-92c7-8637053aada9