### PR TITLE
feat(storybook): add unified storybook-all composition for CI

### DIFF
--- a/.circleci/ci/src/jobs/frontend/index.ts
+++ b/.circleci/ci/src/jobs/frontend/index.ts
@@ -15,7 +15,7 @@
  */
 export * from './job-chromatic-console';
 export * from './job-console-webui-build';
-export * from './job-storybook-console';
+export * from './job-storybook-all';
 export * from './job-portal-webui-build';
 export * from './job-nx-format-check';
 export * from './job-webui-lint-test';

--- a/.circleci/ci/src/jobs/frontend/job-chromatic-console.ts
+++ b/.circleci/ci/src/jobs/frontend/job-chromatic-console.ts
@@ -55,7 +55,7 @@ export class ChromaticConsoleJob {
       //  - Create a new project in Chromatic and update the token
       new commands.Run({
         name: 'Running Chromatic',
-        command: `SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\\/\\/[0-9a-z-]*\\.chromatic\\.com" | grep -o "https:.*")
+        command: `SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\\/\\/[0-9a-z-]*\\.chromatic\\.com" | grep -o "https:.*")
 echo "export SB_URL=$SB_URL" >> $BASH_ENV`,
       }),
       new reusable.ReusedCommand(orbs.github.commands['setup']),

--- a/.circleci/ci/src/jobs/frontend/job-storybook-all.ts
+++ b/.circleci/ci/src/jobs/frontend/job-storybook-all.ts
@@ -19,8 +19,8 @@ import { NodeLtsExecutor } from '../../executors';
 import { InstallYarnCommand, NotifyOnFailureCommand, WorkspaceInstallCommand } from '../../commands';
 import { CircleCIEnvironment } from '../../pipelines';
 
-export class StorybookConsoleJob {
-  private static jobName = 'job-console-webui-build-storybook';
+export class StorybookAllJob {
+  private static jobName = 'job-build-all-storybooks';
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     const installYarnCmd = InstallYarnCommand.get();
@@ -37,16 +37,16 @@ export class StorybookConsoleJob {
       new reusable.ReusedCommand(installYarnCmd),
       new reusable.ReusedCommand(workspaceInstallCommand),
       new commands.Run({
-        name: 'Build Storybook Console',
-        command: 'NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook',
+        name: 'Build all Storybooks',
+        command: 'NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2',
       }),
       new reusable.ReusedCommand(notifyOnFailureCommand),
       new commands.workspace.Persist({
         root: '.',
-        paths: ['gravitee-apim-console-webui/storybook-static', 'gravitee-apim-console-webui/dist-lib'],
+        paths: ['storybook-all/storybook-static', 'gravitee-apim-console-webui/dist-lib'],
       }),
     ];
 
-    return new Job(StorybookConsoleJob.jobName, NodeLtsExecutor.create('large'), steps);
+    return new Job(StorybookAllJob.jobName, NodeLtsExecutor.create('large'), steps);
   }
 }

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -630,74 +630,6 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: large
-    steps:
-      - checkout
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
-      - cmd-notify-on-failure
-      - persist_to_workspace:
-          root: .
-          paths:
-            - gravitee-apim-console-webui/storybook-static
-            - gravitee-apim-console-webui/dist-lib
-  job-console-webui-chromatic-deployment:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: small
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
-          var-name: CHROMATIC_PROJECT_TOKEN
-      - run:
-          name: Running Chromatic
-          command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
-            echo "export SB_URL=$SB_URL" >> $BASH_ENV
-      - gh/setup
-      - run:
-          name: Edit Pull Request Description
-          command: |-
-            # First check there is an associated pull request, otherwise just stop the job here
-            if ! gh pr view --json title;
-            then
-              echo "No PR found for this branch, stopping the job here."
-              exit 0
-            fi
-
-            # If PR state is different from OPEN
-            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-            then
-              echo "PR is not opened, stopping the job here."
-              exit 0
-            fi
-
-            export PR_BODY_STORYBOOK_SECTION="
-            <!-- Storybook placeholder -->
-            ---
-
-            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
-            <!-- Storybook placeholder end -->
-            "
-
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
-
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
-      - cmd-notify-on-failure
   job-build-docker-webui-image:
     parameters:
       apim-project:
@@ -756,6 +688,74 @@ jobs:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-all-storybooks:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - storybook-all/storybook-static
+            - gravitee-apim-console-webui/dist-lib
+  job-console-webui-chromatic-deployment:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
+          var-name: CHROMATIC_PROJECT_TOKEN
+      - run:
+          name: Running Chromatic
+          command: |-
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            echo "export SB_URL=$SB_URL" >> $BASH_ENV
+      - gh/setup
+      - run:
+          name: Edit Pull Request Description
+          command: |-
+            # First check there is an associated pull request, otherwise just stop the job here
+            if ! gh pr view --json title;
+            then
+              echo "No PR found for this branch, stopping the job here."
+              exit 0
+            fi
+
+            # If PR state is different from OPEN
+            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+            then
+              echo "PR is not opened, stopping the job here."
+              exit 0
+            fi
+
+            export PR_BODY_STORYBOOK_SECTION="
+            <!-- Storybook placeholder -->
+            ---
+
+            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+            <!-- Storybook placeholder end -->
+            "
+
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+      - cmd-notify-on-failure
   job-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -1415,16 +1415,6 @@ workflows:
           apim-project: gravitee-apim-console-webui
           docker-context: .
           docker-image-name: apim-management-ui
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -1433,6 +1423,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -183,74 +183,6 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: large
-    steps:
-      - checkout
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
-      - cmd-notify-on-failure
-      - persist_to_workspace:
-          root: .
-          paths:
-            - gravitee-apim-console-webui/storybook-static
-            - gravitee-apim-console-webui/dist-lib
-  job-console-webui-chromatic-deployment:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: small
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
-          var-name: CHROMATIC_PROJECT_TOKEN
-      - run:
-          name: Running Chromatic
-          command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
-            echo "export SB_URL=$SB_URL" >> $BASH_ENV
-      - gh/setup
-      - run:
-          name: Edit Pull Request Description
-          command: |-
-            # First check there is an associated pull request, otherwise just stop the job here
-            if ! gh pr view --json title;
-            then
-              echo "No PR found for this branch, stopping the job here."
-              exit 0
-            fi
-
-            # If PR state is different from OPEN
-            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-            then
-              echo "PR is not opened, stopping the job here."
-              exit 0
-            fi
-
-            export PR_BODY_STORYBOOK_SECTION="
-            <!-- Storybook placeholder -->
-            ---
-
-            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
-            <!-- Storybook placeholder end -->
-            "
-
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
-
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
-      - cmd-notify-on-failure
   job-sonarcloud-analysis:
     parameters:
       working_directory:
@@ -288,6 +220,74 @@ jobs:
             - /opt/sonar-scanner/.sonar/cache
           key: gravitee-api-management-v14-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
+  job-build-all-storybooks:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - storybook-all/storybook-static
+            - gravitee-apim-console-webui/dist-lib
+  job-console-webui-chromatic-deployment:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
+          var-name: CHROMATIC_PROJECT_TOKEN
+      - run:
+          name: Running Chromatic
+          command: |-
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            echo "export SB_URL=$SB_URL" >> $BASH_ENV
+      - gh/setup
+      - run:
+          name: Edit Pull Request Description
+          command: |-
+            # First check there is an associated pull request, otherwise just stop the job here
+            if ! gh pr view --json title;
+            then
+              echo "No PR found for this branch, stopping the job here."
+              exit 0
+            fi
+
+            # If PR state is different from OPEN
+            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+            then
+              echo "PR is not opened, stopping the job here."
+              exit 0
+            fi
+
+            export PR_BODY_STORYBOOK_SECTION="
+            <!-- Storybook placeholder -->
+            ---
+
+            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+            <!-- Storybook placeholder end -->
+            "
+
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+      - cmd-notify-on-failure
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -332,16 +332,6 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -350,6 +340,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
@@ -136,6 +136,74 @@ jobs:
           name: Check prettier formatting for nx projects
           command: yarn prettier
       - cmd-notify-on-failure
+  job-build-all-storybooks:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - storybook-all/storybook-static
+            - gravitee-apim-console-webui/dist-lib
+  job-console-webui-chromatic-deployment:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
+          var-name: CHROMATIC_PROJECT_TOKEN
+      - run:
+          name: Running Chromatic
+          command: |-
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            echo "export SB_URL=$SB_URL" >> $BASH_ENV
+      - gh/setup
+      - run:
+          name: Edit Pull Request Description
+          command: |-
+            # First check there is an associated pull request, otherwise just stop the job here
+            if ! gh pr view --json title;
+            then
+              echo "No PR found for this branch, stopping the job here."
+              exit 0
+            fi
+
+            # If PR state is different from OPEN
+            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+            then
+              echo "PR is not opened, stopping the job here."
+              exit 0
+            fi
+
+            export PR_BODY_STORYBOOK_SECTION="
+            <!-- Storybook placeholder -->
+            ---
+
+            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+            <!-- Storybook placeholder end -->
+            "
+
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+      - cmd-notify-on-failure
   job-nx-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -284,6 +352,16 @@ workflows:
           name: Check prettier formatting for nx projects
           context:
             - cicd-orchestrator
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:
@@ -313,3 +391,4 @@ orbs:
   keeper: gravitee-io/keeper@0.7.0
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5
+  gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -606,7 +606,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
+  job-build-all-storybooks:
     docker:
       - image: cimg/node:22.12.0
     resource_class: large
@@ -615,13 +615,13 @@ jobs:
       - cmd-install-yarn
       - cmd-workspace-install
       - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
           paths:
-            - gravitee-apim-console-webui/storybook-static
+            - storybook-all/storybook-static
             - gravitee-apim-console-webui/dist-lib
   job-console-webui-chromatic-deployment:
     docker:
@@ -642,7 +642,7 @@ jobs:
       - run:
           name: Running Chromatic
           command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
             echo "export SB_URL=$SB_URL" >> $BASH_ENV
       - gh/setup
       - run:
@@ -907,16 +907,6 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -925,6 +915,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -630,74 +630,6 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: large
-    steps:
-      - checkout
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
-      - cmd-notify-on-failure
-      - persist_to_workspace:
-          root: .
-          paths:
-            - gravitee-apim-console-webui/storybook-static
-            - gravitee-apim-console-webui/dist-lib
-  job-console-webui-chromatic-deployment:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: small
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
-          var-name: CHROMATIC_PROJECT_TOKEN
-      - run:
-          name: Running Chromatic
-          command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
-            echo "export SB_URL=$SB_URL" >> $BASH_ENV
-      - gh/setup
-      - run:
-          name: Edit Pull Request Description
-          command: |-
-            # First check there is an associated pull request, otherwise just stop the job here
-            if ! gh pr view --json title;
-            then
-              echo "No PR found for this branch, stopping the job here."
-              exit 0
-            fi
-
-            # If PR state is different from OPEN
-            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-            then
-              echo "PR is not opened, stopping the job here."
-              exit 0
-            fi
-
-            export PR_BODY_STORYBOOK_SECTION="
-            <!-- Storybook placeholder -->
-            ---
-
-            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
-            <!-- Storybook placeholder end -->
-            "
-
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
-
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
-      - cmd-notify-on-failure
   job-build-docker-webui-image:
     parameters:
       apim-project:
@@ -756,6 +688,74 @@ jobs:
           docker_image_to_scan: graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-all-storybooks:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - storybook-all/storybook-static
+            - gravitee-apim-console-webui/dist-lib
+  job-console-webui-chromatic-deployment:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
+          var-name: CHROMATIC_PROJECT_TOKEN
+      - run:
+          name: Running Chromatic
+          command: |-
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            echo "export SB_URL=$SB_URL" >> $BASH_ENV
+      - gh/setup
+      - run:
+          name: Edit Pull Request Description
+          command: |-
+            # First check there is an associated pull request, otherwise just stop the job here
+            if ! gh pr view --json title;
+            then
+              echo "No PR found for this branch, stopping the job here."
+              exit 0
+            fi
+
+            # If PR state is different from OPEN
+            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+            then
+              echo "PR is not opened, stopping the job here."
+              exit 0
+            fi
+
+            export PR_BODY_STORYBOOK_SECTION="
+            <!-- Storybook placeholder -->
+            ---
+
+            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+            <!-- Storybook placeholder end -->
+            "
+
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+      - cmd-notify-on-failure
   job-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -1472,16 +1472,6 @@ workflows:
           apim-project: gravitee-apim-console-webui
           docker-context: .
           docker-image-name: apim-management-ui
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -1490,6 +1480,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -606,7 +606,7 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
+  job-build-all-storybooks:
     docker:
       - image: cimg/node:22.12.0
     resource_class: large
@@ -615,13 +615,13 @@ jobs:
       - cmd-install-yarn
       - cmd-workspace-install
       - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
       - cmd-notify-on-failure
       - persist_to_workspace:
           root: .
           paths:
-            - gravitee-apim-console-webui/storybook-static
+            - storybook-all/storybook-static
             - gravitee-apim-console-webui/dist-lib
   job-console-webui-chromatic-deployment:
     docker:
@@ -642,7 +642,7 @@ jobs:
       - run:
           name: Running Chromatic
           command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
             echo "export SB_URL=$SB_URL" >> $BASH_ENV
       - gh/setup
       - run:
@@ -907,16 +907,6 @@ workflows:
           name: Build APIM Console
           context:
             - cicd-orchestrator
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -925,6 +915,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -631,74 +631,6 @@ jobs:
           root: .
           paths:
             - gravitee-apim-console-webui/dist
-  job-console-webui-build-storybook:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: large
-    steps:
-      - checkout
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - run:
-          name: Build Storybook Console
-          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run console:build-storybook
-      - cmd-notify-on-failure
-      - persist_to_workspace:
-          root: .
-          paths:
-            - gravitee-apim-console-webui/storybook-static
-            - gravitee-apim-console-webui/dist-lib
-  job-console-webui-chromatic-deployment:
-    docker:
-      - image: cimg/node:22.12.0
-    resource_class: small
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - cmd-install-yarn
-      - cmd-workspace-install
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
-          var-name: CHROMATIC_PROJECT_TOKEN
-      - run:
-          name: Running Chromatic
-          command: |-
-            SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
-            echo "export SB_URL=$SB_URL" >> $BASH_ENV
-      - gh/setup
-      - run:
-          name: Edit Pull Request Description
-          command: |-
-            # First check there is an associated pull request, otherwise just stop the job here
-            if ! gh pr view --json title;
-            then
-              echo "No PR found for this branch, stopping the job here."
-              exit 0
-            fi
-
-            # If PR state is different from OPEN
-            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-            then
-              echo "PR is not opened, stopping the job here."
-              exit 0
-            fi
-
-            export PR_BODY_STORYBOOK_SECTION="
-            <!-- Storybook placeholder -->
-            ---
-
-            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
-            <!-- Storybook placeholder end -->
-            "
-
-            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
-
-            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
-      - cmd-notify-on-failure
   job-build-docker-webui-image:
     parameters:
       apim-project:
@@ -732,6 +664,74 @@ jobs:
             << parameters.docker-context >>
           working_directory: << parameters.apim-project >>
       - cmd-docker-logout
+  job-build-all-storybooks:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Build all Storybooks
+          command: NODE_OPTIONS=--max_old_space_size=8192 yarn nx run storybook-all:build-storybook --parallel=2
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - storybook-all/storybook-static
+            - gravitee-apim-console-webui/dist-lib
+  job-console-webui-chromatic-deployment:
+    docker:
+      - image: cimg/node:22.12.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password
+          var-name: CHROMATIC_PROJECT_TOKEN
+      - run:
+          name: Running Chromatic
+          command: |-
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-all/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            echo "export SB_URL=$SB_URL" >> $BASH_ENV
+      - gh/setup
+      - run:
+          name: Edit Pull Request Description
+          command: |-
+            # First check there is an associated pull request, otherwise just stop the job here
+            if ! gh pr view --json title;
+            then
+              echo "No PR found for this branch, stopping the job here."
+              exit 0
+            fi
+
+            # If PR state is different from OPEN
+            if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+            then
+              echo "PR is not opened, stopping the job here."
+              exit 0
+            fi
+
+            export PR_BODY_STORYBOOK_SECTION="
+            <!-- Storybook placeholder -->
+            ---
+
+            📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+            <!-- Storybook placeholder end -->
+            "
+
+            export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+            gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+      - cmd-notify-on-failure
   job-webui-lint-test:
     parameters:
       apim-ui-project:
@@ -1192,16 +1192,6 @@ workflows:
           apim-project: gravitee-apim-console-webui
           docker-context: .
           docker-image-name: apim-management-ui
-      - job-console-webui-build-storybook:
-          name: Build Console Storybook
-          context:
-            - cicd-orchestrator
-      - job-console-webui-chromatic-deployment:
-          name: Deploy console in chromatic
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build Console Storybook
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-console-webui
           context:
@@ -1210,6 +1200,16 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
           cache_type: frontend
+      - job-build-all-storybooks:
+          name: Build all Storybooks
+          context:
+            - cicd-orchestrator
+      - job-console-webui-chromatic-deployment:
+          name: Deploy Storybook to Chromatic
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build all Storybooks
       - job-nx-webui-lint-test:
           name: Lint & test APIM Portal Next
           context:

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
@@ -82,8 +82,8 @@ export const SingleNode: Story = {
 export const NoRack: Story = {
   args: {
     nodes: [
-      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com', rack: null, logDirSize: null }),
-      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com', rack: null, logDirSize: null }),
+      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com', rack: undefined, logDirSize: undefined }),
+      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com', rack: undefined, logDirSize: undefined }),
     ],
     controllerId: 1,
   },

--- a/package.json
+++ b/package.json
@@ -214,6 +214,8 @@
         "markdown:test": "nx test markdown",
         "dashboard:storybook": "nx storybook dashboard",
         "dashboard:test": "nx test dashboard",
+        "storybook-all:build": "nx run storybook-all:build-storybook",
+        "storybook-all:serve": "nx run storybook-all:serve-storybook",
         "clean": "rm -rf gravitee-apim-console-webui/node_modules gravitee-apim-console-webui/.angular gravitee-apim-console-webui/dist gravitee-apim-console-webui/dist-lib gravitee-apim-portal-webui-next/node_modules gravitee-apim-portal-webui-next/.angular gravitee-apim-portal-webui-next/dist && echo '✅ Clean done.'",
         "postinstall": "yarn clean"
     },

--- a/storybook-all/.storybook/main.ts
+++ b/storybook-all/.storybook/main.ts
@@ -1,0 +1,24 @@
+import type { StorybookConfig } from '@storybook/angular';
+
+// This is a composition-only Storybook that aggregates all project Storybooks via refs.
+// It has no stories of its own — the preview build is skipped using --preview-url in the
+// build command (see project.json), which avoids requiring an Angular browserTarget.
+const config: StorybookConfig = {
+  framework: {
+    name: '@storybook/angular',
+    options: {},
+  },
+  stories: [],
+  core: {
+    disableTelemetry: true,
+  },
+  refs: {
+    console: { title: 'Console', url: './console' },
+    'portal-next': { title: 'Portal Next', url: './portal-next' },
+    markdown: { title: 'Markdown', url: './markdown' },
+    dashboard: { title: 'Dashboard', url: './dashboard' },
+    'kafka-explorer': { title: 'Kafka Explorer', url: './kafka-explorer' },
+  },
+};
+
+export default config;

--- a/storybook-all/assemble.mjs
+++ b/storybook-all/assemble.mjs
@@ -1,0 +1,37 @@
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const hostStatic = resolve(root, 'storybook-all/storybook-static');
+
+const projects = [
+  { name: 'console', dir: 'gravitee-apim-console-webui/storybook-static' },
+  { name: 'portal-next', dir: 'gravitee-apim-portal-webui-next/storybook-static' },
+  { name: 'markdown', dir: 'gravitee-apim-webui-libs/gravitee-markdown/storybook-static' },
+  { name: 'dashboard', dir: 'gravitee-apim-webui-libs/gravitee-dashboard/storybook-static' },
+  { name: 'kafka-explorer', dir: 'gravitee-apim-webui-libs/gravitee-kafka-explorer/storybook-static' },
+];
+
+for (const { name, dir } of projects) {
+  const src = resolve(root, dir);
+  const dest = resolve(hostStatic, name);
+
+  if (!existsSync(src)) {
+    console.warn(`[assemble] Skipping "${name}": ${src} does not exist`);
+    continue;
+  }
+
+  console.log(`[assemble] Copying ${name} → ${dest}`);
+  cpSync(src, dest, { recursive: true });
+
+  // Inject <base href> so webpack chunks resolve from the correct subdirectory
+  const iframePath = resolve(dest, 'iframe.html');
+  if (existsSync(iframePath)) {
+    const html = readFileSync(iframePath, 'utf-8');
+    const patched = html.replace('<head>', `<head><base href="/${name}/">`);
+    writeFileSync(iframePath, patched, 'utf-8');
+    console.log(`[assemble] Patched ${name}/iframe.html with <base href="/${name}/">`);
+  }
+}
+
+console.log('[assemble] Done.');

--- a/storybook-all/project.json
+++ b/storybook-all/project.json
@@ -1,0 +1,53 @@
+{
+  "name": "storybook-all",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "targets": {
+    "serve-storybook": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-storybook"],
+      "options": {
+        "command": "npx http-server storybook-all/storybook-static -p 9009 -c-1"
+      }
+    },
+    "build-storybook-shell": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx storybook build -c storybook-all/.storybook -o storybook-all/storybook-static --preview-url /iframe.html"
+      }
+    },
+    "build-storybook": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "projects": ["console"],
+          "target": "build-storybook"
+        },
+        {
+          "projects": ["portal-next"],
+          "target": "build-storybook"
+        },
+        {
+          "projects": ["markdown"],
+          "target": "build-storybook"
+        },
+        {
+          "projects": ["dashboard"],
+          "target": "build-storybook"
+        },
+        {
+          "projects": ["kafka-explorer"],
+          "target": "build-storybook"
+        },
+        {
+          "target": "build-storybook-shell"
+        }
+      ],
+      "options": {
+        "commands": [
+          "node storybook-all/assemble.mjs"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Create a `storybook-all` project that composes all 5 individual Storybooks (console, portal-next, markdown, dashboard, kafka-explorer) into a single static build
- Replace the console-only Storybook CI job with a unified build that runs all Storybooks in parallel via `nx run-many`, then assembles them into a composed output deployed to Chromatic
- Add `shouldBuildStorybook()` function to trigger the build when console, portal-next, or webui-libs files change

## Test plan

- [ ] Run `nx run storybook-all:build-storybook` locally and verify `storybook-all/storybook-static/` contains subdirectories for each project
- [ ] Serve with `npx http-server storybook-all/storybook-static -p 9009 -c-1` and verify composition works (sidebar dropdown per project, stories load correctly)
- [ ] Verify CI TypeScript compiles without errors
- [ ] Verify Chromatic deployment works with the new `storybook-all/storybook-static` path