### PR TITLE
feat: enrich broker info in kafka-explorer with rack, partitions and disk usage

### DIFF
--- a/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/details/configuration/cluster-configuration.component.scss
@@ -22,3 +22,10 @@
     margin-bottom: 8px;
   }
 }
+
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerDetail.java
@@ -15,6 +15,4 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-import java.util.List;
-
-public record KafkaClusterInfo(String clusterId, KafkaNode controller, List<BrokerDetail> nodes, int totalTopics, int totalPartitions) {}
+public record BrokerDetail(int id, String host, int port, String rack, int leaderPartitions, int replicaPartitions, Long logDirSize) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -98,8 +98,6 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new KafkaExplorerException("Connection to Kafka cluster was interrupted", TechnicalCode.INTERRUPTED, e);
-        } catch (KafkaExplorerException e) {
-            throw e;
         } catch (Exception e) {
             throw new KafkaExplorerException("Failed to connect to Kafka cluster: " + e.getMessage(), TechnicalCode.CONNECTION_FAILED, e);
         } finally {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.mapper;
 
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
@@ -28,4 +29,6 @@ public interface KafkaExplorerMapper {
     DescribeClusterResponse map(KafkaClusterInfo clusterInfo);
 
     io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaNode map(KafkaNode node);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.BrokerDetail map(BrokerDetail brokerDetail);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -70,7 +70,15 @@ components:
                 nodes:
                     type: array
                     items:
-                        $ref: "#/components/schemas/KafkaNode"
+                        $ref: "#/components/schemas/BrokerDetail"
+                totalTopics:
+                    type: integer
+                    format: int32
+                    description: Total number of topics in the cluster
+                totalPartitions:
+                    type: integer
+                    format: int32
+                    description: Total number of partitions across all topics
 
         KafkaNode:
             type: object
@@ -83,6 +91,33 @@ components:
                 port:
                     type: integer
                     format: int32
+
+        BrokerDetail:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int32
+                host:
+                    type: string
+                port:
+                    type: integer
+                    format: int32
+                rack:
+                    type: string
+                    description: Rack identifier of this broker, or null if not configured
+                leaderPartitions:
+                    type: integer
+                    format: int32
+                    description: Number of partitions for which this broker is the leader
+                replicaPartitions:
+                    type: integer
+                    format: int32
+                    description: Number of partition replicas hosted on this broker
+                logDirSize:
+                    type: integer
+                    format: int64
+                    description: Total size of all log directories on this broker in bytes, or null if unavailable
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeKafkaClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeKafkaClusterUseCaseTest.java
@@ -23,6 +23,7 @@ import inmemory.ClusterCrudServiceInMemory;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
@@ -59,7 +60,9 @@ class DescribeKafkaClusterUseCaseTest {
         var expectedInfo = new KafkaClusterInfo(
             "cluster-1",
             new KafkaNode(0, "broker-host", 9092),
-            List.of(new KafkaNode(0, "broker-host", 9092))
+            List.of(new BrokerDetail(0, "broker-host", 9092, null, 5, 10, 1024L)),
+            1,
+            5
         );
         clusterDomainService.givenClusterInfo(expectedInfo);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
@@ -117,6 +117,14 @@ class KafkaExplorerResourceIntegrationTest {
             assertThat(body.getClusterId()).isNotBlank();
             assertThat(body.getController()).isNotNull();
             assertThat(body.getNodes()).isNotEmpty();
+            assertThat(body.getTotalTopics()).isGreaterThanOrEqualTo(0);
+            assertThat(body.getTotalPartitions()).isGreaterThanOrEqualTo(0);
+
+            var firstNode = body.getNodes().get(0);
+            assertThat(firstNode.getHost()).isNotBlank();
+            assertThat(firstNode.getPort()).isGreaterThan(0);
+            assertThat(firstNode.getLeaderPartitions()).isGreaterThanOrEqualTo(0);
+            assertThat(firstNode.getReplicaPartitions()).isGreaterThanOrEqualTo(0);
         }
     }
 
@@ -147,6 +155,8 @@ class KafkaExplorerResourceIntegrationTest {
             var body = (DescribeClusterResponse) response.getEntity();
             assertThat(body.getClusterId()).isNotBlank();
             assertThat(body.getNodes()).isNotEmpty();
+            assertThat(body.getTotalTopics()).isGreaterThanOrEqualTo(0);
+            assertThat(body.getTotalPartitions()).isGreaterThanOrEqualTo(0);
         }
 
         @Test

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
@@ -23,7 +23,14 @@
     <table mat-table [dataSource]="nodes()">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef>Node ID</th>
-        <td mat-cell *matCellDef="let node">{{ node.id }}</td>
+        <td mat-cell *matCellDef="let node">
+          <span class="brokers__node-id">
+            {{ node.id }}
+            @if (node.id === controllerId()) {
+              <span class="brokers__controller-badge">Controller</span>
+            }
+          </span>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="host">
@@ -34,6 +41,26 @@
       <ng-container matColumnDef="port">
         <th mat-header-cell *matHeaderCellDef>Port</th>
         <td mat-cell *matCellDef="let node">{{ node.port }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="rack">
+        <th mat-header-cell *matHeaderCellDef>Rack</th>
+        <td mat-cell *matCellDef="let node">{{ node.rack || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="leaderPartitions">
+        <th mat-header-cell *matHeaderCellDef>Leader Partitions</th>
+        <td mat-cell *matCellDef="let node">{{ node.leaderPartitions }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="replicaPartitions">
+        <th mat-header-cell *matHeaderCellDef>Replica Partitions</th>
+        <td mat-cell *matCellDef="let node">{{ node.replicaPartitions }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="logDirSize">
+        <th mat-header-cell *matHeaderCellDef>Disk Usage</th>
+        <td mat-cell *matCellDef="let node">{{ formatBytes(node.logDirSize) }}</td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
@@ -18,4 +18,19 @@
   table {
     width: 100%;
   }
+
+  &__node-id {
+    white-space: nowrap;
+  }
+
+  &__controller-badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-primary-container, #e8def8);
+    color: var(--mat-sys-on-primary-container, #1d192b);
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
@@ -17,7 +17,7 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { Meta, StoryObj, applicationConfig } from '@storybook/angular';
 
 import { BrokersComponent } from './brokers.component';
-import { fakeKafkaNode } from '../models/kafka-cluster.fixture';
+import { fakeBrokerDetail } from '../models/kafka-cluster.fixture';
 
 const meta: Meta<BrokersComponent> = {
   title: 'Brokers',
@@ -35,15 +35,56 @@ type Story = StoryObj<BrokersComponent>;
 export const Default: Story = {
   args: {
     nodes: [
-      fakeKafkaNode({ id: 0, host: 'kafka-broker-0.example.com' }),
-      fakeKafkaNode({ id: 1, host: 'kafka-broker-1.example.com' }),
-      fakeKafkaNode({ id: 2, host: 'kafka-broker-2.example.com' }),
+      fakeBrokerDetail({
+        id: 0,
+        host: 'kafka-broker-0.example.com',
+        rack: 'us-east-1a',
+        leaderPartitions: 50,
+        replicaPartitions: 100,
+        logDirSize: 5368709120,
+      }),
+      fakeBrokerDetail({
+        id: 1,
+        host: 'kafka-broker-1.example.com',
+        rack: 'us-east-1b',
+        leaderPartitions: 48,
+        replicaPartitions: 100,
+        logDirSize: 4294967296,
+      }),
+      fakeBrokerDetail({
+        id: 2,
+        host: 'kafka-broker-2.example.com',
+        rack: 'us-east-1c',
+        leaderPartitions: 52,
+        replicaPartitions: 100,
+        logDirSize: 5905580032,
+      }),
     ],
+    controllerId: 0,
   },
 };
 
 export const SingleNode: Story = {
   args: {
-    nodes: [fakeKafkaNode({ id: 0, host: 'kafka-broker-0.example.com' })],
+    nodes: [
+      fakeBrokerDetail({
+        id: 0,
+        host: 'kafka-broker-0.example.com',
+        leaderPartitions: 150,
+        replicaPartitions: 150,
+        logDirSize: 10737418240,
+      }),
+    ],
+    controllerId: 0,
+  },
+};
+
+export const NoRack: Story = {
+  args: {
+    nodes: [
+      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com', rack: null, logDirSize: null }),
+      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com', rack: null, logDirSize: null }),
+    ],
+    controllerId: 1,
   },
 };

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
@@ -18,7 +18,7 @@ import { Component, input } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 
-import { KafkaNode } from '../models/kafka-cluster.model';
+import { BrokerDetail } from '../models/kafka-cluster.model';
 
 @Component({
   selector: 'gke-brokers',
@@ -28,7 +28,17 @@ import { KafkaNode } from '../models/kafka-cluster.model';
   styleUrls: ['./brokers.component.scss'],
 })
 export class BrokersComponent {
-  nodes = input<KafkaNode[]>([]);
+  nodes = input<BrokerDetail[]>([]);
+  controllerId = input<number>(-1);
 
-  displayedColumns = ['id', 'host', 'port'];
+  displayedColumns = ['id', 'host', 'port', 'rack', 'leaderPartitions', 'replicaPartitions', 'logDirSize'];
+
+  formatBytes(bytes: number | null): string {
+    if (bytes === null || bytes === undefined) return '-';
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
@@ -41,10 +41,22 @@
             <span class="mat-caption">Controller</span>
             <span class="mat-body-2">{{ info.controller.host }}:{{ info.controller.port }} (node {{ info.controller.id }})</span>
           </div>
+          <div class="kafka-explorer__topbar-item">
+            <span class="mat-caption">Brokers</span>
+            <span class="mat-body-2">{{ info.nodes.length }}</span>
+          </div>
+          <div class="kafka-explorer__topbar-item">
+            <span class="mat-caption">Topics</span>
+            <span class="mat-body-2">{{ info.totalTopics }}</span>
+          </div>
+          <div class="kafka-explorer__topbar-item">
+            <span class="mat-caption">Partitions</span>
+            <span class="mat-body-2">{{ info.totalPartitions }}</span>
+          </div>
         </div>
       </mat-card-content>
     </mat-card>
 
-    <gke-brokers [nodes]="info.nodes" />
+    <gke-brokers [nodes]="info.nodes" [controllerId]="info.controller.id" />
   </div>
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
@@ -71,6 +71,8 @@ describe('KafkaExplorerComponent', () => {
     const topbarText = await harness.getTopbarText();
     expect(topbarText).toContain('test-cluster-id');
     expect(topbarText).toContain('kafka-broker-0.example.com');
+    expect(topbarText).toContain('5');
+    expect(topbarText).toContain('15');
   });
 
   it('should render broker nodes table via BrokersHarness', async () => {
@@ -82,7 +84,9 @@ describe('KafkaExplorerComponent', () => {
 
     const rows = await brokersHarness!.getRowsData();
     expect(rows.length).toBe(3);
-    expect(rows[0]).toEqual({ id: '0', host: 'kafka-broker-0.example.com', port: '9092' });
+    expect(rows[0]['host']).toBe('kafka-broker-0.example.com');
+    expect(rows[0]['port']).toBe('9092');
+    expect(rows[0]['id']).toContain('0');
   });
 
   it('should show error on failure', async () => {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.stories.ts
@@ -27,7 +27,7 @@ import { Meta, StoryObj, applicationConfig } from '@storybook/angular';
 import { EMPTY, Observable, delay, of, throwError } from 'rxjs';
 
 import { KafkaExplorerComponent } from './kafka-explorer.component';
-import { fakeDescribeClusterResponse, fakeKafkaNode } from '../models/kafka-cluster.fixture';
+import { fakeBrokerDetail, fakeDescribeClusterResponse, fakeKafkaNode } from '../models/kafka-cluster.fixture';
 import { DescribeClusterResponse } from '../models/kafka-cluster.model';
 
 function mockSuccessInterceptor(response: DescribeClusterResponse): HttpInterceptorFn {
@@ -58,7 +58,45 @@ export const Default: Story = {
   args: { baseURL: '/api/v2', clusterId: 'my-cluster' },
   decorators: [
     applicationConfig({
-      providers: [provideAnimationsAsync(), provideHttpClient(withInterceptors([mockSuccessInterceptor(fakeDescribeClusterResponse())]))],
+      providers: [
+        provideAnimationsAsync(),
+        provideHttpClient(
+          withInterceptors([
+            mockSuccessInterceptor(
+              fakeDescribeClusterResponse({
+                nodes: [
+                  fakeBrokerDetail({
+                    id: 0,
+                    host: 'kafka-broker-0.example.com',
+                    rack: 'us-east-1a',
+                    leaderPartitions: 50,
+                    replicaPartitions: 100,
+                    logDirSize: 5368709120,
+                  }),
+                  fakeBrokerDetail({
+                    id: 1,
+                    host: 'kafka-broker-1.example.com',
+                    rack: 'us-east-1b',
+                    leaderPartitions: 48,
+                    replicaPartitions: 100,
+                    logDirSize: 4294967296,
+                  }),
+                  fakeBrokerDetail({
+                    id: 2,
+                    host: 'kafka-broker-2.example.com',
+                    rack: 'us-east-1c',
+                    leaderPartitions: 52,
+                    replicaPartitions: 100,
+                    logDirSize: 5905580032,
+                  }),
+                ],
+                totalTopics: 42,
+                totalPartitions: 150,
+              }),
+            ),
+          ]),
+        ),
+      ],
     }),
   ],
 };
@@ -73,8 +111,10 @@ export const SingleNode: Story = {
           withInterceptors([
             mockSuccessInterceptor(
               fakeDescribeClusterResponse({
-                nodes: [fakeKafkaNode({ id: 0, host: 'kafka-broker-0.example.com' })],
+                nodes: [fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com' })],
                 controller: fakeKafkaNode({ id: 0 }),
+                totalTopics: 3,
+                totalPartitions: 12,
               }),
             ),
           ]),

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DescribeClusterResponse, KafkaNode } from './kafka-cluster.model';
+import { BrokerDetail, DescribeClusterResponse, KafkaNode } from './kafka-cluster.model';
 
 export function fakeKafkaNode(overrides: Partial<KafkaNode> = {}): KafkaNode {
   return {
@@ -24,15 +24,30 @@ export function fakeKafkaNode(overrides: Partial<KafkaNode> = {}): KafkaNode {
   };
 }
 
+export function fakeBrokerDetail(overrides: Partial<BrokerDetail> = {}): BrokerDetail {
+  return {
+    id: 0,
+    host: 'kafka-broker-0.example.com',
+    port: 9092,
+    rack: null,
+    leaderPartitions: 10,
+    replicaPartitions: 20,
+    logDirSize: 1073741824,
+    ...overrides,
+  };
+}
+
 export function fakeDescribeClusterResponse(overrides: Partial<DescribeClusterResponse> = {}): DescribeClusterResponse {
   return {
     clusterId: 'test-cluster-id',
     controller: fakeKafkaNode({ id: 0 }),
     nodes: [
-      fakeKafkaNode({ id: 0, host: 'kafka-broker-0.example.com' }),
-      fakeKafkaNode({ id: 1, host: 'kafka-broker-1.example.com' }),
-      fakeKafkaNode({ id: 2, host: 'kafka-broker-2.example.com' }),
+      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com' }),
+      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com' }),
+      fakeBrokerDetail({ id: 2, host: 'kafka-broker-2.example.com' }),
     ],
+    totalTopics: 5,
+    totalPartitions: 15,
     ...overrides,
   };
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -19,8 +19,20 @@ export interface KafkaNode {
   port: number;
 }
 
+export interface BrokerDetail {
+  id: number;
+  host: string;
+  port: number;
+  rack: string | null;
+  leaderPartitions: number;
+  replicaPartitions: number;
+  logDirSize: number | null;
+}
+
 export interface DescribeClusterResponse {
   clusterId: string;
   controller: KafkaNode;
-  nodes: KafkaNode[];
+  nodes: BrokerDetail[];
+  totalTopics: number;
+  totalPartitions: number;
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12789
## Summary
- Enrich the Kafka Explorer broker view with rack, leader/replica partition counts, and disk usage per broker
- Add cluster-level stats (total topics, total partitions) to the topbar
- Add a controller badge next to the controller node ID

## Changes
**Backend:**
- New `BrokerDetail` domain model with rack, leaderPartitions, replicaPartitions, logDirSize
- Enriched `KafkaClusterInfo` with `totalTopics`, `totalPartitions` and `List<BrokerDetail>`
- `KafkaClusterDomainServiceImpl`: calls `listTopics` + `describeTopics` for partition stats, `describeLogDirs` for disk usage (best-effort)
- Updated OpenAPI spec with `BrokerDetail` schema and enriched `DescribeClusterResponse`

**Frontend:**
- New `BrokerDetail` TypeScript model
- Brokers table: added rack, leader partitions, replica partitions, disk usage columns
- Controller badge with `white-space: nowrap` to prevent line breaks
- Topbar: added Brokers count, Topics, Partitions stats
- Updated tests, harnesses, stories and fixtures
<img width="1777" height="770" alt="image" src="https://github.com/user-attachments/assets/6b3b17f8-0892-4729-ba13-77a381d66b3c" />

<img width="1783" height="773" alt="image" src="https://github.com/user-attachments/assets/d86e9162-4709-4bde-826b-9fce8a24f495" />
