### PR TITLE
ci: use -Dmaven.test.skip=true instead of -DskipTests in build jobs

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -37,7 +37,7 @@ export class BuildBackendJob {
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
       new commands.Run({
         name: 'Build project',
-        command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc`,
+        command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc`,
         environment: {
           BUILD_ID: environment.buildId,
           BUILD_NUMBER: environment.buildNum,

--- a/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
@@ -35,7 +35,7 @@ export class CommunityBuildBackendJob {
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
       new commands.Run({
         name: 'Build project',
-        command: `mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C`,
+        command: `mvn clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C`,
       }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new reusable.ReusedCommand(saveMavenJobCacheCmd, { jobName: jobName }),

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -154,7 +154,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -160,7 +160,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -161,7 +161,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -160,7 +160,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -214,7 +214,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -1069,7 +1069,7 @@ jobs:
           jobName: job-community-build
       - run:
           name: Build project
-          command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C
+          command: mvn clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-community-build

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -129,7 +129,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -190,7 +190,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -214,7 +214,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -1069,7 +1069,7 @@ jobs:
           jobName: job-community-build
       - run:
           name: Build project
-          command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C
+          command: mvn clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-community-build

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -190,7 +190,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -215,7 +215,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -92,7 +92,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -161,7 +161,7 @@ jobs:
           jobName: job-build
       - run:
           name: Build project
-          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -Dmaven.test.skip=true -Dskip.validation=true -Dgravitee.archrules.skip=false -T 2C -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Skip both test compilation and test execution in CI build jobs. -DskipTests only skips execution but still compiles all test sources across 133 modules, including protobuf/gRPC code generation. Tests are compiled in dedicated test jobs downstream.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

