### PR TITLE
feat(kafka-explorer): add broker detail page

### DIFF
--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.spec.ts
@@ -177,6 +177,9 @@ describe('ClustersListPageComponent', () => {
         description: 'A test cluster created by automated test',
         configuration: {
           bootstrapServers: 'kafka-test-new.example.com:9092',
+          security: {
+            protocol: 'PLAINTEXT',
+          },
         },
       }),
     );

--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
@@ -160,6 +160,9 @@ export class ClusterListComponent implements OnInit {
             description: result.description,
             configuration: {
               bootstrapServers: result.bootstrapServers,
+              security: {
+                protocol: 'PLAINTEXT',
+              },
             },
           });
         }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
 
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
@@ -24,4 +25,5 @@ public interface KafkaClusterDomainService {
     KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
     TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
     TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
+    BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerInfo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record BrokerInfo(
+    int id,
+    String host,
+    int port,
+    String rack,
+    boolean isController,
+    int leaderPartitions,
+    int replicaPartitions,
+    Long logDirSize,
+    List<BrokerLogDirEntry> logDirEntries,
+    List<TopicConfigEntry> configs
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerLogDirEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrokerLogDirEntry.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+public record BrokerLogDirEntry(String path, String error, int topics, int partitions, long size) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+
+@UseCase
+public class DescribeBrokerUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public DescribeBrokerUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var brokerInfo = kafkaClusterDomainService.describeBroker(config, input.brokerId());
+        return new Output(brokerInfo);
+    }
+
+    public record Input(String clusterId, String environmentId, int brokerId) {}
+
+    public record Output(BrokerInfo brokerInfo) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.kafkaexplorer.mapper;
 
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerLogDirEntry;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
@@ -23,6 +25,7 @@ import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicPartitionDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
@@ -50,6 +53,10 @@ public interface KafkaExplorerMapper {
     io.gravitee.rest.api.kafkaexplorer.rest.model.TopicPartition map(TopicPartitionDetail partition);
 
     io.gravitee.rest.api.kafkaexplorer.rest.model.TopicConfig map(TopicConfigEntry config);
+
+    DescribeBrokerResponse map(BrokerInfo brokerInfo);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.BrokerLogDirEntry map(BrokerLogDirEntry entry);
 
     default ListTopicsResponse map(TopicsPage topicsPage, int page, int perPage) {
         return new ListTopicsResponse()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -130,6 +130,40 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/describe-broker:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: Describe a Kafka broker
+            description: |
+                Connects to a Kafka cluster and returns detailed information about a specific broker including log directories and configuration.
+            operationId: describeBroker
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DescribeBrokerRequest"
+            responses:
+                "200":
+                    description: Broker detail
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DescribeBrokerResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
 components:
     schemas:
         DescribeClusterRequest:
@@ -329,6 +363,80 @@ components:
                     type: boolean
                 sensitive:
                     type: boolean
+
+        DescribeBrokerRequest:
+            type: object
+            required:
+                - clusterId
+                - brokerId
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                brokerId:
+                    type: integer
+                    format: int32
+                    description: ID of the broker to describe
+
+        DescribeBrokerResponse:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int32
+                host:
+                    type: string
+                port:
+                    type: integer
+                    format: int32
+                rack:
+                    type: string
+                    description: Rack identifier of this broker, or null if not configured
+                isController:
+                    type: boolean
+                    description: Whether this broker is the cluster controller
+                leaderPartitions:
+                    type: integer
+                    format: int32
+                    description: Number of partitions for which this broker is the leader
+                replicaPartitions:
+                    type: integer
+                    format: int32
+                    description: Number of partition replicas hosted on this broker
+                logDirSize:
+                    type: integer
+                    format: int64
+                    description: Total size of all log directories on this broker in bytes, or null if unavailable
+                logDirEntries:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/BrokerLogDirEntry"
+                configs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TopicConfig"
+
+        BrokerLogDirEntry:
+            type: object
+            properties:
+                path:
+                    type: string
+                    description: File system path of the log directory
+                error:
+                    type: string
+                    description: Error status of this log directory, or null if healthy
+                topics:
+                    type: integer
+                    format: int32
+                    description: Number of distinct topics stored in this log directory
+                partitions:
+                    type: integer
+                    format: int32
+                    description: Number of partition replicas stored in this log directory
+                size:
+                    type: integer
+                    format: int64
+                    description: Total size of this log directory in bytes
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCaseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerLogDirEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DescribeBrokerUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private DescribeBrokerUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new DescribeBrokerUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_broker_info() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var expectedBrokerInfo = new BrokerInfo(
+            0,
+            "broker-host",
+            9092,
+            null,
+            true,
+            10,
+            20,
+            1073741824L,
+            List.of(new BrokerLogDirEntry("/bitnami/kafka/data", null, 5, 12, 524288L)),
+            List.of(new TopicConfigEntry("log.retention.hours", "168", "STATIC_BROKER_CONFIG", true, false))
+        );
+        clusterDomainService.givenBrokerInfo(expectedBrokerInfo);
+
+        var result = useCase.execute(new DescribeBrokerUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, 0));
+
+        assertThat(result.brokerInfo()).isEqualTo(expectedBrokerInfo);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
+
+        assertThatThrownBy(() -> useCase.execute(new DescribeBrokerUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, 0)))
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service;
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
@@ -30,6 +31,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     private KafkaClusterInfo result;
     private List<KafkaTopic> topics;
     private TopicDetail topicDetail;
+    private BrokerInfo brokerInfo;
     private KafkaExplorerException exception;
 
     public void givenClusterInfo(KafkaClusterInfo info) {
@@ -47,11 +49,17 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         this.exception = null;
     }
 
+    public void givenBrokerInfo(BrokerInfo info) {
+        this.brokerInfo = info;
+        this.exception = null;
+    }
+
     public void givenException(KafkaExplorerException exception) {
         this.exception = exception;
         this.result = null;
         this.topics = null;
         this.topicDetail = null;
+        this.brokerInfo = null;
     }
 
     @Override
@@ -87,5 +95,13 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
             throw exception;
         }
         return topicDetail;
+    }
+
+    @Override
+    public BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId) {
+        if (exception != null) {
+            throw exception;
+        }
+        return brokerInfo;
     }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gke-broker-detail [brokerDetail]="brokerDetail()" [loading]="loading()" (back)="onBack()" />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.spec.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { BrokerDetailPageComponent } from './broker-detail-page.component';
+import { BrokerDetailHarness } from './broker-detail.harness';
+import { fakeDescribeBrokerResponse } from '../models/kafka-cluster.fixture';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+
+describe('BrokerDetailPageComponent', () => {
+  let fixture: ComponentFixture<BrokerDetailPageComponent>;
+  let httpTesting: HttpTestingController;
+  let loader: HarnessLoader;
+
+  const router = { navigate: jest.fn() };
+  const route = { snapshot: { params: { brokerId: '0' } } };
+
+  beforeEach(async () => {
+    router.navigate.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [BrokerDetailPageComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        KafkaExplorerStore,
+        provideNoopAnimations(),
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+      ],
+    }).compileComponents();
+
+    httpTesting = TestBed.inject(HttpTestingController);
+    const store = TestBed.inject(KafkaExplorerStore);
+    store.baseURL.set('/api/v2');
+    store.clusterId.set('test-cluster-id');
+
+    fixture = TestBed.createComponent(BrokerDetailPageComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushBroker(response = fakeDescribeBrokerResponse()) {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-broker').flush(response);
+    fixture.detectChanges();
+  }
+
+  it('should call describeBroker on init with route param', () => {
+    const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-broker');
+    expect(req.request.body).toEqual({ clusterId: 'test-cluster-id', brokerId: 0 });
+    req.flush(fakeDescribeBrokerResponse());
+  });
+
+  it('should display broker id and host', async () => {
+    flushBroker();
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    expect(await harness.getBrokerTitle()).toBe('Broker 0');
+  });
+
+  it('should show controller badge for controller broker', async () => {
+    flushBroker(fakeDescribeBrokerResponse({ isController: true }));
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    expect(await harness.isController()).toBe(true);
+  });
+
+  it('should not show controller badge for non-controller broker', async () => {
+    flushBroker(fakeDescribeBrokerResponse({ isController: false }));
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    expect(await harness.isController()).toBe(false);
+  });
+
+  it('should display log directory entries table', async () => {
+    flushBroker();
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    const rows = await harness.getLogDirRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]['path']).toBe('/bitnami/kafka/data');
+    expect(rows[0]['error']).toBe('—');
+    expect(rows[0]['topics']).toBe('5');
+    expect(rows[0]['partitions']).toBe('12');
+    expect(rows[0]['size']).toBe('512 KB');
+  });
+
+  it('should display config table', async () => {
+    flushBroker();
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    const rows = await harness.getConfigRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['name']).toBe('log.retention.hours');
+    expect(rows[0]['value']).toBe('168');
+    expect(rows[0]['source']).toBe('STATIC_BROKER_CONFIG');
+  });
+
+  it('should show empty message when no log dir entries', async () => {
+    flushBroker(fakeDescribeBrokerResponse({ logDirEntries: [] }));
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    expect(await harness.getLogDirEmptyMessage()).toBe('Log dir data not available');
+    expect(await harness.getLogDirRows()).toEqual([]);
+  });
+
+  it('should show loading bar while loading', async () => {
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    expect(await harness.isLoading()).toBe(true);
+
+    flushBroker();
+  });
+
+  it('should navigate back on back button click', async () => {
+    flushBroker();
+
+    const harness = await loader.getHarness(BrokerDetailHarness);
+    await harness.clickBack();
+
+    expect(router.navigate).toHaveBeenCalledWith(['..'], { relativeTo: route });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail-page.component.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { BrokerDetailComponent } from './broker-detail.component';
+import { DescribeBrokerResponse } from '../models/kafka-cluster.model';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+import { KafkaExplorerService } from '../services/kafka-explorer.service';
+
+@Component({
+  selector: 'gke-broker-detail-page',
+  standalone: true,
+  imports: [BrokerDetailComponent],
+  templateUrl: './broker-detail-page.component.html',
+})
+export class BrokerDetailPageComponent implements OnInit {
+  store = inject(KafkaExplorerStore);
+  private readonly service = inject(KafkaExplorerService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  brokerDetail = signal<DescribeBrokerResponse | undefined>(undefined);
+  loading = signal(false);
+
+  ngOnInit() {
+    const brokerId = Number(this.route.snapshot.params['brokerId']);
+    this.loading.set(true);
+    this.service
+      .describeBroker(this.store.baseURL(), this.store.clusterId(), brokerId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: detail => {
+          this.brokerDetail.set(detail);
+          this.loading.set(false);
+        },
+        error: err => {
+          this.store.error.set(err?.error?.message ?? 'Failed to load broker details');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  onBack() {
+    this.router.navigate(['..'], { relativeTo: this.route });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.html
@@ -1,0 +1,118 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="broker-detail">
+  <div class="broker-detail__header">
+    <button mat-icon-button (click)="back.emit()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+    <h3 class="broker-detail__title">Broker {{ brokerDetail()?.id }}</h3>
+    @if (brokerDetail(); as detail) {
+      <span class="broker-detail__host">{{ detail.host }}:{{ detail.port }}</span>
+      @if (detail.rack) {
+        <span class="broker-detail__rack-badge">{{ detail.rack }}</span>
+      }
+      @if (detail.isController) {
+        <span class="broker-detail__controller-badge">Controller</span>
+      }
+    }
+  </div>
+
+  @if (loading()) {
+    <mat-progress-bar mode="indeterminate" />
+  }
+
+  @if (brokerDetail(); as detail) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Log Directories</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        @if (detail.logDirEntries.length === 0) {
+          <p class="broker-detail__empty-message">Log dir data not available</p>
+        } @else {
+          <table id="log-dir-table" mat-table [dataSource]="detail.logDirEntries">
+            <ng-container matColumnDef="path">
+              <th mat-header-cell *matHeaderCellDef>Path</th>
+              <td mat-cell *matCellDef="let e">{{ e.path }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="error">
+              <th mat-header-cell *matHeaderCellDef>Error</th>
+              <td mat-cell *matCellDef="let e">{{ e.error ?? '—' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="topics">
+              <th mat-header-cell *matHeaderCellDef>Topics</th>
+              <td mat-cell *matCellDef="let e">{{ e.topics }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="partitions">
+              <th mat-header-cell *matHeaderCellDef>Partitions</th>
+              <td mat-cell *matCellDef="let e">{{ e.partitions }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="size">
+              <th mat-header-cell *matHeaderCellDef>Size</th>
+              <td mat-cell *matCellDef="let e">{{ e.size | gkeFileSize }}</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="logDirColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: logDirColumns"></tr>
+          </table>
+        }
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Configuration</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table id="config-table" mat-table [dataSource]="detail.configs">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="value">
+            <th mat-header-cell *matHeaderCellDef>Value</th>
+            <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="source">
+            <th mat-header-cell *matHeaderCellDef>Source</th>
+            <td mat-cell *matCellDef="let c">{{ c.source }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="readOnly">
+            <th mat-header-cell *matHeaderCellDef>Read Only</th>
+            <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="sensitive">
+            <th mat-header-cell *matHeaderCellDef>Sensitive</th>
+            <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.scss
@@ -14,58 +14,56 @@
  * limitations under the License.
  */
 
-.brokers {
+.broker-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__title {
+    margin: 0;
+  }
+
+  &__host {
+    color: var(--mat-sys-on-surface-variant, #49454f);
+    font-size: 14px;
+  }
+
+  &__rack-badge,
+  &__controller-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  &__rack-badge {
+    background-color: var(--mat-sys-surface-variant, #e7e0ec);
+    color: var(--mat-sys-on-surface-variant, #49454f);
+  }
+
+  &__controller-badge {
+    background-color: var(--mat-sys-primary-container, #e8def8);
+    color: var(--mat-sys-on-primary-container, #1d192b);
+  }
+
+  &__empty-message {
+    color: var(--mat-sys-on-surface-variant, #49454f);
+    font-style: italic;
+    margin: 8px 0;
+  }
+
   mat-card-content {
     overflow-x: auto;
   }
 
   table {
     width: 100%;
-  }
-
-  &__node-id {
-    white-space: nowrap;
-  }
-
-  &__controller-badge {
-    display: inline-block;
-    margin-left: 8px;
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 500;
-    background-color: var(--mat-sys-primary-container, #e8def8);
-    color: var(--mat-sys-on-primary-container, #1d192b);
-  }
-
-  &__cluster-info {
-    margin-top: 4px;
-    margin-bottom: 16px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid var(--mat-sys-outline-variant, #cac4d0);
-  }
-
-  &__cluster-info-items {
-    display: flex;
-    gap: 32px;
-    flex-wrap: wrap;
-  }
-
-  &__cluster-info-item {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  &__section-title {
-    margin: 0 0 8px;
-  }
-
-  &__row {
-    cursor: pointer;
-
-    &:hover {
-      background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.04));
-    }
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.component.ts
@@ -15,28 +15,28 @@
  */
 import { CommonModule } from '@angular/common';
 import { Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTableModule } from '@angular/material/table';
 
-import { BrokerDetail, KafkaNode } from '../models/kafka-cluster.model';
+import { DescribeBrokerResponse } from '../models/kafka-cluster.model';
 import { FileSizePipe } from '../pipes/file-size.pipe';
 
 @Component({
-  selector: 'gke-brokers',
+  selector: 'gke-broker-detail',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule, FileSizePipe],
-  templateUrl: './brokers.component.html',
-  styleUrls: ['./brokers.component.scss'],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatIconModule, MatButtonModule, MatProgressBarModule, FileSizePipe],
+  templateUrl: './broker-detail.component.html',
+  styleUrls: ['./broker-detail.component.scss'],
 })
-export class BrokersComponent {
-  nodes = input<BrokerDetail[]>([]);
-  controllerId = input<number>(-1);
-  clusterId = input<string>('');
-  controller = input<KafkaNode | undefined>(undefined);
-  totalTopics = input<number>(0);
-  totalPartitions = input<number>(0);
+export class BrokerDetailComponent {
+  brokerDetail = input<DescribeBrokerResponse | undefined>();
+  loading = input(false);
 
-  brokerSelect = output<number>();
+  back = output<void>();
 
-  displayedColumns = ['id', 'host', 'port', 'rack', 'leaderPartitions', 'replicaPartitions', 'logDirSize'];
+  logDirColumns = ['path', 'error', 'topics', 'partitions', 'size'];
+  configColumns = ['name', 'value', 'source', 'readOnly', 'sensitive'];
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/broker-detail/broker-detail.harness.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class BrokerDetailHarness extends ComponentHarness {
+  static hostSelector = 'gke-broker-detail';
+
+  private readonly getLogDirTable = this.locatorForOptional(MatTableHarness.with({ selector: '#log-dir-table' }));
+  private readonly getConfigTable = this.locatorForOptional(MatTableHarness.with({ selector: '#config-table' }));
+  private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getTitle = this.locatorFor('.broker-detail__title');
+  private readonly getControllerBadge = this.locatorForOptional('.broker-detail__controller-badge');
+  private readonly getEmptyMessage = this.locatorForOptional('.broker-detail__empty-message');
+
+  async getBrokerTitle() {
+    const title = await this.getTitle();
+    return title.text();
+  }
+
+  async isController() {
+    return (await this.getControllerBadge()) !== null;
+  }
+
+  async isLoading() {
+    return (await this.getProgressBar()) !== null;
+  }
+
+  async clickBack() {
+    const button = await this.getBackButton();
+    await button.click();
+  }
+
+  async getLogDirEmptyMessage() {
+    const el = await this.getEmptyMessage();
+    return el ? el.text() : null;
+  }
+
+  async getLogDirRows() {
+    const table = await this.getLogDirTable();
+    if (!table) return [];
+    const rows = await table.getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async getConfigRows() {
+    const table = await this.getConfigTable();
+    if (!table) return [];
+    const rows = await table.getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers-page.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Component, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { BrokersComponent } from './brokers.component';
 import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
@@ -31,10 +32,17 @@ import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
         [controller]="info.controller"
         [totalTopics]="info.totalTopics"
         [totalPartitions]="info.totalPartitions"
+        (brokerSelect)="onBrokerSelect($event)"
       />
     }
   `,
 })
 export class BrokersPageComponent {
   store = inject(KafkaExplorerStore);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+
+  onBrokerSelect(brokerId: number) {
+    this.router.navigate([brokerId], { relativeTo: this.route });
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
@@ -92,7 +92,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="brokers__row" (click)="brokerSelect.emit(row.id)"></tr>
     </table>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.stories.ts
@@ -82,8 +82,8 @@ export const SingleNode: Story = {
 export const NoRack: Story = {
   args: {
     nodes: [
-      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com', rack: null, logDirSize: null }),
-      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com', rack: null, logDirSize: null }),
+      fakeBrokerDetail({ id: 0, host: 'kafka-broker-0.example.com', rack: undefined, logDirSize: undefined }),
+      fakeBrokerDetail({ id: 1, host: 'kafka-broker-1.example.com', rack: undefined, logDirSize: undefined }),
     ],
     controllerId: 1,
   },

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
@@ -16,6 +16,7 @@
 import { Routes } from '@angular/router';
 
 import { KafkaExplorerComponent } from './kafka-explorer.component';
+import { BrokerDetailPageComponent } from '../broker-detail/broker-detail-page.component';
 import { BrokersPageComponent } from '../brokers/brokers-page.component';
 import { TopicDetailPageComponent } from '../topic-detail/topic-detail-page.component';
 import { TopicsPageComponent } from '../topics/topics-page.component';
@@ -27,6 +28,7 @@ export const KAFKA_EXPLORER_ROUTES: Routes = [
     children: [
       { path: '', redirectTo: 'brokers', pathMatch: 'full' },
       { path: 'brokers', component: BrokersPageComponent },
+      { path: 'brokers/:brokerId', component: BrokerDetailPageComponent },
       { path: 'topics', component: TopicsPageComponent },
       { path: 'topics/:topicName', component: TopicDetailPageComponent },
     ],

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -15,6 +15,8 @@
  */
 import {
   BrokerDetail,
+  BrokerLogDirEntry,
+  DescribeBrokerResponse,
   DescribeClusterResponse,
   DescribeTopicResponse,
   KafkaNode,
@@ -134,6 +136,34 @@ export function fakeDescribeTopicResponse(overrides: Partial<DescribeTopicRespon
     configs: [
       fakeTopicConfig({ name: 'retention.ms', value: '604800000' }),
       fakeTopicConfig({ name: 'cleanup.policy', value: 'delete', source: 'DEFAULT_CONFIG' }),
+    ],
+    ...overrides,
+  };
+}
+
+export function fakeBrokerLogDirEntry(overrides: Partial<BrokerLogDirEntry> = {}): BrokerLogDirEntry {
+  return {
+    path: '/bitnami/kafka/data',
+    topics: 5,
+    partitions: 12,
+    size: 524288,
+    ...overrides,
+  };
+}
+
+export function fakeDescribeBrokerResponse(overrides: Partial<DescribeBrokerResponse> = {}): DescribeBrokerResponse {
+  return {
+    id: 0,
+    host: 'kafka-broker-0.example.com',
+    port: 9092,
+    isController: true,
+    leaderPartitions: 10,
+    replicaPartitions: 20,
+    logDirSize: 1073741824,
+    logDirEntries: [fakeBrokerLogDirEntry()],
+    configs: [
+      fakeTopicConfig({ name: 'log.retention.hours', value: '168', source: 'STATIC_BROKER_CONFIG' }),
+      fakeTopicConfig({ name: 'num.partitions', value: '1', source: 'DEFAULT_CONFIG' }),
     ],
     ...overrides,
   };

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -82,3 +82,24 @@ export interface DescribeTopicResponse {
   partitions: TopicPartitionDetail[];
   configs: TopicConfig[];
 }
+
+export interface BrokerLogDirEntry {
+  path: string;
+  error?: string;
+  topics: number;
+  partitions: number;
+  size: number;
+}
+
+export interface DescribeBrokerResponse {
+  id: number;
+  host: string;
+  port: number;
+  rack?: string;
+  isController: boolean;
+  leaderPartitions: number;
+  replicaPartitions: number;
+  logDirSize?: number;
+  logDirEntries: BrokerLogDirEntry[];
+  configs: TopicConfig[];
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -17,7 +17,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DescribeClusterResponse, DescribeTopicResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
+import { DescribeBrokerResponse, DescribeClusterResponse, DescribeTopicResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
 
 @Injectable({
   providedIn: 'root',
@@ -41,5 +41,9 @@ export class KafkaExplorerService {
 
   describeTopic(baseURL: string, clusterId: string, topicName: string): Observable<DescribeTopicResponse> {
     return this.http.post<DescribeTopicResponse>(`${baseURL}/kafka-explorer/describe-topic`, { clusterId, topicName });
+  }
+
+  describeBroker(baseURL: string, clusterId: string, brokerId: number): Observable<DescribeBrokerResponse> {
+    return this.http.post<DescribeBrokerResponse>(`${baseURL}/kafka-explorer/describe-broker`, { clusterId, brokerId });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
@@ -29,4 +29,6 @@ export * from './lib/topics/topics.component';
 export * from './lib/topics/topics-page.component';
 export * from './lib/topic-detail/topic-detail.component';
 export * from './lib/topic-detail/topic-detail-page.component';
+export * from './lib/broker-detail/broker-detail.component';
+export * from './lib/broker-detail/broker-detail-page.component';
 export * from './lib/pipes/file-size.pipe';

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
@@ -21,4 +21,5 @@ export * from './lib/kafka-explorer/kafka-explorer.harness';
 export * from './lib/brokers/brokers.harness';
 export * from './lib/topics/topics.harness';
 export * from './lib/topic-detail/topic-detail.harness';
+export * from './lib/broker-detail/broker-detail.harness';
 export * from './lib/models/kafka-cluster.fixture';


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12789

## Summary
- Add backend `POST /kafka-explorer/describe-broker` endpoint returning broker info, log directories (path, error, topics, partitions, size) and configuration
- Add frontend broker detail page with log directories and configuration tables, accessible by clicking a broker row
- Fix cluster creation to include default `PLAINTEXT` security protocol

## Test plan
- [x] Backend unit tests (DescribeBrokerUseCaseTest)
- [x] Backend integration tests (KafkaExplorerResourceIntegrationTest.DescribeBroker)
- [x] Frontend tests (broker-detail-page, brokers-page navigation)
- [x] Manual test: click broker row → detail with log dirs and configs → back returns to list
<img width="2560" height="1215" alt="image" src="https://github.com/user-attachments/assets/d801a9d1-83bd-49c7-a15b-022d52dc3833" />

Maybe next to improve. add filter input for configs list and paginate
