### PR TITLE
feat(portal): Add support for default OpenAPI page content creation a…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolde
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
@@ -74,17 +75,25 @@ public interface PortalNavigationItemsMapper {
         target = "portalPageContentId",
         expression = "java(page.getPortalPageContentId() == null ? null : io.gravitee.apim.core.portal_page.model.PortalPageContentId.of(page.getPortalPageContentId().toString()))"
     )
+    @Mapping(
+        target = "contentType",
+        expression = "java(page.getContentType() == null ? io.gravitee.apim.core.portal_page.model.PortalPageContentType.GRAVITEE_MARKDOWN : map(page.getContentType()))"
+    )
     io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage page
     );
 
+    @Mapping(target = "contentType", constant = "GRAVITEE_MARKDOWN")
     io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder folder
     );
 
+    @Mapping(target = "contentType", constant = "GRAVITEE_MARKDOWN")
     io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink link
     );
+
+    @Mapping(target = "contentType", constant = "GRAVITEE_MARKDOWN")
     io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi api
     );
@@ -115,6 +124,11 @@ public interface PortalNavigationItemsMapper {
 
     default String map(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId id) {
         return id != null ? id.json() : null;
+    }
+
+    default io.gravitee.apim.core.portal_page.model.PortalPageContentType map(PortalPageContentType type) {
+        if (type == null) return null;
+        return io.gravitee.apim.core.portal_page.model.PortalPageContentType.valueOf(type.name());
     }
 
     default io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem map(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2122,6 +2122,9 @@ components:
               format: uuid
               description: The UUID of the portal page content
               example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+            contentType:
+              $ref: "#/components/schemas/PortalPageContentType"
+              description: The content type for the page. Defaults to GRAVITEE_MARKDOWN if not provided.
     CreatePortalNavigationLink:
       type: object
       title: "CreatePortalNavigationLink"
@@ -2264,6 +2267,13 @@ components:
           LINK: "#/components/schemas/UpdatePortalNavigationLink"
           API: "#/components/schemas/UpdatePortalNavigationApi"
 
+    PortalPageContentType:
+      type: string
+      description: Type of portal page content
+      enum:
+        - GRAVITEE_MARKDOWN
+        - OPENAPI
+
     PortalPageContent:
       type: object
       description: Portal page content
@@ -2272,11 +2282,7 @@ components:
           type: string
           description: The unique ID of the portal page content
         type:
-          type: string
-          description: Content type
-          enum:
-            - GRAVITEE_MARKDOWN
-            - OPENAPI
+          $ref: "#/components/schemas/PortalPageContentType"
         content:
           type: string
           description: The content of the page

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolde
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -200,6 +201,17 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(1);
             assertThat(result.getParentId().id()).isEqualTo(page.getParentId());
             assertThat(result.getPortalPageContentId().id()).isEqualTo(((CreatePortalNavigationPage) page).getPortalPageContentId());
+        }
+
+        @Test
+        void should_map_content_type_from_create_portal_navigation_page() {
+            final var page = (CreatePortalNavigationPage) PortalNavigationItemsFixtures.aCreatePortalNavigationPage();
+            page.setContentType(PortalPageContentType.OPENAPI);
+
+            var result = mapper.map(page);
+
+            assertThat(result).isInstanceOf(CreatePortalNavigationItem.class);
+            assertThat(result.getContentType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalPageContentType.OPENAPI);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalPageContentFixtures;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
-import io.gravitee.rest.api.management.v2.rest.model.PortalPageContent;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -56,7 +56,7 @@ class PortalPageContentMapperTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo("12345678-1234-1234-1234-123456789abc");
         assertThat(result.getContent()).isEqualTo("# Welcome\n\nThis is a test page.");
-        assertThat(result.getType()).isEqualTo(PortalPageContent.TypeEnum.GRAVITEE_MARKDOWN);
+        assertThat(result.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
     }
 
     @Test
@@ -84,6 +84,6 @@ class PortalPageContentMapperTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(contentId.json());
         assertThat(result.getContent()).isEqualTo("Test content");
-        assertThat(result.getType()).isEqualTo(PortalPageContent.TypeEnum.GRAVITEE_MARKDOWN);
+        assertThat(result.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
@@ -23,11 +23,8 @@ import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalPageContentFixtures;
-import inmemory.PortalPageContentCrudServiceInMemory;
-import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
-import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -45,7 +42,6 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author GraviteeSource Team
@@ -125,7 +121,7 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
                 assertThat(result.getId()).isEqualTo(CONTENT_ID);
                 assertThat(result.getContent()).isEqualTo(PortalPageContentFixtures.CONTENT);
                 assertThat(result.getType()).isEqualTo(
-                    io.gravitee.rest.api.management.v2.rest.model.PortalPageContent.TypeEnum.GRAVITEE_MARKDOWN
+                    io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType.GRAVITEE_MARKDOWN
                 );
             });
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -58,7 +59,11 @@ public class PortalNavigationItemDomainService {
             createPortalNavigationItem.getType() == PortalNavigationItemType.PAGE &&
             createPortalNavigationItem.getPortalPageContentId() == null
         ) {
-            final var defaultPageContent = pageContentCrudService.createDefault(organizationId, environmentId);
+            final var defaultPageContent = pageContentCrudService.createDefault(
+                organizationId,
+                environmentId,
+                createPortalNavigationItem.getContentType()
+            );
             createPortalNavigationItem.setPortalPageContentId(defaultPageContent.getId());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -33,6 +34,10 @@ public final class CreatePortalNavigationItem {
     private PortalNavigationItemType type;
     private PortalNavigationItemId parentId;
     private PortalPageContentId portalPageContentId;
+
+    @NotNull
+    private PortalPageContentType contentType;
+
     private String url;
     private String apiId;
     private PortalVisibility visibility;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -144,7 +145,13 @@ public class CreateDefaultPortalNavigationItemsUseCase {
     }
 
     private CreatePortalNavigationItem buildCommonItem(String title, PortalNavigationItemId parentId, PortalArea area) {
-        return CreatePortalNavigationItem.builder().title(title).area(area).parentId(parentId).published(true).build();
+        return CreatePortalNavigationItem.builder()
+            .title(title)
+            .area(area)
+            .parentId(parentId)
+            .published(true)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .build();
     }
 
     private PortalPageContent<?> createPortalPageContent(String organizationId, String environmentId, String contentPath) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultGraviteeMarkdownProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultGraviteeMarkdownProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_page.adapter;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultGraviteeMarkdownProvider implements DefaultPortalPageContentProvider {
+
+    private String defaultPortalPageContent;
+
+    @Override
+    public boolean appliesTo(PortalPageContentType contentType) {
+        return contentType == PortalPageContentType.GRAVITEE_MARKDOWN;
+    }
+
+    @Override
+    public PortalPageContent<?> provide(String organizationId, String environmentId) {
+        return new GraviteeMarkdownPageContent(
+            PortalPageContentId.random(),
+            organizationId,
+            environmentId,
+            new GraviteeMarkdown(getDefaultPortalPageContent())
+        );
+    }
+
+    private String getDefaultPortalPageContent() {
+        if (defaultPortalPageContent == null) {
+            try {
+                final var resource = new ClassPathResource("templates/default-portal-page-content.md");
+                defaultPortalPageContent = resource.getContentAsString(StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not load default portal page template", e);
+            }
+        }
+        return defaultPortalPageContent;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultOpenApiProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultOpenApiProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_page.adapter;
+
+import io.gravitee.apim.core.open_api.OpenApi;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultOpenApiProvider implements DefaultPortalPageContentProvider {
+
+    private OpenApi defaultOpenApiContent;
+
+    @Override
+    public boolean appliesTo(PortalPageContentType contentType) {
+        return contentType == PortalPageContentType.OPENAPI;
+    }
+
+    @Override
+    public PortalPageContent<?> provide(String organizationId, String environmentId) {
+        return new OpenApiPageContent(PortalPageContentId.random(), organizationId, environmentId, getDefaultOpenApiContent());
+    }
+
+    private OpenApi getDefaultOpenApiContent() {
+        if (defaultOpenApiContent == null) {
+            try {
+                final var resource = new ClassPathResource("templates/default-portal-openapi-page-content.yaml");
+                final var yaml = resource.getContentAsString(StandardCharsets.UTF_8);
+                defaultOpenApiContent = OpenApi.of(yaml);
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not load default OpenAPI portal page template", e);
+            }
+        }
+        return defaultOpenApiContent;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultPortalPageContentProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultPortalPageContentProvider.java
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.crud_service;
+package io.gravitee.apim.infra.crud_service.portal_page.adapter;
 
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 
-public interface PortalPageContentCrudService {
-    PortalPageContent<?> create(PortalPageContent<?> content);
+/**
+ * Provides default portal page content for a given content type.
+ * Implementations can be added for new content types without modifying the crud service.
+ */
+public interface DefaultPortalPageContentProvider {
+    boolean appliesTo(PortalPageContentType contentType);
 
-    PortalPageContent<?> createDefault(String organizationId, String environmentId, PortalPageContentType contentType);
-
-    PortalPageContent<?> update(PortalPageContent<?> content);
-
-    void delete(PortalPageContentId id);
+    PortalPageContent<?> provide(String organizationId, String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-portal-openapi-page-content.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-portal-openapi-page-content.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Petstore API
+  version: 1.0.0
+  description: Default OpenAPI page content
+paths:
+  /pets:
+    get:
+      summary: List pets
+      operationId: listPets
+      responses:
+        '200':
+          description: A list of pets
+    post:
+      summary: Create a pet
+      operationId: createPet
+      responses:
+        '201':
+          description: Created

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
@@ -18,8 +18,10 @@ package inmemory;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,14 +52,17 @@ public class PortalPageContentCrudServiceInMemory implements InMemoryAlternative
     }
 
     @Override
-    public PortalPageContent<?> createDefault(String organizationId, String environmentId) {
+    public PortalPageContent<?> createDefault(String organizationId, String environmentId, PortalPageContentType contentType) {
         final var pageContentId = PortalPageContentId.random();
-        final var portalPageContent = new GraviteeMarkdownPageContent(
-            pageContentId,
-            organizationId,
-            environmentId,
-            new GraviteeMarkdown("default page content")
-        );
+        PortalPageContent<?> portalPageContent = switch (contentType) {
+            case OPENAPI -> OpenApiPageContent.create(organizationId, environmentId, "openapi: 3.0.3");
+            case GRAVITEE_MARKDOWN -> new GraviteeMarkdownPageContent(
+                pageContentId,
+                organizationId,
+                environmentId,
+                new GraviteeMarkdown("default page content")
+            );
+        };
         return this.create(portalPageContent);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,6 +83,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -100,6 +102,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.HOMEPAGE)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
             navigationItemsQueryService.storage().add(PortalNavigationItem.from(createPortalNavigationItem, ORG_ID, ENV_ID));
 
@@ -122,6 +125,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -141,6 +145,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
                 .url("invalid-url")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -161,6 +166,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId(null)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -181,6 +187,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -200,6 +207,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
                 .apiId("api-id")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -220,6 +228,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("api-id")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -240,6 +249,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("api-1")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -260,6 +270,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(API1_FOLDER_ID))
                 .apiId("api-id")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -280,6 +291,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("api-2")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // Then
@@ -296,6 +308,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("api-2")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             final var createLinkPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -304,6 +317,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .order(1)
                 .url("https://example.org/docs")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             final var secondCreateApiPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -313,6 +327,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(2)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("api-3")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // Then
@@ -333,6 +348,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
                 .url("https://example.org/docs")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             final var invalidCreateApiPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -341,6 +357,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .order(1)
                 .apiId("api-2")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -362,6 +379,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("shared-api-id")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             final var secondCreateApiPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -371,6 +389,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(1)
                 .parentId(PortalNavigationItemId.of(APIS_ID))
                 .apiId("shared-api-id")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -396,6 +415,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
             createPortalNavigationItem.setParentId(PortalNavigationItemId.of(NON_EXISTENT_ID));
 
@@ -416,6 +436,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
             createPortalNavigationItem.setParentId(PortalNavigationItemId.of(PAGE11_ID));
 
@@ -436,6 +457,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .title("title")
                 .area(PortalArea.HOMEPAGE)
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
             createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 
@@ -465,6 +487,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(unpublishedParent.getId())
                 .published(true)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -492,6 +515,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
                 .order(0)
                 .parentId(privateParent.getId())
                 .visibility(PortalVisibility.PUBLIC)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
@@ -24,6 +24,7 @@ import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.List;
@@ -108,7 +109,8 @@ public class PortalNavigationItemDomainServiceTest {
         void should_delete_page_with_content() {
             var pageContent = portalPageContentCrudService.createDefault(
                 PortalNavigationItemFixtures.ORG_ID,
-                PortalNavigationItemFixtures.ENV_ID
+                PortalNavigationItemFixtures.ENV_ID,
+                PortalPageContentType.GRAVITEE_MARKDOWN
             );
             var toDelete = PortalNavigationItemFixtures.aPage(PortalNavigationItemFixtures.PAGE11_ID, "page11", null)
                 .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -35,11 +35,13 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVali
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,6 +94,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .apiId("apiId")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
         createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 
@@ -123,6 +126,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .apiId("wrongApiId")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
         createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 
@@ -145,6 +149,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .title("title")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
         createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 
@@ -179,6 +184,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .url("invalid url")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
         createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 
@@ -201,6 +207,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .title("title")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
         final var numberOfContents = pageContentCrudService.storage().size();
 
@@ -222,6 +229,36 @@ class CreatePortalNavigationItemUseCaseTest {
     }
 
     @Test
+    void should_create_openapi_page_content_when_content_type_is_openapi() {
+        // Given
+        final var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .type(PortalNavigationItemType.PAGE)
+            .title("title")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .contentType(PortalPageContentType.OPENAPI)
+            .build();
+        final var numberOfContents = pageContentCrudService.storage().size();
+
+        // When
+        final var output = useCase.execute(new CreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, createPortalNavigationItem));
+
+        // Then
+        final var contentId = ((PortalNavigationPage) output.item()).getPortalPageContentId();
+        final var contents = pageContentCrudService.storage();
+        assertThat(contents)
+            .hasSize(numberOfContents + 1)
+            .anySatisfy(content -> {
+                assertThat(content.getId()).isEqualTo(contentId);
+                assertThat(content.getOrganizationId()).isEqualTo(ORG_ID);
+                assertThat(content.getEnvironmentId()).isEqualTo(ENV_ID);
+                assertThat(content).isInstanceOf(OpenApiPageContent.class);
+                assertThat(((OpenApiPageContent) content).getContent().value()).isEqualTo("openapi: 3.0.3");
+            });
+    }
+
+    @Test
     void should_set_portal_navigation_item_to_not_published() {
         // Given
         final var createPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -230,6 +267,7 @@ class CreatePortalNavigationItemUseCaseTest {
             .title("title")
             .area(PortalArea.TOP_NAVBAR)
             .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .build();
 
         // When
@@ -252,6 +290,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .parentId(PortalNavigationItemId.of(API1_ID))
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -272,6 +311,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .parentId(PortalNavigationItemId.of(API1_ID))
                 .url("https://gravitee.io")
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -291,6 +331,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .area(PortalArea.TOP_NAVBAR)
                 .parentId(PortalNavigationItemId.of(API1_ID))
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -310,6 +351,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .apiId("apiId")
                 .parentId(PortalNavigationItemId.of(API1_ID))
                 .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             // When
@@ -342,6 +384,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(order)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
 
             final var existingSiblingOrdersById = queryService
@@ -393,6 +436,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 .title("title")
                 .area(PortalArea.TOP_NAVBAR)
                 .order(order)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .build();
             createPortalNavigationItem.setParentId(PortalNavigationItemId.of(APIS_ID));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundE
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -152,7 +153,8 @@ public class DeletePortalNavigationItemUseCaseTest {
         // Given
         var pageContent = portalPageContentCrudService.createDefault(
             PortalNavigationItemFixtures.ORG_ID,
-            PortalNavigationItemFixtures.ENV_ID
+            PortalNavigationItemFixtures.ENV_ID,
+            PortalPageContentType.GRAVITEE_MARKDOWN
         );
         var toDelete = PortalNavigationItemFixtures.aPage(PortalNavigationItemFixtures.PAGE11_ID, "page11", null)
             .toBuilder()


### PR DESCRIPTION
…nd mapping

## Issue

https://gravitee.atlassian.net/browse/APIM-12811

## Description


https://github.com/user-attachments/assets/3bfe897b-0fa0-48d0-9bde-13b3a968cd2a

 - REST API & OpenAPI
   - updates to PortalNavigationItemsMapper and PortalPageContentMapper.
   - OpenAPI spec changes in openapi-environments.yaml.
 - Domain & CRUD
   - PortalNavigationItemDomainService: support for new navigation item/content behavior.
   - PortalPageContentCrudService / PortalPageContentCrudServiceImpl: OpenAPI content type handling and CRUD logic.
   - CreatePortalNavigationItem model: new/updated field(s) for content type.
   - PortalPageContentCrudServiceInMemory: in-memory implementation aligned with new behavior.
 - Default content
   -New default portal OpenAPI page content resource (e.g. default-portal-openapi-page-content.yaml).
 - Tests
  - PortalNavigationItemsMapperTest, PortalPageContentMapperTest, PortalPageContentsResourceTest,  CreatePortalNavigationItemUseCaseTest, PortalPageContentCrudServiceImplTest: updated/added tests for OpenAPI content and navigation items.

 - Excluded from the PR
     - backend support for any other contenttype except openapi

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

