### PR TITLE
resolve display names for API, plan, application, and gateway in environment logs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -97,6 +97,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
+import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -160,6 +161,7 @@ import io.gravitee.apim.infra.domain_service.analytics_engine.definition.Analyti
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1018,6 +1020,11 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public LogNamesPostProcessor logNamesPostProcessor() {
+        return new LogNamesPostProcessorImpl();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -217,6 +217,10 @@ components:
           type: string
           description: Id of the API.
           example: 6c530064-0b2c-4004-9300-640b2ce0047b
+        apiName:
+          type: string
+          description: Name of the API.
+          example: My API
         timestamp:
           type: string
           format: date-time

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -112,6 +112,7 @@ import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.crud_service.LicenseCrudService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -187,6 +188,7 @@ import io.gravitee.apim.infra.domain_service.analytics_engine.definition.Analyti
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1164,6 +1166,11 @@ public class ResourceContextConfiguration {
     @Bean
     public UserContextLoader userContextLoader() {
         return mock(UserContextLoader.class);
+    }
+
+    @Bean
+    public LogNamesPostProcessor logNamesPostProcessor() {
+        return new LogNamesPostProcessorImpl();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -91,6 +91,7 @@ import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
+import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -148,6 +149,7 @@ import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceIm
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1202,6 +1204,11 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public LogNamesPostProcessor logNamesPostProcessor() {
+        return new LogNamesPostProcessorImpl();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -83,6 +83,7 @@ import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainS
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
+import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
@@ -138,6 +139,7 @@ import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceIm
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1094,6 +1096,11 @@ public class ResourceContextConfiguration {
     @Bean
     public BucketNamesPostProcessor namesPostprocessor() {
         return mock(BucketNamesPostProcessor.class);
+    }
+
+    @Bean
+    public LogNamesPostProcessor logNamesPostProcessor() {
+        return new LogNamesPostProcessorImpl();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/query_service/InstanceQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/gateway/query_service/InstanceQueryService.java
@@ -17,11 +17,12 @@ package io.gravitee.apim.core.gateway.query_service;
 
 import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.model.Instance;
-import io.gravitee.rest.api.model.InstanceEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Collection;
 import java.util.List;
 
 public interface InstanceQueryService {
     List<Instance> findAllStarted(String organizationId, String environmentId);
     BaseInstance findById(ExecutionContext executionContext, String instanceId);
+    List<BaseInstance> findByIds(ExecutionContext executionContext, Collection<String> instanceIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/LogNamesPostProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/LogNamesPostProcessor.java
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.logs_engine.model;
+package io.gravitee.apim.core.logs_engine.domain_service;
 
-public record BaseApplication(
-    String id,
-    String name,
-    String description,
-    String domain,
-    String type,
-    PrimaryOwner primaryOwner,
-    ApiKeyMode apiKeyMode
-) {
-    public BaseApplication withName(String name) {
-        return new BaseApplication(id, name, description, domain, type, primaryOwner, apiKeyMode);
-    }
+import io.gravitee.apim.core.logs_engine.model.SearchLogsResponse;
+import io.gravitee.apim.core.user.model.UserContext;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface LogNamesPostProcessor {
+    SearchLogsResponse mapLogNames(UserContext context, SearchLogsResponse response);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 public record ApiLog(
     String apiId,
+    String apiName,
     OffsetDateTime timestamp,
     String id,
     String requestId,
@@ -41,4 +42,112 @@ public record ApiLog(
     String errorComponentType,
     List<ApiLogDiagnostic> warnings,
     Map<String, Object> additionalMetrics
-) {}
+) {
+    public ApiLog withApiName(String apiName) {
+        return new ApiLog(
+            apiId,
+            apiName,
+            timestamp,
+            id,
+            requestId,
+            method,
+            clientIdentifier,
+            plan,
+            application,
+            transactionId,
+            status,
+            requestEnded,
+            gatewayResponseTime,
+            gateway,
+            uri,
+            endpoint,
+            message,
+            errorKey,
+            errorComponentName,
+            errorComponentType,
+            warnings,
+            additionalMetrics
+        );
+    }
+
+    public ApiLog withPlan(BasePlan plan) {
+        return new ApiLog(
+            apiId,
+            apiName,
+            timestamp,
+            id,
+            requestId,
+            method,
+            clientIdentifier,
+            plan,
+            application,
+            transactionId,
+            status,
+            requestEnded,
+            gatewayResponseTime,
+            gateway,
+            uri,
+            endpoint,
+            message,
+            errorKey,
+            errorComponentName,
+            errorComponentType,
+            warnings,
+            additionalMetrics
+        );
+    }
+
+    public ApiLog withApplication(BaseApplication application) {
+        return new ApiLog(
+            apiId,
+            apiName,
+            timestamp,
+            id,
+            requestId,
+            method,
+            clientIdentifier,
+            plan,
+            application,
+            transactionId,
+            status,
+            requestEnded,
+            gatewayResponseTime,
+            gateway,
+            uri,
+            endpoint,
+            message,
+            errorKey,
+            errorComponentName,
+            errorComponentType,
+            warnings,
+            additionalMetrics
+        );
+    }
+
+    public ApiLog withGateway(String gateway) {
+        return new ApiLog(
+            apiId,
+            apiName,
+            timestamp,
+            id,
+            requestId,
+            method,
+            clientIdentifier,
+            plan,
+            application,
+            transactionId,
+            status,
+            requestEnded,
+            gatewayResponseTime,
+            gateway,
+            uri,
+            endpoint,
+            message,
+            errorKey,
+            errorComponentName,
+            errorComponentType,
+            warnings,
+            additionalMetrics
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/BasePlan.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/BasePlan.java
@@ -15,4 +15,8 @@
  */
 package io.gravitee.apim.core.logs_engine.model;
 
-public record BasePlan(String id, String name, String description, String apiId, PlanSecurity security, PlanMode mode) {}
+public record BasePlan(String id, String name, String description, String apiId, PlanSecurity security, PlanMode mode) {
+    public BasePlan withName(String name) {
+        return new BasePlan(id, name, description, apiId, security, mode);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/UserContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/UserContext.java
@@ -25,21 +25,31 @@ public record UserContext(
     AuditInfo auditInfo,
     Optional<Map<String, String>> apiNameById,
     Optional<Map<String, String>> applicationNameById,
+    Optional<Map<String, String>> planNameById,
+    Optional<Map<String, String>> gatewayHostnameById,
     Optional<List<Api>> apis
 ) {
     public UserContext(AuditInfo auditInfo) {
-        this(auditInfo, Optional.empty(), Optional.empty(), Optional.empty());
+        this(auditInfo, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public UserContext withApiNamesById(Map<String, String> apiNameById) {
-        return new UserContext(auditInfo, Optional.ofNullable(apiNameById), applicationNameById, apis);
+        return new UserContext(auditInfo, Optional.ofNullable(apiNameById), applicationNameById, planNameById, gatewayHostnameById, apis);
     }
 
     public UserContext withApplicationNameById(Map<String, String> applicationNameById) {
-        return new UserContext(auditInfo, apiNameById, Optional.ofNullable(applicationNameById), apis);
+        return new UserContext(auditInfo, apiNameById, Optional.ofNullable(applicationNameById), planNameById, gatewayHostnameById, apis);
+    }
+
+    public UserContext withPlanNameById(Map<String, String> planNameById) {
+        return new UserContext(auditInfo, apiNameById, applicationNameById, Optional.ofNullable(planNameById), gatewayHostnameById, apis);
+    }
+
+    public UserContext withGatewayHostnameById(Map<String, String> gatewayHostnameById) {
+        return new UserContext(auditInfo, apiNameById, applicationNameById, planNameById, Optional.ofNullable(gatewayHostnameById), apis);
     }
 
     public UserContext withApis(List<Api> apis) {
-        return new UserContext(auditInfo, apiNameById, applicationNameById, Optional.ofNullable(apis));
+        return new UserContext(auditInfo, apiNameById, applicationNameById, planNameById, gatewayHostnameById, Optional.ofNullable(apis));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.logs_engine;
+
+import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
+import io.gravitee.apim.core.logs_engine.model.ApiLog;
+import io.gravitee.apim.core.logs_engine.model.SearchLogsResponse;
+import io.gravitee.apim.core.user.model.UserContext;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Service
+public class LogNamesPostProcessorImpl implements LogNamesPostProcessor {
+
+    private static final String UNKNOWN_APPLICATION = "Unknown";
+
+    @Override
+    public SearchLogsResponse mapLogNames(UserContext context, SearchLogsResponse response) {
+        var enrichedLogs = response
+            .data()
+            .stream()
+            .map(log -> enrichLog(context, log))
+            .toList();
+        return new SearchLogsResponse(enrichedLogs, response.pagination());
+    }
+
+    private ApiLog enrichLog(UserContext context, ApiLog log) {
+        var apiName = context
+            .apiNameById()
+            .map(m -> m.get(log.apiId()))
+            .orElse(null);
+
+        var plan = log.plan() == null
+            ? null
+            : log
+                .plan()
+                .withName(
+                    context
+                        .planNameById()
+                        .map(m -> m.get(log.plan().id()))
+                        .orElse(null)
+                );
+
+        var application = log.application() == null
+            ? null
+            : log
+                .application()
+                .withName(
+                    context
+                        .applicationNameById()
+                        .map(m -> m.get(log.application().id()))
+                        .orElse(UNKNOWN_APPLICATION)
+                );
+
+        var gateway = log.gateway() == null
+            ? null
+            : context
+                .gatewayHostnameById()
+                .map(m -> m.get(log.gateway()))
+                .orElse(log.gateway());
+
+        return log.withApiName(apiName).withPlan(plan).withApplication(application).withGateway(gateway);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/gateway/InstanceQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/gateway/InstanceQueryServiceLegacyWrapper.java
@@ -21,7 +21,10 @@ import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.infra.adapter.InstanceAdapter;
 import io.gravitee.rest.api.service.InstanceService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -39,5 +42,19 @@ public class InstanceQueryServiceLegacyWrapper implements InstanceQueryService {
     @Override
     public BaseInstance findById(ExecutionContext executionContext, String instanceId) {
         return InstanceAdapter.INSTANCE.toBaseInstance(instanceService.findById(executionContext, instanceId));
+    }
+
+    @Override
+    public List<BaseInstance> findByIds(ExecutionContext executionContext, Collection<String> instanceIds) {
+        return instanceIds
+            .stream()
+            .flatMap(id -> {
+                try {
+                    return Stream.of(findById(executionContext, id));
+                } catch (InstanceNotFoundException e) {
+                    return Stream.empty();
+                }
+            })
+            .toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class InstanceQueryServiceInMemory implements InstanceQueryService, InMemoryAlternative<Instance> {
@@ -45,6 +46,15 @@ public class InstanceQueryServiceInMemory implements InstanceQueryService, InMem
             .findFirst()
             .map(instance -> BaseInstance.builder().ip(instance.getIp()).id(instance.getId()).hostname(instance.getHostname()).build())
             .orElseThrow(() -> new InstanceNotFoundException(instanceId));
+    }
+
+    @Override
+    public List<BaseInstance> findByIds(ExecutionContext executionContext, Collection<String> instanceIds) {
+        return storage
+            .stream()
+            .filter(i -> instanceIds.contains(i.getId()) && i.getEnvironments().contains(executionContext.getEnvironmentId()))
+            .map(i -> BaseInstance.builder().id(i.getId()).hostname(i.getHostname()).ip(i.getIp()).build())
+            .toList();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.logs_engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import io.gravitee.apim.core.logs_engine.model.ApiKeyMode;
+import io.gravitee.apim.core.logs_engine.model.ApiLog;
+import io.gravitee.apim.core.logs_engine.model.ApiLogDiagnostic;
+import io.gravitee.apim.core.logs_engine.model.BaseApplication;
+import io.gravitee.apim.core.logs_engine.model.BasePlan;
+import io.gravitee.apim.core.logs_engine.model.HttpMethod;
+import io.gravitee.apim.core.logs_engine.model.MembershipMemberType;
+import io.gravitee.apim.core.logs_engine.model.Pagination;
+import io.gravitee.apim.core.logs_engine.model.PlanMode;
+import io.gravitee.apim.core.logs_engine.model.PlanSecurity;
+import io.gravitee.apim.core.logs_engine.model.PlanSecurityType;
+import io.gravitee.apim.core.logs_engine.model.PrimaryOwner;
+import io.gravitee.apim.core.logs_engine.model.SearchLogsResponse;
+import io.gravitee.apim.core.user.model.UserContext;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LogNamesPostProcessorImplTest {
+
+    private static final Pagination PAGINATION = new Pagination(1, 10, 1, 1, 1L);
+    private static final UserContext BASE_CONTEXT = new UserContext(AuditInfoFixtures.anAuditInfo("org", "env", "user"));
+
+    private LogNamesPostProcessorImpl processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new LogNamesPostProcessorImpl();
+    }
+
+    private static ApiLog aLogWith(String apiId, BasePlan plan, BaseApplication application) {
+        return aLogWith(apiId, plan, application, null);
+    }
+
+    private static ApiLog aLogWith(String apiId, BasePlan plan, BaseApplication application, String gateway) {
+        return new ApiLog(
+            apiId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            plan,
+            application,
+            null,
+            null,
+            null,
+            null,
+            gateway,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            Map.of()
+        );
+    }
+
+    private static BasePlan aPlan(String planId) {
+        return new BasePlan(planId, null, null, null, null, null);
+    }
+
+    private static BaseApplication anApplication(String appId) {
+        return new BaseApplication(appId, null, null, null, null, null, null);
+    }
+
+    @Nested
+    class WhenAllNamesArePresent {
+
+        @Test
+        void should_resolve_api_name() {
+            var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "My API"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiName()).isEqualTo("My API");
+        }
+
+        @Test
+        void should_resolve_plan_name() {
+            var context = BASE_CONTEXT.withPlanNameById(Map.of("plan-1", "My Plan"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", aPlan("plan-1"), null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().plan().name()).isEqualTo("My Plan");
+        }
+
+        @Test
+        void should_resolve_application_name() {
+            var context = BASE_CONTEXT.withApplicationNameById(Map.of("app-1", "My App"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, anApplication("app-1"))), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().application().name()).isEqualTo("My App");
+        }
+
+        @Test
+        void should_resolve_all_names_at_once() {
+            var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "My API"))
+                .withPlanNameById(Map.of("plan-1", "My Plan"))
+                .withApplicationNameById(Map.of("app-1", "My App"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", aPlan("plan-1"), anApplication("app-1"))), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            var log = result.data().getFirst();
+            assertThat(log.apiName()).isEqualTo("My API");
+            assertThat(log.plan().name()).isEqualTo("My Plan");
+            assertThat(log.application().name()).isEqualTo("My App");
+        }
+    }
+
+    @Nested
+    class WhenNamesAreMissingFromMaps {
+
+        @Test
+        void should_return_null_api_name_when_id_not_in_map() {
+            var context = BASE_CONTEXT.withApiNamesById(Map.of("other-api", "Other API"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiName()).isNull();
+        }
+
+        @Test
+        void should_return_null_plan_name_when_id_not_in_map() {
+            var context = BASE_CONTEXT.withPlanNameById(Map.of("other-plan", "Other Plan"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", aPlan("plan-1"), null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().plan().name()).isNull();
+        }
+
+        @Test
+        void should_return_unknown_application_name_when_id_not_in_map() {
+            var context = BASE_CONTEXT.withApplicationNameById(Map.of("other-app", "Other App"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, anApplication("app-1"))), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().application().name()).isEqualTo("Unknown");
+        }
+    }
+
+    @Nested
+    class WhenPlanOrApplicationIsNull {
+
+        @Test
+        void should_keep_plan_null_without_npe() {
+            var context = BASE_CONTEXT.withPlanNameById(Map.of("plan-1", "My Plan"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().plan()).isNull();
+        }
+
+        @Test
+        void should_keep_application_null_without_npe() {
+            var context = BASE_CONTEXT.withApplicationNameById(Map.of("app-1", "My App"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().application()).isNull();
+        }
+    }
+
+    @Nested
+    class WhenMapsAreEmptyOptionals {
+
+        @Test
+        void should_return_null_names_when_context_has_empty_optionals() {
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", aPlan("plan-1"), anApplication("app-1"))), PAGINATION);
+
+            var result = processor.mapLogNames(BASE_CONTEXT, response);
+
+            var log = result.data().getFirst();
+            assertThat(log.apiName()).isNull();
+            assertThat(log.plan().name()).isNull();
+            assertThat(result.data().getFirst().application().name()).isEqualTo("Unknown");
+        }
+    }
+
+    @Nested
+    class WhenFieldPreservation {
+
+        @Test
+        void should_preserve_all_non_name_fields_through_enrichment() {
+            var timestamp = OffsetDateTime.parse("2026-01-15T10:30:00Z");
+            var security = new PlanSecurity(PlanSecurityType.API_KEY, "config");
+            var primaryOwner = new PrimaryOwner("owner-1", "owner@test.com", "Owner", MembershipMemberType.USER);
+            var warning = new ApiLogDiagnostic("comp-type", "comp-name", "warn-key", "warn-msg");
+
+            var originalPlan = new BasePlan("plan-1", "old-plan-name", "plan-desc", "api-1", security, PlanMode.STANDARD);
+            var originalApp = new BaseApplication(
+                "app-1",
+                "old-app-name",
+                "app-desc",
+                "domain.com",
+                "web",
+                primaryOwner,
+                ApiKeyMode.SHARED
+            );
+            var originalLog = new ApiLog(
+                "api-1",
+                "old-api-name",
+                timestamp,
+                "log-id",
+                "req-1",
+                HttpMethod.GET,
+                "client-1",
+                originalPlan,
+                originalApp,
+                "tx-1",
+                200,
+                true,
+                42,
+                "gw-1",
+                "/path",
+                "http://backend",
+                "msg",
+                "err-key",
+                "err-comp",
+                "err-type",
+                List.of(warning),
+                Map.of("k", "v")
+            );
+
+            var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "New API"))
+                .withPlanNameById(Map.of("plan-1", "New Plan"))
+                .withApplicationNameById(Map.of("app-1", "New App"))
+                .withGatewayHostnameById(Map.of("gw-1", "resolved-hostname"));
+            var response = new SearchLogsResponse(List.of(originalLog), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+            var log = result.data().getFirst();
+
+            // Names should be enriched
+            assertThat(log.apiName()).isEqualTo("New API");
+            assertThat(log.plan().name()).isEqualTo("New Plan");
+            assertThat(log.application().name()).isEqualTo("New App");
+
+            // All other ApiLog fields must survive unchanged
+            assertThat(log.apiId()).isEqualTo("api-1");
+            assertThat(log.timestamp()).isEqualTo(timestamp);
+            assertThat(log.id()).isEqualTo("log-id");
+            assertThat(log.requestId()).isEqualTo("req-1");
+            assertThat(log.method()).isEqualTo(HttpMethod.GET);
+            assertThat(log.clientIdentifier()).isEqualTo("client-1");
+            assertThat(log.transactionId()).isEqualTo("tx-1");
+            assertThat(log.status()).isEqualTo(200);
+            assertThat(log.requestEnded()).isTrue();
+            assertThat(log.gatewayResponseTime()).isEqualTo(42);
+            assertThat(log.gateway()).isEqualTo("resolved-hostname");
+            assertThat(log.uri()).isEqualTo("/path");
+            assertThat(log.endpoint()).isEqualTo("http://backend");
+            assertThat(log.message()).isEqualTo("msg");
+            assertThat(log.errorKey()).isEqualTo("err-key");
+            assertThat(log.errorComponentName()).isEqualTo("err-comp");
+            assertThat(log.errorComponentType()).isEqualTo("err-type");
+            assertThat(log.warnings()).containsExactly(warning);
+            assertThat(log.additionalMetrics()).containsEntry("k", "v");
+
+            // Plan non-name fields must survive unchanged
+            assertThat(log.plan().id()).isEqualTo("plan-1");
+            assertThat(log.plan().description()).isEqualTo("plan-desc");
+            assertThat(log.plan().apiId()).isEqualTo("api-1");
+            assertThat(log.plan().security()).isEqualTo(security);
+            assertThat(log.plan().mode()).isEqualTo(PlanMode.STANDARD);
+
+            // Application non-name fields must survive unchanged
+            assertThat(log.application().id()).isEqualTo("app-1");
+            assertThat(log.application().description()).isEqualTo("app-desc");
+            assertThat(log.application().domain()).isEqualTo("domain.com");
+            assertThat(log.application().type()).isEqualTo("web");
+            assertThat(log.application().primaryOwner()).isEqualTo(primaryOwner);
+            assertThat(log.application().apiKeyMode()).isEqualTo(ApiKeyMode.SHARED);
+        }
+    }
+
+    @Nested
+    class WhenMultipleLogs {
+
+        @Test
+        void should_enrich_multiple_logs_independently() {
+            var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "API One", "api-2", "API Two"))
+                .withPlanNameById(Map.of("plan-1", "Plan One", "plan-2", "Plan Two"))
+                .withApplicationNameById(Map.of("app-1", "App One", "app-2", "App Two"));
+            var log1 = aLogWith("api-1", aPlan("plan-1"), anApplication("app-1"));
+            var log2 = aLogWith("api-2", aPlan("plan-2"), anApplication("app-2"));
+            var response = new SearchLogsResponse(List.of(log1, log2), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data()).hasSize(2);
+            assertThat(result.data().get(0).apiName()).isEqualTo("API One");
+            assertThat(result.data().get(0).plan().name()).isEqualTo("Plan One");
+            assertThat(result.data().get(0).application().name()).isEqualTo("App One");
+            assertThat(result.data().get(1).apiName()).isEqualTo("API Two");
+            assertThat(result.data().get(1).plan().name()).isEqualTo("Plan Two");
+            assertThat(result.data().get(1).application().name()).isEqualTo("App Two");
+        }
+    }
+
+    @Nested
+    class WhenGatewayHostnameResolution {
+
+        @Test
+        void should_resolve_gateway_hostname() {
+            var context = BASE_CONTEXT.withGatewayHostnameById(Map.of("gw-1", "gateway-host-1"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null, "gw-1")), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().gateway()).isEqualTo("gateway-host-1");
+        }
+
+        @Test
+        void should_fall_back_to_raw_id_when_hostname_not_in_map() {
+            var context = BASE_CONTEXT.withGatewayHostnameById(Map.of("other-gw", "other-host"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null, "gw-1")), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().gateway()).isEqualTo("gw-1");
+        }
+
+        @Test
+        void should_fall_back_to_raw_id_when_map_is_empty_optional() {
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null, "gw-1")), PAGINATION);
+
+            var result = processor.mapLogNames(BASE_CONTEXT, response);
+
+            assertThat(result.data().getFirst().gateway()).isEqualTo("gw-1");
+        }
+
+        @Test
+        void should_keep_gateway_null_when_log_has_no_gateway() {
+            var context = BASE_CONTEXT.withGatewayHostnameById(Map.of("gw-1", "gateway-host-1"));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().gateway()).isNull();
+        }
+    }
+
+    @Test
+    void should_preserve_pagination() {
+        var pagination = new Pagination(3, 5, 10, 5, 50L);
+        var response = new SearchLogsResponse(List.of(), pagination);
+
+        var result = processor.mapLogNames(BASE_CONTEXT, response);
+
+        assertThat(result.data()).isEmpty();
+        assertThat(result.pagination()).isEqualTo(pagination);
+    }
+}


### PR DESCRIPTION
## Issue

[GKO-2406](https://gravitee.atlassian.net/browse/GKO-2406)

## Description

Environment log entries currently return raw IDs for APIs, plans, applications, and gateways. This PR adds a post-processing step that batch-loads display names and enriches each log entry before returning the response.

The enrichment resolves four kinds of names:

| Field | Source | Behavior on miss |
|---|---|---|
| **API name** | `UserContext.apiNameById` (already loaded) | `null` |
| **Plan name** | `PlanCrudService.findByIds` | `null` |
| **Application name** | `ApplicationCrudService.findByIds` | `"Unknown"` |
| **Gateway hostname** | `InstanceQueryService.findByIds` | keeps original gateway ID |

### Changes

**Core domain**
- Add `apiName` field to `ApiLog` record and `withApiName`, `withPlan`, `withApplication`, `withGateway` wither methods
- Add `withName` wither to `BasePlan` and `BaseApplication` records
- Extend `UserContext` with `planNameById` and `gatewayHostnameById` lookup maps and corresponding wither methods
- Introduce `LogNamesPostProcessor` domain service interface
- Implement `LogNamesPostProcessorImpl` (`@Service`) that maps api name, plan name, application name, and gateway hostname onto each `ApiLog` using the `UserContext` lookup maps

**Query service**
- Add `findByIds(ExecutionContext, Collection<String>)` batch method to `InstanceQueryService` interface
- Implement in `InstanceQueryServiceLegacyWrapper` (loops `findById`, swallows `InstanceNotFoundException`) and `InstanceQueryServiceInMemory` test fixture

**Use case**
- Inject `LogNamesPostProcessor`, `PlanCrudService`, `ApplicationCrudService`, and `InstanceQueryService` into `SearchEnvironmentLogsUseCase`
- After fetching raw connection logs, batch-load plan names, application names, and gateway hostnames into `UserContext`, then delegate to the post-processor to enrich the response

**OpenAPI**
- Add `apiName` field to `EnvironmentApiLog` schema in `openapi-logs.yaml`

**Tests**
- Unit tests for `LogNamesPostProcessorImpl` (name resolution, null/missing ID handling, fallback behavior)
- Unit tests for `SearchEnvironmentLogsUseCase` name enrichment (batch loading, delegation to post-processor)
- Integration test (`LogsSearchResourceTest`) verifying end-to-end name resolution through the REST layer
- Register `LogNamesPostProcessorImpl` bean in `ResourceContextConfiguration` for integration tests

## Additional context

Part of the logs engine feature ([GKO-2397](https://gravitee.atlassian.net/browse/GKO-2397)).

[GKO-2406]: https://gravitee.atlassian.net/browse/GKO-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GKO-2397]: https://gravitee.atlassian.net/browse/GKO-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ