### PR TITLE
fix(console): include content type when creating a new portal nav item

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -147,6 +147,7 @@ export function fakeNewPagePortalNavigationItem(overrides?: Partial<NewPagePorta
     type: 'PAGE',
     area: 'HOMEPAGE',
     visibility: 'PUBLIC',
+    contentType: 'GRAVITEE_MARKDOWN',
   };
 
   if (isFunction(overrides)) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12791

## Description

Test failing due to missing content type when creating a new portal nav item.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

