### PR TITLE
feat: set `allow_in_products` to false by default

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
@@ -69,12 +69,6 @@ public class NewHttpApi extends AbstractNewApi {
             .flowExecution(flowExecution)
             .failover(failover);
 
-        if (
-            definitionVersion == io.gravitee.definition.model.DefinitionVersion.V4 && type == io.gravitee.definition.model.v4.ApiType.PROXY
-        ) {
-            builder.allowedInApiProducts(true);
-        }
-
         return builder;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -129,10 +129,6 @@ public class ApiModelFactory {
             return apiExport.apiDefinitionNativeV4(api.toNativeApiDefinitionBuilder().id(id).build()).build();
         }
 
-        if (api.getDefinitionVersion() == DefinitionVersion.V4 && api.getType() == ApiType.PROXY && api.getAllowedInApiProducts() == null) {
-            api.setAllowedInApiProducts(true);
-        }
-
         return apiExport.apiDefinitionHttpV4(api.toApiDefinitionBuilder().id(id).build()).build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -257,12 +257,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, userId, apiEntity.getPrimaryOwner());
         apiValidationService.validateAndSanitizeImportApiForCreation(executionContext, apiEntity, primaryOwner);
 
-        if (apiEntity.getDefinitionVersion() == DefinitionVersion.V4) {
-            if (apiEntity.getType() == ApiType.PROXY) {
-                apiEntity.setAllowedInApiProducts(true);
-            } else {
-                apiEntity.setAllowedInApiProducts(null);
-            }
+        if (apiEntity.getDefinitionVersion() == DefinitionVersion.V4 && apiEntity.getType() != ApiType.PROXY) {
+            apiEntity.setAllowedInApiProducts(null);
         }
 
         Api repositoryApi = apiMapper.toRepository(executionContext, apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -413,9 +413,6 @@ public class ApiMapper {
             apiDefinition.setFailover(newApiEntity.getFailover());
             apiDefinition.setFlowExecution(newApiEntity.getFlowExecution());
             apiDefinition.setFlows(newApiEntity.getFlows());
-            if (newApiEntity.getType() == ApiType.PROXY) {
-                apiDefinition.setAllowedInApiProducts(true);
-            }
 
             return objectMapper.writeValueAsString(apiDefinition);
         } catch (JsonProcessingException jse) {
@@ -581,10 +578,8 @@ public class ApiMapper {
             apiDefinition.setFlows(apiEntity.getFlows());
             apiDefinition.setResponseTemplates(apiEntity.getResponseTemplates());
             apiDefinition.setServices(apiEntity.getServices());
-            if (apiEntity.getType() == ApiType.PROXY) {
-                apiDefinition.setAllowedInApiProducts(
-                    apiEntity.getAllowedInApiProducts() != null ? apiEntity.getAllowedInApiProducts() : false
-                );
+            if (apiEntity.getType() == ApiType.PROXY && apiEntity.getAllowedInApiProducts() != null) {
+                apiDefinition.setAllowedInApiProducts(apiEntity.getAllowedInApiProducts());
             }
 
             return objectMapper.writeValueAsString(apiDefinition);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/NewHttpApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/NewHttpApiTest.java
@@ -28,15 +28,14 @@ import org.junit.jupiter.api.Test;
 class NewHttpApiTest {
 
     @Test
-    void should_set_allowedInApiProducts_true_for_v4_proxy_http_api() {
-        // Given a new V4 HTTP PROXY API
+    void should_not_set_allowedInApiProducts_by_default_for_v4_proxy_http_api() {
         NewHttpApi newHttpApi = NewApiFixtures.aProxyApiV4();
 
         var definition = newHttpApi.toApiDefinitionBuilder().build();
 
         assertThat(definition.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
-        assertThat(definition.getAllowedInApiProducts()).isTrue();
+        assertThat(definition.getAllowedInApiProducts()).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
@@ -31,7 +31,7 @@ class ApiModelFactoryTest {
     private static final String ENVIRONMENT_ID = "environment-id";
 
     @Test
-    void fromApiExport_should_default_allowedInApiProducts_true_for_v4_http_proxy_export_when_flag_missing() {
+    void fromApiExport_should_leave_allowedInApiProducts_null_for_v4_http_proxy_export_when_flag_missing() {
         ApiExport apiExport = ApiExport.builder()
             .name("my-api")
             .apiVersion("1.0.0")
@@ -45,7 +45,7 @@ class ApiModelFactoryTest {
         var definition = api.getApiDefinitionHttpV4();
         assertThat(definition.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
-        assertThat(definition.getAllowedInApiProducts()).isTrue();
+        assertThat(definition.getAllowedInApiProducts()).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -972,6 +972,7 @@ class ImportApiDefinitionUseCaseTest {
             .id(null)
             .apiVersion("1.0.0")
             .analytics(Analytics.builder().enabled(false).build())
+            .allowedInApiProducts(true)
             .background(null)
             .categories(null)
             .crossId(API_CROSS_ID)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12976

## Description

- The “Allow API Products” toggle is available at the API configuration level.
- The toggle is disabled by default for all existing APIs after upgrade.
- The toggle is disabled by default for all newly created APIs.
- When the toggle is disabled, the API cannot be added to any API Product (UI and backend validation enforced).
- When the toggle is enabled, the API becomes selectable during API Product creation or update.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

