### PR TITLE
feat: add ATTR_API_PRODUCT attribute in context

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -23,6 +23,7 @@ import static io.gravitee.gateway.api.ExecutionContext.ATTR_SUBSCRIPTION_ID;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_SKIP;
 import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
 
+import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
@@ -48,6 +49,7 @@ public class SubscriptionProcessor implements Processor {
     static final String PLAN_ANONYMOUS = "1";
     static final String SUBSCRIPTION_CONTEXT_ATTRIBUTE = "subscription";
     private String clientIdentifierHeader = DEFAULT_CLIENT_IDENTIFIER_HEADER;
+    public static final String ATTR_API_PRODUCT = ExecutionContext.ATTR_PREFIX + "apiProduct";
 
     public static SubscriptionProcessor instance(final String clientIdentifierHeader) {
         SubscriptionProcessor subscriptionProcessor = Holder.INSTANCE;
@@ -130,6 +132,9 @@ public class SubscriptionProcessor implements Processor {
                 subscription.setApplication(applicationId);
                 subscription.setStatus(ACCEPTED.name());
                 ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
+            }
+            if (subscription.getMetadata() != null && subscription.getMetadata().containsKey("productId")) {
+                ctx.setAttribute(ATTR_API_PRODUCT, subscription.getMetadata().get("productId"));
             }
             ctx
                 .getTemplateEngine()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12954
## Description

- Detect selected API Product and API Product plan during request execution
- Expose api product in policy/flow condition context
- Allow conditional flow execution based on api-product ID
- No behavior change for APIs without plan conditions

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

