### PR TITLE
display metadata in console

### DIFF
--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
@@ -67,6 +67,7 @@ export interface Subscription {
   security?: string;
   origin: SubscriptionOrigin;
   configuration?: SubscriptionConsumerConfiguration;
+  metadata?: { [key: string]: string };
   referenceType?: string;
   referenceId?: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/api-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/api-subscriptions.module.ts
@@ -37,6 +37,7 @@ import {
   GioFormTagsInputModule,
   GioIconsModule,
   GioLoaderModule,
+  GioMonacoEditorModule,
 } from '@gravitee/ui-particles-angular';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { OwlMomentDateTimeModule } from '@danielmoncada/angular-datetime-picker-moment-adapter';
@@ -58,6 +59,7 @@ import { ApiPortalSubscriptionExpireApiKeyDialogComponent } from './components/d
 import { SubscriptionEditPushConfigComponent } from '../../../components/subscription-edit-push-config/subscription-edit-push-config.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { SubscriptionMetadataViewerComponent } from '../../../shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component';
 
 @NgModule({
   declarations: [
@@ -102,6 +104,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioAvatarModule,
     GioClipboardModule,
     GioFormJsonSchemaModule,
+    GioMonacoEditorModule,
     GioFormTagsInputModule,
     GioIconsModule,
     GioLoaderModule,
@@ -109,6 +112,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioTableWrapperModule,
     GioBannerModule,
     SubscriptionEditPushConfigComponent,
+    SubscriptionMetadataViewerComponent,
   ],
   providers: [DatePipe],
 })

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -124,6 +124,11 @@
           <dd data-testId="subscription-domain">
             {{ subscription.domain || '-' }}
           </dd>
+
+          <dt>Metadata</dt>
+          <dd class="subscription__metadata-cell" data-testId="subscription-metadata">
+            <subscription-metadata-viewer [metadata]="subscription.metadata" />
+          </dd>
         </dl>
       </mat-card-content>
       <mat-card-actions>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.scss
@@ -32,6 +32,11 @@
     }
   }
 
+  &__metadata-cell {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   &__api-keys {
     &__subtitle {
       padding-bottom: 24px;

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
@@ -139,6 +139,7 @@ describe('ApiSubscriptionEditComponent', () => {
       expect(await harness.getStartingAt()).toEqual('Jan 1, 2020, 12:00:00 AM');
       expect(await harness.getEndingAt()).toEqual('-');
       expect(await harness.getDomain()).toEqual('https://my-domain.com');
+      expect(await harness.metadataEditorIsVisible()).toEqual(true);
 
       expect(await harness.footerIsVisible()).toEqual(true);
 
@@ -265,6 +266,25 @@ describe('ApiSubscriptionEditComponent', () => {
 
       const harness = await loader.getHarness(ApiSubscriptionEditHarness);
       expect(await harness.footerIsVisible()).toEqual(false);
+    });
+  });
+
+  describe('metadata display', () => {
+    it('should show dash when subscription has no metadata', async () => {
+      await initComponent({ subscription: { ...BASIC_SUBSCRIPTION(), metadata: undefined } });
+      expectApiKeyListGet();
+
+      const harness = await loader.getHarness(ApiSubscriptionEditHarness);
+      expect(await harness.getMetadata()).toEqual('-');
+      expect(await harness.metadataEditorIsVisible()).toEqual(false);
+    });
+
+    it('should show monaco editor when subscription has metadata', async () => {
+      await initComponent({ subscription: BASIC_SUBSCRIPTION() });
+      expectApiKeyListGet();
+
+      const harness = await loader.getHarness(ApiSubscriptionEditHarness);
+      expect(await harness.metadataEditorIsVisible()).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
@@ -101,6 +101,14 @@ export class ApiSubscriptionEditHarness extends ComponentHarness {
     return this.getSubscriptionDetailText('domain');
   }
 
+  public async getMetadata(): Promise<string> {
+    return this.getSubscriptionDetailText('metadata');
+  }
+
+  public async metadataEditorIsVisible(): Promise<boolean> {
+    return this.isVisible(this.locatorFor('subscription-metadata-viewer .metadata-editor')());
+  }
+
   /**
    * FOOTER
    */

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
@@ -101,6 +101,11 @@
         }
         <dt>Closed at</dt>
         <dd>{{ (pageVM.subscription.closed_at | date: 'medium') || '-' }}</dd>
+
+        <dt>Metadata</dt>
+        <dd class="subscription__metadata-cell" data-testid="subscription-metadata">
+          <subscription-metadata-viewer [metadata]="pageVM.subscription.metadata" />
+        </dd>
       </dl>
     </mat-card-content>
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
@@ -116,6 +116,7 @@ describe('ApplicationSubscriptionComponent', () => {
       ['Paused at', '-'],
       ['Ending at', '-'],
       ['Closed at', '-'],
+      ['Metadata', '-'],
     ]);
 
     const subscriptionApiKeysHarness = await componentHarness.getSubscriptionApiKeysHarness();
@@ -128,6 +129,31 @@ describe('ApplicationSubscriptionComponent', () => {
         actions: 'hasRevokeButton',
       },
     ]);
+  });
+
+  describe('metadata display', () => {
+    it('should show dash when subscription has no metadata', async () => {
+      expect(await componentHarness.getMetadata()).toEqual('-');
+      expect(await componentHarness.metadataEditorIsVisible()).toEqual(false);
+    });
+
+    it('should show monaco editor when subscription has metadata', async () => {
+      const subscriptionWithMetadata = fakeSubscription({
+        id: subscriptionId,
+        plan: { id: 'planId', name: 'Free Spaceshuttle', security: 'API_KEY' },
+        metadata: { env: 'prod', version: '1' },
+      });
+
+      fixture = TestBed.createComponent(ApplicationSubscriptionComponent);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationSubscriptionHarness);
+      fixture.autoDetectChanges();
+      expectApplicationSubscriptionGet(applicationId, subscriptionWithMetadata);
+      fixture.detectChanges();
+      expectApplicationApiKeysGetRequest();
+
+      expect(await componentHarness.metadataEditorIsVisible()).toEqual(true);
+    });
   });
 
   it('should update consumer subscription configuration', async () => {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
@@ -42,6 +42,7 @@ import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ApplicationSubscriptionService } from '../../../../../services-ngx/application-subscription.service';
 import { SubscriptionApiKeysComponent } from '../components/subscription-api-keys/subscription-api-keys.component';
 import { SubscriptionEditPushConfigComponent } from '../../../../../components/subscription-edit-push-config/subscription-edit-push-config.component';
+import { SubscriptionMetadataViewerComponent } from '../../../../../shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component';
 
 type PageVM = {
   application: Application;
@@ -65,6 +66,7 @@ type PageVM = {
     SubscriptionApiKeysComponent,
     MatTooltip,
     SubscriptionEditPushConfigComponent,
+    SubscriptionMetadataViewerComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -89,10 +91,7 @@ export class ApplicationSubscriptionComponent {
   private application$ = this.applicationService.getLastApplicationFetch(this.activatedRoute.snapshot.params.applicationId);
 
   public pageVM$: Observable<PageVM> = combineLatest([this.application$, this.subscription$]).pipe(
-    map(([application, subscription]) => ({
-      application,
-      subscription,
-    })),
+    map(([application, subscription]) => ({ application, subscription })),
   );
 
   public closeSubscription(application: Application, subscription: Subscription) {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.harness.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.harness.ts
@@ -33,6 +33,15 @@ export class ApplicationSubscriptionHarness extends ComponentHarness {
     return chunk(subscriptionDetailsToChunk, 2);
   }
 
+  async getMetadata(): Promise<string> {
+    const el = await this.locatorFor('[data-testid="subscription-metadata"]')();
+    return (await el.text()).trim();
+  }
+
+  async metadataEditorIsVisible(): Promise<boolean> {
+    return this.locatorForOptional('subscription-metadata-viewer .metadata-editor')().then(el => el !== null);
+  }
+
   async closeSubscription(): Promise<void> {
     const button = await this.locatorFor(MatButtonHarness.with({ text: /Close/ }))();
     return button.click();

--- a/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.html
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (metadataJson()) {
+  <div class="metadata-editor" gioMonacoClipboardCopy>
+    <gio-monaco-editor [options]="monacoEditorOptions" [languageConfig]="languageConfig" [ngModel]="metadataJson()" [disableMiniMap]="true">
+    </gio-monaco-editor>
+  </div>
+} @else {
+  -
+}

--- a/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,33 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
 
-@use '../../../../../scss/gio-layout' as gio-layout;
-
-:host {
-  @include gio-layout.gio-responsive-content-container;
-}
-
-.subscriptionDetailsCard {
-  margin-top: 8px;
-  margin-bottom: 16px;
-
-  .subscription__metadata-cell {
-    min-width: 0;
-    max-width: 100%;
-  }
-
-  .kubernetes-origin-message {
-    margin: 15px 0 0 15px;
-    display: flex;
-
-    .matt-icon__origin {
-      color: #326ce5;
-      margin-right: 5px;
-    }
-
-    p {
-      margin-top: 1px;
-    }
-  }
+.metadata-editor {
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter60');
+  border-radius: 4px;
+  overflow: hidden;
 }

--- a/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SubscriptionMetadataViewerComponent } from './subscription-metadata-viewer.component';
+
+@Component({
+  template: `<subscription-metadata-viewer [metadata]="metadata()" />`,
+  standalone: true,
+  imports: [SubscriptionMetadataViewerComponent],
+})
+class TestHostComponent {
+  metadata = input<Record<string, string> | null | undefined>();
+}
+
+describe('SubscriptionMetadataViewerComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  const getEditor = () => fixture.nativeElement.querySelector('.metadata-editor');
+  const getText = () => (fixture.nativeElement.textContent as string).trim();
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should show dash when metadata is undefined', () => {
+    expect(getEditor()).toBeNull();
+    expect(getText()).toBe('-');
+  });
+
+  it('should show dash when metadata is null', async () => {
+    fixture.componentRef.setInput('metadata', null);
+    fixture.detectChanges();
+
+    expect(getEditor()).toBeNull();
+    expect(getText()).toBe('-');
+  });
+
+  it('should show dash when metadata is an empty object', () => {
+    fixture.componentRef.setInput('metadata', {});
+    fixture.detectChanges();
+
+    expect(getEditor()).toBeNull();
+    expect(getText()).toBe('-');
+  });
+
+  it('should show monaco editor when metadata has values', () => {
+    fixture.componentRef.setInput('metadata', { key1: 'value1', key2: 'value2' });
+    fixture.detectChanges();
+
+    expect(getEditor()).not.toBeNull();
+  });
+
+  it('should update when metadata input changes', () => {
+    fixture.componentRef.setInput('metadata', { key: 'value' });
+    fixture.detectChanges();
+    expect(getEditor()).not.toBeNull();
+
+    fixture.componentRef.setInput('metadata', null);
+    fixture.detectChanges();
+    expect(getEditor()).toBeNull();
+    expect(getText()).toBe('-');
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/subscription-metadata-viewer/subscription-metadata-viewer.component.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { GioMonacoEditorModule, MonacoEditorLanguageConfig } from '@gravitee/ui-particles-angular';
+import { FormsModule } from '@angular/forms';
+import { editor } from 'monaco-editor';
+
+@Component({
+  selector: 'subscription-metadata-viewer',
+  templateUrl: './subscription-metadata-viewer.component.html',
+  styleUrls: ['./subscription-metadata-viewer.component.scss'],
+  standalone: true,
+  imports: [GioMonacoEditorModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionMetadataViewerComponent {
+  metadata = input<Record<string, string> | null | undefined>();
+
+  protected metadataJson = computed(() => {
+    const m = this.metadata();
+    return !m || Object.keys(m).length === 0 ? '' : JSON.stringify(m, null, 2);
+  });
+
+  protected readonly monacoEditorOptions: editor.IStandaloneEditorConstructionOptions = {
+    lineNumbers: 'off',
+    renderLineHighlight: 'none',
+    hideCursorInOverviewRuler: true,
+    overviewRulerBorder: false,
+    readOnly: true,
+    wordWrap: 'on',
+    scrollBeyondLastLine: false,
+    padding: { top: 0, bottom: 0 },
+    scrollbar: {
+      vertical: 'auto',
+      horizontal: 'hidden',
+      useShadows: false,
+    },
+  };
+
+  protected readonly languageConfig: MonacoEditorLanguageConfig = { language: 'json', schemas: [] };
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
@@ -280,6 +280,7 @@ public class ApplicationSubscriptionResource extends AbstractResource {
             subscriptionEntity.getOrigin() != null ? OriginContext.Origin.valueOf(subscriptionEntity.getOrigin()) : null
         );
         subscription.setConfiguration(subscriptionEntity.getConfiguration());
+        subscription.setMetadata(subscriptionEntity.getMetadata());
 
         return subscription;
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12159

## Description
This PR closes the subscription flow by letting API publishers and portal admins view subscription metadata in the Subscription Details screen. They can see what consumers submitted during subscription (e.g. via subscription form) and use it when approving or reviewing subscriptions.
Included in this PR

### Subscription Details – metadata display: 
Subscription metadata is shown in the API subscription edit screen and in the application subscription screen. When metadata exists, it is displayed in a read-only Monaco editor with JSON formatting (key-value structure). When there is no metadata, or it is empty, a dash (-) is shown instead.
### Where it appears: 
Metadata is visible in the subscription details when reviewing a pending subscription (before approve/reject), and  after approval for later reference.
### Security: 
Metadata is rendered via Angular property binding and the read-only Monaco editor only; no innerHTML or raw HTML injection of user-provided values.

## Additional context

<img width="3986" height="1814" alt="image" src="https://github.com/user-attachments/assets/5e6e36ee-a879-4de5-9342-b3d4656477ab" />


### 🎬 : 

https://github.com/user-attachments/assets/5ba3c5e2-cb9a-4cc9-b62c-3be196de23ec

