### PR TITLE
feat: Multi-DCR provider support with Authentication Strategies

### DIFF
--- a/docs/design/multi-dcr-competitive-analysis.md
+++ b/docs/design/multi-dcr-competitive-analysis.md
@@ -1,0 +1,170 @@
+# Multi-DCR Competitive Analysis: Gravitee vs Kong vs Tyk
+
+## Overview
+
+This document compares how Gravitee, Kong Konnect, and Tyk handle Dynamic Client Registration (DCR) for developer portal applications, and recommends an architecture for multi-DCR support in Gravitee.
+
+---
+
+## 1. Gravitee (Current State)
+
+### Architecture
+
+- **Scope:** Single DCR provider per environment
+- **Configuration level:** Environment settings
+- **Developer choice:** None -- all applications use the same provider
+
+### How It Works
+
+1. Admin configures one `ClientRegistrationProvider` per environment via Console UI (Settings > Client Registration).
+2. The provider stores an OIDC discovery endpoint, credentials (initial access token or client credentials), and optional TLS settings.
+3. When a developer creates an application with an OAuth type (Browser, Web, Native, Backend-to-Backend), the system calls `ClientRegistrationService.register()`.
+4. `register()` retrieves all providers for the environment and picks the first one (`providers.iterator().next()`).
+5. The DCR response (`client_id`, `client_secret`, `registration_access_token`) is stored in application metadata.
+6. Applications do **not** store which provider was used.
+
+### Key Limitations
+
+| Limitation | Impact |
+|---|---|
+| Only one provider per environment (enforced at creation) | Cannot support multiple IdPs |
+| No provider reference stored in application metadata | Cannot route updates/renewals to the correct provider |
+| No per-API or per-plan provider selection | All APIs in the environment share the same IdP |
+| No developer choice | Developers cannot pick which IdP to register with |
+
+### Pros
+
+- Simple to configure and understand
+- No ambiguity in provider selection
+- Works well for single-IdP organizations
+
+### Cons
+
+- Cannot support multiple IdPs (e.g., Okta for external, Keycloak for internal)
+- Cannot migrate between IdPs gradually
+- No multi-tenant or multi-business-unit support within an environment
+- No per-API granularity for authentication requirements
+
+---
+
+## 2. Kong Konnect
+
+### Architecture
+
+- **Scope:** Two-tier model -- DCR Providers + Authentication Strategies
+- **Configuration level:** Per API / per API package (via strategy assignment)
+- **Developer choice:** Yes -- developers select strategy when creating an application
+
+### How It Works
+
+1. Admin creates **DCR Providers** representing raw IdP connections (Okta, Auth0, Curity, Azure, Kong Identity). Each defines the auth server URL and provider type.
+2. Admin creates **Authentication Strategies** that reference a DCR provider and add policy-level settings: scopes, credential claims, auth methods (client_credentials, bearer, session), auto-approve, etc.
+3. Multiple strategies can share the same provider with different configurations (e.g., "okta-readonly" with read scope, "okta-readwrite" with read+write scopes).
+4. Strategies are applied **per API** or **per API package** when publishing to a Dev Portal.
+5. A **default auth strategy** can be set at the Dev Portal level.
+6. When a developer creates an application, they select an auth strategy. One application can serve multiple APIs only if those APIs share the same strategy.
+
+### Key Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| Separate provider from strategy | Reuse one IdP connection with different policies |
+| Strategy assigned at API level | Different APIs can enforce different IdPs/policies |
+| One strategy per application | Simplifies credential management |
+| Support for custom HTTP DCR bridge | Extend to non-natively-supported IdPs |
+
+### Supported Strategy Types
+
+- **Key Auth**: Built-in key authentication (no DCR)
+- **OpenID Connect (Self-managed)**: Developer brings their own pre-registered client_id
+- **DCR**: Automatic client registration with supported IdPs
+
+### Pros
+
+- Most flexible model of the three
+- Separation of infrastructure (provider) from policy (strategy) enables fine-grained access control
+- Per-API strategy assignment allows different APIs to use different IdPs
+- Reusable strategies reduce configuration duplication
+- HTTP DCR bridge pattern supports custom/unsupported IdPs
+- Developer has choice of strategy
+
+### Cons
+
+- More complex configuration (two layers of abstraction)
+- Developers must understand which strategy to use
+- One auth strategy per application means multiple applications needed for different strategies
+- Requires Kong Konnect (SaaS) -- not available for self-hosted Kong OSS
+
+---
+
+## 3. Tyk
+
+### Architecture
+
+- **Scope:** Provider-centric model -- DCR configured at the API Provider level
+- **Configuration level:** Per API Product (implicitly, via Provider binding)
+- **Developer choice:** None -- dictated by the API Product's provider
+
+### How It Works
+
+1. Admin creates **Providers** representing connections to Tyk Dashboard instances. Each provider can be in a different region, environment, or team.
+2. DCR is configured per provider: identity provider connection, initial access token, OAuth scopes.
+3. Each **API Product** is tied to a single Provider.
+4. Since the DCR configuration lives on the Provider, and each API Product uses one Provider, DCR is effectively per API Product.
+5. OAuth scopes are configured per API Product/Plan combination for access control and rate limiting.
+6. The same authentication method must be used for all APIs within an API Product.
+7. When developers request access, credentials are issued through the provider's DCR flow.
+
+### Key Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| Provider = Tyk Dashboard instance | Multi-region/multi-env infrastructure mapping |
+| Each API Product bound to one Provider | Credentials are provider-specific |
+| No developer choice of provider | Provider is dictated by the API Product |
+| Multi-provider for infrastructure, not IdP choice | Designed for geographic/organizational separation |
+
+### Pros
+
+- Natural fit for multi-region / multi-environment setups
+- API Product-level granularity
+- Clean separation between portal (presentation) and provider (access control)
+- Supports multiple popular IdPs (Okta, Keycloak, Curity, Gluu)
+
+### Cons
+
+- Confusing conceptual model -- "Provider" means Tyk Dashboard instance, not IdP
+- Developers don't choose the DCR provider; it is dictated by the API Product
+- Credentials from one Provider can't be used with APIs from another Provider
+- Less flexible than Kong's strategy model -- no reuse of provider configs with different policies
+- Primarily designed for infrastructure topology, not for multi-IdP within a single environment
+- Requires Tyk Enterprise for full DCR support
+
+---
+
+## Summary Comparison
+
+| Capability | Gravitee | Kong Konnect | Tyk |
+|---|---|---|---|
+| **DCR assignment granularity** | Environment | Per API (via strategy) | Per API Product (via provider) |
+| **Multiple IdPs per environment** | No | Yes | Yes (via multiple providers) |
+| **Developer choice of provider** | No | Yes (select strategy) | No (implicit via product) |
+| **Reusable configurations** | N/A | Yes (strategies) | No |
+| **Configuration layers** | 1 (provider) | 2 (provider + strategy) | 1 (provider) |
+| **Custom IdP support** | Any OIDC-compliant | HTTP DCR bridge | Via guides |
+| **Self-hosted availability** | Yes | No (Konnect SaaS only) | Enterprise only |
+| **Auth method flexibility** | Per provider | Per strategy | Per provider |
+
+---
+
+## Recommendation
+
+Adopt a two-tier model inspired by Kong's approach but adapted for Gravitee's architecture:
+
+1. **Keep `ClientRegistrationProvider`** as the raw IdP connection layer (environment-scoped, multiple allowed)
+2. **Introduce `AuthenticationStrategy`** as the policy layer that references a provider and adds scopes, auth methods, credential claims, etc.
+3. **Assign strategies at the Plan level** for OAuth2/JWT plans, with a default strategy at the environment level
+4. **Store strategy reference in application metadata** so updates/renewals route to the correct provider
+5. **Migrate existing single-provider setups** automatically via data migration
+
+This gives Gravitee the flexibility of Kong's model while remaining self-hosted and backward-compatible.

--- a/gravitee-apim-console-webui/src/entities/authentication-strategy/authenticationStrategy.ts
+++ b/gravitee-apim-console-webui/src/entities/authentication-strategy/authenticationStrategy.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AuthenticationStrategyType = 'KEY_AUTH' | 'DCR' | 'SELF_MANAGED_OIDC';
+
+export interface AuthenticationStrategy {
+  id?: string;
+  name: string;
+  display_name?: string;
+  description?: string;
+  type: AuthenticationStrategyType;
+  client_registration_provider_id?: string;
+  scopes?: string[];
+  auth_methods?: string[];
+  credential_claims?: string;
+  auto_approve?: boolean;
+  hide_credentials?: boolean;
+  created_at?: number;
+  updated_at?: number;
+}

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.html
@@ -1,0 +1,135 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="title">
+  <h2>Authentication Strategies</h2>
+</div>
+
+<mat-card class="authentication-strategies__card">
+  <mat-card-content>
+    <div class="authentication-strategies__card__title">
+      <h3>Manage Authentication Strategies</h3>
+      <span>
+        Authentication strategies define how applications authenticate with your APIs.
+        You can create multiple strategies referencing different DCR providers with different scopes,
+        auth methods, and configurations. Strategies are applied per API or per plan.
+      </span>
+    </div>
+
+    <div class="authentication-strategies__card__add-btn">
+      <div *gioPermission="{ anyOf: ['environment-client_registration_provider-c'] }">
+        <button type="button" mat-raised-button color="primary" (click)="onAddStrategy()">
+          <mat-icon svgIcon="gio:plus"></mat-icon>Add a strategy
+        </button>
+      </div>
+    </div>
+
+    <table
+      mat-table
+      matSort
+      [dataSource]="strategiesTableDS"
+      class="authentication-strategies__card__table"
+      id="strategiesTable"
+      aria-label="Authentication strategies table"
+    >
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+        <td mat-cell *matCellDef="let element">
+          <span>{{ element.name }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Display Name Column -->
+      <ng-container matColumnDef="displayName">
+        <th mat-header-cell *matHeaderCellDef id="displayName">Display Name</th>
+        <td mat-cell *matCellDef="let element">
+          <span>{{ element.displayName }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Type Column -->
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef id="type">Type</th>
+        <td mat-cell *matCellDef="let element">
+          <span class="authentication-strategies__type-badge" [attr.data-type]="element.type">
+            {{ element.type }}
+          </span>
+        </td>
+      </ng-container>
+
+      <!-- Description Column -->
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef id="description">Description</th>
+        <td mat-cell *matCellDef="let element">
+          <span>{{ element.description }}</span>
+        </td>
+      </ng-container>
+
+      <!-- updatedAt Column -->
+      <ng-container matColumnDef="updatedAt">
+        <th mat-header-cell *matHeaderCellDef id="updatedAt">Last updated at</th>
+        <td mat-cell *matCellDef="let element">
+          <span>{{ element.updatedAt | date: 'medium' }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="actions">
+            <button
+              (click)="onEditActionClicked(element)"
+              mat-icon-button
+              aria-label="Button to edit a strategy"
+              matTooltip="Edit strategy"
+            >
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <button
+              *gioPermission="{ anyOf: ['environment-client_registration_provider-d'] }"
+              (click)="onRemoveActionClicked(element)"
+              mat-icon-button
+              aria-label="Button to remove a strategy"
+              matTooltip="Remove strategy"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td
+          *ngIf="!isLoadingData && strategiesTableDS.length === 0"
+          class="mat-mdc-cell mdc-data-table__cell"
+          [attr.colspan]="displayedColumns.length"
+        >
+          {{ 'No authentication strategies configured.' }}
+        </td>
+        <td *ngIf="isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+          {{ 'Loading...' }}
+        </td>
+      </tr>
+    </table>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.scss
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+.title {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.authentication-strategies {
+  &__card {
+    margin-bottom: 16px;
+
+    &__title {
+      margin-bottom: 16px;
+    }
+
+    &__add-btn {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 16px;
+    }
+
+    &__table {
+      width: 100%;
+    }
+  }
+
+  &__type-badge {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: uppercase;
+
+    &[data-type='KEY_AUTH'] {
+      background-color: #e3f2fd;
+      color: #1565c0;
+    }
+
+    &[data-type='DCR'] {
+      background-color: #e8f5e9;
+      color: #2e7d32;
+    }
+
+    &[data-type='SELF_MANAGED_OIDC'] {
+      background-color: #fff3e0;
+      color: #e65100;
+    }
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.component.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { EMPTY, Subject } from 'rxjs';
+import { catchError, filter, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AuthenticationStrategyService } from '../../../services-ngx/authentication-strategy.service';
+import { AuthenticationStrategy } from '../../../entities/authentication-strategy/authenticationStrategy';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+export type StrategiesTableDS = {
+  id: string;
+  name: string;
+  displayName: string;
+  type: string;
+  description: string;
+  updatedAt: number;
+};
+
+@Component({
+  selector: 'authentication-strategies',
+  templateUrl: './authentication-strategies.component.html',
+  styleUrls: ['./authentication-strategies.component.scss'],
+  standalone: false,
+})
+export class AuthenticationStrategiesComponent implements OnInit, OnDestroy {
+  strategiesTableDS: StrategiesTableDS[] = [];
+  displayedColumns = ['name', 'displayName', 'type', 'description', 'updatedAt', 'actions'];
+  isLoadingData = true;
+  private unsubscribe$ = new Subject<void>();
+
+  constructor(
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly authenticationStrategyService: AuthenticationStrategyService,
+    private readonly snackBarService: SnackBarService,
+    private readonly matDialog: MatDialog,
+  ) {}
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  ngOnInit(): void {
+    this.authenticationStrategyService
+      .list()
+      .pipe(
+        tap(strategies => {
+          this.strategiesTableDS = toStrategiesTableDS(strategies);
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this.isLoadingData = false;
+      });
+  }
+
+  onAddStrategy() {
+    return this.router.navigate(['new'], { relativeTo: this.activatedRoute });
+  }
+
+  onEditActionClicked(strategy: StrategiesTableDS) {
+    return this.router.navigate([strategy.id], { relativeTo: this.activatedRoute });
+  }
+
+  onRemoveActionClicked(strategy: StrategiesTableDS) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Delete authentication strategy',
+          content: `Are you sure you want to delete the authentication strategy <strong>${strategy.name}</strong>?`,
+          confirmButton: 'Delete',
+        },
+        role: 'alertdialog',
+        id: 'removeAuthenticationStrategyConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.authenticationStrategyService.delete(strategy.id)),
+        tap(() => this.snackBarService.success(`"${strategy.name}" has been deleted.`)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => this.ngOnInit());
+  }
+}
+
+const toStrategiesTableDS = (strategies: AuthenticationStrategy[]): StrategiesTableDS[] => {
+  return (strategies || []).map(strategy => ({
+    id: strategy.id,
+    name: strategy.name,
+    displayName: strategy.display_name || '',
+    type: strategy.type,
+    description: strategy.description || '',
+    updatedAt: strategy.updated_at,
+  }));
+};

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategies.module.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import {
+  GioFormSlideToggleModule,
+  GioIconsModule,
+  GioSaveBarModule,
+} from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { AuthenticationStrategiesComponent } from './authentication-strategies.component';
+import { AuthenticationStrategyComponent } from './authentication-strategy/authentication-strategy.component';
+
+import { GioGoBackButtonModule } from '../../../shared/components/gio-go-back-button/gio-go-back-button.module';
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSlideToggleModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+
+    GioFormSlideToggleModule,
+    GioGoBackButtonModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioSaveBarModule,
+  ],
+  declarations: [AuthenticationStrategiesComponent, AuthenticationStrategyComponent],
+  exports: [AuthenticationStrategiesComponent, AuthenticationStrategyComponent],
+})
+export class AuthenticationStrategiesModule {}

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.html
@@ -1,0 +1,92 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="title">
+  <gio-go-back-button></gio-go-back-button>
+  <h2>{{ updateMode ? 'Edit' : 'Create' }} Authentication Strategy</h2>
+</div>
+
+<form [formGroup]="strategyForm" autocomplete="off" (ngSubmit)="onSubmit()">
+  <mat-card class="strategy-form__card">
+    <mat-card-content>
+      <h3>General</h3>
+
+      <mat-form-field appearance="outline" class="strategy-form__field">
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" placeholder="e.g. okta-external" />
+        <mat-hint>Internal identifier for this strategy</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="strategy-form__field">
+        <mat-label>Display Name</mat-label>
+        <input matInput formControlName="display_name" placeholder="e.g. Okta - External APIs" />
+        <mat-hint>Developer-facing name shown in the portal</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="strategy-form__field">
+        <mat-label>Description</mat-label>
+        <textarea matInput formControlName="description" rows="3"></textarea>
+      </mat-form-field>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card class="strategy-form__card">
+    <mat-card-content>
+      <h3>Strategy Type</h3>
+
+      <mat-form-field appearance="outline" class="strategy-form__field">
+        <mat-label>Type</mat-label>
+        <mat-select formControlName="type">
+          <mat-option *ngFor="let t of strategyTypes" [value]="t.value">{{ t.label }}</mat-option>
+        </mat-select>
+        <mat-hint>
+          <span *ngIf="strategyForm.get('type')?.value === 'DCR'">Automatic client registration with an identity provider</span>
+          <span *ngIf="strategyForm.get('type')?.value === 'KEY_AUTH'">Built-in API key authentication (no DCR)</span>
+          <span *ngIf="strategyForm.get('type')?.value === 'SELF_MANAGED_OIDC'">Developer brings their own pre-registered client</span>
+        </mat-hint>
+      </mat-form-field>
+
+      <mat-form-field *ngIf="requiresProvider" appearance="outline" class="strategy-form__field">
+        <mat-label>DCR Provider</mat-label>
+        <mat-select formControlName="client_registration_provider_id">
+          <mat-option *ngFor="let p of providers" [value]="p.id">{{ p.name }}</mat-option>
+        </mat-select>
+        <mat-hint>The identity provider to use for dynamic client registration</mat-hint>
+      </mat-form-field>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card class="strategy-form__card">
+    <mat-card-content>
+      <h3>Settings</h3>
+
+      <gio-form-slide-toggle class="strategy-form__toggle">
+        <gio-form-label>Auto-approve</gio-form-label>
+        Automatically approve subscription requests using this strategy
+        <mat-slide-toggle gioFormSlideToggle formControlName="auto_approve"></mat-slide-toggle>
+      </gio-form-slide-toggle>
+
+      <gio-form-slide-toggle class="strategy-form__toggle">
+        <gio-form-label>Hide credentials</gio-form-label>
+        Hide client credentials from API consumers
+        <mat-slide-toggle gioFormSlideToggle formControlName="hide_credentials"></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    </mat-card-content>
+  </mat-card>
+
+  <gio-save-bar [form]="strategyForm" [formInitialValues]="formInitialValues"></gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.title {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.strategy-form {
+  &__card {
+    margin-bottom: 16px;
+  }
+
+  &__field {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  &__toggle {
+    margin-bottom: 16px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/authentication-strategies/authentication-strategy/authentication-strategy.component.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { EMPTY, Subject } from 'rxjs';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { catchError, takeUntil, tap } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AuthenticationStrategyService } from '../../../../services-ngx/authentication-strategy.service';
+import { ClientRegistrationProvidersService } from '../../../../services-ngx/client-registration-providers.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { AuthenticationStrategy, AuthenticationStrategyType } from '../../../../entities/authentication-strategy/authenticationStrategy';
+import { ClientRegistrationProvider } from '../../../../entities/client-registration-provider/clientRegistrationProvider';
+
+@Component({
+  selector: 'authentication-strategy',
+  templateUrl: './authentication-strategy.component.html',
+  styleUrls: ['./authentication-strategy.component.scss'],
+  standalone: false,
+})
+export class AuthenticationStrategyComponent implements OnInit, OnDestroy {
+  private unsubscribe$ = new Subject<void>();
+  updateMode = false;
+  strategyForm: UntypedFormGroup;
+  formInitialValues: unknown;
+  providers: ClientRegistrationProvider[] = [];
+
+  strategyTypes: { label: string; value: AuthenticationStrategyType }[] = [
+    { label: 'Dynamic Client Registration (DCR)', value: 'DCR' },
+    { label: 'Key Authentication', value: 'KEY_AUTH' },
+    { label: 'Self-managed OIDC', value: 'SELF_MANAGED_OIDC' },
+  ];
+
+  constructor(
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly authenticationStrategyService: AuthenticationStrategyService,
+    private readonly clientRegistrationProvidersService: ClientRegistrationProvidersService,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  ngOnInit(): void {
+    this.clientRegistrationProvidersService
+      .list()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(providers => {
+        this.providers = providers;
+      });
+
+    this.strategyForm = new UntypedFormGroup({
+      name: new UntypedFormControl('', [Validators.required]),
+      display_name: new UntypedFormControl(''),
+      description: new UntypedFormControl(''),
+      type: new UntypedFormControl('DCR', [Validators.required]),
+      client_registration_provider_id: new UntypedFormControl(''),
+      scopes: new UntypedFormControl([]),
+      auth_methods: new UntypedFormControl([]),
+      credential_claims: new UntypedFormControl(''),
+      auto_approve: new UntypedFormControl(false),
+      hide_credentials: new UntypedFormControl(false),
+    });
+
+    const strategyId = this.activatedRoute.snapshot.params['strategyId'];
+    if (strategyId) {
+      this.updateMode = true;
+      this.authenticationStrategyService
+        .get(strategyId)
+        .pipe(takeUntil(this.unsubscribe$))
+        .subscribe(strategy => {
+          this.strategyForm.patchValue(strategy);
+          this.formInitialValues = this.strategyForm.getRawValue();
+        });
+    } else {
+      this.formInitialValues = this.strategyForm.getRawValue();
+    }
+  }
+
+  onSubmit(): void {
+    const formValue = this.strategyForm.getRawValue();
+
+    if (this.updateMode) {
+      const strategyId = this.activatedRoute.snapshot.params['strategyId'];
+      const strategy: AuthenticationStrategy = { ...formValue, id: strategyId };
+      this.authenticationStrategyService
+        .update(strategy)
+        .pipe(
+          tap(() => {
+            this.snackBarService.success('Authentication strategy updated.');
+            this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+          }),
+          catchError(({ error }) => {
+            this.snackBarService.error(error.message);
+            return EMPTY;
+          }),
+          takeUntil(this.unsubscribe$),
+        )
+        .subscribe();
+    } else {
+      this.authenticationStrategyService
+        .create(formValue)
+        .pipe(
+          tap(() => {
+            this.snackBarService.success('Authentication strategy created.');
+            this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+          }),
+          catchError(({ error }) => {
+            this.snackBarService.error(error.message);
+            return EMPTY;
+          }),
+          takeUntil(this.unsubscribe$),
+        )
+        .subscribe();
+    }
+  }
+
+  get requiresProvider(): boolean {
+    const type = this.strategyForm?.get('type')?.value;
+    return type === 'DCR' || type === 'SELF_MANAGED_OIDC';
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/client-registration-providers/client-registration-providers.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/client-registration-providers/client-registration-providers.component.html
@@ -149,10 +149,8 @@
       <div
         *gioPermission="{ anyOf: ['environment-client_registration_provider-c'] }"
         [gioLicense]="dcrRegistrationLicenseOptions"
-        matTooltip="Only one DCR provider is allowed."
-        [matTooltipDisabled]="providersTableDS.length < 1"
       >
-        <button type="button" mat-raised-button color="primary" (click)="onAddProvider()" [disabled]="providersTableDS.length >= 1">
+        <button type="button" mat-raised-button color="primary" (click)="onAddProvider()">
           <mat-icon svgIcon="gio:plus"></mat-icon>Add a provider
           <mat-icon *ngIf="hasDcrRegistrationLock$ | async" iconPositionEnd svgIcon="gio:lock"></mat-icon>
         </button>

--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.service.ts
@@ -71,6 +71,11 @@ export class SettingsNavigationService {
             permissions: ['environment-client_registration_provider-r'],
           },
           {
+            displayName: 'Authentication Strategies',
+            routerLink: './authentication-strategies',
+            permissions: ['environment-client_registration_provider-r'],
+          },
+          {
             displayName: 'Documentation',
             routerLink: './documentation',
             permissions: ['environment-documentation-r'],

--- a/gravitee-apim-console-webui/src/management/settings/settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings-routing.module.ts
@@ -24,6 +24,8 @@ import { CategoryComponent } from './categories/category/category.component';
 import { GroupsComponent } from './groups/groups.component';
 import { GroupComponent } from './groups/group/group.component';
 import { ApiPortalHeaderComponent as ApiPortalHeaderComponentMigrated } from './api-portal-header/api-portal-header.component';
+import { AuthenticationStrategiesComponent } from './authentication-strategies/authentication-strategies.component';
+import { AuthenticationStrategyComponent } from './authentication-strategies/authentication-strategy/authentication-strategy.component';
 import { ClientRegistrationProvidersComponent } from './client-registration-providers/client-registration-providers.component';
 import { ClientRegistrationProviderComponent } from './client-registration-providers/client-registration-provider/client-registration-provider.component';
 import { EnvironmentMetadataComponent } from './metadata/environment-metadata.component';
@@ -197,6 +199,38 @@ export const settingsRoutes: Routes = [
           docs: {
             page: 'management-configuration-client-registration-provider',
           },
+          permissions: {
+            anyOf: [
+              'environment-client_registration_provider-r',
+              'environment-client_registration_provider-u',
+              'environment-client_registration_provider-d',
+            ],
+          },
+        },
+      },
+      {
+        path: 'authentication-strategies',
+        component: AuthenticationStrategiesComponent,
+        data: {
+          permissions: {
+            anyOf: ['environment-client_registration_provider-r'],
+            unauthorizedFallbackTo: '../client-registration-providers',
+          },
+        },
+      },
+      {
+        path: 'authentication-strategies/new',
+        component: AuthenticationStrategyComponent,
+        data: {
+          permissions: {
+            anyOf: ['environment-client_registration_provider-c'],
+          },
+        },
+      },
+      {
+        path: 'authentication-strategies/:strategyId',
+        component: AuthenticationStrategyComponent,
+        data: {
           permissions: {
             anyOf: [
               'environment-client_registration_provider-r',

--- a/gravitee-apim-console-webui/src/management/settings/settings.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/settings.module.ts
@@ -24,6 +24,7 @@ import { SettingsAnalyticsComponent } from './analytics/settings-analytics.compo
 import { SettingsNavigationComponent } from './settings-navigation/settings-navigation.component';
 import { SettingsAnalyticsDashboardComponent } from './analytics/dashboard/settings-analytics-dashboard.component';
 import { EnvironmentMetadataModule } from './metadata/environment-metadata.module';
+import { AuthenticationStrategiesModule } from './authentication-strategies/authentication-strategies.module';
 import { ClientRegistrationProvidersModule } from './client-registration-providers/client-registration-providers.module';
 import { PortalThemeComponent } from './portal-theme/portalTheme.component';
 import { ApiLoggingModule } from './api-logging/api-logging.module';
@@ -53,6 +54,7 @@ import { DocumentationModule } from '../../components/documentation/documentatio
     CommonModule,
     DocumentationModule,
     EnvironmentMetadataModule,
+    AuthenticationStrategiesModule,
     ClientRegistrationProvidersModule,
     ApiLoggingModule,
     IdentityProvidersModule,

--- a/gravitee-apim-console-webui/src/services-ngx/authentication-strategy.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/authentication-strategy.service.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { AuthenticationStrategy } from '../entities/authentication-strategy/authenticationStrategy';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthenticationStrategyService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  list(): Observable<AuthenticationStrategy[]> {
+    return this.http.get<AuthenticationStrategy[]>(
+      `${this.constants.env.baseURL}/configuration/applications/authentication-strategies`,
+    );
+  }
+
+  get(id: string): Observable<AuthenticationStrategy> {
+    return this.http.get<AuthenticationStrategy>(
+      `${this.constants.env.baseURL}/configuration/applications/authentication-strategies/${id}`,
+    );
+  }
+
+  create(strategy: AuthenticationStrategy): Observable<AuthenticationStrategy> {
+    return this.http.post<AuthenticationStrategy>(
+      `${this.constants.env.baseURL}/configuration/applications/authentication-strategies`,
+      strategy,
+    );
+  }
+
+  update(strategy: AuthenticationStrategy): Observable<AuthenticationStrategy> {
+    return this.http.put<AuthenticationStrategy>(
+      `${this.constants.env.baseURL}/configuration/applications/authentication-strategies/${strategy.id}`,
+      {
+        name: strategy.name,
+        display_name: strategy.display_name,
+        description: strategy.description,
+        type: strategy.type,
+        client_registration_provider_id: strategy.client_registration_provider_id,
+        scopes: strategy.scopes,
+        auth_methods: strategy.auth_methods,
+        credential_claims: strategy.credential_claims,
+        auto_approve: strategy.auto_approve,
+        hide_credentials: strategy.hide_credentials,
+      },
+    );
+  }
+
+  delete(id: string): Observable<any> {
+    return this.http.delete(
+      `${this.constants.env.baseURL}/configuration/applications/authentication-strategies/${id}`,
+    );
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/applications/create-application/create-application.component.html
@@ -91,6 +91,22 @@
                     </mat-form-field>
                   }
 
+                  @if (!isSimpleType() && hasMultipleStrategies()) {
+                    <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                      <mat-label i18n="@@createApplicationAuthStrategy">Authentication Strategy</mat-label>
+                      <mat-select [formControl]="strategyControl">
+                        @for (strategy of dcrStrategies(); track strategy.id) {
+                          <mat-option [value]="strategy.id">
+                            {{ strategy.display_name || strategy.name }}
+                          </mat-option>
+                        }
+                      </mat-select>
+                      <mat-hint i18n="@@createApplicationAuthStrategyHint">
+                        Select the authentication strategy that determines which identity provider to register with.
+                      </mat-hint>
+                    </mat-form-field>
+                  }
+
                   @if (grantTypesList().length > 0) {
                     <div class="grant-types-container">
                       <div>

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -139,4 +139,5 @@ export interface ApplicationInput {
   settings: ApplicationSettings;
   background?: string;
   api_key_mode?: string;
+  authentication_strategy_id?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/services/authentication-strategy.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/authentication-strategy.service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+
+export interface AuthenticationStrategy {
+  id: string;
+  name: string;
+  display_name?: string;
+  description?: string;
+  type: 'KEY_AUTH' | 'DCR' | 'SELF_MANAGED_OIDC';
+  client_registration_provider_id?: string;
+  scopes?: string[];
+  auth_methods?: string[];
+  credential_claims?: string;
+  auto_approve?: boolean;
+  hide_credentials?: boolean;
+  created_at?: number;
+  updated_at?: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthenticationStrategyService {
+  constructor(
+    private readonly http: HttpClient,
+    private configService: ConfigService,
+  ) {}
+
+  list(): Observable<AuthenticationStrategy[]> {
+    return this.http.get<AuthenticationStrategy[]>(
+      `${this.configService.baseURL}/configuration/applications/authentication-strategies`,
+    );
+  }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AuthenticationStrategyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AuthenticationStrategyRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.AuthenticationStrategy;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Repository for AuthenticationStrategy entities.
+ * An authentication strategy defines how applications authenticate with APIs,
+ * optionally referencing a ClientRegistrationProvider for DCR-based strategies.
+ */
+public interface AuthenticationStrategyRepository extends CrudRepository<AuthenticationStrategy, String> {
+    /**
+     * List all authentication strategies.
+     */
+    Set<AuthenticationStrategy> findAll() throws TechnicalException;
+
+    /**
+     * List all authentication strategies for a given environment.
+     */
+    Set<AuthenticationStrategy> findAllByEnvironment(String environmentId) throws TechnicalException;
+
+    /**
+     * Find all authentication strategies that reference a given client registration provider.
+     */
+    Set<AuthenticationStrategy> findByClientRegistrationProviderId(String clientRegistrationProviderId) throws TechnicalException;
+
+    /**
+     * Delete all authentication strategies for a given environment.
+     * @return list of deleted IDs
+     */
+    List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
@@ -51,6 +51,7 @@ public class Application {
     public static final String METADATA_TYPE = "type";
     public static final String METADATA_REGISTRATION_PAYLOAD = "registration_payload";
     public static final String METADATA_ADDITIONAL_CLIENT_METADATA = "additional_client_metadata";
+    public static final String METADATA_AUTH_STRATEGY_ID = "auth_strategy_id";
 
     public enum AuditEvent implements Audit.AuditEvent {
         APPLICATION_CREATED,

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
@@ -70,6 +70,7 @@ public class Audit {
         ENTRYPOINT,
         REQUEST_ID,
         CLIENT_REGISTRATION_PROVIDER,
+        AUTHENTICATION_STRATEGY,
         QUALITY_RULE,
         API_QUALITY_RULE,
         DASHBOARD,

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AuthenticationStrategy.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AuthenticationStrategy.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class AuthenticationStrategy {
+
+    public enum AuditEvent implements Audit.AuditEvent {
+        AUTHENTICATION_STRATEGY_CREATED,
+        AUTHENTICATION_STRATEGY_UPDATED,
+        AUTHENTICATION_STRATEGY_DELETED,
+    }
+
+    public enum Type {
+        KEY_AUTH,
+        DCR,
+        SELF_MANAGED_OIDC,
+    }
+
+    private String id;
+
+    private String name;
+
+    private String displayName;
+
+    private String description;
+
+    private String environmentId;
+
+    private Type type;
+
+    /**
+     * Reference to the ClientRegistrationProvider.
+     * Null when type is KEY_AUTH.
+     */
+    private String clientRegistrationProviderId;
+
+    private List<String> scopes;
+
+    private List<String> authMethods;
+
+    private String credentialClaims;
+
+    private boolean autoApprove;
+
+    private boolean hideCredentials;
+
+    private Date createdAt;
+
+    private Date updatedAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public String getClientRegistrationProviderId() {
+        return clientRegistrationProviderId;
+    }
+
+    public void setClientRegistrationProviderId(String clientRegistrationProviderId) {
+        this.clientRegistrationProviderId = clientRegistrationProviderId;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<String> getAuthMethods() {
+        return authMethods;
+    }
+
+    public void setAuthMethods(List<String> authMethods) {
+        this.authMethods = authMethods;
+    }
+
+    public String getCredentialClaims() {
+        return credentialClaims;
+    }
+
+    public void setCredentialClaims(String credentialClaims) {
+        this.credentialClaims = credentialClaims;
+    }
+
+    public boolean isAutoApprove() {
+        return autoApprove;
+    }
+
+    public void setAutoApprove(boolean autoApprove) {
+        this.autoApprove = autoApprove;
+    }
+
+    public boolean isHideCredentials() {
+        return hideCredentials;
+    }
+
+    public void setHideCredentials(boolean hideCredentials) {
+        this.hideCredentials = hideCredentials;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationStrategy that = (AuthenticationStrategy) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ClientRegistrationProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ClientRegistrationProvider.java
@@ -87,6 +87,12 @@ public class ClientRegistrationProvider {
 
     private String softwareId;
 
+    /**
+     * HTTP bridge endpoint for custom IdPs that don't support OIDC DCR natively.
+     * When set, the bridge endpoint is used instead of the OIDC discovery endpoint.
+     */
+    private String httpBridgeEndpoint;
+
     private String trustStoreType;
 
     private String trustStorePath;
@@ -243,6 +249,14 @@ public class ClientRegistrationProvider {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public String getHttpBridgeEndpoint() {
+        return httpBridgeEndpoint;
+    }
+
+    public void setHttpBridgeEndpoint(String httpBridgeEndpoint) {
+        this.httpBridgeEndpoint = httpBridgeEndpoint;
     }
 
     public String getTrustStoreType() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -149,6 +149,12 @@ public class Plan {
 
     private String generalConditionsHrid;
 
+    /**
+     * Optional authentication strategy for this plan.
+     * When set, applications subscribing must use the same strategy.
+     */
+    private String authenticationStrategyId;
+
     @Builder.Default
     private Set<String> tags = new HashSet<>();
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuthenticationStrategyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuthenticationStrategyRepository.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static java.lang.String.format;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.AuthenticationStrategyRepository;
+import io.gravitee.repository.management.model.AuthenticationStrategy;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@CustomLog
+@Repository
+public class JdbcAuthenticationStrategyRepository
+    extends JdbcAbstractCrudRepository<AuthenticationStrategy, String>
+    implements AuthenticationStrategyRepository {
+
+    private final String AUTH_STRATEGY_SCOPES;
+    private final String AUTH_STRATEGY_AUTH_METHODS;
+
+    JdbcAuthenticationStrategyRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "authentication_strategies");
+        AUTH_STRATEGY_SCOPES = getTableNameFor("authentication_strategy_scopes");
+        AUTH_STRATEGY_AUTH_METHODS = getTableNameFor("authentication_strategy_auth_methods");
+    }
+
+    @Override
+    protected JdbcObjectMapper<AuthenticationStrategy> buildOrm() {
+        return JdbcObjectMapper.builder(AuthenticationStrategy.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("name", Types.NVARCHAR, String.class)
+            .addColumn("display_name", Types.NVARCHAR, String.class)
+            .addColumn("description", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("type", Types.NVARCHAR, AuthenticationStrategy.Type.class)
+            .addColumn("client_registration_provider_id", Types.NVARCHAR, String.class)
+            .addColumn("credential_claims", Types.NVARCHAR, String.class)
+            .addColumn("auto_approve", Types.BOOLEAN, boolean.class)
+            .addColumn("hide_credentials", Types.BOOLEAN, boolean.class)
+            .addColumn("created_at", Types.TIMESTAMP, Date.class)
+            .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .build();
+    }
+
+    @Override
+    protected String getId(AuthenticationStrategy item) {
+        return item.getId();
+    }
+
+    private void addScopes(AuthenticationStrategy item) {
+        List<String> scopes = jdbcTemplate.queryForList(
+            "select scope from " + AUTH_STRATEGY_SCOPES + " where authentication_strategy_id = ?",
+            String.class,
+            item.getId()
+        );
+        item.setScopes(new ArrayList<>(scopes));
+    }
+
+    private void addAuthMethods(AuthenticationStrategy item) {
+        List<String> methods = jdbcTemplate.queryForList(
+            "select auth_method from " + AUTH_STRATEGY_AUTH_METHODS + " where authentication_strategy_id = ?",
+            String.class,
+            item.getId()
+        );
+        item.setAuthMethods(new ArrayList<>(methods));
+    }
+
+    private void addCollections(AuthenticationStrategy item) {
+        addScopes(item);
+        addAuthMethods(item);
+    }
+
+    private void storeScopes(AuthenticationStrategy item, boolean deleteFirst) {
+        if (deleteFirst) {
+            jdbcTemplate.update(
+                "delete from " + AUTH_STRATEGY_SCOPES + " where authentication_strategy_id = ?",
+                item.getId()
+            );
+        }
+        List<String> filtered = getOrm().filterStrings(item.getScopes());
+        if (!filtered.isEmpty()) {
+            jdbcTemplate.batchUpdate(
+                "insert into " + AUTH_STRATEGY_SCOPES + " ( authentication_strategy_id, scope ) values ( ?, ? )",
+                getOrm().getBatchStringSetter(item.getId(), filtered)
+            );
+        }
+    }
+
+    private void storeAuthMethods(AuthenticationStrategy item, boolean deleteFirst) {
+        if (deleteFirst) {
+            jdbcTemplate.update(
+                "delete from " + AUTH_STRATEGY_AUTH_METHODS + " where authentication_strategy_id = ?",
+                item.getId()
+            );
+        }
+        List<String> filtered = getOrm().filterStrings(item.getAuthMethods());
+        if (!filtered.isEmpty()) {
+            jdbcTemplate.batchUpdate(
+                "insert into " + AUTH_STRATEGY_AUTH_METHODS + " ( authentication_strategy_id, auth_method ) values ( ?, ? )",
+                getOrm().getBatchStringSetter(item.getId(), filtered)
+            );
+        }
+    }
+
+    private void storeCollections(AuthenticationStrategy item, boolean deleteFirst) {
+        storeScopes(item, deleteFirst);
+        storeAuthMethods(item, deleteFirst);
+    }
+
+    @Override
+    public Optional<AuthenticationStrategy> findById(String id) throws TechnicalException {
+        final Optional<AuthenticationStrategy> result = super.findById(id);
+        result.ifPresent(this::addCollections);
+        return result;
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findAll() throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.findAll()");
+        Set<AuthenticationStrategy> strategies = super.findAll();
+        for (AuthenticationStrategy s : strategies) {
+            addCollections(s);
+        }
+        return strategies;
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findAllByEnvironment(String environmentId) throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.findAllByEnvironment({})", environmentId);
+        try {
+            Set<AuthenticationStrategy> strategies = new HashSet<>(
+                jdbcTemplate.query(getOrm().getSelectAllSql() + " where environment_id = ?", getOrm().getRowMapper(), environmentId)
+            );
+            for (AuthenticationStrategy s : strategies) {
+                addCollections(s);
+            }
+            return strategies;
+        } catch (final Exception ex) {
+            log.error("Failed to find authentication strategies by environment:", ex);
+            throw new TechnicalException("Failed to find authentication strategies by environment", ex);
+        }
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findByClientRegistrationProviderId(String clientRegistrationProviderId) throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.findByClientRegistrationProviderId({})", clientRegistrationProviderId);
+        try {
+            Set<AuthenticationStrategy> strategies = new HashSet<>(
+                jdbcTemplate.query(
+                    getOrm().getSelectAllSql() + " where client_registration_provider_id = ?",
+                    getOrm().getRowMapper(),
+                    clientRegistrationProviderId
+                )
+            );
+            for (AuthenticationStrategy s : strategies) {
+                addCollections(s);
+            }
+            return strategies;
+        } catch (final Exception ex) {
+            log.error("Failed to find authentication strategies by provider:", ex);
+            throw new TechnicalException("Failed to find authentication strategies by provider", ex);
+        }
+    }
+
+    @Override
+    public AuthenticationStrategy create(AuthenticationStrategy item) throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.create({})", item);
+        try {
+            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(item));
+            storeCollections(item, false);
+            return findById(item.getId()).orElse(null);
+        } catch (final Exception ex) {
+            log.error("Failed to create authentication strategy", ex);
+            throw new TechnicalException("Failed to create authentication strategy", ex);
+        }
+    }
+
+    @Override
+    public AuthenticationStrategy update(AuthenticationStrategy item) throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.update({})", item);
+        if (item == null) {
+            throw new IllegalStateException("Failed to update null");
+        }
+        try {
+            jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(item, item.getId()));
+            storeCollections(item, true);
+            return findById(item.getId()).orElseThrow(() ->
+                new IllegalStateException(format("No authentication strategy found with id [%s]", item.getId()))
+            );
+        } catch (final IllegalStateException ex) {
+            throw ex;
+        } catch (final Exception ex) {
+            log.error("Failed to update authentication strategy", ex);
+            throw new TechnicalException("Failed to update authentication strategy", ex);
+        }
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        jdbcTemplate.update("delete from " + AUTH_STRATEGY_SCOPES + " where authentication_strategy_id = ?", id);
+        jdbcTemplate.update("delete from " + AUTH_STRATEGY_AUTH_METHODS + " where authentication_strategy_id = ?", id);
+        jdbcTemplate.update(getOrm().getDeleteSql(), id);
+    }
+
+    @Override
+    public List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcAuthenticationStrategyRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            List<String> ids = jdbcTemplate.queryForList(
+                "select id from " + tableName + " where environment_id = ?",
+                String.class,
+                environmentId
+            );
+
+            if (!ids.isEmpty()) {
+                String inClause = getOrm().buildInClause(ids);
+                jdbcTemplate.update(
+                    "delete from " + AUTH_STRATEGY_SCOPES + " where authentication_strategy_id IN (" + inClause + ")",
+                    ids.toArray()
+                );
+                jdbcTemplate.update(
+                    "delete from " + AUTH_STRATEGY_AUTH_METHODS + " where authentication_strategy_id IN (" + inClause + ")",
+                    ids.toArray()
+                );
+                jdbcTemplate.update("delete from " + tableName + " where environment_id = ?", environmentId);
+            }
+
+            return ids;
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to delete authentication strategies by environment", ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuthenticationStrategyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuthenticationStrategyRepository.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AuthenticationStrategyRepository;
+import io.gravitee.repository.management.model.AuthenticationStrategy;
+import io.gravitee.repository.mongodb.management.internal.application.AuthenticationStrategyMongoRepository;
+import io.gravitee.repository.mongodb.management.internal.model.AuthenticationStrategyMongo;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class MongoAuthenticationStrategyRepository implements AuthenticationStrategyRepository {
+
+    @Autowired
+    private AuthenticationStrategyMongoRepository internalRepository;
+
+    @Autowired
+    private GraviteeMapper mapper;
+
+    @Override
+    public Optional<AuthenticationStrategy> findById(String id) throws TechnicalException {
+        log.debug("Find authentication strategy by ID [{}]", id);
+        AuthenticationStrategyMongo mongo = internalRepository.findById(id).orElse(null);
+        log.debug("Find authentication strategy by ID [{}] - Done", id);
+        return Optional.ofNullable(map(mongo));
+    }
+
+    @Override
+    public AuthenticationStrategy create(AuthenticationStrategy strategy) throws TechnicalException {
+        log.debug("Create authentication strategy [{}]", strategy.getName());
+        AuthenticationStrategyMongo mongo = map(strategy);
+        AuthenticationStrategyMongo created = internalRepository.insert(mongo);
+        log.debug("Create authentication strategy [{}] - Done", strategy.getName());
+        return map(created);
+    }
+
+    @Override
+    public AuthenticationStrategy update(AuthenticationStrategy strategy) throws TechnicalException {
+        if (strategy == null) {
+            throw new IllegalStateException("Authentication strategy must not be null");
+        }
+
+        AuthenticationStrategyMongo mongo = internalRepository.findById(strategy.getId()).orElse(null);
+        if (mongo == null) {
+            throw new IllegalStateException(
+                String.format("No authentication strategy found with id [%s]", strategy.getId())
+            );
+        }
+
+        try {
+            mongo.setName(strategy.getName());
+            mongo.setDisplayName(strategy.getDisplayName());
+            mongo.setDescription(strategy.getDescription());
+            mongo.setEnvironmentId(strategy.getEnvironmentId());
+            mongo.setType(strategy.getType() != null ? strategy.getType().name() : null);
+            mongo.setClientRegistrationProviderId(strategy.getClientRegistrationProviderId());
+            mongo.setScopes(strategy.getScopes());
+            mongo.setAuthMethods(strategy.getAuthMethods());
+            mongo.setCredentialClaims(strategy.getCredentialClaims());
+            mongo.setAutoApprove(strategy.isAutoApprove());
+            mongo.setHideCredentials(strategy.isHideCredentials());
+            mongo.setUpdatedAt(strategy.getUpdatedAt());
+
+            AuthenticationStrategyMongo updated = internalRepository.save(mongo);
+            return map(updated);
+        } catch (Exception e) {
+            log.error("An error occurs when updating authentication strategy", e);
+            throw new TechnicalException("An error occurs when updating authentication strategy");
+        }
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        try {
+            internalRepository.deleteById(id);
+        } catch (Exception e) {
+            log.error("An error occurs when deleting authentication strategy [{}]", id, e);
+            throw new TechnicalException("An error occurs when deleting authentication strategy");
+        }
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findAll() throws TechnicalException {
+        log.debug("Find all authentication strategies");
+        List<AuthenticationStrategyMongo> all = internalRepository.findAll();
+        Set<AuthenticationStrategy> result = mapper.mapAuthenticationStrategies(all);
+        log.debug("Find all authentication strategies - Done");
+        return result;
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findAllByEnvironment(String environmentId) throws TechnicalException {
+        log.debug("Find all authentication strategies by environment [{}]", environmentId);
+        List<AuthenticationStrategyMongo> all = internalRepository.findByEnvironmentId(environmentId);
+        Set<AuthenticationStrategy> result = mapper.mapAuthenticationStrategies(all);
+        log.debug("Find all authentication strategies by environment - Done");
+        return result;
+    }
+
+    @Override
+    public Set<AuthenticationStrategy> findByClientRegistrationProviderId(String clientRegistrationProviderId) throws TechnicalException {
+        log.debug("Find authentication strategies by provider [{}]", clientRegistrationProviderId);
+        List<AuthenticationStrategyMongo> all = internalRepository.findByClientRegistrationProviderId(clientRegistrationProviderId);
+        Set<AuthenticationStrategy> result = mapper.mapAuthenticationStrategies(all);
+        log.debug("Find authentication strategies by provider - Done");
+        return result;
+    }
+
+    @Override
+    public List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("Delete authentication strategies by environment [{}]", environmentId);
+        try {
+            List<String> deleted = internalRepository
+                .deleteByEnvironmentId(environmentId)
+                .stream()
+                .map(AuthenticationStrategyMongo::getId)
+                .toList();
+            log.debug("Delete authentication strategies by environment [{}] - Done", environmentId);
+            return deleted;
+        } catch (Exception e) {
+            log.error("Failed to delete authentication strategies by environment [{}]", environmentId, e);
+            throw new TechnicalException("Failed to delete authentication strategies by environment");
+        }
+    }
+
+    private AuthenticationStrategy map(AuthenticationStrategyMongo mongo) {
+        return (mongo == null) ? null : mapper.map(mongo);
+    }
+
+    private AuthenticationStrategyMongo map(AuthenticationStrategy strategy) {
+        return (strategy == null) ? null : mapper.map(strategy);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/AuthenticationStrategyMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/AuthenticationStrategyMongoRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.application;
+
+import io.gravitee.repository.mongodb.management.internal.model.AuthenticationStrategyMongo;
+import java.util.List;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthenticationStrategyMongoRepository extends MongoRepository<AuthenticationStrategyMongo, String> {
+    @Query("{ 'environmentId': ?0 }")
+    List<AuthenticationStrategyMongo> findByEnvironmentId(String environmentId);
+
+    @Query("{ 'clientRegistrationProviderId': ?0 }")
+    List<AuthenticationStrategyMongo> findByClientRegistrationProviderId(String clientRegistrationProviderId);
+
+    @Query(value = "{ 'environmentId': ?0 }", delete = true)
+    List<AuthenticationStrategyMongo> deleteByEnvironmentId(String environmentId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AuthenticationStrategyMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AuthenticationStrategyMongo.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Setter
+@Getter
+@EqualsAndHashCode(of = { "id" }, callSuper = false)
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}authentication_strategies")
+public class AuthenticationStrategyMongo extends DeprecatedAuditable {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String displayName;
+
+    private String description;
+
+    private String environmentId;
+
+    private String type;
+
+    private String clientRegistrationProviderId;
+
+    private List<String> scopes;
+
+    private List<String> authMethods;
+
+    private String credentialClaims;
+
+    private boolean autoApprove;
+
+    private boolean hideCredentials;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -92,6 +92,13 @@ public interface GraviteeMapper {
 
     Set<ApiCategoryOrder> map(Collection<ApiCategoryOrderMongo> toMap);
 
+    // AuthenticationStrategy mapping
+    AuthenticationStrategy map(AuthenticationStrategyMongo toMap);
+
+    AuthenticationStrategyMongo map(AuthenticationStrategy toMap);
+
+    Set<AuthenticationStrategy> mapAuthenticationStrategies(Collection<AuthenticationStrategyMongo> toMap);
+
     // Category mapping
     Category map(CategoryMongo toMap);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.configuration.application.registration.AuthenticationStrategiesResource;
 import io.gravitee.rest.api.management.rest.resource.configuration.application.registration.ClientRegistrationProvidersResource;
 import io.gravitee.rest.api.management.rest.resource.configuration.dictionary.DictionariesResource;
 import io.gravitee.rest.api.management.rest.resource.configuration.identity.IdentityProvidersResource;
@@ -169,6 +170,11 @@ public class EnvironmentConfigurationResource {
     @Path("applications/registration/providers")
     public ClientRegistrationProvidersResource getClientRegistrationProvidersResource() {
         return resourceContext.getResource(ClientRegistrationProvidersResource.class);
+    }
+
+    @Path("applications/authentication-strategies")
+    public AuthenticationStrategiesResource getAuthenticationStrategiesResource() {
+        return resourceContext.getResource(AuthenticationStrategiesResource.class);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/AuthenticationStrategiesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/AuthenticationStrategiesResource.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.configuration.application.registration;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.NewAuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.application.AuthenticationStrategyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag(name = "Authentication Strategies")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AuthenticationStrategiesResource extends AbstractResource {
+
+    @Autowired
+    private AuthenticationStrategyService authenticationStrategyService;
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @GET
+    @Permissions(@Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.READ))
+    @Operation(
+        summary = "Get the list of authentication strategies",
+        description = "User must have the ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER[READ] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "List authentication strategies",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            array = @ArraySchema(schema = @Schema(implementation = AuthenticationStrategyEntity.class))
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public Set<AuthenticationStrategyEntity> getAuthenticationStrategies() {
+        return authenticationStrategyService.findAll(GraviteeContext.getExecutionContext());
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.CREATE) })
+    @Operation(
+        summary = "Create an authentication strategy",
+        description = "User must have the ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER[CREATE] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "201",
+        description = "Authentication strategy successfully created",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = AuthenticationStrategyEntity.class)
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public Response createAuthenticationStrategy(
+        @Parameter(name = "strategy", required = true) @Valid @NotNull NewAuthenticationStrategyEntity newStrategy
+    ) {
+        AuthenticationStrategyEntity created = authenticationStrategyService.create(
+            GraviteeContext.getExecutionContext(),
+            newStrategy
+        );
+
+        if (created != null) {
+            return Response.created(this.getLocationHeader(created.getId()))
+                .entity(created)
+                .build();
+        }
+
+        return Response.serverError().build();
+    }
+
+    @Path("{authenticationStrategy}")
+    public AuthenticationStrategyResource getAuthenticationStrategyResource() {
+        return resourceContext.getResource(AuthenticationStrategyResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/AuthenticationStrategyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/AuthenticationStrategyResource.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.configuration.application.registration;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.UpdateAuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.application.AuthenticationStrategyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag(name = "Authentication Strategies")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class AuthenticationStrategyResource extends AbstractResource {
+
+    @Autowired
+    private AuthenticationStrategyService authenticationStrategyService;
+
+    @PathParam("authenticationStrategy")
+    @Parameter(name = "authenticationStrategy", required = true)
+    private String authenticationStrategyId;
+
+    @GET
+    @Permissions(@Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.READ))
+    @Operation(
+        summary = "Get an authentication strategy",
+        description = "User must have the ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER[READ] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Authentication strategy",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = AuthenticationStrategyEntity.class)
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public AuthenticationStrategyEntity getAuthenticationStrategy() {
+        return authenticationStrategyService.findById(
+            GraviteeContext.getExecutionContext().getEnvironmentId(),
+            authenticationStrategyId
+        );
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.UPDATE) })
+    @Operation(
+        summary = "Update an authentication strategy",
+        description = "User must have the ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER[UPDATE] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Updated authentication strategy",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = AuthenticationStrategyEntity.class)
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public AuthenticationStrategyEntity updateAuthenticationStrategy(
+        @Parameter(name = "strategy", required = true) @Valid @NotNull UpdateAuthenticationStrategyEntity updateStrategy
+    ) {
+        return authenticationStrategyService.update(
+            GraviteeContext.getExecutionContext(),
+            authenticationStrategyId,
+            updateStrategy
+        );
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.DELETE) })
+    @Operation(
+        summary = "Delete an authentication strategy",
+        description = "User must have the ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER[DELETE] permission to use this service"
+    )
+    @ApiResponse(responseCode = "204", description = "Authentication strategy successfully deleted")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public void deleteAuthenticationStrategy() {
+        authenticationStrategyService.delete(GraviteeContext.getExecutionContext(), authenticationStrategyId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewApplicationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewApplicationEntity.java
@@ -84,6 +84,10 @@ public class NewApplicationEntity {
     @JsonProperty("disable_membership_notifications")
     private boolean disableMembershipNotifications;
 
+    @JsonProperty("authentication_strategy_id")
+    @Schema(description = "The authentication strategy to use for DCR registration.")
+    private String authenticationStrategyId;
+
     public String getId() {
         return id;
     }
@@ -194,6 +198,14 @@ public class NewApplicationEntity {
 
     public void setDisableMembershipNotifications(boolean disableMembershipNotifications) {
         this.disableMembershipNotifications = disableMembershipNotifications;
+    }
+
+    public String getAuthenticationStrategyId() {
+        return authenticationStrategyId;
+    }
+
+    public void setAuthenticationStrategyId(String authenticationStrategyId) {
+        this.authenticationStrategyId = authenticationStrategyId;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/AuthenticationStrategyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/AuthenticationStrategyEntity.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.application.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class AuthenticationStrategyEntity {
+
+    private String id;
+
+    private String name;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    private String description;
+
+    private AuthenticationStrategyType type;
+
+    @JsonProperty("client_registration_provider_id")
+    private String clientRegistrationProviderId;
+
+    private List<String> scopes;
+
+    @JsonProperty("auth_methods")
+    private List<String> authMethods;
+
+    @JsonProperty("credential_claims")
+    private String credentialClaims;
+
+    @JsonProperty("auto_approve")
+    private boolean autoApprove;
+
+    @JsonProperty("hide_credentials")
+    private boolean hideCredentials;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public AuthenticationStrategyType getType() {
+        return type;
+    }
+
+    public void setType(AuthenticationStrategyType type) {
+        this.type = type;
+    }
+
+    public String getClientRegistrationProviderId() {
+        return clientRegistrationProviderId;
+    }
+
+    public void setClientRegistrationProviderId(String clientRegistrationProviderId) {
+        this.clientRegistrationProviderId = clientRegistrationProviderId;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<String> getAuthMethods() {
+        return authMethods;
+    }
+
+    public void setAuthMethods(List<String> authMethods) {
+        this.authMethods = authMethods;
+    }
+
+    public String getCredentialClaims() {
+        return credentialClaims;
+    }
+
+    public void setCredentialClaims(String credentialClaims) {
+        this.credentialClaims = credentialClaims;
+    }
+
+    public boolean isAutoApprove() {
+        return autoApprove;
+    }
+
+    public void setAutoApprove(boolean autoApprove) {
+        this.autoApprove = autoApprove;
+    }
+
+    public boolean isHideCredentials() {
+        return hideCredentials;
+    }
+
+    public void setHideCredentials(boolean hideCredentials) {
+        this.hideCredentials = hideCredentials;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationStrategyEntity that = (AuthenticationStrategyEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/AuthenticationStrategyType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/AuthenticationStrategyType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.application.registration;
+
+public enum AuthenticationStrategyType {
+    KEY_AUTH,
+    DCR,
+    SELF_MANAGED_OIDC,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/ClientRegistrationProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/ClientRegistrationProviderEntity.java
@@ -67,6 +67,9 @@ public class ClientRegistrationProviderEntity {
     @JsonProperty("software_id")
     private String softwareId;
 
+    @JsonProperty("http_bridge_endpoint")
+    private String httpBridgeEndpoint;
+
     @JsonProperty("trust_store")
     private TrustStoreEntity trustStore = new TrustStoreEntity();
 
@@ -191,6 +194,14 @@ public class ClientRegistrationProviderEntity {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public String getHttpBridgeEndpoint() {
+        return httpBridgeEndpoint;
+    }
+
+    public void setHttpBridgeEndpoint(String httpBridgeEndpoint) {
+        this.httpBridgeEndpoint = httpBridgeEndpoint;
     }
 
     public TrustStoreEntity getTrustStore() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/NewAuthenticationStrategyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/NewAuthenticationStrategyEntity.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.application.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public class NewAuthenticationStrategyEntity {
+
+    @NotNull
+    private String name;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    private String description;
+
+    @NotNull
+    private AuthenticationStrategyType type;
+
+    @JsonProperty("client_registration_provider_id")
+    private String clientRegistrationProviderId;
+
+    private List<String> scopes;
+
+    @JsonProperty("auth_methods")
+    private List<String> authMethods;
+
+    @JsonProperty("credential_claims")
+    private String credentialClaims;
+
+    @JsonProperty("auto_approve")
+    private boolean autoApprove;
+
+    @JsonProperty("hide_credentials")
+    private boolean hideCredentials;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public AuthenticationStrategyType getType() {
+        return type;
+    }
+
+    public void setType(AuthenticationStrategyType type) {
+        this.type = type;
+    }
+
+    public String getClientRegistrationProviderId() {
+        return clientRegistrationProviderId;
+    }
+
+    public void setClientRegistrationProviderId(String clientRegistrationProviderId) {
+        this.clientRegistrationProviderId = clientRegistrationProviderId;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<String> getAuthMethods() {
+        return authMethods;
+    }
+
+    public void setAuthMethods(List<String> authMethods) {
+        this.authMethods = authMethods;
+    }
+
+    public String getCredentialClaims() {
+        return credentialClaims;
+    }
+
+    public void setCredentialClaims(String credentialClaims) {
+        this.credentialClaims = credentialClaims;
+    }
+
+    public boolean isAutoApprove() {
+        return autoApprove;
+    }
+
+    public void setAutoApprove(boolean autoApprove) {
+        this.autoApprove = autoApprove;
+    }
+
+    public boolean isHideCredentials() {
+        return hideCredentials;
+    }
+
+    public void setHideCredentials(boolean hideCredentials) {
+        this.hideCredentials = hideCredentials;
+    }
+
+    @Override
+    public String toString() {
+        return "NewAuthenticationStrategyEntity{name='" + name + "', type=" + type + '}';
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/UpdateAuthenticationStrategyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/UpdateAuthenticationStrategyEntity.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.application.registration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public class UpdateAuthenticationStrategyEntity {
+
+    @NotNull
+    private String name;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    private String description;
+
+    @NotNull
+    private AuthenticationStrategyType type;
+
+    @JsonProperty("client_registration_provider_id")
+    private String clientRegistrationProviderId;
+
+    private List<String> scopes;
+
+    @JsonProperty("auth_methods")
+    private List<String> authMethods;
+
+    @JsonProperty("credential_claims")
+    private String credentialClaims;
+
+    @JsonProperty("auto_approve")
+    private boolean autoApprove;
+
+    @JsonProperty("hide_credentials")
+    private boolean hideCredentials;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public AuthenticationStrategyType getType() {
+        return type;
+    }
+
+    public void setType(AuthenticationStrategyType type) {
+        this.type = type;
+    }
+
+    public String getClientRegistrationProviderId() {
+        return clientRegistrationProviderId;
+    }
+
+    public void setClientRegistrationProviderId(String clientRegistrationProviderId) {
+        this.clientRegistrationProviderId = clientRegistrationProviderId;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<String> getAuthMethods() {
+        return authMethods;
+    }
+
+    public void setAuthMethods(List<String> authMethods) {
+        this.authMethods = authMethods;
+    }
+
+    public String getCredentialClaims() {
+        return credentialClaims;
+    }
+
+    public void setCredentialClaims(String credentialClaims) {
+        this.credentialClaims = credentialClaims;
+    }
+
+    public boolean isAutoApprove() {
+        return autoApprove;
+    }
+
+    public void setAutoApprove(boolean autoApprove) {
+        this.autoApprove = autoApprove;
+    }
+
+    public boolean isHideCredentials() {
+        return hideCredentials;
+    }
+
+    public void setHideCredentials(boolean hideCredentials) {
+        this.hideCredentials = hideCredentials;
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAuthenticationStrategyEntity{name='" + name + "', type=" + type + '}';
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthenticationStrategiesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthenticationStrategiesResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.application.AuthenticationStrategyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.*;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Portal endpoint for listing available authentication strategies.
+ * Developers use this to select which strategy to use when creating applications.
+ */
+@Tag(name = "Authentication Strategies")
+@Produces(MediaType.APPLICATION_JSON)
+public class AuthenticationStrategiesResource extends AbstractResource {
+
+    @Autowired
+    private AuthenticationStrategyService authenticationStrategyService;
+
+    @GET
+    @Operation(summary = "List available authentication strategies for the current environment")
+    @ApiResponse(
+        responseCode = "200",
+        description = "List of available authentication strategies",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            array = @ArraySchema(schema = @Schema(implementation = AuthenticationStrategyEntity.class))
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public Set<AuthenticationStrategyEntity> getAuthenticationStrategies() {
+        return authenticationStrategyService.findAll(GraviteeContext.getExecutionContext());
+    }
+
+    @GET
+    @Path("{strategyId}")
+    @Operation(summary = "Get a specific authentication strategy")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Authentication strategy details",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = AuthenticationStrategyEntity.class)
+        )
+    )
+    @ApiResponse(responseCode = "404", description = "Authentication strategy not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    public AuthenticationStrategyEntity getAuthenticationStrategy(@PathParam("strategyId") String strategyId) {
+        return authenticationStrategyService.findById(
+            GraviteeContext.getExecutionContext().getEnvironmentId(),
+            strategyId
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
@@ -34,7 +34,9 @@ import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.configuration.application.AuthenticationStrategyService;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -69,6 +71,9 @@ public class ConfigurationResource extends AbstractResource {
 
     @Autowired
     private ApplicationTypeService applicationTypeService;
+
+    @Autowired
+    private AuthenticationStrategyService authenticationStrategyService;
 
     @Inject
     private CustomUserFieldService customUserFieldService;
@@ -217,6 +222,16 @@ public class ConfigurationResource extends AbstractResource {
         } else {
             return new Link().name(p.getName()).resourceRef(p.getId()).resourceType(ResourceTypeEnum.PAGE);
         }
+    }
+
+    @GET
+    @Path("applications/authentication-strategies")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAuthenticationStrategies() {
+        java.util.Set<AuthenticationStrategyEntity> strategies = authenticationStrategyService.findAll(
+            GraviteeContext.getExecutionContext()
+        );
+        return Response.ok(strategies).build();
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/AuthenticationStrategyService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/AuthenticationStrategyService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.configuration.application;
+
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.NewAuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.UpdateAuthenticationStrategyEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+
+/**
+ * Service for managing authentication strategies.
+ * An authentication strategy defines how applications authenticate with APIs,
+ * optionally referencing a ClientRegistrationProvider for DCR-based strategies.
+ */
+public interface AuthenticationStrategyService {
+
+    Set<AuthenticationStrategyEntity> findAll(ExecutionContext executionContext);
+
+    AuthenticationStrategyEntity findById(String environmentId, String id);
+
+    AuthenticationStrategyEntity create(
+        ExecutionContext executionContext,
+        NewAuthenticationStrategyEntity newStrategy
+    );
+
+    AuthenticationStrategyEntity update(
+        ExecutionContext executionContext,
+        String id,
+        UpdateAuthenticationStrategyEntity updateStrategy
+    );
+
+    void delete(ExecutionContext executionContext, String id);
+
+    /**
+     * Find all strategies that reference a given DCR provider.
+     */
+    Set<AuthenticationStrategyEntity> findByClientRegistrationProviderId(
+        ExecutionContext executionContext,
+        String clientRegistrationProviderId
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
@@ -48,11 +48,31 @@ public interface ClientRegistrationService {
 
     ClientRegistrationResponse register(ExecutionContext executionContext, NewApplicationEntity application);
 
+    /**
+     * Register an application with a specific DCR provider (identified by ID).
+     */
+    ClientRegistrationResponse register(ExecutionContext executionContext, NewApplicationEntity application, String providerId);
+
     ClientRegistrationResponse update(
         ExecutionContext executionContext,
         String previousRegistrationResponse,
         UpdateApplicationEntity application
     );
 
+    /**
+     * Update an application's DCR registration using a specific provider.
+     */
+    ClientRegistrationResponse update(
+        ExecutionContext executionContext,
+        String previousRegistrationResponse,
+        UpdateApplicationEntity application,
+        String providerId
+    );
+
     ClientRegistrationResponse renewClientSecret(ExecutionContext executionContext, String previousRegistrationResponse);
+
+    /**
+     * Renew client secret using a specific provider.
+     */
+    ClientRegistrationResponse renewClientSecret(ExecutionContext executionContext, String previousRegistrationResponse, String providerId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/AuthenticationStrategyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/AuthenticationStrategyServiceImpl.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.application.registration;
+
+import static io.gravitee.repository.management.model.Audit.AuditProperties.AUTHENTICATION_STRATEGY;
+import static io.gravitee.repository.management.model.AuthenticationStrategy.AuditEvent.*;
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AuthenticationStrategyRepository;
+import io.gravitee.repository.management.api.ClientRegistrationProviderRepository;
+import io.gravitee.repository.management.model.AuthenticationStrategy;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.AuthenticationStrategyType;
+import io.gravitee.rest.api.model.configuration.application.registration.NewAuthenticationStrategyEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.UpdateAuthenticationStrategyEntity;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.configuration.application.AuthenticationStrategyService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import java.util.Date;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class AuthenticationStrategyServiceImpl extends AbstractService implements AuthenticationStrategyService {
+
+    @Lazy
+    @Autowired
+    private AuthenticationStrategyRepository authenticationStrategyRepository;
+
+    @Lazy
+    @Autowired
+    private ClientRegistrationProviderRepository clientRegistrationProviderRepository;
+
+    @Autowired
+    private AuditService auditService;
+
+    @Override
+    public Set<AuthenticationStrategyEntity> findAll(ExecutionContext executionContext) {
+        try {
+            return authenticationStrategyRepository
+                .findAllByEnvironment(executionContext.getEnvironmentId())
+                .stream()
+                .map(this::convert)
+                .collect(Collectors.toSet());
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find all authentication strategies", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all authentication strategies", ex);
+        }
+    }
+
+    @Override
+    public AuthenticationStrategyEntity findById(String environmentId, String id) {
+        try {
+            Optional<AuthenticationStrategy> opt = authenticationStrategyRepository.findById(id);
+            if (opt.isEmpty()) {
+                throw new IllegalStateException("No authentication strategy found with id: " + id);
+            }
+            return convert(opt.get());
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find authentication strategy {}", id, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find authentication strategy " + id, ex);
+        }
+    }
+
+    @Override
+    public AuthenticationStrategyEntity create(
+        ExecutionContext executionContext,
+        NewAuthenticationStrategyEntity newStrategy
+    ) {
+        try {
+            log.debug("Create authentication strategy {}", newStrategy);
+
+            validateProviderReference(newStrategy.getType(), newStrategy.getClientRegistrationProviderId());
+
+            AuthenticationStrategy strategy = convert(newStrategy);
+            strategy.setId(UuidString.generateRandom());
+            strategy.setEnvironmentId(executionContext.getEnvironmentId());
+            strategy.setCreatedAt(new Date());
+            strategy.setUpdatedAt(strategy.getCreatedAt());
+
+            AuthenticationStrategy created = authenticationStrategyRepository.create(strategy);
+
+            auditService.createAuditLog(
+                executionContext,
+                AuditService.AuditLogData.builder()
+                    .properties(singletonMap(AUTHENTICATION_STRATEGY, created.getId()))
+                    .event(AUTHENTICATION_STRATEGY_CREATED)
+                    .createdAt(created.getUpdatedAt())
+                    .oldValue(null)
+                    .newValue(created)
+                    .build()
+            );
+
+            return convert(created);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to create authentication strategy {}", newStrategy, ex);
+            throw new TechnicalManagementException("An error occurs while trying to create authentication strategy", ex);
+        }
+    }
+
+    @Override
+    public AuthenticationStrategyEntity update(
+        ExecutionContext executionContext,
+        String id,
+        UpdateAuthenticationStrategyEntity updateStrategy
+    ) {
+        try {
+            log.debug("Update authentication strategy {}", updateStrategy);
+
+            Optional<AuthenticationStrategy> opt = authenticationStrategyRepository.findById(id);
+            if (opt.isEmpty()) {
+                throw new IllegalStateException("No authentication strategy found with id: " + id);
+            }
+
+            AuthenticationStrategy existing = opt.get();
+            validateProviderReference(updateStrategy.getType(), updateStrategy.getClientRegistrationProviderId());
+
+            AuthenticationStrategy toUpdate = convert(updateStrategy);
+            toUpdate.setId(id);
+            toUpdate.setEnvironmentId(existing.getEnvironmentId());
+            toUpdate.setCreatedAt(existing.getCreatedAt());
+            toUpdate.setUpdatedAt(new Date());
+
+            AuthenticationStrategy updated = authenticationStrategyRepository.update(toUpdate);
+
+            auditService.createAuditLog(
+                executionContext,
+                AuditService.AuditLogData.builder()
+                    .properties(singletonMap(AUTHENTICATION_STRATEGY, updated.getId()))
+                    .event(AUTHENTICATION_STRATEGY_UPDATED)
+                    .createdAt(updated.getUpdatedAt())
+                    .oldValue(existing)
+                    .newValue(updated)
+                    .build()
+            );
+
+            return convert(updated);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to update authentication strategy {}", id, ex);
+            throw new TechnicalManagementException("An error occurs while trying to update authentication strategy", ex);
+        }
+    }
+
+    @Override
+    public void delete(ExecutionContext executionContext, String id) {
+        try {
+            log.debug("Delete authentication strategy {}", id);
+
+            Optional<AuthenticationStrategy> opt = authenticationStrategyRepository.findById(id);
+            if (opt.isEmpty()) {
+                throw new IllegalStateException("No authentication strategy found with id: " + id);
+            }
+
+            authenticationStrategyRepository.delete(id);
+
+            auditService.createAuditLog(
+                executionContext,
+                AuditService.AuditLogData.builder()
+                    .properties(singletonMap(AUTHENTICATION_STRATEGY, id))
+                    .event(AUTHENTICATION_STRATEGY_DELETED)
+                    .createdAt(new Date())
+                    .oldValue(opt.get())
+                    .newValue(null)
+                    .build()
+            );
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to delete authentication strategy {}", id, ex);
+            throw new TechnicalManagementException("An error occurs while trying to delete authentication strategy", ex);
+        }
+    }
+
+    @Override
+    public Set<AuthenticationStrategyEntity> findByClientRegistrationProviderId(
+        ExecutionContext executionContext,
+        String clientRegistrationProviderId
+    ) {
+        try {
+            return authenticationStrategyRepository
+                .findByClientRegistrationProviderId(clientRegistrationProviderId)
+                .stream()
+                .map(this::convert)
+                .collect(Collectors.toSet());
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find strategies by provider {}", clientRegistrationProviderId, ex);
+            throw new TechnicalManagementException("An error occurs while finding strategies by provider", ex);
+        }
+    }
+
+    private void validateProviderReference(AuthenticationStrategyType type, String providerId) {
+        if (type == AuthenticationStrategyType.DCR || type == AuthenticationStrategyType.SELF_MANAGED_OIDC) {
+            if (providerId == null || providerId.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "A client registration provider ID is required for " + type + " authentication strategies"
+                );
+            }
+            try {
+                if (clientRegistrationProviderRepository.findById(providerId).isEmpty()) {
+                    throw new IllegalStateException("No client registration provider found with id: " + providerId);
+                }
+            } catch (TechnicalException ex) {
+                throw new TechnicalManagementException("Failed to validate provider reference", ex);
+            }
+        }
+    }
+
+    private AuthenticationStrategyEntity convert(AuthenticationStrategy strategy) {
+        AuthenticationStrategyEntity entity = new AuthenticationStrategyEntity();
+        entity.setId(strategy.getId());
+        entity.setName(strategy.getName());
+        entity.setDisplayName(strategy.getDisplayName());
+        entity.setDescription(strategy.getDescription());
+        entity.setType(strategy.getType() != null ? AuthenticationStrategyType.valueOf(strategy.getType().name()) : null);
+        entity.setClientRegistrationProviderId(strategy.getClientRegistrationProviderId());
+        entity.setScopes(strategy.getScopes());
+        entity.setAuthMethods(strategy.getAuthMethods());
+        entity.setCredentialClaims(strategy.getCredentialClaims());
+        entity.setAutoApprove(strategy.isAutoApprove());
+        entity.setHideCredentials(strategy.isHideCredentials());
+        entity.setCreatedAt(strategy.getCreatedAt());
+        entity.setUpdatedAt(strategy.getUpdatedAt());
+        return entity;
+    }
+
+    private AuthenticationStrategy convert(NewAuthenticationStrategyEntity entity) {
+        AuthenticationStrategy strategy = new AuthenticationStrategy();
+        strategy.setName(entity.getName());
+        strategy.setDisplayName(entity.getDisplayName());
+        strategy.setDescription(entity.getDescription());
+        strategy.setType(entity.getType() != null ? AuthenticationStrategy.Type.valueOf(entity.getType().name()) : null);
+        strategy.setClientRegistrationProviderId(entity.getClientRegistrationProviderId());
+        strategy.setScopes(entity.getScopes());
+        strategy.setAuthMethods(entity.getAuthMethods());
+        strategy.setCredentialClaims(entity.getCredentialClaims());
+        strategy.setAutoApprove(entity.isAutoApprove());
+        strategy.setHideCredentials(entity.isHideCredentials());
+        return strategy;
+    }
+
+    private AuthenticationStrategy convert(UpdateAuthenticationStrategyEntity entity) {
+        AuthenticationStrategy strategy = new AuthenticationStrategy();
+        strategy.setName(entity.getName());
+        strategy.setDisplayName(entity.getDisplayName());
+        strategy.setDescription(entity.getDescription());
+        strategy.setType(entity.getType() != null ? AuthenticationStrategy.Type.valueOf(entity.getType().name()) : null);
+        strategy.setClientRegistrationProviderId(entity.getClientRegistrationProviderId());
+        strategy.setScopes(entity.getScopes());
+        strategy.setAuthMethods(entity.getAuthMethods());
+        strategy.setCredentialClaims(entity.getCredentialClaims());
+        strategy.setAutoApprove(entity.isAutoApprove());
+        strategy.setHideCredentials(entity.isHideCredentials());
+        return strategy;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/HttpBridgeDynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/HttpBridgeDynamicClientRegistrationProviderClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.application.registration.client;
+
+import io.gravitee.rest.api.model.configuration.application.registration.KeyStoreEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.TrustStoreEntity;
+import io.gravitee.rest.api.service.impl.configuration.application.registration.client.common.SecureHttpClientUtils;
+import io.gravitee.rest.api.service.impl.configuration.application.registration.client.token.InitialAccessTokenProvider;
+import java.util.Collections;
+
+/**
+ * HTTP Bridge client for custom IdPs that don't natively support OIDC DCR.
+ * Instead of OIDC discovery, this client directly targets a user-provided
+ * HTTP endpoint (the "bridge") that translates between the standard DCR
+ * request format and the custom IdP's API.
+ *
+ * <p>The bridge endpoint is expected to accept standard RFC 7591 DCR payloads
+ * and return standard DCR responses. The bridge implementation handles the
+ * translation to whatever format the custom IdP requires.</p>
+ *
+ * <p>This pattern is inspired by Kong Konnect's HTTP DCR bridge approach.</p>
+ */
+public class HttpBridgeDynamicClientRegistrationProviderClient extends DynamicClientRegistrationProviderClient {
+
+    private final String bridgeEndpoint;
+    private final InitialAccessTokenProvider initialAccessTokenProvider;
+    private final TrustStoreEntity trustStore;
+    private final KeyStoreEntity keyStore;
+
+    public HttpBridgeDynamicClientRegistrationProviderClient(
+        String bridgeEndpoint,
+        InitialAccessTokenProvider initialAccessTokenProvider,
+        TrustStoreEntity trustStore,
+        KeyStoreEntity keyStore
+    ) {
+        this.bridgeEndpoint = bridgeEndpoint;
+        this.initialAccessTokenProvider = initialAccessTokenProvider;
+        this.trustStore = trustStore;
+        this.keyStore = keyStore;
+        initialize();
+    }
+
+    private void initialize() {
+        try {
+            httpClient = SecureHttpClientUtils.createHttpClient(trustStore, keyStore);
+            this.registrationEndpoint = bridgeEndpoint;
+        } catch (Exception ex) {
+            log.error("An error occurred while initializing HTTP bridge DCR client for endpoint {}", bridgeEndpoint, ex);
+            throw new DynamicClientRegistrationException(
+                "An error occurred while initializing HTTP bridge DCR client for endpoint " + bridgeEndpoint, ex
+            );
+        }
+    }
+
+    @Override
+    public String getInitialAccessToken() {
+        return initialAccessTokenProvider.get(Collections.emptyMap(), this.trustStore, this.keyStore);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce a two-tier **Authentication Strategies** model (inspired by Kong Konnect) that allows multiple DCR providers per environment with per-application strategy selection
- Remove the single-provider restriction that previously prevented configuring more than one DCR provider
- Add full-stack implementation: repository layer (MongoDB + JDBC), service layer, REST API endpoints (Management + Portal), Console UI settings page, and Portal UI strategy selector

## What changed

### Backend
- **New `AuthenticationStrategy` entity** with types: `DCR`, `KEY_AUTH`, `SELF_MANAGED_OIDC` — each optionally referencing a `ClientRegistrationProvider`
- **Repository**: `AuthenticationStrategyRepository` interface + MongoDB and JDBC implementations
- **Service**: `AuthenticationStrategyService` with full CRUD, audit logging, and provider validation
- **ClientRegistrationService**: New provider-specific overloads for `register()`, `update()`, `renewClientSecret()` with a `resolveProvider()` helper
- **ApplicationServiceImpl**: Resolves provider via strategy, stores `auth_strategy_id` in application metadata
- **HTTP Bridge client**: For custom IdPs that don't support OIDC DCR natively (Kong-inspired pattern)
- **Plan model**: Added optional `authenticationStrategyId` for per-plan strategy enforcement

### REST API
- `GET/POST /configuration/applications/authentication-strategies` — list and create strategies
- `GET/PUT/DELETE /configuration/applications/authentication-strategies/{id}` — individual strategy CRUD
- Portal API endpoint for listing available strategies

### Console UI
- New **Authentication Strategies** page under Settings with list view and create/edit form
- Removed "Only one DCR provider is allowed" button restriction on Client Registration page
- Navigation menu entry for the new page

### Portal UI (Next)
- Strategy selector dropdown in application creation flow (appears when 2+ DCR strategies exist)
- `authentication_strategy_id` passed during application creation

### Documentation
- Competitive analysis document comparing Gravitee, Kong Konnect, and Tyk DCR approaches

## Test plan
- [ ] Create 2+ DCR providers in Console UI Settings → Client Registration
- [ ] Create authentication strategies referencing different providers in Settings → Authentication Strategies
- [ ] Verify strategy list/create/edit/delete works in Console UI
- [ ] Create application in Portal with strategy selector visible
- [ ] Verify DCR registration routes to correct provider based on selected strategy
- [ ] Verify application updates/secret renewals use the stored strategy for provider resolution
- [ ] Verify backward compatibility: apps without a strategy still use first available provider


Made with [Cursor](https://cursor.com)