### PR TITLE
feat(kafka-explorer): add sidebar navigation and topic detail view

### DIFF
--- a/gravitee-apim-console-webui/src/management/clusters/details/explorer/cluster-explorer-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/details/explorer/cluster-explorer-page.component.scss
@@ -1,5 +1,5 @@
 @use '../../../../scss/gio-layout' as gio-layout;
 
 :host {
-  @include gio-layout.gio-responsive-margin-container;
+  @include gio-layout.gio-responsive-content-container;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -17,9 +17,11 @@ package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
 
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 
 public interface KafkaClusterDomainService {
     KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
     TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
+    TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicConfigEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicConfigEntry.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+public record TopicConfigEntry(String name, String value, String source, boolean readOnly, boolean sensitive) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicDetail.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record TopicDetail(String name, boolean internal, List<TopicPartitionDetail> partitions, List<TopicConfigEntry> configs) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicPartitionDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/TopicPartitionDetail.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record TopicPartitionDetail(int id, KafkaNode leader, List<KafkaNode> replicas, List<KafkaNode> isr, List<KafkaNode> offline) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
+
+@UseCase
+public class DescribeTopicUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public DescribeTopicUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var topicDetail = kafkaClusterDomainService.describeTopic(config, input.topicName());
+        return new Output(topicDetail);
+    }
+
+    public record Input(String clusterId, String environmentId, String topicName) {}
+
+    public record Output(TopicDetail topicDetail) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -193,15 +193,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
                 .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .get(topicName);
 
-            boolean internal = adminClient
-                .listTopics(new ListTopicsOptions().listInternal(true))
-                .listings()
-                .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .stream()
-                .filter(l -> l.name().equals(topicName))
-                .findFirst()
-                .map(TopicListing::isInternal)
-                .orElse(false);
+            boolean internal = description.isInternal();
 
             List<TopicPartitionDetail> partitions = description
                 .partitions()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -19,8 +19,12 @@ import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicPartitionDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.Pagination;
 import java.util.List;
@@ -40,6 +44,12 @@ public interface KafkaExplorerMapper {
     io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaTopic map(KafkaTopic topic);
 
     List<io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaTopic> mapTopics(List<KafkaTopic> topics);
+
+    DescribeTopicResponse map(TopicDetail topicDetail);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.TopicPartition map(TopicPartitionDetail partition);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.TopicConfig map(TopicConfigEntry config);
 
     default ListTopicsResponse map(TopicsPage topicsPage, int page, int perPage) {
         return new ListTopicsResponse()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -18,9 +18,11 @@ package io.gravitee.rest.api.kafkaexplorer.resource;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.mapper.KafkaExplorerMapper;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
@@ -47,6 +49,9 @@ public class KafkaExplorerResource {
 
     @Inject
     private ListTopicsUseCase listTopicsUseCase;
+
+    @Inject
+    private DescribeTopicUseCase describeTopicUseCase;
 
     @POST
     @Path("/describe-cluster")
@@ -102,6 +107,38 @@ public class KafkaExplorerResource {
                 new ListTopicsUseCase.Input(request.getClusterId(), environmentId, request.getNameFilter(), page0Based, perPage)
             );
             return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.topicsPage(), page, perPage)).build();
+        } catch (KafkaExplorerException e) {
+            return Response.status(Response.Status.BAD_GATEWAY)
+                .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))
+                .build();
+        }
+    }
+
+    @POST
+    @Path("/describe-topic")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @GraviteeLicenseFeature("apim-native-kafka-explorer")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = RolePermissionAction.READ) })
+    public Response describeTopic(DescribeTopicRequest request) {
+        if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("clusterId is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (request.getTopicName() == null || request.getTopicName().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("topicName is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        try {
+            var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+            var result = describeTopicUseCase.execute(
+                new DescribeTopicUseCase.Input(request.getClusterId(), environmentId, request.getTopicName())
+            );
+            return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.topicDetail())).build();
         } catch (KafkaExplorerException e) {
             return Response.status(Response.Status.BAD_GATEWAY)
                 .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -96,6 +96,40 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/describe-topic:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: Describe a Kafka topic
+            description: |
+                Connects to a Kafka cluster and returns detailed information about a specific topic including partitions and configuration.
+            operationId: describeTopic
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DescribeTopicRequest"
+            responses:
+                "200":
+                    description: Topic detail
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DescribeTopicResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
 components:
     schemas:
         DescribeClusterRequest:
@@ -231,6 +265,70 @@ components:
                     type: integer
                     format: int64
                     description: Total number of messages (sum of latest offsets), or null if unavailable
+
+        DescribeTopicRequest:
+            type: object
+            required:
+                - clusterId
+                - topicName
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                topicName:
+                    type: string
+                    description: Name of the topic to describe
+
+        DescribeTopicResponse:
+            type: object
+            properties:
+                name:
+                    type: string
+                internal:
+                    type: boolean
+                partitions:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TopicPartition"
+                configs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TopicConfig"
+
+        TopicPartition:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int32
+                leader:
+                    $ref: "#/components/schemas/KafkaNode"
+                replicas:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaNode"
+                isr:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaNode"
+                offline:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaNode"
+
+        TopicConfig:
+            type: object
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+                source:
+                    type: string
+                readOnly:
+                    type: boolean
+                sensitive:
+                    type: boolean
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCaseTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicPartitionDetail;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DescribeTopicUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private DescribeTopicUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new DescribeTopicUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_topic_detail() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var expectedDetail = new TopicDetail(
+            "my-topic",
+            false,
+            List.of(
+                new TopicPartitionDetail(
+                    0,
+                    new KafkaNode(0, "broker-host", 9092),
+                    List.of(new KafkaNode(0, "broker-host", 9092)),
+                    List.of(new KafkaNode(0, "broker-host", 9092)),
+                    List.of()
+                )
+            ),
+            List.of(new TopicConfigEntry("retention.ms", "604800000", "DYNAMIC_TOPIC_CONFIG", false, false))
+        );
+        clusterDomainService.givenTopicDetail(expectedDetail);
+
+        var result = useCase.execute(new DescribeTopicUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic"));
+
+        assertThat(result.topicDetail()).isEqualTo(expectedDetail);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
+
+        assertThatThrownBy(() -> useCase.execute(new DescribeTopicUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic")))
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDoma
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 import java.util.Comparator;
 import java.util.List;
@@ -28,6 +29,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
 
     private KafkaClusterInfo result;
     private List<KafkaTopic> topics;
+    private TopicDetail topicDetail;
     private KafkaExplorerException exception;
 
     public void givenClusterInfo(KafkaClusterInfo info) {
@@ -40,10 +42,16 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         this.exception = null;
     }
 
+    public void givenTopicDetail(TopicDetail detail) {
+        this.topicDetail = detail;
+        this.exception = null;
+    }
+
     public void givenException(KafkaExplorerException exception) {
         this.exception = exception;
         this.result = null;
         this.topics = null;
+        this.topicDetail = null;
     }
 
     @Override
@@ -71,5 +79,13 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         int toIndex = Math.min(fromIndex + perPage, totalCount);
 
         return new TopicsPage(filtered.subList(fromIndex, toIndex), totalCount, page, perPage);
+    }
+
+    @Override
+    public TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName) {
+        if (exception != null) {
+            throw exception;
+        }
+        return topicDetail;
     }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
@@ -17,9 +17,37 @@
 -->
 <mat-card class="brokers">
   <mat-card-header>
-    <mat-card-title>Broker Nodes</mat-card-title>
+    <mat-card-title>Brokers</mat-card-title>
   </mat-card-header>
   <mat-card-content>
+    @if (controller(); as ctrl) {
+      <div class="brokers__cluster-info">
+        <div class="brokers__cluster-info-items">
+          <div class="brokers__cluster-info-item">
+            <span class="mat-caption">Cluster ID</span>
+            <span class="mat-body-2">{{ clusterId() }}</span>
+          </div>
+          <div class="brokers__cluster-info-item">
+            <span class="mat-caption">Controller</span>
+            <span class="mat-body-2">{{ ctrl.host }}:{{ ctrl.port }} (node {{ ctrl.id }})</span>
+          </div>
+          <div class="brokers__cluster-info-item">
+            <span class="mat-caption">Brokers</span>
+            <span class="mat-body-2">{{ nodes().length }}</span>
+          </div>
+          <div class="brokers__cluster-info-item">
+            <span class="mat-caption">Topics</span>
+            <span class="mat-body-2">{{ totalTopics() }}</span>
+          </div>
+          <div class="brokers__cluster-info-item">
+            <span class="mat-caption">Partitions</span>
+            <span class="mat-body-2">{{ totalPartitions() }}</span>
+          </div>
+        </div>
+      </div>
+    }
+
+    <h5 class="brokers__section-title">Broker Nodes</h5>
     <table mat-table [dataSource]="nodes()">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef>Node ID</th>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
@@ -37,4 +37,27 @@
     background-color: var(--mat-sys-primary-container, #e8def8);
     color: var(--mat-sys-on-primary-container, #1d192b);
   }
+
+  &__cluster-info {
+    margin-top: 4px;
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--mat-sys-outline-variant, #cac4d0);
+  }
+
+  &__cluster-info-items {
+    display: flex;
+    gap: 32px;
+    flex-wrap: wrap;
+  }
+
+  &__cluster-info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__section-title {
+    margin: 0 0 8px;
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.ts
@@ -18,7 +18,7 @@ import { Component, input } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 
-import { BrokerDetail } from '../models/kafka-cluster.model';
+import { BrokerDetail, KafkaNode } from '../models/kafka-cluster.model';
 import { FileSizePipe } from '../pipes/file-size.pipe';
 
 @Component({
@@ -31,6 +31,10 @@ import { FileSizePipe } from '../pipes/file-size.pipe';
 export class BrokersComponent {
   nodes = input<BrokerDetail[]>([]);
   controllerId = input<number>(-1);
+  clusterId = input<string>('');
+  controller = input<KafkaNode | undefined>(undefined);
+  totalTopics = input<number>(0);
+  totalPartitions = input<number>(0);
 
   displayedColumns = ['id', 'host', 'port', 'rack', 'leaderPartitions', 'replicaPartitions', 'logDirSize'];
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.harness.ts
@@ -20,6 +20,12 @@ export class BrokersHarness extends ComponentHarness {
   static hostSelector = 'gke-brokers';
 
   private readonly getTable = this.locatorFor(MatTableHarness);
+  private readonly getClusterInfo = this.locatorForOptional('.brokers__cluster-info');
+
+  async getClusterInfoText() {
+    const info = await this.getClusterInfo();
+    return info ? info.text() : null;
+  }
 
   async getRows() {
     const table = await this.getTable();

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
@@ -62,15 +62,20 @@
             />
           }
           @case ('topics') {
-            <gke-topics
-              [topics]="topicsPage()?.data ?? []"
-              [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
-              [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
-              [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
-              [loading]="topicsLoading()"
-              (filterChange)="onTopicsFilterChange($event)"
-              (pageChange)="onTopicsPageChange($event)"
-            />
+            @if (selectedTopic()) {
+              <gke-topic-detail [topicDetail]="topicDetail()" [loading]="topicDetailLoading()" (back)="onTopicBack()" />
+            } @else {
+              <gke-topics
+                [topics]="topicsPage()?.data ?? []"
+                [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
+                [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
+                [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
+                [loading]="topicsLoading()"
+                (filterChange)="onTopicsFilterChange($event)"
+                (pageChange)="onTopicsPageChange($event)"
+                (topicSelect)="onTopicSelect($event)"
+              />
+            }
           }
         }
       </div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
@@ -30,43 +30,50 @@
 
 @if (clusterInfo(); as info) {
   <div class="kafka-explorer">
-    <mat-card class="kafka-explorer__topbar">
-      <mat-card-content>
-        <div class="kafka-explorer__topbar-items">
-          <div class="kafka-explorer__topbar-item">
-            <span class="mat-caption">Cluster ID</span>
-            <span class="mat-body-2">{{ info.clusterId }}</span>
-          </div>
-          <div class="kafka-explorer__topbar-item">
-            <span class="mat-caption">Controller</span>
-            <span class="mat-body-2">{{ info.controller.host }}:{{ info.controller.port }} (node {{ info.controller.id }})</span>
-          </div>
-          <div class="kafka-explorer__topbar-item">
-            <span class="mat-caption">Brokers</span>
-            <span class="mat-body-2">{{ info.nodes.length }}</span>
-          </div>
-          <div class="kafka-explorer__topbar-item">
-            <span class="mat-caption">Topics</span>
-            <span class="mat-body-2">{{ info.totalTopics }}</span>
-          </div>
-          <div class="kafka-explorer__topbar-item">
-            <span class="mat-caption">Partitions</span>
-            <span class="mat-body-2">{{ info.totalPartitions }}</span>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-card>
-
-    <gke-brokers [nodes]="info.nodes" [controllerId]="info.controller.id" />
-
-    <gke-topics
-      [topics]="topicsPage()?.data ?? []"
-      [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
-      [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
-      [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
-      [loading]="topicsLoading()"
-      (filterChange)="onTopicsFilterChange($event)"
-      (pageChange)="onTopicsPageChange($event)"
-    />
+    <div class="kafka-explorer__layout">
+      <aside class="kafka-explorer__sidebar">
+        <button
+          mat-button
+          class="kafka-explorer__sidebar-btn"
+          [class.kafka-explorer__sidebar-btn--active]="activeSection() === 'brokers'"
+          (click)="activeSection.set('brokers')"
+        >
+          Brokers
+        </button>
+        <button
+          mat-button
+          class="kafka-explorer__sidebar-btn"
+          [class.kafka-explorer__sidebar-btn--active]="activeSection() === 'topics'"
+          (click)="activeSection.set('topics')"
+        >
+          Topics
+        </button>
+      </aside>
+      <div class="kafka-explorer__content">
+        @switch (activeSection()) {
+          @case ('brokers') {
+            <gke-brokers
+              [nodes]="info.nodes"
+              [controllerId]="info.controller.id"
+              [clusterId]="info.clusterId"
+              [controller]="info.controller"
+              [totalTopics]="info.totalTopics"
+              [totalPartitions]="info.totalPartitions"
+            />
+          }
+          @case ('topics') {
+            <gke-topics
+              [topics]="topicsPage()?.data ?? []"
+              [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
+              [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
+              [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
+              [loading]="topicsLoading()"
+              (filterChange)="onTopicsFilterChange($event)"
+              (pageChange)="onTopicsPageChange($event)"
+            />
+          }
+        }
+      </div>
+    </div>
   </div>
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.scss
@@ -15,26 +15,34 @@
  */
 
 .kafka-explorer {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-
-  &__topbar {
-    mat-card-content {
-      padding: 16px;
-    }
-  }
-
-  &__topbar-items {
+  &__layout {
     display: flex;
-    gap: 32px;
-    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
   }
 
-  &__topbar-item {
+  &__sidebar {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-width: 120px;
+  }
+
+  &__sidebar-btn {
+    justify-content: flex-start;
+    background-color: transparent;
+    color: var(--mat-sys-on-surface, #1d1b20);
+
+    &--active {
+      background-color: var(--mat-sys-surface-variant, #e7e0ec);
+      color: var(--mat-sys-on-surface-variant, #49454f);
+    }
+  }
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+    max-width: 1200px;
   }
 }
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.stories.ts
@@ -30,15 +30,23 @@ import { KafkaExplorerComponent } from './kafka-explorer.component';
 import {
   fakeBrokerDetail,
   fakeDescribeClusterResponse,
+  fakeDescribeTopicResponse,
   fakeKafkaNode,
   fakeKafkaTopic,
   fakeListTopicsResponse,
   fakePagination,
 } from '../models/kafka-cluster.fixture';
-import { DescribeClusterResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
+import { DescribeClusterResponse, DescribeTopicResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
 
-function mockSuccessInterceptor(clusterResponse: DescribeClusterResponse, topicsResponse: ListTopicsResponse): HttpInterceptorFn {
+function mockSuccessInterceptor(
+  clusterResponse: DescribeClusterResponse,
+  topicsResponse: ListTopicsResponse,
+  topicDetailResponse: DescribeTopicResponse = fakeDescribeTopicResponse(),
+): HttpInterceptorFn {
   return (req: HttpRequest<unknown>, _next: HttpHandlerFn): Observable<HttpEvent<unknown>> => {
+    if (req.url.includes('describe-topic')) {
+      return of(new HttpResponse({ status: 200, body: topicDetailResponse })).pipe(delay(200));
+    }
     if (req.url.includes('list-topics')) {
       return of(new HttpResponse({ status: 200, body: topicsResponse })).pipe(delay(0));
     }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.ts
@@ -16,7 +16,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, OnInit, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
@@ -29,7 +29,7 @@ import { TopicsComponent } from '../topics/topics.component';
 @Component({
   selector: 'gke-kafka-explorer',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatProgressSpinnerModule, MatIconModule, BrokersComponent, TopicsComponent],
+  imports: [CommonModule, MatButtonModule, MatProgressSpinnerModule, MatIconModule, BrokersComponent, TopicsComponent],
   templateUrl: './kafka-explorer.component.html',
   styleUrls: ['./kafka-explorer.component.scss'],
 })
@@ -37,6 +37,7 @@ export class KafkaExplorerComponent implements OnInit {
   baseURL = input.required<string>();
   clusterId = input.required<string>();
 
+  activeSection = signal<'brokers' | 'topics'>('brokers');
   clusterInfo = signal<DescribeClusterResponse | undefined>(undefined);
   topicsPage = signal<ListTopicsResponse | undefined>(undefined);
   loading = signal(false);

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/testing';
 
 import { BrokersHarness } from '../brokers/brokers.harness';
@@ -26,7 +27,7 @@ export class KafkaExplorerHarness extends ComponentHarness {
   private readonly getBrokers = this.locatorForOptional(BrokersHarness);
   private readonly getTopics = this.locatorForOptional(TopicsHarness);
   private readonly getErrorBanner = this.locatorForOptional('.kafka-explorer__error');
-  private readonly getTopbar = this.locatorForOptional('.kafka-explorer__topbar');
+  private readonly getSidebarButtons = this.locatorForAll(MatButtonHarness.with({ ancestor: '.kafka-explorer__sidebar' }));
 
   async isLoading() {
     return (await this.getSpinner()) !== null;
@@ -37,9 +38,20 @@ export class KafkaExplorerHarness extends ComponentHarness {
     return error ? error.text() : null;
   }
 
-  async getTopbarText() {
-    const topbar = await this.getTopbar();
-    return topbar ? topbar.text() : null;
+  async selectSection(label: string) {
+    const buttons = await this.getSidebarButtons();
+    for (const button of buttons) {
+      if ((await button.getText()) === label) {
+        await button.click();
+        return;
+      }
+    }
+    throw new Error(`Sidebar button "${label}" not found`);
+  }
+
+  async getSidebarLabels() {
+    const buttons = await this.getSidebarButtons();
+    return Promise.all(buttons.map(b => b.getText()));
   }
 
   async getBrokersHarness() {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.harness.ts
@@ -18,6 +18,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/testing';
 
 import { BrokersHarness } from '../brokers/brokers.harness';
+import { TopicDetailHarness } from '../topic-detail/topic-detail.harness';
 import { TopicsHarness } from '../topics/topics.harness';
 
 export class KafkaExplorerHarness extends ComponentHarness {
@@ -60,5 +61,9 @@ export class KafkaExplorerHarness extends ComponentHarness {
 
   async getTopicsHarness() {
     return this.getTopics();
+  }
+
+  async getTopicDetailHarness() {
+    return this.locatorForOptional(TopicDetailHarness)();
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -13,7 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BrokerDetail, DescribeClusterResponse, KafkaNode, KafkaTopic, ListTopicsResponse, Pagination } from './kafka-cluster.model';
+import {
+  BrokerDetail,
+  DescribeClusterResponse,
+  DescribeTopicResponse,
+  KafkaNode,
+  KafkaTopic,
+  ListTopicsResponse,
+  Pagination,
+  TopicConfig,
+  TopicPartitionDetail,
+} from './kafka-cluster.model';
 
 export function fakeKafkaNode(overrides: Partial<KafkaNode> = {}): KafkaNode {
   return {
@@ -90,6 +100,41 @@ export function fakeListTopicsResponse(overrides: Partial<ListTopicsResponse> = 
       }),
     ],
     pagination: fakePagination(),
+    ...overrides,
+  };
+}
+
+export function fakeTopicPartitionDetail(overrides: Partial<TopicPartitionDetail> = {}): TopicPartitionDetail {
+  return {
+    id: 0,
+    leader: fakeKafkaNode({ id: 0 }),
+    replicas: [fakeKafkaNode({ id: 0 }), fakeKafkaNode({ id: 1 })],
+    isr: [fakeKafkaNode({ id: 0 }), fakeKafkaNode({ id: 1 })],
+    offline: [],
+    ...overrides,
+  };
+}
+
+export function fakeTopicConfig(overrides: Partial<TopicConfig> = {}): TopicConfig {
+  return {
+    name: 'retention.ms',
+    value: '604800000',
+    source: 'DYNAMIC_TOPIC_CONFIG',
+    readOnly: false,
+    sensitive: false,
+    ...overrides,
+  };
+}
+
+export function fakeDescribeTopicResponse(overrides: Partial<DescribeTopicResponse> = {}): DescribeTopicResponse {
+  return {
+    name: 'my-topic',
+    internal: false,
+    partitions: [fakeTopicPartitionDetail({ id: 0 }), fakeTopicPartitionDetail({ id: 1, leader: fakeKafkaNode({ id: 1 }) })],
+    configs: [
+      fakeTopicConfig({ name: 'retention.ms', value: '604800000' }),
+      fakeTopicConfig({ name: 'cleanup.policy', value: 'delete', source: 'DEFAULT_CONFIG' }),
+    ],
     ...overrides,
   };
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -59,3 +59,26 @@ export interface ListTopicsResponse {
   data: KafkaTopic[];
   pagination: Pagination;
 }
+
+export interface TopicPartitionDetail {
+  id: number;
+  leader: KafkaNode;
+  replicas: KafkaNode[];
+  isr: KafkaNode[];
+  offline: KafkaNode[];
+}
+
+export interface TopicConfig {
+  name: string;
+  value: string;
+  source: string;
+  readOnly: boolean;
+  sensitive: boolean;
+}
+
+export interface DescribeTopicResponse {
+  name: string;
+  internal: boolean;
+  partitions: TopicPartitionDetail[];
+  configs: TopicConfig[];
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -17,7 +17,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DescribeClusterResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
+import { DescribeClusterResponse, DescribeTopicResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
 
 @Injectable({
   providedIn: 'root',
@@ -37,5 +37,9 @@ export class KafkaExplorerService {
         params: { page: page.toString(), perPage: perPage.toString() },
       },
     );
+  }
+
+  describeTopic(baseURL: string, clusterId: string, topicName: string): Observable<DescribeTopicResponse> {
+    return this.http.post<DescribeTopicResponse>(`${baseURL}/kafka-explorer/describe-topic`, { clusterId, topicName });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.html
@@ -1,0 +1,108 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="topic-detail">
+  <div class="topic-detail__header">
+    <button mat-icon-button (click)="back.emit()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+    <h3 class="topic-detail__title">{{ topicDetail()?.name }}</h3>
+    @if (topicDetail()?.internal) {
+      <span class="topic-detail__internal-badge">Internal</span>
+    }
+  </div>
+
+  @if (loading()) {
+    <mat-progress-bar mode="indeterminate" />
+  }
+
+  @if (topicDetail(); as detail) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Partitions</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table mat-table [dataSource]="detail.partitions">
+          <ng-container matColumnDef="id">
+            <th mat-header-cell *matHeaderCellDef>ID</th>
+            <td mat-cell *matCellDef="let p">{{ p.id }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="leader">
+            <th mat-header-cell *matHeaderCellDef>Leader</th>
+            <td mat-cell *matCellDef="let p">{{ p.leader?.host }}:{{ p.leader?.port }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="replicas">
+            <th mat-header-cell *matHeaderCellDef>Replicas</th>
+            <td mat-cell *matCellDef="let p">{{ p.replicas?.length }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="isr">
+            <th mat-header-cell *matHeaderCellDef>ISR</th>
+            <td mat-cell *matCellDef="let p">{{ p.isr?.length }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="offline">
+            <th mat-header-cell *matHeaderCellDef>Offline</th>
+            <td mat-cell *matCellDef="let p">{{ p.offline?.length }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="partitionColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: partitionColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Configuration</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table mat-table [dataSource]="detail.configs">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="value">
+            <th mat-header-cell *matHeaderCellDef>Value</th>
+            <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="source">
+            <th mat-header-cell *matHeaderCellDef>Source</th>
+            <td mat-cell *matCellDef="let c">{{ c.source }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="readOnly">
+            <th mat-header-cell *matHeaderCellDef>Read Only</th>
+            <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="sensitive">
+            <th mat-header-cell *matHeaderCellDef>Sensitive</th>
+            <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.scss
@@ -14,46 +14,36 @@
  * limitations under the License.
  */
 
-.topics {
-  mat-card-content {
-    overflow-x: auto;
+.topic-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
-  table {
-    width: 100%;
-  }
-
-  &__filter {
-    width: 100%;
-    margin-bottom: 8px;
-  }
-
-  &__warning-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 500;
-    background-color: var(--mat-sys-error-container, #fff3e0);
-    color: var(--mat-sys-on-error-container, #e65100);
-  }
-
-  &__row {
-    cursor: pointer;
-
-    &:hover {
-      background-color: var(--mat-sys-surface-variant, #f5f5f5);
-    }
+  &__title {
+    margin: 0;
   }
 
   &__internal-badge {
     display: inline-block;
-    margin-left: 8px;
     padding: 2px 8px;
     border-radius: 12px;
     font-size: 11px;
     font-weight: 500;
     background-color: var(--mat-sys-surface-variant, #e7e0ec);
     color: var(--mat-sys-on-surface-variant, #49454f);
+  }
+
+  mat-card-content {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { TopicDetailComponent } from './topic-detail.component';
+import { TopicDetailHarness } from './topic-detail.harness';
+import { fakeDescribeTopicResponse, fakeKafkaNode, fakeTopicPartitionDetail } from '../models/kafka-cluster.fixture';
+import { DescribeTopicResponse } from '../models/kafka-cluster.model';
+
+@Component({
+  standalone: true,
+  imports: [TopicDetailComponent],
+  template: `<gke-topic-detail [topicDetail]="topicDetail()" [loading]="loading()" (back)="backCalled = true" />`,
+})
+class TestHostComponent {
+  topicDetail = signal<DescribeTopicResponse | undefined>(undefined);
+  loading = signal(false);
+  backCalled = false;
+}
+
+describe('TopicDetailComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let harness: TopicDetailHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.componentInstance.topicDetail.set(fakeDescribeTopicResponse());
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TopicDetailHarness);
+  });
+
+  it('should display topic name', async () => {
+    expect(await harness.getTopicName()).toBe('my-topic');
+  });
+
+  it('should not show internal badge for non-internal topic', async () => {
+    expect(await harness.isInternal()).toBe(false);
+  });
+
+  it('should show internal badge for internal topic', async () => {
+    fixture.componentInstance.topicDetail.set(fakeDescribeTopicResponse({ internal: true }));
+    fixture.detectChanges();
+
+    expect(await harness.isInternal()).toBe(true);
+  });
+
+  it('should display partitions table', async () => {
+    const rows = await harness.getPartitionsRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['id']).toBe('0');
+    expect(rows[0]['leader']).toContain('kafka-broker-0.example.com');
+    expect(rows[0]['replicas']).toBe('2');
+    expect(rows[0]['isr']).toBe('2');
+    expect(rows[0]['offline']).toBe('0');
+  });
+
+  it('should display config table', async () => {
+    const rows = await harness.getConfigRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['name']).toBe('retention.ms');
+    expect(rows[0]['value']).toBe('604800000');
+    expect(rows[0]['source']).toBe('DYNAMIC_TOPIC_CONFIG');
+  });
+
+  it('should emit back on back button click', async () => {
+    await harness.clickBack();
+    expect(fixture.componentInstance.backCalled).toBe(true);
+  });
+
+  it('should show loading bar when loading', async () => {
+    fixture.componentInstance.loading.set(true);
+    fixture.detectChanges();
+
+    expect(await harness.isLoading()).toBe(true);
+  });
+
+  it('should display offline count when replicas are offline', async () => {
+    fixture.componentInstance.topicDetail.set(
+      fakeDescribeTopicResponse({
+        partitions: [
+          fakeTopicPartitionDetail({
+            id: 0,
+            replicas: [fakeKafkaNode({ id: 0 }), fakeKafkaNode({ id: 1 })],
+            isr: [fakeKafkaNode({ id: 0 })],
+            offline: [fakeKafkaNode({ id: 1 })],
+          }),
+        ],
+      }),
+    );
+    fixture.detectChanges();
+
+    const rows = await harness.getPartitionsRows();
+    expect(rows[0]['offline']).toBe('1');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTableModule } from '@angular/material/table';
+
+import { DescribeTopicResponse } from '../models/kafka-cluster.model';
+
+@Component({
+  selector: 'gke-topic-detail',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatTableModule, MatIconModule, MatButtonModule, MatProgressBarModule],
+  templateUrl: './topic-detail.component.html',
+  styleUrls: ['./topic-detail.component.scss'],
+})
+export class TopicDetailComponent {
+  topicDetail = input<DescribeTopicResponse | undefined>();
+  loading = input(false);
+
+  back = output<void>();
+
+  partitionColumns = ['id', 'leader', 'replicas', 'isr', 'offline'];
+  configColumns = ['name', 'value', 'source', 'readOnly', 'sensitive'];
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topic-detail/topic-detail.harness.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class TopicDetailHarness extends ComponentHarness {
+  static hostSelector = 'gke-topic-detail';
+
+  private readonly getTables = this.locatorForAll(MatTableHarness);
+  private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getTitle = this.locatorFor('.topic-detail__title');
+  private readonly getInternalBadge = this.locatorForOptional('.topic-detail__internal-badge');
+
+  async getTopicName() {
+    const title = await this.getTitle();
+    return title.text();
+  }
+
+  async isInternal() {
+    return (await this.getInternalBadge()) !== null;
+  }
+
+  async isLoading() {
+    return (await this.getProgressBar()) !== null;
+  }
+
+  async clickBack() {
+    const button = await this.getBackButton();
+    await button.click();
+  }
+
+  async getPartitionsRows() {
+    const tables = await this.getTables();
+    if (tables.length < 1) return [];
+    const rows = await tables[0].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async getConfigRows() {
+    const tables = await this.getTables();
+    if (tables.length < 2) return [];
+    const rows = await tables[1].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.html
@@ -74,7 +74,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="topics__row" (click)="topicSelect.emit(row.name)"></tr>
     </table>
 
     <mat-paginator

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics.component.ts
@@ -51,6 +51,7 @@ export class TopicsComponent {
 
   filterChange = output<string>();
   pageChange = output<{ page: number; pageSize: number }>();
+  topicSelect = output<string>();
 
   displayedColumns = ['name', 'partitionCount', 'replicationFactor', 'underReplicatedCount', 'messageCount', 'size'];
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
@@ -26,4 +26,6 @@ export * from './lib/brokers/brokers.component';
 export * from './lib/brokers/brokers.harness';
 export * from './lib/topics/topics.component';
 export * from './lib/topics/topics.harness';
+export * from './lib/topic-detail/topic-detail.component';
+export * from './lib/topic-detail/topic-detail.harness';
 export * from './lib/pipes/file-size.pipe';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12789

## Description

Adds sidebar navigation and topic detail view to the Kafka Explorer.

### Sidebar navigation
- Replace vertical stacking of Brokers/Topics with a sidebar + content layout
- Sidebar buttons allow switching between Brokers and Topics sections
- Cluster info (cluster ID, controller, total topics, total partitions) is now displayed within the Brokers card

### Describe topic backend endpoint
- New `POST /kafka-explorer/describe-topic` endpoint returning partitions and configuration for a given topic
- Domain models: `TopicDetail`, `TopicPartitionDetail`, `TopicConfigEntry`
- `DescribeTopicUseCase` following existing clean architecture patterns
- `KafkaClusterDomainServiceImpl.describeTopic()` using `withAdminClient` helper
- OpenAPI spec, MapStruct mapper, unit and integration tests

### Topic detail frontend view
- New `gke-topic-detail` dumb component with partitions table and configuration table
- Click on a topic row in the list navigates to the detail view
- Back button returns to the topic list
- Service method `describeTopic()`, models, fixtures, harness, and tests

## Screenshots

https://github.com/user-attachments/assets/77286b75-9021-45b2-848f-e3def59cd583

