### PR TITLE
feat(kafka-explorer): add list-topics endpoint with standard pagination

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaTopic.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaTopic.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
-import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
-import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
-
-public interface KafkaClusterDomainService {
-    KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
-    TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
-}
+public record KafkaTopic(
+    String name,
+    int partitionCount,
+    int replicationFactor,
+    int underReplicatedCount,
+    boolean internal,
+    Long size,
+    Long messageCount
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicsPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicsPage.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
-import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
-import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
+import java.util.List;
 
-public interface KafkaClusterDomainService {
-    KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
-    TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
-}
+public record TopicsPage(List<KafkaTopic> data, long totalCount, int page, int perPage) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
+
+@UseCase
+public class ListTopicsUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public ListTopicsUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var topicsPage = kafkaClusterDomainService.listTopics(config, input.nameFilter(), input.page(), input.perPage());
+        return new Output(topicsPage);
+    }
+
+    public record Input(String clusterId, String environmentId, String nameFilter, int page, int perPage) {}
+
+    public record Output(TopicsPage topicsPage) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -18,7 +18,12 @@ package io.gravitee.rest.api.kafkaexplorer.mapper;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.Pagination;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
@@ -31,4 +36,21 @@ public interface KafkaExplorerMapper {
     io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaNode map(KafkaNode node);
 
     io.gravitee.rest.api.kafkaexplorer.rest.model.BrokerDetail map(BrokerDetail brokerDetail);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaTopic map(KafkaTopic topic);
+
+    List<io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaTopic> mapTopics(List<KafkaTopic> topics);
+
+    default ListTopicsResponse map(TopicsPage topicsPage, int page, int perPage) {
+        return new ListTopicsResponse()
+            .data(mapTopics(topicsPage.data()))
+            .pagination(
+                new Pagination()
+                    .page(page)
+                    .perPage(perPage)
+                    .pageCount((int) Math.ceil((double) topicsPage.totalCount() / perPage))
+                    .pageItemsCount(topicsPage.data().size())
+                    .totalCount(topicsPage.totalCount())
+            );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -49,6 +49,53 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/list-topics:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: List topics of a Kafka cluster
+            description: |
+                Connects to a Kafka cluster and returns the list of topics with their metadata.
+            operationId: listTopics
+            parameters:
+                - name: page
+                  in: query
+                  schema:
+                      type: integer
+                      default: 1
+                  description: Page number (1-based)
+                - name: perPage
+                  in: query
+                  schema:
+                      type: integer
+                      default: 10
+                  description: Number of topics per page
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ListTopicsRequest"
+            responses:
+                "200":
+                    description: List of topics
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListTopicsResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
 components:
     schemas:
         DescribeClusterRequest:
@@ -118,6 +165,72 @@ components:
                     type: integer
                     format: int64
                     description: Total size of all log directories on this broker in bytes, or null if unavailable
+
+        ListTopicsRequest:
+            type: object
+            required:
+                - clusterId
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                nameFilter:
+                    type: string
+                    description: Optional filter to match topic names (case-insensitive contains)
+
+        ListTopicsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaTopic"
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
+
+        Pagination:
+            type: object
+            properties:
+                page:
+                    type: integer
+                perPage:
+                    type: integer
+                pageCount:
+                    type: integer
+                pageItemsCount:
+                    type: integer
+                totalCount:
+                    type: integer
+                    format: int64
+
+        KafkaTopic:
+            type: object
+            properties:
+                name:
+                    type: string
+                partitionCount:
+                    type: integer
+                    format: int32
+                    description: Number of partitions for this topic
+                replicationFactor:
+                    type: integer
+                    format: int32
+                    description: Replication factor of this topic
+                underReplicatedCount:
+                    type: integer
+                    format: int32
+                    description: Number of partitions where ISR size is less than replica count
+                internal:
+                    type: boolean
+                    description: Whether this is an internal Kafka topic
+                size:
+                    type: integer
+                    format: int64
+                    description: Total size of the topic in bytes across all brokers, or null if unavailable
+                messageCount:
+                    type: integer
+                    format: int64
+                    description: Total number of messages (sum of latest offsets), or null if unavailable
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCaseTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ListTopicsUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private ListTopicsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new ListTopicsUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_topics_page() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var allTopics = List.of(
+            new KafkaTopic("__consumer_offsets", 50, 1, 0, true, 1024L, 100L),
+            new KafkaTopic("my-topic", 3, 2, 0, false, 2048L, 200L)
+        );
+        clusterDomainService.givenTopics(allTopics);
+
+        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25));
+
+        assertThat(result.topicsPage().data()).hasSize(2);
+        assertThat(result.topicsPage().totalCount()).isEqualTo(2);
+        assertThat(result.topicsPage().page()).isEqualTo(0);
+        assertThat(result.topicsPage().perPage()).isEqualTo(25);
+    }
+
+    @Test
+    void should_filter_topics_by_name() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var allTopics = List.of(
+            new KafkaTopic("__consumer_offsets", 50, 1, 0, true, 1024L, 100L),
+            new KafkaTopic("my-topic", 3, 2, 0, false, 2048L, 200L),
+            new KafkaTopic("orders", 6, 3, 0, false, 4096L, 500L)
+        );
+        clusterDomainService.givenTopics(allTopics);
+
+        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", 0, 25));
+
+        assertThat(result.topicsPage().data()).hasSize(1);
+        assertThat(result.topicsPage().data().get(0).name()).isEqualTo("my-topic");
+        assertThat(result.topicsPage().totalCount()).isEqualTo(1);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
+
+        assertThatThrownBy(() -> useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25)))
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImplTest.java
@@ -69,7 +69,7 @@ class KafkaClusterDomainServiceImplTest {
 
         assertThatThrownBy(() -> service.describeCluster(CONFIG))
             .isInstanceOf(KafkaExplorerException.class)
-            .hasMessageContaining("Cannot create admin client")
+            .hasMessageContaining("Failed to connect to Kafka cluster")
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
     }
 
@@ -112,7 +112,7 @@ class KafkaClusterDomainServiceImplTest {
 
         assertThatThrownBy(() -> service.describeCluster(CONFIG))
             .isInstanceOf(KafkaExplorerException.class)
-            .hasMessageContaining("Something went wrong")
+            .hasMessageContaining("Failed to connect to Kafka cluster")
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
@@ -21,10 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.ClusterCrudServiceInMemory;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceImpl;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +37,17 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -77,7 +90,9 @@ class KafkaExplorerResourceIntegrationTest {
         var clusterService = new KafkaClusterDomainServiceImpl();
         var objectMapper = new ObjectMapper();
         var describeUseCase = new DescribeKafkaClusterUseCase(clusterCrudService, clusterService, objectMapper);
+        var listTopicsUseCase = new ListTopicsUseCase(clusterCrudService, clusterService, objectMapper);
         injectField(resource, "describeKafkaClusterUseCase", describeUseCase);
+        injectField(resource, "listTopicsUseCase", listTopicsUseCase);
     }
 
     @BeforeEach
@@ -313,6 +328,109 @@ class KafkaExplorerResourceIntegrationTest {
             var response = resource.describeCluster(request);
 
             assertThat(response.getStatus()).isEqualTo(400);
+        }
+    }
+
+    @Nested
+    class ListTopics {
+
+        private static final String TEST_TOPIC = "test-topic-for-integration";
+        private static final int TEST_MESSAGES_COUNT = 5;
+
+        @BeforeAll
+        static void createTestTopic() throws Exception {
+            var props = new Properties();
+            props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+            try (var admin = AdminClient.create(props)) {
+                admin.createTopics(List.of(new NewTopic(TEST_TOPIC, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+            }
+
+            var producerProps = new Properties();
+            producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+            producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            try (var producer = new KafkaProducer<String, String>(producerProps)) {
+                for (int i = 0; i < TEST_MESSAGES_COUNT; i++) {
+                    producer.send(new ProducerRecord<>(TEST_TOPIC, "key-" + i, "value-" + i)).get();
+                }
+            }
+        }
+
+        @Test
+        void should_return_200_with_topics() {
+            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+            var response = resource.listTopics(request, 1, 10);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            var body = (ListTopicsResponse) response.getEntity();
+            assertThat(body.getData()).isNotNull();
+            assertThat(body.getData()).isNotEmpty();
+            assertThat(body.getData()).anyMatch(t -> TEST_TOPIC.equals(t.getName()));
+            assertThat(body.getPagination()).isNotNull();
+            assertThat(body.getPagination().getTotalCount()).isGreaterThan(0);
+            assertThat(body.getPagination().getPage()).isEqualTo(1);
+            assertThat(body.getPagination().getPerPage()).isEqualTo(10);
+            assertThat(body.getPagination().getPageItemsCount()).isEqualTo(body.getData().size());
+            assertThat(body.getPagination().getPageCount()).isGreaterThanOrEqualTo(1);
+        }
+
+        @Test
+        void should_return_topics_with_size_and_message_count() {
+            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+            var request = new ListTopicsRequest().clusterId(CLUSTER_ID).nameFilter(TEST_TOPIC);
+
+            var response = resource.listTopics(request, 1, 10);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            var body = (ListTopicsResponse) response.getEntity();
+            assertThat(body.getData()).isNotEmpty();
+            var testTopic = body
+                .getData()
+                .stream()
+                .filter(t -> TEST_TOPIC.equals(t.getName()))
+                .findFirst();
+            assertThat(testTopic).isPresent();
+            assertThat(testTopic.get().getSize()).isNotNull().isGreaterThan(0);
+            assertThat(testTopic.get().getMessageCount()).isNotNull().isEqualTo((long) TEST_MESSAGES_COUNT);
+        }
+
+        @Test
+        void should_return_400_when_request_is_null() {
+            var response = resource.listTopics(null, 1, 10);
+
+            assertThat(response.getStatus()).isEqualTo(400);
+            var error = (KafkaExplorerError) response.getEntity();
+            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+        }
+
+        @Test
+        void should_return_400_when_page_is_less_than_1() {
+            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+            var response = resource.listTopics(request, 0, 10);
+
+            assertThat(response.getStatus()).isEqualTo(400);
+            var error = (KafkaExplorerError) response.getEntity();
+            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+        }
+
+        @Test
+        void should_return_502_when_broker_unreachable() {
+            givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+            var response = resource.listTopics(request, 1, 10);
+
+            assertThat(response.getStatus()).isEqualTo(502);
+            var error = (KafkaExplorerError) response.getEntity();
+            assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
         }
     }
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
@@ -60,7 +60,7 @@
 
       <ng-container matColumnDef="logDirSize">
         <th mat-header-cell *matHeaderCellDef>Disk Usage</th>
-        <td mat-cell *matCellDef="let node">{{ formatBytes(node.logDirSize) }}</td>
+        <td mat-cell *matCellDef="let node">{{ node.logDirSize | gkeFileSize }}</td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
@@ -15,6 +15,10 @@
  */
 
 .brokers {
+  mat-card-content {
+    overflow-x: auto;
+  }
+
   table {
     width: 100%;
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
@@ -19,11 +19,12 @@ import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 
 import { BrokerDetail } from '../models/kafka-cluster.model';
+import { FileSizePipe } from '../pipes/file-size.pipe';
 
 @Component({
   selector: 'gke-brokers',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule],
+  imports: [CommonModule, MatCardModule, MatTableModule, FileSizePipe],
   templateUrl: './brokers.component.html',
   styleUrls: ['./brokers.component.scss'],
 })
@@ -32,13 +33,4 @@ export class BrokersComponent {
   controllerId = input<number>(-1);
 
   displayedColumns = ['id', 'host', 'port', 'rack', 'leaderPartitions', 'replicaPartitions', 'logDirSize'];
-
-  formatBytes(bytes: number | null): string {
-    if (bytes === null || bytes === undefined) return '-';
-    if (bytes === 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
@@ -58,5 +58,15 @@
     </mat-card>
 
     <gke-brokers [nodes]="info.nodes" [controllerId]="info.controller.id" />
+
+    <gke-topics
+      [topics]="topicsPage()?.data ?? []"
+      [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
+      [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
+      [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
+      [loading]="topicsLoading()"
+      (filterChange)="onTopicsFilterChange($event)"
+      (pageChange)="onTopicsPageChange($event)"
+    />
   </div>
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.ts
@@ -19,15 +19,17 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
 
 import { BrokersComponent } from '../brokers/brokers.component';
-import { DescribeClusterResponse } from '../models/kafka-cluster.model';
+import { DescribeClusterResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
 import { KafkaExplorerService } from '../services/kafka-explorer.service';
+import { TopicsComponent } from '../topics/topics.component';
 
 @Component({
   selector: 'gke-kafka-explorer',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatProgressSpinnerModule, MatIconModule, BrokersComponent],
+  imports: [CommonModule, MatCardModule, MatProgressSpinnerModule, MatIconModule, BrokersComponent, TopicsComponent],
   templateUrl: './kafka-explorer.component.html',
   styleUrls: ['./kafka-explorer.component.scss'],
 })
@@ -36,8 +38,15 @@ export class KafkaExplorerComponent implements OnInit {
   clusterId = input.required<string>();
 
   clusterInfo = signal<DescribeClusterResponse | undefined>(undefined);
+  topicsPage = signal<ListTopicsResponse | undefined>(undefined);
   loading = signal(false);
+  topicsLoading = signal(false);
   error = signal<string | null>(null);
+
+  private currentFilter = '';
+  private currentPage = 0;
+  private currentPageSize = 10;
+  private readonly filterSubject = new Subject<string>();
 
   private readonly kafkaExplorerService = inject(KafkaExplorerService);
   private readonly destroyRef = inject(DestroyRef);
@@ -50,13 +59,46 @@ export class KafkaExplorerComponent implements OnInit {
       .describeCluster(this.baseURL(), this.clusterId())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: response => {
-          this.clusterInfo.set(response);
+        next: cluster => {
+          this.clusterInfo.set(cluster);
           this.loading.set(false);
+          this.loadTopics(this.currentFilter, this.currentPage, this.currentPageSize);
         },
         error: err => {
-          this.error.set(err?.error?.message || 'Failed to describe cluster');
+          this.error.set(err?.error?.message || 'Failed to load cluster data');
           this.loading.set(false);
+        },
+      });
+
+    this.filterSubject.pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef)).subscribe(filter => {
+      this.currentFilter = filter;
+      this.currentPage = 0;
+      this.loadTopics(filter, 0, this.currentPageSize);
+    });
+  }
+
+  onTopicsFilterChange(filter: string) {
+    this.filterSubject.next(filter);
+  }
+
+  onTopicsPageChange(event: { page: number; pageSize: number }) {
+    this.currentPage = event.page;
+    this.currentPageSize = event.pageSize;
+    this.loadTopics(this.currentFilter, event.page, event.pageSize);
+  }
+
+  private loadTopics(nameFilter: string, page: number, pageSize: number) {
+    this.topicsLoading.set(true);
+    this.kafkaExplorerService
+      .listTopics(this.baseURL(), this.clusterId(), nameFilter || undefined, page + 1, pageSize)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => {
+          this.topicsPage.set(response);
+          this.topicsLoading.set(false);
+        },
+        error: () => {
+          this.topicsLoading.set(false);
         },
       });
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
@@ -17,12 +17,14 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/testing';
 
 import { BrokersHarness } from '../brokers/brokers.harness';
+import { TopicsHarness } from '../topics/topics.harness';
 
 export class KafkaExplorerHarness extends ComponentHarness {
   static hostSelector = 'gke-kafka-explorer';
 
   private readonly getSpinner = this.locatorForOptional(MatProgressSpinnerHarness);
   private readonly getBrokers = this.locatorForOptional(BrokersHarness);
+  private readonly getTopics = this.locatorForOptional(TopicsHarness);
   private readonly getErrorBanner = this.locatorForOptional('.kafka-explorer__error');
   private readonly getTopbar = this.locatorForOptional('.kafka-explorer__topbar');
 
@@ -42,5 +44,9 @@ export class KafkaExplorerHarness extends ComponentHarness {
 
   async getBrokersHarness() {
     return this.getBrokers();
+  }
+
+  async getTopicsHarness() {
+    return this.getTopics();
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BrokerDetail, DescribeClusterResponse, KafkaNode } from './kafka-cluster.model';
+import { BrokerDetail, DescribeClusterResponse, KafkaNode, KafkaTopic, ListTopicsResponse, Pagination } from './kafka-cluster.model';
 
 export function fakeKafkaNode(overrides: Partial<KafkaNode> = {}): KafkaNode {
   return {
@@ -29,7 +29,6 @@ export function fakeBrokerDetail(overrides: Partial<BrokerDetail> = {}): BrokerD
     id: 0,
     host: 'kafka-broker-0.example.com',
     port: 9092,
-    rack: null,
     leaderPartitions: 10,
     replicaPartitions: 20,
     logDirSize: 1073741824,
@@ -48,6 +47,49 @@ export function fakeDescribeClusterResponse(overrides: Partial<DescribeClusterRe
     ],
     totalTopics: 5,
     totalPartitions: 15,
+    ...overrides,
+  };
+}
+
+export function fakeKafkaTopic(overrides: Partial<KafkaTopic> = {}): KafkaTopic {
+  return {
+    name: 'my-topic',
+    partitionCount: 3,
+    replicationFactor: 2,
+    underReplicatedCount: 0,
+    internal: false,
+    size: 1048576,
+    messageCount: 1500,
+    ...overrides,
+  };
+}
+
+export function fakePagination(overrides: Partial<Pagination> = {}): Pagination {
+  return {
+    page: 1,
+    perPage: 10,
+    pageCount: 1,
+    pageItemsCount: 3,
+    totalCount: 3,
+    ...overrides,
+  };
+}
+
+export function fakeListTopicsResponse(overrides: Partial<ListTopicsResponse> = {}): ListTopicsResponse {
+  return {
+    data: [
+      fakeKafkaTopic({ name: 'my-topic' }),
+      fakeKafkaTopic({ name: 'orders', partitionCount: 6, replicationFactor: 3, size: 5242880, messageCount: 12000 }),
+      fakeKafkaTopic({
+        name: '__consumer_offsets',
+        partitionCount: 50,
+        replicationFactor: 1,
+        internal: true,
+        size: 10485760,
+        messageCount: 50000,
+      }),
+    ],
+    pagination: fakePagination(),
     ...overrides,
   };
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -23,10 +23,10 @@ export interface BrokerDetail {
   id: number;
   host: string;
   port: number;
-  rack: string | null;
+  rack?: string;
   leaderPartitions: number;
   replicaPartitions: number;
-  logDirSize: number | null;
+  logDirSize?: number;
 }
 
 export interface DescribeClusterResponse {
@@ -35,4 +35,27 @@ export interface DescribeClusterResponse {
   nodes: BrokerDetail[];
   totalTopics: number;
   totalPartitions: number;
+}
+
+export interface KafkaTopic {
+  name: string;
+  partitionCount: number;
+  replicationFactor: number;
+  underReplicatedCount: number;
+  internal: boolean;
+  size?: number;
+  messageCount?: number;
+}
+
+export interface Pagination {
+  page: number;
+  perPage: number;
+  pageCount: number;
+  pageItemsCount: number;
+  totalCount: number;
+}
+
+export interface ListTopicsResponse {
+  data: KafkaTopic[];
+  pagination: Pagination;
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/pipes/file-size.pipe.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/pipes/file-size.pipe.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FileSizePipe } from './file-size.pipe';
+
+describe('FileSizePipe', () => {
+  const pipe = new FileSizePipe();
+
+  it('should return "-" for null', () => {
+    expect(pipe.transform(null)).toBe('-');
+  });
+
+  it('should return "-" for undefined', () => {
+    expect(pipe.transform(undefined)).toBe('-');
+  });
+
+  it('should return "-" for negative values', () => {
+    expect(pipe.transform(-1)).toBe('-');
+    expect(pipe.transform(-100)).toBe('-');
+  });
+
+  it('should return "0 B" for zero', () => {
+    expect(pipe.transform(0)).toBe('0 B');
+  });
+
+  it('should format bytes', () => {
+    expect(pipe.transform(500)).toBe('500 B');
+  });
+
+  it('should format kilobytes', () => {
+    expect(pipe.transform(1024)).toBe('1 KB');
+    expect(pipe.transform(1536)).toBe('1.5 KB');
+  });
+
+  it('should format megabytes', () => {
+    expect(pipe.transform(1048576)).toBe('1 MB');
+  });
+
+  it('should format gigabytes', () => {
+    expect(pipe.transform(1073741824)).toBe('1 GB');
+  });
+
+  it('should format terabytes', () => {
+    expect(pipe.transform(1099511627776)).toBe('1 TB');
+  });
+
+  it('should cap at TB for very large values', () => {
+    expect(pipe.transform(1099511627776 * 1024)).toBe('1024 TB');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/pipes/file-size.pipe.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/pipes/file-size.pipe.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'gkeFileSize',
+  standalone: true,
+})
+export class FileSizePipe implements PipeTransform {
+  private static readonly UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+  transform(bytes: number | null | undefined): string {
+    if (bytes == null || bytes < 0) {
+      return '-';
+    }
+    if (bytes === 0) {
+      return '0 B';
+    }
+    const k = 1024;
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const unitIndex = Math.min(i, FileSizePipe.UNITS.length - 1);
+    const value = bytes / Math.pow(k, unitIndex);
+    return `${value % 1 === 0 ? value : value.toFixed(1)} ${FileSizePipe.UNITS[unitIndex]}`;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -17,7 +17,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DescribeClusterResponse } from '../models/kafka-cluster.model';
+import { DescribeClusterResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
 
 @Injectable({
   providedIn: 'root',
@@ -27,5 +27,15 @@ export class KafkaExplorerService {
 
   describeCluster(baseURL: string, clusterId: string): Observable<DescribeClusterResponse> {
     return this.http.post<DescribeClusterResponse>(`${baseURL}/kafka-explorer/describe-cluster`, { clusterId });
+  }
+
+  listTopics(baseURL: string, clusterId: string, nameFilter?: string, page = 1, perPage = 10): Observable<ListTopicsResponse> {
+    return this.http.post<ListTopicsResponse>(
+      `${baseURL}/kafka-explorer/list-topics`,
+      { clusterId, nameFilter },
+      {
+        params: { page: page.toString(), perPage: perPage.toString() },
+      },
+    );
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.html
@@ -1,0 +1,88 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="topics">
+  <mat-card-header>
+    <mat-card-title>Topics</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <mat-form-field class="topics__filter" appearance="outline">
+      <mat-label>Filter by name</mat-label>
+      <input matInput (input)="onFilterInput($event)" placeholder="Search topics..." />
+    </mat-form-field>
+
+    @if (loading()) {
+      <mat-progress-bar mode="indeterminate" />
+    }
+
+    <table mat-table [dataSource]="topics()">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let topic">
+          <span class="topics__topic-name">
+            {{ topic.name }}
+            @if (topic.internal) {
+              <span class="topics__internal-badge">Internal</span>
+            }
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="partitionCount">
+        <th mat-header-cell *matHeaderCellDef>Partitions</th>
+        <td mat-cell *matCellDef="let topic">{{ topic.partitionCount }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="replicationFactor">
+        <th mat-header-cell *matHeaderCellDef>Replication Factor</th>
+        <td mat-cell *matCellDef="let topic">{{ topic.replicationFactor }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="underReplicatedCount">
+        <th mat-header-cell *matHeaderCellDef>Under-Replicated</th>
+        <td mat-cell *matCellDef="let topic">
+          @if (topic.underReplicatedCount > 0) {
+            <span class="topics__warning-badge">{{ topic.underReplicatedCount }}</span>
+          } @else {
+            {{ topic.underReplicatedCount }}
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="messageCount">
+        <th mat-header-cell *matHeaderCellDef>Number of messages</th>
+        <td mat-cell *matCellDef="let topic">{{ topic.messageCount !== undefined ? (topic.messageCount | number) : '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="size">
+        <th mat-header-cell *matHeaderCellDef>Size</th>
+        <td mat-cell *matCellDef="let topic">{{ topic.size | gkeFileSize }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator
+      [length]="totalElements()"
+      [pageIndex]="page()"
+      [pageSize]="pageSize()"
+      [pageSizeOptions]="[25, 50, 100]"
+      (page)="onPageEvent($event)"
+    />
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.topics {
+  mat-card-content {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+
+  &__filter {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  &__warning-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-error-container, #fff3e0);
+    color: var(--mat-sys-on-error-container, #e65100);
+  }
+
+  &__internal-badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-surface-variant, #e7e0ec);
+    color: var(--mat-sys-on-surface-variant, #49454f);
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { TopicsComponent } from './topics.component';
+import { TopicsHarness } from './topics.harness';
+import { fakeKafkaTopic } from '../models/kafka-cluster.fixture';
+import { KafkaTopic } from '../models/kafka-cluster.model';
+
+@Component({
+  standalone: true,
+  imports: [TopicsComponent],
+  template: `<gke-topics
+    [topics]="topics"
+    [totalElements]="totalElements"
+    [page]="page"
+    [pageSize]="pageSize"
+    [loading]="loading"
+    (filterChange)="lastFilter = $event"
+    (pageChange)="lastPageEvent = $event"
+  />`,
+})
+class TestHostComponent {
+  topics: KafkaTopic[] = [];
+  totalElements = 0;
+  page = 0;
+  pageSize = 25;
+  loading = false;
+  lastFilter: string | undefined;
+  lastPageEvent: { page: number; pageSize: number } | undefined;
+}
+
+describe('TopicsComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let harness: TopicsHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('should render topics in the table', async () => {
+    host.topics = [
+      fakeKafkaTopic({ name: 'my-topic', partitionCount: 3, replicationFactor: 2, underReplicatedCount: 0, internal: false }),
+      fakeKafkaTopic({ name: 'orders', partitionCount: 6, replicationFactor: 3, underReplicatedCount: 1, internal: false }),
+    ];
+    host.totalElements = 2;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        name: 'my-topic',
+        partitionCount: '3',
+        replicationFactor: '2',
+        underReplicatedCount: '0',
+      }),
+    );
+    expect(rows[1]['name']).toBe('orders');
+  });
+
+  it('should show warning badge for under-replicated partitions', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'topic-1', underReplicatedCount: 2 })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows[0]['underReplicatedCount']).toContain('2');
+  });
+
+  it('should show Internal badge next to name for internal topics', async () => {
+    host.topics = [fakeKafkaTopic({ name: '__consumer_offsets', internal: true })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows[0]['name']).toContain('__consumer_offsets');
+    expect(rows[0]['name']).toContain('Internal');
+  });
+
+  it('should not show Internal badge for non-internal topics', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic', internal: false })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows[0]['name']).toBe('my-topic');
+    expect(rows[0]['name']).not.toContain('Internal');
+  });
+
+  it('should emit filterChange when typing in filter', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'orders' })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    await harness.setFilter('order');
+    expect(host.lastFilter).toBe('order');
+  });
+
+  it('should render an empty table when no topics', async () => {
+    host.topics = [];
+    host.totalElements = 0;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    expect(await harness.getRowCount()).toBe(0);
+  });
+
+  it('should display size and messageCount columns', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic', size: 1048576, messageCount: 1500 })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows[0]['size']).toBe('1 MB');
+    expect(rows[0]['messageCount']).toContain('1,500');
+  });
+
+  it('should display dash for undefined size and messageCount', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic', size: undefined, messageCount: undefined })];
+    host.totalElements = 1;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rows = await harness.getRowsData();
+    expect(rows[0]['size']).toBe('-');
+    expect(rows[0]['messageCount']).toBe('-');
+  });
+
+  it('should show paginator with correct range', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic' })];
+    host.totalElements = 50;
+    host.page = 0;
+    host.pageSize = 25;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    const rangeLabel = await harness.getRangeLabel();
+    expect(rangeLabel).toContain('1');
+    expect(rangeLabel).toContain('50');
+  });
+
+  it('should show progress bar when loading', async () => {
+    host.topics = [];
+    host.totalElements = 0;
+    host.loading = true;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    expect(await harness.isLoading()).toBe(true);
+  });
+
+  it('should not show progress bar when not loading', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic' })];
+    host.totalElements = 1;
+    host.loading = false;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should emit pageChange when navigating', async () => {
+    host.topics = [fakeKafkaTopic({ name: 'my-topic' })];
+    host.totalElements = 50;
+    host.page = 0;
+    host.pageSize = 25;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicsHarness);
+
+    await harness.goToNextPage();
+    expect(host.lastPageEvent).toEqual({ page: 1, pageSize: 25 });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.stories.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { Meta, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { TopicsComponent } from './topics.component';
+import { fakeKafkaTopic } from '../models/kafka-cluster.fixture';
+
+const meta: Meta<TopicsComponent> = {
+  title: 'Topics',
+  component: TopicsComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideAnimationsAsync()],
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<TopicsComponent>;
+
+export const Default: Story = {
+  args: {
+    topics: [
+      fakeKafkaTopic({
+        name: 'orders',
+        partitionCount: 6,
+        replicationFactor: 3,
+        underReplicatedCount: 0,
+        size: 5242880,
+        messageCount: 12000,
+      }),
+      fakeKafkaTopic({
+        name: 'payments',
+        partitionCount: 3,
+        replicationFactor: 3,
+        underReplicatedCount: 0,
+        size: 2097152,
+        messageCount: 3500,
+      }),
+      fakeKafkaTopic({
+        name: 'notifications',
+        partitionCount: 1,
+        replicationFactor: 2,
+        underReplicatedCount: 0,
+        size: 524288,
+        messageCount: 800,
+      }),
+      fakeKafkaTopic({
+        name: '__consumer_offsets',
+        partitionCount: 50,
+        replicationFactor: 1,
+        underReplicatedCount: 0,
+        internal: true,
+        size: 10485760,
+        messageCount: 50000,
+      }),
+      fakeKafkaTopic({
+        name: '__transaction_state',
+        partitionCount: 50,
+        replicationFactor: 1,
+        underReplicatedCount: 0,
+        internal: true,
+        size: 1048576,
+        messageCount: 200,
+      }),
+    ],
+    totalElements: 5,
+    page: 0,
+    pageSize: 25,
+  },
+};
+
+export const WithUnderReplicated: Story = {
+  args: {
+    topics: [
+      fakeKafkaTopic({
+        name: 'orders',
+        partitionCount: 6,
+        replicationFactor: 3,
+        underReplicatedCount: 2,
+        size: 5242880,
+        messageCount: 12000,
+      }),
+      fakeKafkaTopic({
+        name: 'payments',
+        partitionCount: 3,
+        replicationFactor: 3,
+        underReplicatedCount: 0,
+        size: 2097152,
+        messageCount: 3500,
+      }),
+      fakeKafkaTopic({
+        name: 'events',
+        partitionCount: 12,
+        replicationFactor: 3,
+        underReplicatedCount: 5,
+        size: 52428800,
+        messageCount: 100000,
+      }),
+    ],
+    totalElements: 3,
+    page: 0,
+    pageSize: 25,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    topics: [],
+    totalElements: 0,
+    page: 0,
+    pageSize: 25,
+  },
+};

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule, DecimalPipe } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTableModule } from '@angular/material/table';
+
+import { KafkaTopic } from '../models/kafka-cluster.model';
+import { FileSizePipe } from '../pipes/file-size.pipe';
+
+@Component({
+  selector: 'gke-topics',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatProgressBarModule,
+    FileSizePipe,
+    DecimalPipe,
+  ],
+  templateUrl: './topics.component.html',
+  styleUrls: ['./topics.component.scss'],
+})
+export class TopicsComponent {
+  topics = input<KafkaTopic[]>([]);
+  totalElements = input(0);
+  page = input(0);
+  pageSize = input(25);
+  loading = input(false);
+
+  filterChange = output<string>();
+  pageChange = output<{ page: number; pageSize: number }>();
+
+  displayedColumns = ['name', 'partitionCount', 'replicationFactor', 'underReplicatedCount', 'messageCount', 'size'];
+
+  onFilterInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.filterChange.emit(value);
+  }
+
+  onPageEvent(event: PageEvent) {
+    this.pageChange.emit({ page: event.pageIndex, pageSize: event.pageSize });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.harness.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatPaginatorHarness } from '@angular/material/paginator/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class TopicsHarness extends ComponentHarness {
+  static hostSelector = 'gke-topics';
+
+  private readonly getTable = this.locatorFor(MatTableHarness);
+  private readonly getFilterInput = this.locatorFor(MatInputHarness);
+  private readonly getPaginator = this.locatorFor(MatPaginatorHarness);
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+
+  async getRows() {
+    const table = await this.getTable();
+    return table.getRows();
+  }
+
+  async getRowsData() {
+    const rows = await this.getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async getRowCount() {
+    const rows = await this.getRows();
+    return rows.length;
+  }
+
+  async setFilter(value: string) {
+    const input = await this.getFilterInput();
+    await input.setValue(value);
+  }
+
+  async getPaginatorHarness() {
+    return this.getPaginator();
+  }
+
+  async getRangeLabel() {
+    const paginator = await this.getPaginator();
+    return paginator.getRangeLabel();
+  }
+
+  async goToNextPage() {
+    const paginator = await this.getPaginator();
+    await paginator.goToNextPage();
+  }
+
+  async isLoading() {
+    const progressBar = await this.getProgressBar();
+    return progressBar !== null;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
@@ -24,3 +24,6 @@ export * from './lib/kafka-explorer/kafka-explorer.harness';
 export * from './lib/services/kafka-explorer.service';
 export * from './lib/brokers/brokers.component';
 export * from './lib/brokers/brokers.harness';
+export * from './lib/topics/topics.component';
+export * from './lib/topics/topics.harness';
+export * from './lib/pipes/file-size.pipe';


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12789

## Summary
- Add `POST /kafka-explorer/list-topics` backend endpoint with 1-based `page`/`perPage` query params and standard `data[]` + `pagination{}` response
- Add `gkeFileSize` pipe extracting `formatBytes` from BrokersComponent
- Add `TopicsComponent` with paginated table, name filter, and size/message count display
- Wire up frontend to list-topics API with 0-based paginator ↔ 1-based API conversion

https://github.com/user-attachments/assets/a4cedc73-4c55-46a8-8046-af9655f6a2e1


Next PR : improve UI / add topic detail page