### PR TITLE
 fix: event property filtering when multiple properties are defined

### DIFF
--- a/gravitee-apim-e2e/api-test/jest.setup.ts
+++ b/gravitee-apim-e2e/api-test/jest.setup.ts
@@ -28,7 +28,6 @@ beforeAll(async () => {
   const currentUserResourceAsApiUser = new CurrentUserApi(forManagementAsApiUser());
   const currentUserResourceAsAppUser = new CurrentUserApi(forManagementAsAppUser());
 
-  console.log('Initializing API and App users for tests.');
   // Ensure that API user and App User are properly initialized before using them in tests.
   // APIM should create these two users automatically
   const apiResponse = await currentUserResourceAsApiUser.getCurrentUserRaw({

--- a/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v1/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v1/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -29,6 +29,7 @@ import { DebugApiEntity, DebugApiEntityFromJSON } from '@gravitee/management-web
 import { describeIfV3, succeed } from '@lib/jest-utils';
 import { from, Observable, switchMap, map, retry, Subscription } from 'rxjs';
 import { EventEntity } from '@gravitee/management-webclient-sdk/src/lib/models/EventEntity';
+import { faker } from '@faker-js/faker';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -69,6 +70,7 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
         orgId,
         envId,
         newApiEntity: ApisFaker.newApi({
+          name: `debug-v2-${faker.commerce.productName()}`,
           gravitee: '2.0.0',
           // With flow on root path
           flows: [

--- a/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v1/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v1/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -40,6 +40,7 @@ const organizationApi = new OrganizationApi(forManagementAsAdminUser());
 describe('Call my API (incl. query params, Headers and body) and view debug session with proper info', () => {
   describeIfV3('-- only if v3 --', () => {
     let apiEntity: ApiEntity;
+    let debugEventSubscription: Subscription;
 
     beforeAll(async () => {
       // Create Global Flow
@@ -145,7 +146,7 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
       let debugResult;
 
       beforeEach((done) => {
-        createAndWaitForDebugResult$({
+        debugEventSubscription = createAndWaitForDebugResult$({
           ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
           entrypoints: undefined,
           request: {
@@ -158,6 +159,10 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
           debugResult = JSON.parse(value.payload);
           done();
         });
+      });
+
+      afterEach(() => {
+        debugEventSubscription.unsubscribe();
       });
 
       test('Should contain response', () => {
@@ -216,7 +221,6 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
 
     describe('Get debug event on `GET /?name=TheFox`', () => {
       let debugResult;
-      let debugEventSubscription: Subscription;
 
       beforeEach((done) => {
         debugEventSubscription = createAndWaitForDebugResult$({
@@ -247,7 +251,7 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
       let debugResult;
 
       beforeEach((done) => {
-        createAndWaitForDebugResult$({
+        debugEventSubscription = createAndWaitForDebugResult$({
           ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
           entrypoints: undefined,
           request: {
@@ -265,6 +269,10 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
         });
       });
 
+      afterEach(() => {
+        debugEventSubscription.unsubscribe();
+      });
+
       test('Should contain preprocessorStep', () => {
         expect(debugResult.preprocessorStep.headers['array-header']).toEqual(['1', '2', '3']);
         expect(debugResult.preprocessorStep.headers['string-header']).toEqual(['string-value']);
@@ -275,7 +283,7 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
       let debugResult;
 
       beforeEach((done) => {
-        createAndWaitForDebugResult$({
+        debugEventSubscription = createAndWaitForDebugResult$({
           ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
           entrypoints: undefined,
           request: {
@@ -288,6 +296,10 @@ describe('Call my API (incl. query params, Headers and body) and view debug sess
           debugResult = JSON.parse(value.payload);
           done();
         });
+      });
+
+      afterEach(() => {
+        debugEventSubscription.unsubscribe();
       });
 
       test('Should contain body in the policy-assign-content', () => {

--- a/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -37,6 +37,7 @@ import { teardownApisAndApplications, teardownV4ApisAndApplications } from '@gra
 import { from, map, retry, Subscription, switchMap } from 'rxjs';
 import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
 import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { faker } from '@faker-js/faker';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -67,6 +68,7 @@ describeIfClientGatewayCompatible('Debug my API (incl. query params, Headers and
         exportApiV4: MAPIV2ApisFaker.apiImportV4({
           plans: [MAPIV2PlansFaker.planV4({ security: { type: PlanSecurityType.KEY_LESS }, validation: 'AUTO' })],
           api: MAPIV2ApisFaker.apiV4Proxy({
+            name: `debug-v4-${faker.lorem.words(10)}`,
             endpointGroups: [
               {
                 name: 'Default HTTP proxy group',

--- a/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -329,6 +329,7 @@ describeIfClientGatewayCompatible('Debug my API (incl. query params, Headers and
         envId,
         orgId,
         body: ApisFaker.apiImport({
+          name: `debug-v2-${faker.lorem.words(10)}`,
           execution_mode: 'v3',
           plans: [
             PlansFaker.plan({

--- a/gravitee-apim-e2e/docker/common/docker-compose-base.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-base.yml
@@ -30,6 +30,8 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gravitee-apim-e2e-elasticsearch
     restart: always
+    logging:
+      driver: "none"
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
     environment:

--- a/gravitee-apim-e2e/docker/common/docker-compose-jdbc.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-jdbc.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - data-jdbc:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
@@ -262,5 +262,33 @@
     },
     "createdAt": 1463739200000,
     "updatedAt": 1463740200000
+  },
+  {
+    "id": "event21",
+    "organizations": ["org1"],
+    "environments": ["env1"],
+    "type": "DEBUG_API",
+    "payload": "{}",
+    "parentId": null,
+    "properties": {
+      "api_debug_status": "TO_DEBUG",
+      "gateway_id": "gateway-1"
+    },
+    "createdAt": 1459468800000,
+    "updatedAt": 1459468800000
+  },
+  {
+    "id": "event22",
+    "organizations": ["org1"],
+    "environments": ["env1"],
+    "type": "DEBUG_API",
+    "payload": "{}",
+    "parentId": null,
+    "properties": {
+      "api_debug_status": "SUCCESS",
+      "gateway_id": "gateway-1"
+    },
+    "createdAt": 1463739200000,
+    "updatedAt": 1463740200000
   }
 ]


### PR DESCRIPTION
## Description

The `EventRepository.search` method for the JDBC repository was returning incorrect result when multiple properties were set in the criteria. I think it may be the cause of the flakyness of Debug Mode e2e tests on JDBC.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

