### PR TITLE
fix(console): add missing A2A Proxy API type in list view filter and labels

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -52,6 +52,7 @@
         <mat-option value="V4_HTTP_PROXY">HTTP Proxy</mat-option>
         <mat-option value="V4_LLM_PROXY">LLM Proxy</mat-option>
         <mat-option value="V4_MCP_PROXY">MCP Proxy</mat-option>
+        <mat-option value="V4_A2A_PROXY">A2A Proxy</mat-option>
         <mat-option value="V4_TCP_PROXY">TCP Proxy</mat-option>
         <mat-option value="V4_KAFKA">Kafka Native</mat-option>
         <mat-option value="V4_MESSAGE">Message</mat-option>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -503,6 +503,39 @@ describe('ApisListComponent', () => {
     });
   });
 
+  describe('with A2A Proxy API', () => {
+    describe('without quality score', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [ApiListModule, MatIconTestingModule, NoopAnimationsModule, GioTestingModule],
+          providers: [
+            { provide: GioTestingPermissionProvider, useValue: ['environment-api-c'] },
+            { provide: Constants, useValue: fakeConstants },
+          ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ApiListComponent);
+        httpTestingController = TestBed.inject(HttpTestingController);
+      });
+
+      it('should display a table with one row', fakeAsync(async () => {
+        const api = fakeApiV4({ type: 'A2A_PROXY', listeners: [] });
+        await initComponent([api]);
+
+        const { rowCells } = await computeApisTableCells();
+        expect(rowCells).toEqual([['', '🪐 Planets (1.0)', 'A2A Proxy Gravitee', '', '', '', '', '', 'admin', '', 'public', 'edit']]);
+        expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
+      }));
+
+      async function initComponent(apis: Api[]) {
+        // APIs are sorted by name by default
+        expectApisListRequest(apis, 'name');
+        loader = TestbedHarnessEnvironment.loader(fixture);
+        fixture.detectChanges();
+      }
+    });
+  });
+
   describe('with LLM Proxy API', () => {
     describe('without quality score', () => {
       beforeEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -430,6 +430,9 @@ export class ApiListComponent implements OnInit, OnDestroy {
     if (api.type === 'LLM_PROXY') {
       return 'LLM Proxy';
     }
+    if (api.type === 'A2A_PROXY') {
+      return 'A2A Proxy';
+    }
 
     return api.listeners.map((listener: Listener): ListenerType => listener.type).includes('TCP') ? 'TCP Proxy' : 'HTTP Proxy';
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12939

## Description

Add A2A Proxy API type in APIs list view

## Additional context
<img width="420" height="451" alt="Capture d’écran 2026-02-26 à 11 50 52" src="https://github.com/user-attachments/assets/44132138-8cc3-4303-9d68-89f8c1617849" />

