### PR TITLE
move name resolution from frontend to backend for environment logs

### DIFF
--- a/gravitee-apim-console-webui/src/management/analytics/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-logs/env-logs.component.spec.ts
@@ -46,6 +46,7 @@ describe('EnvLogsComponent', () => {
     data: [
       {
         apiId: 'api-1',
+        apiName: 'My API',
         timestamp: '2025-06-15T12:00:00Z',
         id: 'log-1',
         requestId: 'req-1',
@@ -53,10 +54,10 @@ describe('EnvLogsComponent', () => {
         status: 200,
         requestEnded: true,
         gatewayResponseTime: 44,
-        gateway: 'gw-uuid-1',
+        gateway: 'gateway-host-1',
         uri: '/poke',
-        plan: { id: 'plan-1' },
-        application: { id: 'app-1' },
+        plan: { id: 'plan-1', name: 'Gold Plan' },
+        application: { id: 'app-1', name: 'My App' },
       },
     ],
     pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
@@ -78,82 +79,16 @@ describe('EnvLogsComponent', () => {
     fixture.destroy();
   });
 
-  function flushSearchAndResolution(
-    response: SearchLogsResponse,
-    overrides?: { failApp?: boolean; failPlan?: boolean; failGateway?: boolean },
-    searchUrl: string = SEARCH_URL,
-  ) {
-    // Flush the search request
+  function flushSearch(response: SearchLogsResponse, searchUrl: string = SEARCH_URL) {
     const req = httpTestingController.expectOne({ method: 'POST', url: searchUrl });
     req.flush(response);
-
-    // Flush API name resolution requests
-    const apiIds = [...new Set(response.data.map(log => log.apiId).filter(Boolean))];
-    for (const apiId of apiIds) {
-      const apiReq = httpTestingController.expectOne({
-        method: 'GET',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}`,
-      });
-      apiReq.flush({ id: apiId, name: `Resolved ${apiId}` });
-    }
-
-    // Flush application name resolution requests (excluding keyless app '1')
-    const appIds = [...new Set(response.data.map(log => log.application?.id).filter(id => Boolean(id) && id !== '1'))];
-    for (const appId of appIds) {
-      const appReq = httpTestingController.expectOne({
-        method: 'GET',
-        url: `${CONSTANTS_TESTING.env.baseURL}/applications/${appId}`,
-      });
-      if (overrides?.failApp) {
-        appReq.flush('Not Found', { status: 404, statusText: 'Not Found' });
-      } else {
-        appReq.flush({ id: appId, name: `Resolved ${appId}` });
-      }
-    }
-
-    // Flush gateway name resolution requests
-    const gatewayIds = [...new Set(response.data.map(log => log.gateway).filter(Boolean))];
-    for (const gwId of gatewayIds) {
-      const gwReq = httpTestingController.expectOne({
-        method: 'GET',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/instances/${gwId}`,
-      });
-      if (overrides?.failGateway) {
-        gwReq.flush('Not Found', { status: 404, statusText: 'Not Found' });
-      } else {
-        gwReq.flush({ id: gwId, hostname: `Resolved ${gwId}` });
-      }
-    }
-
-    // Flush plan name resolution requests
-    const planEntries = [
-      ...new Map(
-        response.data.filter(log => log.plan?.id && log.apiId).map(log => [log.plan.id, { apiId: log.apiId, planId: log.plan.id }]),
-      ).values(),
-    ];
-    for (const { apiId, planId } of planEntries) {
-      const planReq = httpTestingController.expectOne({
-        method: 'GET',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans/${planId}`,
-      });
-      if (overrides?.failPlan) {
-        planReq.flush('Server Error', { status: 500, statusText: 'Internal Server Error' });
-      } else {
-        planReq.flush({ id: planId, name: `Resolved ${planId}` });
-      }
-    }
-
-    // Re-render with fetched data
     fixture.detectChanges();
   }
 
-  function initComponent(
-    response: SearchLogsResponse = EMPTY_RESPONSE,
-    overrides?: { failApp?: boolean; failPlan?: boolean; failGateway?: boolean },
-  ) {
+  function initComponent(response: SearchLogsResponse = EMPTY_RESPONSE) {
     fixture.detectChanges();
     tick();
-    flushSearchAndResolution(response, overrides);
+    flushSearch(response);
   }
 
   it('should create', fakeAsync(() => {
@@ -189,44 +124,64 @@ describe('EnvLogsComponent', () => {
     expect(tableSection).toBeTruthy();
   }));
 
-  it('should fetch logs on init and resolve API, application, plan, and gateway names', fakeAsync(() => {
+  it('should fetch logs on init and use backend-provided names', fakeAsync(() => {
     initComponent(MOCK_RESPONSE);
 
     const logs = component.logs();
     expect(logs.length).toBe(1);
-    expect(logs[0].api).toBe('Resolved api-1');
+    expect(logs[0].api).toBe('My API');
     expect(logs[0].method).toBe('GET');
     expect(logs[0].status).toBe(200);
     expect(logs[0].path).toBe('/poke');
-    expect(logs[0].application).toBe('Resolved app-1');
+    expect(logs[0].application).toBe('My App');
     expect(logs[0].responseTime).toBe('44 ms');
-    expect(logs[0].gateway).toBe('Resolved gw-uuid-1');
-    expect(logs[0].plan?.name).toBe('Resolved plan-1');
+    expect(logs[0].gateway).toBe('gateway-host-1');
+    expect(logs[0].plan?.name).toBe('Gold Plan');
     expect(logs[0].requestEnded).toBe(true);
   }));
 
-  it('should fall back to ID when name resolution fails', fakeAsync(() => {
-    initComponent(MOCK_RESPONSE, { failApp: true, failPlan: true, failGateway: true });
+  it('should fall back to ID when name is absent in the response', fakeAsync(() => {
+    const responseWithoutNames: SearchLogsResponse = {
+      data: [
+        {
+          apiId: 'api-1',
+          timestamp: '2025-06-15T12:00:00Z',
+          id: 'log-1',
+          requestId: 'req-1',
+          method: 'GET',
+          status: 200,
+          requestEnded: true,
+          uri: '/poke',
+          plan: { id: 'plan-1' },
+          application: { id: 'app-1' },
+        },
+      ],
+      pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+    };
+
+    initComponent(responseWithoutNames);
 
     const logs = component.logs();
     expect(logs.length).toBe(1);
+    expect(logs[0].api).toBe('api-1');
     expect(logs[0].application).toBe('app-1');
-    expect(logs[0].plan?.name).toBe('api-1|plan-1');
-    expect(logs[0].gateway).toBe('gw-uuid-1');
+    expect(logs[0].plan).toBeUndefined();
+    expect(logs[0].gateway).toBeUndefined();
   }));
 
-  it('should display "Unknown application (keyless)" for default application ID', fakeAsync(() => {
+  it('should display "Default application" for default application ID', fakeAsync(() => {
     const responseWithDefaultApp: SearchLogsResponse = {
       data: [
         {
           apiId: 'api-1',
+          apiName: 'My API',
           timestamp: '2025-06-15T12:00:00Z',
           id: 'log-2',
           requestId: 'req-2',
           method: 'GET',
           status: 200,
           requestEnded: true,
-          gateway: 'gw-uuid-1',
+          gateway: 'gateway-host-1',
           uri: '/test',
           application: { id: '1' },
         },
@@ -236,9 +191,8 @@ describe('EnvLogsComponent', () => {
 
     initComponent(responseWithDefaultApp);
 
-    // No application HTTP request should have been made (verified by httpTestingController.verify() in afterEach)
     const logs = component.logs();
-    expect(logs[0].application).toBe('Unknown application (keyless)');
+    expect(logs[0].application).toBe('Default application');
   }));
 
   it('should update pagination from response', fakeAsync(() => {
@@ -262,7 +216,7 @@ describe('EnvLogsComponent', () => {
     tick(1);
 
     const page2Url = `${CONSTANTS_TESTING.env.v2BaseURL}/logs/search?page=2&perPage=10`;
-    flushSearchAndResolution(EMPTY_RESPONSE, undefined, page2Url);
+    flushSearch(EMPTY_RESPONSE, page2Url);
 
     expect(component.logs().length).toBe(0);
   }));
@@ -275,13 +229,13 @@ describe('EnvLogsComponent', () => {
     tick(1);
 
     const page2Url = `${CONSTANTS_TESTING.env.v2BaseURL}/logs/search?page=2&perPage=10`;
-    flushSearchAndResolution(EMPTY_RESPONSE, undefined, page2Url);
+    flushSearch(EMPTY_RESPONSE, page2Url);
 
     component.onRefresh();
     fixture.detectChanges();
     tick(1);
 
-    flushSearchAndResolution(MOCK_RESPONSE);
+    flushSearch(MOCK_RESPONSE);
 
     expect(component.logs().length).toBe(1);
     expect(component.pagination().page).toBe(1);
@@ -300,11 +254,12 @@ describe('EnvLogsComponent', () => {
     expect(component.logs().length).toBe(0);
   }));
 
-  it('should deduplicate IDs across multiple log entries', fakeAsync(() => {
+  it('should display multiple log entries from response', fakeAsync(() => {
     const multiEntryResponse: SearchLogsResponse = {
       data: [
         {
           apiId: 'api-1',
+          apiName: 'My API',
           timestamp: '2025-06-15T12:00:00Z',
           id: 'log-1',
           requestId: 'req-1',
@@ -312,12 +267,13 @@ describe('EnvLogsComponent', () => {
           status: 200,
           requestEnded: true,
           uri: '/a',
-          application: { id: 'app-1' },
-          plan: { id: 'plan-1' },
-          gateway: 'gw-1',
+          application: { id: 'app-1', name: 'My App' },
+          plan: { id: 'plan-1', name: 'Gold Plan' },
+          gateway: 'gateway-host-1',
         },
         {
           apiId: 'api-1',
+          apiName: 'My API',
           timestamp: '2025-06-15T12:01:00Z',
           id: 'log-2',
           requestId: 'req-2',
@@ -325,9 +281,9 @@ describe('EnvLogsComponent', () => {
           status: 201,
           requestEnded: true,
           uri: '/b',
-          application: { id: 'app-1' },
-          plan: { id: 'plan-1' },
-          gateway: 'gw-1',
+          application: { id: 'app-1', name: 'My App' },
+          plan: { id: 'plan-1', name: 'Gold Plan' },
+          gateway: 'gateway-host-1',
         },
       ],
       pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 2, totalCount: 2 },
@@ -335,13 +291,11 @@ describe('EnvLogsComponent', () => {
 
     initComponent(multiEntryResponse);
 
-    // If deduplication works, only 1 API, 1 app, 1 plan, and 1 gateway request
-    // (verified by httpTestingController.verify() in afterEach)
     const logs = component.logs();
     expect(logs.length).toBe(2);
-    expect(logs[0].api).toBe('Resolved api-1');
-    expect(logs[1].api).toBe('Resolved api-1');
-    expect(logs[0].application).toBe('Resolved app-1');
-    expect(logs[1].application).toBe('Resolved app-1');
+    expect(logs[0].api).toBe('My API');
+    expect(logs[1].api).toBe('My API');
+    expect(logs[0].application).toBe('My App');
+    expect(logs[1].application).toBe('My App');
   }));
 });

--- a/gravitee-apim-console-webui/src/management/analytics/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/env-logs/env-logs.component.ts
@@ -20,8 +20,8 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
-import { EMPTY, forkJoin, Observable, of } from 'rxjs';
-import { catchError, debounceTime, map, switchMap, tap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError, debounceTime, switchMap, tap } from 'rxjs/operators';
 
 import type { EnvLog } from './models/env-log.model';
 
@@ -29,24 +29,13 @@ import { EnvLogsFilterBarComponent } from './components/env-logs-filter-bar/env-
 import { EnvLogsTableComponent } from './components/env-logs-table/env-logs-table.component';
 
 import { EnvironmentLogsService, EnvironmentApiLog } from '../../../services-ngx/environment-logs.service';
-import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { ApplicationService } from '../../../services-ngx/application.service';
-import { ApiPlanV2Service } from '../../../services-ngx/api-plan-v2.service';
-import { InstanceService } from '../../../services-ngx/instance.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioTableWrapperPagination } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { Pagination } from '../../../entities/management-api-v2';
 
 /** Gravitee's built-in sentinel ID for unauthenticated / Keyless traffic. */
 const UNKNOWN_APPLICATION_ID = '1';
-const UNKNOWN_APPLICATION_LABEL = 'Unknown application (keyless)';
-
-type ResolvedNames = {
-  api: Record<string, string>;
-  app: Record<string, string>;
-  plan: Record<string, string>;
-  gateway: Record<string, string>;
-};
+const UNKNOWN_APPLICATION_LABEL = 'Default application';
 
 @Component({
   selector: 'env-logs',
@@ -58,10 +47,6 @@ type ResolvedNames = {
 })
 export class EnvLogsComponent {
   private readonly environmentLogsService = inject(EnvironmentLogsService);
-  private readonly apiV2Service = inject(ApiV2Service);
-  private readonly applicationService = inject(ApplicationService);
-  private readonly planService = inject(ApiPlanV2Service);
-  private readonly instanceService = inject(InstanceService);
   private readonly snackBarService = inject(SnackBarService);
   private readonly datePipe = inject(DatePipe);
 
@@ -77,35 +62,6 @@ export class EnvLogsComponent {
     }),
     switchMap(({ page, perPage }) =>
       this.environmentLogsService.searchLogs({ page, perPage }).pipe(
-        switchMap(response => {
-          const apiIds = [...new Set(response.data.map(log => log.apiId).filter(Boolean))];
-          const appIds = [
-            ...new Set(response.data.map(log => log.application?.id).filter(id => Boolean(id) && id !== UNKNOWN_APPLICATION_ID)),
-          ];
-          const gatewayIds = [...new Set(response.data.map(log => log.gateway).filter(Boolean))];
-          const planEntries = [
-            ...new Map(
-              response.data
-                .filter(log => log.plan?.id && log.apiId)
-                .map(log => [`${log.apiId}|${log.plan.id}`, { apiId: log.apiId, planId: log.plan.id }]),
-            ).values(),
-          ];
-
-          const planCompositeKeys = planEntries.map(e => `${e.apiId}|${e.planId}`);
-
-          // TODO: Move name resolution to the backend (SearchEnvironmentLogsUseCase) to match proxy logs pattern.
-          // Currently resolving names via N+1 frontend calls; the backend should return enriched objects
-          // with names (like ConnectionLog does for API runtime logs). See ApplicationMetadataProvider for reference.
-          return forkJoin({
-            api: this.resolveNames(apiIds, id => this.apiV2Service.get(id).pipe(map(a => a.name))),
-            app: this.resolveNames(appIds, id => this.applicationService.getById(id).pipe(map(a => a.name))),
-            plan: this.resolveNames(planCompositeKeys, compositeKey => {
-              const [apiId, planId] = compositeKey.split('|');
-              return this.planService.get(apiId, planId).pipe(map(p => p.name));
-            }),
-            gateway: this.resolveNames(gatewayIds, id => this.instanceService.getByGatewayId(id).pipe(map(i => i.hostname ?? id))),
-          }).pipe(map((resolved: ResolvedNames) => ({ response, resolved })));
-        }),
         tap(() => this.loading.set(false)),
         catchError(err => {
           this.loading.set(false);
@@ -125,12 +81,12 @@ export class EnvLogsComponent {
 
   logs = computed(() => {
     const result = this.logsResult();
-    return result?.response.data.map(log => this.mapToEnvLog(log, result.resolved)) ?? [];
+    return result?.data.map(log => this.mapToEnvLog(log)) ?? [];
   });
   /** Merges backend totalCount into the pagination signal for the table wrapper. */
   paginationWithTotal = computed(() => ({
     ...this.pagination(),
-    totalCount: this.logsResult()?.response.pagination.totalCount ?? 0,
+    totalCount: this.logsResult()?.pagination.totalCount ?? 0,
   }));
 
   onRefresh() {
@@ -141,47 +97,25 @@ export class EnvLogsComponent {
     this.pagination.update(prev => ({ ...prev, page: event.index, perPage: event.size }));
   }
 
-  private resolveNames(ids: string[], fetcher: (id: string) => Observable<string>): Observable<Record<string, string>> {
-    if (ids.length === 0) return of({});
-
-    return forkJoin(
-      Object.fromEntries(
-        ids.map(id => [
-          id,
-          fetcher(id).pipe(
-            catchError(err => {
-              if (err instanceof HttpErrorResponse && (err.status === 401 || err.status === 403)) {
-                throw err;
-              }
-              return of(id);
-            }),
-          ),
-        ]),
-      ),
-    );
-  }
-
-  private mapToEnvLog(log: EnvironmentApiLog, names: ResolvedNames): EnvLog {
-    const planKey = log.plan?.id && log.apiId ? `${log.apiId}|${log.plan.id}` : undefined;
-    const planName = planKey ? names.plan[planKey] : undefined;
+  private mapToEnvLog(log: EnvironmentApiLog): EnvLog {
     const appName = log.application?.id
       ? log.application.id === UNKNOWN_APPLICATION_ID
         ? UNKNOWN_APPLICATION_LABEL
-        : names.app[log.application.id]
+        : (log.application.name ?? log.application.id)
       : undefined;
 
     return {
       id: log.id,
       timestamp: this.datePipe.transform(log.timestamp, 'medium') ?? log.timestamp,
-      api: names.api[log.apiId] ?? log.apiId,
+      api: log.apiName ?? log.apiId,
       apiId: log.apiId,
       application: appName ?? '—',
       method: log.method ?? '—',
       path: log.uri ?? '—',
       status: log.status,
       responseTime: log.gatewayResponseTime != null ? `${log.gatewayResponseTime} ms` : '—',
-      gateway: log.gateway ? (names.gateway[log.gateway] ?? log.gateway) : undefined,
-      plan: planName ? { name: planName } : undefined,
+      gateway: log.gateway ?? undefined,
+      plan: log.plan?.name ? { name: log.plan.name } : undefined,
       requestEnded: log.requestEnded,
       errorKey: log.errorKey,
       warnings: log.warnings?.map(w => ({ key: w.key ?? '' })),

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
@@ -24,6 +24,7 @@ import { Constants } from '../entities/Constants';
  */
 export interface EnvironmentApiLog {
   apiId: string;
+  apiName?: string;
   timestamp: string;
   id: string;
   requestId: string;


### PR DESCRIPTION
## Issue

[GKO-2417](https://gravitee.atlassian.net/browse/GKO-2417) — Remove name resolution from the front-end
Parent: [GKO-2397](https://gravitee.atlassian.net/browse/GKO-2397) — Env logs: move name resolution from frontend to backend

## Description

Environment log entries returned raw IDs for APIs, plans, applications, and gateways. The frontend resolved these via HTTP calls. This PR moves that resolution to the backend, where it is done efficiently in batch, and simplifies the frontend to read names directly from the response.

Note: this PR depends on https://github.com/gravitee-io/gravitee-api-management/pull/15432

### Frontend changes (`env-logs.component.ts`)

- Remove `ApiV2Service`, `ApplicationService`, `ApiPlanV2Service`, `InstanceService` injections
- Remove `forkJoin`-based `resolveNames()` helper and `ResolvedNames` type
- Simplify `mapToEnvLog()` to read names directly from the response (`log.apiName`, `log.plan.name`, `log.application.name`, `log.gateway` as hostname)
- Add `apiName` to the `EnvironmentApiLog` TypeScript interface
- Keyless application sentinel (`id === '1'`) is still handled on the frontend

### Tests

- Frontend tests simplified: `flushSearchAndResolution` (which mocked 4+ HTTP resolution calls per entry) replaced with `flushSearch` (single POST mock); mock data updated to include backend-provided names

## Additional context

Eliminates ~110 lines of frontend orchestration code and replaces N+1 HTTP calls with backend batch lookups.

[GKO-2417]: https://gravitee.atlassian.net/browse/GKO-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GKO-2397]: https://gravitee.atlassian.net/browse/GKO-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ