### PR TITLE
feat(console): Add support for selecting page content type in Section…

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { PortalPageContentType } from '../portalPageContent/portalPageContent';
+
 export type PortalArea = 'HOMEPAGE' | 'TOP_NAVBAR';
 export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API';
 export type PortalVisibility = 'PUBLIC' | 'PRIVATE';
@@ -57,6 +59,7 @@ interface BaseNewPortalNavigationItem<T extends PortalNavigationItemType> {
 
 export interface NewPagePortalNavigationItem extends BaseNewPortalNavigationItem<'PAGE'> {
   portalPageContentId?: string;
+  contentType?: PortalPageContentType;
 }
 
 export interface NewFolderPortalNavigationItem extends BaseNewPortalNavigationItem<'FOLDER'> {}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type PortalPageContentType = 'GRAVITEE_MARKDOWN';
+export type PortalPageContentType = 'GRAVITEE_MARKDOWN' | 'OPENAPI';
 
 export interface PortalPageContent {
   id: string;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -163,7 +163,24 @@ describe('PortalNavigationItemsComponent', () => {
         await dialogHarness.clickSubmitButton();
 
         expectCreateNavigationItem(
-          fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE' }),
+          fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE', contentType: 'GRAVITEE_MARKDOWN' }),
+          fakePortalNavigationPage({
+            title,
+            area: 'TOP_NAVBAR',
+            type: 'PAGE',
+            portalPageContentId: 'content-id',
+          }),
+        );
+        await expectGetNavigationItems(fakeResponse);
+      });
+      it('should create the page with contentType OPENAPI when OpenAPI is selected in the dialog', async () => {
+        const title = 'Open API Page';
+        await dialogHarness.selectPageType('OPENAPI');
+        await dialogHarness.setTitleInputValue(title);
+        await dialogHarness.clickSubmitButton();
+
+        expectCreateNavigationItem(
+          fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE', contentType: 'OPENAPI' }),
           fakePortalNavigationPage({
             title,
             area: 'TOP_NAVBAR',
@@ -190,6 +207,7 @@ describe('PortalNavigationItemsComponent', () => {
             title,
             area: 'TOP_NAVBAR',
             type: 'PAGE',
+            contentType: 'GRAVITEE_MARKDOWN',
           }),
           createdItem,
         );
@@ -454,7 +472,13 @@ describe('PortalNavigationItemsComponent', () => {
       });
 
       expectCreateNavigationItem(
-        fakeNewPagePortalNavigationItem({ title, area: 'TOP_NAVBAR', type: 'PAGE', parentId: folderData.id }),
+        fakeNewPagePortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          type: 'PAGE',
+          parentId: folderData.id,
+          contentType: 'GRAVITEE_MARKDOWN',
+        }),
         createdItem,
       );
       await expectGetNavigationItems(fakeResponse);

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -410,6 +410,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
               url: result.url,
               parentId: existingItem?.id,
               visibility: result.visibility,
+              ...(type === 'PAGE' && result.contentType ? { contentType: result.contentType } : {}),
             });
           } else {
             if (!existingItem) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -21,6 +21,18 @@
 
 <form [formGroup]="form" (ngSubmit)="onSubmit()">
   <mat-dialog-content>
+    @if (showPageTypeSelection()) {
+      <div class="form-field-title">Page Type</div>
+      <gio-form-selection-inline class="section-editor-dialog__page-types" formControlName="contentType">
+        @for (option of pageContentTypeOptions; track option.value) {
+          <gio-form-selection-inline-card [value]="option.value" [disabled]="!option.available">
+            <gio-form-selection-inline-card-content [icon]="option.icon">
+              <gio-card-content-title>{{ option.label }}</gio-card-content-title>
+            </gio-form-selection-inline-card-content>
+          </gio-form-selection-inline-card>
+        }
+      </gio-form-selection-inline>
+    }
     @if (type !== 'API') {
       <div class="form-field-title">Title</div>
       <mat-form-field>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
@@ -18,3 +18,9 @@ mat-dialog-content {
   @include mat.m2-typography-level($typography, subtitle-2);
   color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
 }
+
+.section-editor-dialog__page-types {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -96,7 +96,11 @@ describe('SectionEditorDialogComponent', () => {
         expect(await titleInput.getValue()).toBe('');
         expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
       });
-      it('should save the title', async () => {
+      it('should show Page Type selection when adding a page', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.isPageTypeSelectionVisible()).toBe(true);
+      });
+      it('should save the title with default contentType GRAVITEE_MARKDOWN', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         const titleInput = await dialog.getTitleInput();
 
@@ -108,6 +112,21 @@ describe('SectionEditorDialogComponent', () => {
         expect(component.dialogValue).toEqual({
           title: 'My new page',
           visibility: 'PUBLIC',
+          contentType: 'GRAVITEE_MARKDOWN',
+        });
+      });
+      it('should save contentType OPENAPI when OpenAPI is selected', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        const titleInput = await dialog.getTitleInput();
+        await titleInput.setValue('Open API Page');
+        await dialog.selectPageType('OPENAPI');
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual({
+          title: 'Open API Page',
+          visibility: 'PUBLIC',
+          contentType: 'OPENAPI',
         });
       });
       it('should save authentication', async () => {
@@ -123,6 +142,7 @@ describe('SectionEditorDialogComponent', () => {
         expect(component.dialogValue).toEqual({
           title: 'My new page',
           visibility: 'PRIVATE',
+          contentType: 'GRAVITEE_MARKDOWN',
         });
       });
       it('should close the dialog when canceling', async () => {
@@ -149,6 +169,10 @@ describe('SectionEditorDialogComponent', () => {
 
         await dialog.setUrlInputValue('https://gravitee.io');
         expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+      it('should not show Page Type selection when adding a link', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.isPageTypeSelectionVisible()).toBe(false);
       });
       it('should not allow empty url', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
@@ -195,6 +219,10 @@ describe('SectionEditorDialogComponent', () => {
         const titleInput = await dialog.getTitleInput();
         expect(await titleInput.getValue()).toBe('');
         expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+      it('should not show Page Type selection when adding a folder', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.isPageTypeSelectionVisible()).toBe(false);
       });
       it('should save the title', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
@@ -244,7 +272,11 @@ describe('SectionEditorDialogComponent', () => {
         const titleInput = await dialog.getTitleInput();
         expect(await titleInput.getValue()).toBe('Existing Page');
       });
-      it('should save the updated title', async () => {
+      it('should not show Page Type selection when editing a page', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.isPageTypeSelectionVisible()).toBe(false);
+      });
+      it('should save the updated title without contentType', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         const titleInput = await dialog.getTitleInput();
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -17,6 +17,7 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+import { GioFormSelectionInlineCardHarness } from '@gravitee/ui-particles-angular';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 export class SectionEditorDialogHarness extends ComponentHarness {
@@ -27,38 +28,50 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
   private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private locatePageTypeCards = this.locatorForAll(
+    GioFormSelectionInlineCardHarness.with({ ancestor: '.section-editor-dialog__page-types' }),
+  );
+  private locatePageTypeSection = this.locatorForOptional('.section-editor-dialog__page-types');
 
   async getTitleInput(): Promise<MatInputHarness> {
     return this.locateTitleInput();
   }
+
   async setTitleInputValue(value: string): Promise<void> {
     const titleInput = await this.locateTitleInput();
     return titleInput.setValue(value);
   }
+
   async getTitleInputValue(): Promise<string> {
     const titleInput = await this.locateTitleInput();
     return titleInput.getValue();
   }
+
   async getUrlInputValue(): Promise<string> {
     const urlInput = await this.locateUrlInput();
     return urlInput.getValue();
   }
+
   async setUrlInputValue(value: string): Promise<void> {
     const urlInput = await this.locateUrlInput();
     return urlInput.setValue(value);
   }
+
   async clickCancelButton(): Promise<void> {
     const cancelButton = await this.locateCancelButton();
     return cancelButton.click();
   }
+
   async isSubmitButtonDisabled(): Promise<boolean> {
     const submitButton = await this.locateSubmitButton();
     return await submitButton.isDisabled();
   }
+
   async clickSubmitButton(): Promise<void> {
     const submitButton = await this.locateSubmitButton();
     return submitButton.click();
   }
+
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
@@ -71,5 +84,35 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   async toggleAuthentication(): Promise<void> {
     const toggle = await this.locateAuthenticationToggle();
     return toggle.toggle();
+  }
+
+  async isPageTypeSelectionVisible(): Promise<boolean> {
+    const section = await this.locatePageTypeSection();
+    return section != null;
+  }
+
+  /**
+   * Select a page content type (only when "Add page" dialog shows Page Type section).
+   */
+  async selectPageType(value: 'GRAVITEE_MARKDOWN' | 'OPENAPI'): Promise<void> {
+    const cards = await this.locatePageTypeCards();
+    const card = await this.findCardByValue(cards, value);
+    if (!card) {
+      throw new Error(`Page type card with value "${value}" not found`);
+    }
+    const host = await card.host();
+    await host.click();
+  }
+
+  private async findCardByValue(
+    cards: GioFormSelectionInlineCardHarness[],
+    value: string,
+  ): Promise<GioFormSelectionInlineCardHarness | undefined> {
+    for (const card of cards) {
+      if ((await card.getValue()) === value) {
+        return card;
+      }
+    }
+    return undefined;
   }
 }


### PR DESCRIPTION
… Editor Dialog

## Issue

https://gravitee.atlassian.net/browse/APIM-12812

## Description

 - Entities: PortalPageContentType extended with OPENAPI; NewPagePortalNavigationItem gains optional contentType.

 - Section editor dialog: “Page Type” block only when mode = create and type = PAGE; form control for page type; result includes contentType when applicable; card selection via GioFormSelectionInlineModule.

 - Parent: When creating a PAGE, pass contentType from the dialog into the create payload only when not Markdown (so GMD remains default and no backend change is required for GMD).

 - Tests: Section editor dialog and portal navigation items specs updated for page type visibility, default, OPENAPI selection, and request payload (with/without contentType).

https://github.com/user-attachments/assets/32e45d4b-931e-4e7b-b778-31ddbf1ab132

 - excluded from PR
    - backend support for the new type
    - any other content type except openapi
    - OpenAPI page content editor
    - Portal side (Redoc renderer)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

