### PR TITLE
feat: create _search endpoint and indexable api-product

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiProductsResource.java
@@ -31,7 +31,8 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ApiProductsResource extends AbstractResource {
@@ -51,19 +52,17 @@ public class ApiProductsResource extends AbstractResource {
             .stream()
             .map(ApiProductMapper.INSTANCE::map)
             .collect(Collectors.toList());
-        List<ApiProduct> paginationData = computePaginationData(restApiProducts, paginationParam);
+        List<ApiProduct> paginationApiProducts = computePaginationData(restApiProducts, paginationParam);
         return Response.ok()
             .entity(
-                new HashMap<String, Object>() {
-                    {
-                        put("data", paginationData);
-                        put(
-                            "pagination",
-                            PaginationInfo.computePaginationInfo(restApiProducts.size(), paginationData.size(), paginationParam)
-                        );
-                        put("links", computePaginationLinks(restApiProducts.size(), paginationParam));
-                    }
-                }
+                Map.of(
+                    "data",
+                    paginationApiProducts,
+                    "pagination",
+                    PaginationInfo.computePaginationInfo(restApiProducts.size(), paginationApiProducts.size(), paginationParam),
+                    "links",
+                    computePaginationLinks(restApiProducts.size(), paginationParam)
+                )
             )
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiProductSortByParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiProductSortByParam.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.param;
+
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.QueryParam;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ApiProductSortByParam {
+
+    public enum ApiProductSortByEnum {
+        NAME_ASC("name", "name", true),
+        NAME_DESC("-name", "name", false);
+
+        private final String paramValue;
+        private final String fieldName;
+        private final boolean ascOrder;
+
+        ApiProductSortByEnum(String paramValue, String fieldName, boolean ascOrder) {
+            this.paramValue = paramValue;
+            this.fieldName = fieldName;
+            this.ascOrder = ascOrder;
+        }
+
+        public String getParamValue() {
+            return paramValue;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public boolean isAscOrder() {
+            return ascOrder;
+        }
+
+        public static ApiProductSortByEnum getByValue(String value) {
+            if (value == null) return null;
+            for (ApiProductSortByEnum e : values()) {
+                if (e.getParamValue().equals(value)) {
+                    return e;
+                }
+            }
+            return null;
+        }
+
+        public static String allowedValues() {
+            return Arrays.stream(values()).map(ApiProductSortByEnum::getParamValue).collect(Collectors.joining(", "));
+        }
+    }
+
+    @QueryParam("sortBy")
+    String sortBy;
+
+    public void validate() {
+        if (Objects.nonNull(sortBy) && Objects.isNull(ApiProductSortByEnum.getByValue(sortBy))) {
+            throw new BadRequestException("Invalid sortBy parameter: " + sortBy + ". Allowed: " + ApiProductSortByEnum.allowedValues());
+        }
+    }
+
+    public Sortable toSortable() {
+        if (Objects.isNull(sortBy)) {
+            return new SortableImpl(ApiProductSortByEnum.NAME_ASC.getFieldName(), ApiProductSortByEnum.NAME_ASC.isAscOrder());
+        }
+        ApiProductSortByEnum match = ApiProductSortByEnum.getByValue(sortBy);
+        return new SortableImpl(match.getFieldName(), match.isAscOrder());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -222,6 +222,99 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /environments/{envId}/api-products/_search:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+    post:
+      tags:
+        - API Product
+      summary: Search API Products by name or ID
+      description: |-
+        Search API Products in the environment by name (substring match) and/or by a list of IDs.
+        Optionally filter by text `query` (name, description and owner name) and/or `ids`. If none are provided, all API Products in the environment are returned (paginated).
+        Results are paginated.
+      operationId: searchApiProducts
+      parameters:
+        - name: page
+          in: query
+          description: Page number (starting from 1)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: perPage
+          in: query
+          description: Number of items per page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+        - name: sortBy
+          in: query
+          description: Sort by name. Use "name" for ascending, "-name" for descending. Default is name ascending.
+          required: false
+          schema:
+            type: string
+            enum:
+              - name
+              - "-name"
+            default: name
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApiProductSearchQuery"
+      responses:
+        '200':
+          description: Paginated list of API Products matching the search
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApiProduct'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                        example: 1
+                      perPage:
+                        type: integer
+                        example: 10
+                      pageCount:
+                        type: integer
+                        example: 1
+                      totalCount:
+                        type: integer
+                        example: 1
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                      next:
+                        type: string
+                        nullable: true
+                      prev:
+                        type: string
+                        nullable: true
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /environments/{envId}/api-products/{apiProductId}:
     parameters:
       - $ref: "#/components/parameters/envIdParam"
@@ -1511,6 +1604,23 @@ components:
           description: An optional reason giving details about the result. Present when ok is false.
           example: "API Product name already exists"
 
+    ApiProductSearchQuery:
+      type: object
+      title: "ApiProductSearchQuery"
+      description: Search criteria for API Products. Optionally provide query (text search on name, description and owner name) and/or ids. If none are provided, all API Products in the environment are returned (paginated).
+      properties:
+        query:
+          type: string
+          description: Filter by name (case-insensitive substring match).
+          example: "My Product"
+        ids:
+          type: array
+          description: Filter by exact API Product IDs.
+          items:
+            type: string
+          example:
+            - "api-product-1"
+            - "api-product-2"
     CreateApiProduct:
       type: object
       title: "CreateApiProduct"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -8484,6 +8484,14 @@ components:
               type: string
               description: The API Product version
               example: "1.0.0"
+            apiIds:
+              type: array
+              description: List of API IDs included in the product
+              items:
+                type: string
+              example:
+                - "api-1"
+                - "api-2"
             createdAt:
               type: string
               format: date-time
@@ -8494,6 +8502,9 @@ components:
               format: date-time
               description: API Product last update date
               example: "2025-01-01T10:15:30Z"
+            primaryOwner:
+              $ref: "#/components/schemas/PrimaryOwner"
+              description: The primary owner of the API Product
 
     parameters:
         #############

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -73,6 +73,7 @@ import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
+import io.gravitee.apim.core.api_product.use_case.SearchApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductNameUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -925,6 +926,12 @@ public class ResourceContextConfiguration {
     @Primary
     public GetApiProductsUseCase getApiProductsUseCase() {
         return mock(GetApiProductsUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public SearchApiProductsUseCase searchApiProductsUseCase() {
+        return mock(SearchApiProductsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductIndexerDomainService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.Indexer;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import lombok.CustomLog;
+
+@DomainService
+@CustomLog
+public class ApiProductIndexerDomainService {
+
+    private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
+    private final Indexer indexer;
+
+    public ApiProductIndexerDomainService(ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService, Indexer indexer) {
+        this.apiProductPrimaryOwnerDomainService = apiProductPrimaryOwnerDomainService;
+        this.indexer = indexer;
+    }
+
+    public void index(Context context, ApiProduct apiProductToIndex, PrimaryOwnerEntity primaryOwner) {
+        indexer.index(context.toIndexationContext(), toIndexableApiProduct(apiProductToIndex, primaryOwner));
+    }
+
+    public void delete(Context context, ApiProduct apiProductToDelete) {
+        Indexer.IndexationContext ctx = context.toIndexationContext();
+        indexer.delete(ctx, toIndexableApiProduct(ctx, apiProductToDelete));
+    }
+
+    public IndexableApiProduct toIndexableApiProduct(Indexer.IndexationContext context, ApiProduct apiProduct) {
+        try {
+            var primaryOwner = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(context.organizationId(), apiProduct.getId());
+            return toIndexableApiProduct(apiProduct, primaryOwner);
+        } catch (ApiProductPrimaryOwnerNotFoundException e) {
+            log.warn("Failed to retrieve API Product primary owner, will index without primary owner", e);
+            return toIndexableApiProduct(apiProduct, null);
+        }
+    }
+
+    public IndexableApiProduct toIndexableApiProduct(ApiProduct apiProduct, PrimaryOwnerEntity primaryOwner) {
+        return new IndexableApiProduct(apiProduct, primaryOwner);
+    }
+
+    public static Context oneShotIndexation(AuditInfo auditInfo) {
+        return new Context(auditInfo, false);
+    }
+
+    public static class Context {
+
+        private final Indexer.IndexationContext context;
+
+        public Context(AuditInfo auditInfo, boolean bulk) {
+            this.context = new Indexer.IndexationContext(auditInfo.organizationId(), auditInfo.environmentId(), !bulk);
+        }
+
+        Indexer.IndexationContext toIndexationContext() {
+            return context;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
@@ -16,16 +16,18 @@
 package io.gravitee.apim.core.api_product.query_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import java.util.Map;
-import java.util.Optional;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
 import java.util.Set;
 
-public interface ApiProductQueryService {
-    Optional<ApiProduct> findByEnvironmentIdAndName(String environmentId, String name);
-    Set<ApiProduct> findByEnvironmentId(String environmentId);
-    Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids);
-    Optional<ApiProduct> findById(String apiProductId);
-    Set<ApiProduct> findByApiId(String apiId);
-
-    Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
+public interface ApiProductSearchQueryService {
+    Page<ApiProduct> search(
+        String environmentId,
+        String organizationId,
+        String query,
+        Set<String> ids,
+        Pageable pageable,
+        Sortable sortable
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
+import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
@@ -58,6 +60,7 @@ public class CreateApiProductUseCase {
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
     private final LicenseDomainService licenseDomainService;
+    private final ApiProductIndexerDomainService apiProductIndexerDomainService;
 
     public record Input(CreateApiProduct createApiProduct, AuditInfo auditInfo) {}
 
@@ -108,6 +111,8 @@ public class CreateApiProductUseCase {
             auditInfo.actor().userId()
         );
         apiProductPrimaryOwnerDomainService.createApiProductPrimaryOwnerMembership(created.getId(), primaryOwner, auditInfo);
+
+        apiProductIndexerDomainService.index(oneShotIndexation(auditInfo), created, primaryOwner);
 
         publishDeployEvent(auditInfo, created);
         createAuditLog(created, auditInfo);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
+import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -49,6 +51,7 @@ public class DeleteApiProductUseCase {
     private final ApiStateDomainService apiStateDomainService;
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
+    private final ApiProductIndexerDomainService apiProductIndexerDomainService;
 
     public void execute(Input input) {
         ApiProduct apiProduct = apiProductQueryService
@@ -64,6 +67,7 @@ public class DeleteApiProductUseCase {
         publishUndeployEvent(input.auditInfo(), apiProduct);
 
         apiProductCrudService.delete(input.apiProductId());
+        apiProductIndexerDomainService.delete(oneShotIndexation(input.auditInfo()), apiProduct);
         createAuditLog(input.apiProductId, input.auditInfo());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class SearchApiProductsUseCase {
+
+    private final ApiProductSearchQueryService apiProductSearchQueryService;
+
+    public Output execute(Input input) {
+        Page<ApiProduct> page = apiProductSearchQueryService.search(
+            input.environmentId(),
+            input.organizationId(),
+            input.query(),
+            input.ids(),
+            input.pageable(),
+            input.sortable()
+        );
+        return new Output(page);
+    }
+
+    public record Input(String environmentId, String organizationId, String query, Set<String> ids, Pageable pageable, Sortable sortable) {
+        public static Input of(
+            String environmentId,
+            String organizationId,
+            String query,
+            Set<String> ids,
+            Pageable pageable,
+            Sortable sortable
+        ) {
+            return new Input(environmentId, organizationId, query != null ? query.trim() : null, ids, pageable, sortable);
+        }
+    }
+
+    public record Output(Page<ApiProduct> page) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApiProduct.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.search.model;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexableApiProduct implements Indexable {
+
+    @Builder.Default
+    private ApiProduct apiProduct = new ApiProduct();
+
+    private PrimaryOwnerEntity primaryOwner;
+
+    @Override
+    public String getId() {
+        return apiProduct != null ? apiProduct.getId() : null;
+    }
+
+    @Override
+    public void setId(String id) {
+        if (apiProduct != null) {
+            apiProduct.setId(id);
+        }
+    }
+
+    @Override
+    public String getReferenceType() {
+        return ReferenceContext.Type.ENVIRONMENT.name();
+    }
+
+    @Override
+    public void setReferenceType(String referenceType) {}
+
+    @Override
+    public String getReferenceId() {
+        return apiProduct != null ? apiProduct.getEnvironmentId() : null;
+    }
+
+    @Override
+    public void setReferenceId(String referenceId) {
+        if (apiProduct != null) {
+            apiProduct.setEnvironmentId(referenceId);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
@@ -75,6 +75,24 @@ public class ApiProductQueryServiceImpl implements ApiProductQueryService {
     }
 
     @Override
+    public Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Set.of();
+        }
+        try {
+            log.debug("Finding API Products for environment: {} and ids: {}", environmentId, ids);
+            Set<io.gravitee.repository.management.model.ApiProduct> repoApiProducts = apiProductRepository.findByIds(ids);
+            return repoApiProducts
+                .stream()
+                .filter(repoApiProduct -> environmentId.equals(repoApiProduct.getEnvironmentId()))
+                .map(ApiProductAdapter.INSTANCE::toModel)
+                .collect(Collectors.toSet());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to find API Products by ids", e);
+        }
+    }
+
+    @Override
     public Optional<ApiProduct> findById(String apiProductId) {
         try {
             log.debug("Finding API Product by apiProductId: {}", apiProductId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.api_product;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.apim.core.utils.CollectionUtils;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.ApiProductSearchService;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQueryService {
+
+    private static final String FILTER_TYPE_API_PRODUCT = "api_product";
+
+    private final ApiProductSearchService apiProductSearchService;
+
+    public ApiProductSearchQueryServiceImpl(ApiProductSearchService apiProductSearchService) {
+        this.apiProductSearchService = apiProductSearchService;
+    }
+
+    @Override
+    public Page<ApiProduct> search(
+        String environmentId,
+        String organizationId,
+        String query,
+        Set<String> ids,
+        Pageable pageable,
+        Sortable sortable
+    ) {
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+        QueryBuilder<IndexableApiProduct> queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+
+        if (query != null && !query.isBlank()) {
+            queryBuilder.setQuery(query.trim());
+        }
+        if (CollectionUtils.isNotEmpty(ids)) {
+            queryBuilder.addFilter(FILTER_TYPE_API_PRODUCT, ids);
+        }
+        if (sortable != null) {
+            queryBuilder.setSort(sortable);
+        }
+
+        return apiProductSearchService.search(executionContext, queryBuilder, pageable);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.searcher;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParserBase;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiProductDocumentSearcher extends AbstractDocumentSearcher {
+
+    private static final Map<String, Float> API_PRODUCT_FIELD_BOOST = Map.ofEntries(
+        Map.entry(FIELD_NAME, 20.0f),
+        Map.entry(FIELD_NAME_LOWERCASE, 20.0f),
+        Map.entry(FIELD_NAME_SPLIT, 18.0f),
+        Map.entry(FIELD_DESCRIPTION, 5.0f),
+        Map.entry(FIELD_DESCRIPTION_LOWERCASE, 5.0f),
+        Map.entry(FIELD_DESCRIPTION_SPLIT, 4.0f),
+        Map.entry(FIELD_OWNER, 3.0f),
+        Map.entry(FIELD_OWNER_LOWERCASE, 3.0f)
+    );
+
+    private static final String[] API_PRODUCT_FIELD_SEARCH = new String[] {
+        FIELD_ID,
+        FIELD_NAME,
+        FIELD_NAME_SORTED,
+        FIELD_NAME_LOWERCASE,
+        FIELD_NAME_SPLIT,
+        FIELD_DESCRIPTION,
+        FIELD_DESCRIPTION_LOWERCASE,
+        FIELD_DESCRIPTION_SPLIT,
+        FIELD_OWNER,
+        FIELD_OWNER_LOWERCASE,
+    };
+
+    public ApiProductDocumentSearcher(IndexWriter indexWriter) {
+        super(indexWriter);
+    }
+
+    private BooleanQuery.Builder buildApiProductQuery(ExecutionContext executionContext, Optional<Query> filterQuery) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder().add(
+            new TermQuery(new Term(FIELD_TYPE, FIELD_TYPE_VALUE)),
+            BooleanClause.Occur.FILTER
+        );
+
+        if (executionContext.hasEnvironmentId()) {
+            builder.add(buildEnvCriteria(executionContext), BooleanClause.Occur.FILTER);
+        }
+
+        filterQuery.ifPresent(q -> builder.add(q, BooleanClause.Occur.FILTER));
+
+        return builder;
+    }
+
+    private BooleanQuery buildEnvCriteria(ExecutionContext executionContext) {
+        return new BooleanQuery.Builder()
+            .add(new TermQuery(new Term(FIELD_REFERENCE_TYPE, ReferenceContext.Type.ENVIRONMENT.name())), BooleanClause.Occur.FILTER)
+            .add(new TermQuery(new Term(FIELD_REFERENCE_ID, executionContext.getEnvironmentId())), BooleanClause.Occur.FILTER)
+            .build();
+    }
+
+    private Optional<BooleanQuery> buildTextQuery(
+        ExecutionContext executionContext,
+        io.gravitee.rest.api.service.search.query.Query<?> query,
+        Optional<Query> filterQuery
+    ) throws ParseException {
+        if (isBlank(query.getQuery())) {
+            return Optional.empty();
+        }
+        BooleanQuery.Builder baseQuery = buildApiProductQuery(executionContext, filterQuery);
+        MultiFieldQueryParser parser = new MultiFieldQueryParser(API_PRODUCT_FIELD_SEARCH, new KeywordAnalyzer(), API_PRODUCT_FIELD_BOOST);
+        String escaped = QueryParserBase.escape(query.getQuery());
+        Query parsed = parser.parse(escaped);
+        baseQuery.add(parsed, BooleanClause.Occur.MUST);
+        return Optional.of(baseQuery.build());
+    }
+
+    private Optional<BooleanQuery> buildWildcardQuery(
+        ExecutionContext executionContext,
+        io.gravitee.rest.api.service.search.query.Query<?> query,
+        Optional<Query> filterQuery
+    ) {
+        if (isBlank(query.getQuery())) {
+            return Optional.empty();
+        }
+        BooleanQuery.Builder baseQuery = buildApiProductQuery(executionContext, filterQuery);
+        baseQuery.add(buildNameWildcardQuery(query.getQuery()), BooleanClause.Occur.MUST);
+        return Optional.of(baseQuery.build());
+    }
+
+    private BooleanQuery buildNameWildcardQuery(String query) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        String lower = query.toLowerCase();
+        builder.add(new WildcardQuery(new Term(FIELD_NAME, '*' + query + '*')), BooleanClause.Occur.SHOULD);
+        builder.add(new WildcardQuery(new Term(FIELD_NAME_LOWERCASE, '*' + lower + '*')), BooleanClause.Occur.SHOULD);
+        for (String token : query.split("\\s+")) {
+            if (!token.isEmpty()) {
+                builder.add(new WildcardQuery(new Term(FIELD_NAME, '*' + token + '*')), BooleanClause.Occur.SHOULD);
+                builder.add(new WildcardQuery(new Term(FIELD_NAME_LOWERCASE, '*' + token.toLowerCase() + '*')), BooleanClause.Occur.SHOULD);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public SearchResult search(ExecutionContext executionContext, io.gravitee.rest.api.service.search.query.Query<?> query)
+        throws TechnicalException {
+        BooleanQuery.Builder mainQuery = new BooleanQuery.Builder();
+
+        try {
+            final Optional<Query> baseFilterQuery = buildFilterQuery(query.getFilters(), Map.of(FIELD_TYPE_VALUE, FIELD_ID));
+            buildTextQuery(executionContext, query, baseFilterQuery).ifPresent(q ->
+                mainQuery.add(new BoostQuery(q, 4.0f), BooleanClause.Occur.SHOULD)
+            );
+            buildWildcardQuery(executionContext, query, baseFilterQuery).ifPresent(q -> mainQuery.add(q, BooleanClause.Occur.SHOULD));
+
+            if (!mainQuery.build().clauses().iterator().hasNext()) {
+                mainQuery.add(buildApiProductQuery(executionContext, baseFilterQuery).build(), BooleanClause.Occur.MUST);
+            }
+        } catch (ParseException pe) {
+            log.error("Invalid query to search for API Product documents", pe);
+            throw new TechnicalException("Invalid query to search for API Product documents", pe);
+        }
+
+        BooleanQuery finalQuery = mainQuery.build();
+
+        try {
+            return search(finalQuery, query.getSort());
+        } catch (IndexSearcher.TooManyClauses e) {
+            int maxClauseCount = getClauseCount(finalQuery);
+            increaseMaxClauseCountIfNecessary(maxClauseCount);
+            return search(finalQuery, query.getSort());
+        }
+    }
+
+    private int getClauseCount(Query query) {
+        int result = 0;
+        if (query instanceof BooleanQuery bq) {
+            result = bq.clauses().size();
+            for (BooleanClause clause : bq.clauses()) {
+                result += getClauseCount(clause.query());
+            }
+        } else if (query instanceof BoostQuery bq) {
+            result += getClauseCount(bq.getQuery());
+        }
+        return result;
+    }
+
+    @Override
+    public boolean handle(Class<? extends Indexable> source) {
+        return IndexableApiProduct.class.isAssignableFrom(source);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer.FIELD_REFERENCE_ID;
+import static io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer.FIELD_REFERENCE_TYPE;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer;
+import java.text.CollationKey;
+import java.text.Collator;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.util.BytesRef;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IndexableApiProductDocumentTransformer implements DocumentTransformer<IndexableApiProduct> {
+
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_TYPE_VALUE = "api_product";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_NAME_LOWERCASE = "name_lowercase";
+    public static final String FIELD_NAME_SORTED = "name_sorted";
+    public static final String FIELD_NAME_SPLIT = "name_split";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_DESCRIPTION_LOWERCASE = "description_lowercase";
+    public static final String FIELD_DESCRIPTION_SPLIT = "description_split";
+    public static final String FIELD_OWNER = "ownerName";
+    public static final String FIELD_OWNER_LOWERCASE = "ownerName_lowercase";
+    public static final String FIELD_CREATED_AT = "createdAt";
+    public static final String FIELD_UPDATED_AT = "updatedAt";
+
+    public static final Pattern SPECIAL_CHARS = Pattern.compile("[|\\-+!(){}^\"~*?:&\\/]");
+
+    private final Collator collator = Collator.getInstance(Locale.ENGLISH);
+
+    @Override
+    public Document transform(IndexableApiProduct indexableApiProduct) {
+        ApiProduct apiProduct = indexableApiProduct.getApiProduct();
+        PrimaryOwnerEntity primaryOwner = indexableApiProduct.getPrimaryOwner();
+
+        Document doc = new Document();
+        doc.add(new StringField(FIELD_ID, apiProduct.getId(), Field.Store.YES));
+        doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
+
+        if (apiProduct.getName() == null) {
+            return doc;
+        }
+
+        if (indexableApiProduct.getReferenceId() != null) {
+            doc.add(new StringField(FIELD_REFERENCE_TYPE, indexableApiProduct.getReferenceType(), Field.Store.NO));
+            doc.add(new StringField(FIELD_REFERENCE_ID, indexableApiProduct.getReferenceId(), Field.Store.NO));
+        }
+
+        doc.add(new StringField(FIELD_NAME, apiProduct.getName(), Field.Store.NO));
+        doc.add(new SortedDocValuesField(FIELD_NAME_SORTED, toSortedValue(apiProduct.getName())));
+        doc.add(new StringField(FIELD_NAME_LOWERCASE, apiProduct.getName().toLowerCase(), Field.Store.NO));
+        doc.add(new TextField(FIELD_NAME_SPLIT, apiProduct.getName(), Field.Store.NO));
+
+        if (apiProduct.getDescription() != null) {
+            doc.add(new StringField(FIELD_DESCRIPTION, apiProduct.getDescription(), Field.Store.NO));
+            doc.add(new StringField(FIELD_DESCRIPTION_LOWERCASE, apiProduct.getDescription().toLowerCase(), Field.Store.NO));
+            doc.add(new TextField(FIELD_DESCRIPTION_SPLIT, apiProduct.getDescription(), Field.Store.NO));
+        }
+
+        if (apiProduct.getCreatedAt() != null) {
+            doc.add(new LongPoint(FIELD_CREATED_AT, apiProduct.getCreatedAt().toInstant().toEpochMilli()));
+        }
+        if (apiProduct.getUpdatedAt() != null) {
+            doc.add(new LongPoint(FIELD_UPDATED_AT, apiProduct.getUpdatedAt().toInstant().toEpochMilli()));
+        }
+
+        if (primaryOwner != null && primaryOwner.displayName() != null) {
+            doc.add(new StringField(FIELD_OWNER, primaryOwner.displayName(), Field.Store.NO));
+            doc.add(new StringField(FIELD_OWNER_LOWERCASE, primaryOwner.displayName().toLowerCase(), Field.Store.NO));
+        }
+
+        return doc;
+    }
+
+    private BytesRef toSortedValue(String value) {
+        if (value == null) return new BytesRef("");
+        String cleaned = SPECIAL_CHARS.matcher(value).replaceAll("");
+        collator.setStrength(Collator.SECONDARY);
+        CollationKey key = collator.getCollationKey(cleaned);
+        return new BytesRef(key.toByteArray());
+    }
+
+    @Override
+    public boolean handle(Class<? extends Indexable> source) {
+        return IndexableApiProduct.class.isAssignableFrom(source);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductSearchService.java
@@ -13,19 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api_product.query_service;
+package io.gravitee.rest.api.service.v4;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
 
-public interface ApiProductQueryService {
-    Optional<ApiProduct> findByEnvironmentIdAndName(String environmentId, String name);
-    Set<ApiProduct> findByEnvironmentId(String environmentId);
-    Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids);
-    Optional<ApiProduct> findById(String apiProductId);
-    Set<ApiProduct> findByApiId(String apiId);
-
-    Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
+public interface ApiProductSearchService {
+    Page<ApiProduct> search(ExecutionContext executionContext, QueryBuilder<IndexableApiProduct> queryBuilder, Pageable pageable);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static java.util.stream.Collectors.toList;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.ApiProductSearchService;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@CustomLog
+public class ApiProductSearchServiceImpl implements ApiProductSearchService {
+
+    private final SearchEngineService searchEngineService;
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
+
+    @Override
+    public Page<ApiProduct> search(ExecutionContext executionContext, QueryBuilder<IndexableApiProduct> queryBuilder, Pageable pageable) {
+        var query = queryBuilder.build();
+
+        SearchResult searchResult = searchEngineService.search(executionContext, query);
+
+        if (!searchResult.hasResults()) {
+            return new Page<>(List.of(), 0, 0, 0);
+        }
+
+        List<String> sortedIds = new ArrayList<>(searchResult.getDocuments());
+        List<String> pageIds = getPageSubset(sortedIds, pageable);
+
+        if (pageIds.isEmpty()) {
+            return new Page<>(List.of(), pageable.getPageNumber(), 0, sortedIds.size());
+        }
+
+        Set<ApiProduct> apiProducts = apiProductQueryService.findByEnvironmentIdAndIdIn(
+            executionContext.getEnvironmentId(),
+            Set.copyOf(pageIds)
+        );
+
+        Map<String, ApiProduct> byId = new LinkedHashMap<>();
+        apiProducts.forEach(apiProduct -> byId.put(apiProduct.getId(), apiProduct));
+
+        List<ApiProduct> orderedPage = pageIds
+            .stream()
+            .map(byId::get)
+            .filter(Objects::nonNull)
+            .map(apiProduct -> addPrimaryOwner(apiProduct, executionContext.getOrganizationId()))
+            .collect(toList());
+
+        return new Page<>(orderedPage, pageable.getPageNumber(), orderedPage.size(), sortedIds.size());
+    }
+
+    private ApiProduct addPrimaryOwner(ApiProduct apiProduct, String organizationId) {
+        PrimaryOwnerEntity primaryOwner = null;
+        try {
+            primaryOwner = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(organizationId, apiProduct.getId());
+        } catch (ApiProductPrimaryOwnerNotFoundException e) {
+            log.warn("Failed to retrieve primary owner for API Product [{}]: {}", apiProduct.getId(), e.getMessage());
+        }
+        return apiProduct.toBuilder().primaryOwner(primaryOwner).build();
+    }
+
+    private List<String> getPageSubset(List<String> ids, Pageable pageable) {
+        int total = ids.size();
+        int pageSize = pageable.getPageSize();
+
+        if (pageSize <= 0 || total <= 0) {
+            return List.of();
+        }
+
+        int pageNumber = pageable.getPageNumber();
+        int startIndex = (pageNumber - 1) * pageSize;
+
+        if (startIndex >= total || pageNumber < 1) {
+            throw new PaginationInvalidException();
+        }
+
+        return ids.stream().skip(startIndex).limit(pageSize).collect(toList());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
@@ -42,6 +42,20 @@ public class ApiProductQueryServiceInMemory extends AbstractQueryServiceInMemory
     }
 
     @Override
+    public Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Set.of();
+        }
+        Set<ApiProduct> result = new HashSet<>();
+        for (ApiProduct apiProduct : storage) {
+            if (Objects.equals(environmentId, apiProduct.getEnvironmentId()) && ids.contains(apiProduct.getId())) {
+                result.add(apiProduct);
+            }
+        }
+        return result;
+    }
+
+    @Override
     public Optional<ApiProduct> findById(String apiProductId) {
         return storage
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceInMemory<ApiProduct> implements ApiProductSearchQueryService {
+
+    private String lastEnvironmentId;
+    private String lastOrganizationId;
+
+    public String getLastEnvironmentId() {
+        return lastEnvironmentId;
+    }
+
+    public String getLastOrganizationId() {
+        return lastOrganizationId;
+    }
+
+    @Override
+    public Page<ApiProduct> search(
+        String environmentId,
+        String organizationId,
+        String query,
+        Set<String> ids,
+        Pageable pageable,
+        Sortable sortable
+    ) {
+        this.lastEnvironmentId = environmentId;
+        this.lastOrganizationId = organizationId;
+
+        int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
+        int pageSize = pageable != null ? pageable.getPageSize() : 10;
+
+        Stream<ApiProduct> stream = storage
+            .stream()
+            .filter(apiProduct -> Objects.equals(apiProduct.getEnvironmentId(), environmentId))
+            .filter(apiProduct -> ids == null || ids.isEmpty() || (ids.contains(apiProduct.getId())))
+            .filter(apiProduct -> {
+                if (query == null || query.isBlank()) return true;
+                String queryLower = query.trim().toLowerCase();
+                return (
+                    (apiProduct.getName() != null && apiProduct.getName().toLowerCase().contains(queryLower)) ||
+                    (apiProduct.getDescription() != null && apiProduct.getDescription().toLowerCase().contains(queryLower))
+                );
+            });
+
+        if (sortable != null && sortable.getField() != null) {
+            Comparator<ApiProduct> comparator = comparatorForField(sortable.getField());
+            if (comparator != null) {
+                stream = stream.sorted(sortable.isAscOrder() ? comparator : comparator.reversed());
+            }
+        }
+
+        List<ApiProduct> matched = stream.toList();
+        int total = matched.size();
+
+        if (pageSize <= 0 || total == 0) {
+            return new Page<>(List.of(), pageNumber, 0, total);
+        }
+        int start = (pageNumber - 1) * pageSize;
+        if (start >= total) {
+            return new Page<>(List.of(), pageNumber, 0, total);
+        }
+        int end = Math.min(start + pageSize, total);
+        List<ApiProduct> pageContent = new ArrayList<>(matched.subList(start, end));
+        return new Page<>(pageContent, pageNumber, pageContent.size(), total);
+    }
+
+    private static Comparator<ApiProduct> comparatorForField(String fieldName) {
+        if (fieldName == null) return null;
+        return switch (fieldName) {
+            case "name" -> Comparator.comparing(
+                apiProduct -> apiProduct.getName() != null ? apiProduct.getName() : "",
+                String.CASE_INSENSITIVE_ORDER
+            );
+            case "createdAt" -> Comparator.comparing(
+                apiProduct -> apiProduct.getCreatedAt() != null ? apiProduct.getCreatedAt() : ZonedDateTime.now().minusYears(100),
+                Comparator.naturalOrder()
+            );
+            case "updatedAt" -> Comparator.comparing(
+                apiProduct -> apiProduct.getUpdatedAt() != null ? apiProduct.getUpdatedAt() : ZonedDateTime.now().minusYears(100),
+                Comparator.naturalOrder()
+            );
+            default -> null;
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -537,6 +537,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public ApiProductSearchQueryServiceInMemory apiProductSearchQueryService() {
+        return new ApiProductSearchQueryServiceInMemory();
+    }
+
+    @Bean
     public ClientCertificateCrudServiceInMemory clientCertificateCrudService() {
         return new ClientCertificateCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -37,6 +37,7 @@ import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -81,6 +82,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
 
     private CreateApiProductUseCase createApiProductUseCase;
 
@@ -130,7 +132,8 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
             apiProductPrimaryOwnerFactory,
             eventCrudService,
             eventLatestCrudService,
-            new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager)
+            new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
+            apiProductIndexerDomainService
         );
 
         initRoles();
@@ -177,6 +180,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
 
         verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
         verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq(GENERATED_UUID), any());
+        verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductSearchQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchApiProductsUseCaseTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String ORG_ID = "org-id";
+
+    private ApiProductSearchQueryServiceInMemory apiProductSearchQueryService;
+    private SearchApiProductsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        apiProductSearchQueryService = new ApiProductSearchQueryServiceInMemory();
+        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService);
+    }
+
+    @Test
+    void should_delegate_to_query_service_with_correct_arguments() {
+        var pageable = new PageableImpl(1, 10);
+        var sortable = new SortableImpl("name", true);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "my query", Set.of("id-1"), pageable, sortable);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page()).isNotNull();
+        assertThat(output.page().getContent()).isEmpty();
+        assertThat(output.page().getPageNumber()).isOne();
+        assertThat(output.page().getPageElements()).isZero();
+    }
+
+    @Test
+    void should_trim_query_so_whitespace_only_becomes_null() {
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "   \t  ", null, pageable, null);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page()).isNotNull();
+        assertThat(output.page().getContent()).isEmpty();
+    }
+
+    @Test
+    void should_pass_environment_id_and_organization_id_in_correct_order() {
+        var pageable = new PageableImpl(2, 5);
+        var input = SearchApiProductsUseCase.Input.of("env-1", "org-1", null, null, pageable, null);
+
+        useCase.execute(input);
+
+        assertThat(apiProductSearchQueryService.getLastEnvironmentId()).isEqualTo("env-1");
+        assertThat(apiProductSearchQueryService.getLastOrganizationId()).isEqualTo("org-1");
+    }
+
+    @Test
+    void should_return_empty_page_when_no_criteria() {
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).isEmpty();
+        assertThat(output.page().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_return_product_matching_query_when_stored_in_memory() {
+        var product = ApiProduct.builder().id("product-1").name("My API Product").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "My API", null, pageable, null);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).hasSize(1);
+        assertThat(output.page().getContent().get(0).getId()).isEqualTo("product-1");
+        assertThat(output.page().getContent().get(0).getName()).isEqualTo("My API Product");
+        assertThat(output.page().getTotalElements()).isOne();
+    }
+
+    @Test
+    void should_return_products_filtered_by_ids_when_stored_in_memory() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
+        var product3 = ApiProduct.builder().id("id-3").name("Product Three").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2, product3));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-3"), pageable, null);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).hasSize(2);
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id-1", "id-3");
+        assertThat(output.page().getTotalElements()).isEqualTo(2);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.mock;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
@@ -762,6 +764,16 @@ public class SearchEngineServiceTest {
         @Bean
         public ApiIndexerDomainService apiIndexerDomainService() {
             return mock(ApiIndexerDomainService.class);
+        }
+
+        @Bean
+        public ApiProductIndexerDomainService apiProductIndexerDomainService() {
+            return mock(ApiProductIndexerDomainService.class);
+        }
+
+        @Bean
+        public ApiProductCrudService apiProductCrudService() {
+            return mock(ApiProductCrudService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcherTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.searcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import java.io.IOException;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiProductDocumentSearcherTest {
+
+    private static final String ENV_1 = "env-1";
+    private static final String ENV_2 = "env-2";
+    private static final String ORG_1 = "org-1";
+
+    private IndexWriter indexWriter;
+    private IndexableApiProductDocumentTransformer transformer;
+    private ApiProductDocumentSearcher searcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        ByteBuffersDirectory directory = new ByteBuffersDirectory();
+        indexWriter = new IndexWriter(directory, new IndexWriterConfig());
+        transformer = new IndexableApiProductDocumentTransformer();
+        searcher = new ApiProductDocumentSearcher(indexWriter);
+    }
+
+    @Test
+    void should_handle_indexable_api_product() {
+        assertThat(searcher.handle(IndexableApiProduct.class)).isTrue();
+        assertThat(searcher.handle(Indexable.class)).isFalse();
+    }
+
+    @Test
+    void should_scope_search_by_environment() throws Exception {
+        indexApiProduct("product-1", "Product One", ENV_1);
+        indexApiProduct("product-2", "Product Two", ENV_2);
+        indexWriter.commit();
+
+        ExecutionContext executionContext = new ExecutionContext(ORG_1, ENV_1);
+        var query = QueryBuilder.create(IndexableApiProduct.class).build();
+
+        var result = searcher.search(executionContext, query);
+
+        assertThat(result.getDocuments()).containsExactly("product-1");
+        assertThat(result.getHits()).isEqualTo(1);
+    }
+
+    @Test
+    void should_filter_by_ids_when_ids_provided_via_filter() throws Exception {
+        indexApiProduct("product-1", "Product One", ENV_1);
+        indexApiProduct("product-2", "Product Two", ENV_1);
+        indexApiProduct("product-3", "Product Three", ENV_1);
+        indexWriter.commit();
+
+        ExecutionContext executionContext = new ExecutionContext(ORG_1, ENV_1);
+        var query = QueryBuilder.create(IndexableApiProduct.class)
+            .setQuery(null)
+            .addFilter(IndexableApiProductDocumentTransformer.FIELD_TYPE_VALUE, Set.of("product-1", "product-3"))
+            .build();
+
+        var result = searcher.search(executionContext, query);
+
+        assertThat(result.getDocuments()).containsExactlyInAnyOrder("product-1", "product-3");
+        assertThat(result.getHits()).isEqualTo(2);
+    }
+
+    @Test
+    void should_search_by_text_query() throws Exception {
+        indexApiProduct("product-1", "My API Product", ENV_1);
+        indexApiProduct("product-2", "Other Product", ENV_1);
+        indexWriter.commit();
+
+        ExecutionContext executionContext = new ExecutionContext(ORG_1, ENV_1);
+        var query = QueryBuilder.create(IndexableApiProduct.class).setQuery("API").build();
+
+        var result = searcher.search(executionContext, query);
+
+        assertThat(result.getDocuments()).contains("product-1");
+    }
+
+    private void indexApiProduct(String id, String name, String environmentId) throws IOException {
+        ApiProduct apiProduct = ApiProduct.builder().id(id).environmentId(environmentId).name(name).build();
+        IndexableApiProduct indexable = IndexableApiProduct.builder().apiProduct(apiProduct).build();
+        Document doc = transformer.transform(indexable);
+        indexWriter.addDocument(doc);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_CREATED_AT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_DESCRIPTION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_ID;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_NAME;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_NAME_SORTED;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_TYPE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_TYPE_VALUE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer.FIELD_UPDATED_AT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.junit.jupiter.api.Test;
+
+class IndexableApiProductDocumentTransformerTest {
+
+    private static final String PRODUCT_ID = "api-product-id";
+    private static final PrimaryOwnerEntity PRIMARY_OWNER = new PrimaryOwnerEntity(
+        "user-id",
+        "owner@gravitee.io",
+        "Product Owner",
+        PrimaryOwnerEntity.Type.USER
+    );
+
+    private final IndexableApiProductDocumentTransformer cut = new IndexableApiProductDocumentTransformer();
+
+    @Test
+    void should_transform_id_and_type_only_when_name_is_null() {
+        ApiProduct apiProduct = ApiProduct.builder().id(PRODUCT_ID).environmentId("env-1").name(null).build();
+        IndexableApiProduct indexable = new IndexableApiProduct(apiProduct, PRIMARY_OWNER);
+
+        Document result = cut.transform(indexable);
+
+        assertThat(result.getFields()).hasSize(2);
+        assertThat(result.getField(FIELD_ID).stringValue()).isEqualTo(PRODUCT_ID);
+        assertThat(result.getField(FIELD_TYPE).stringValue()).isEqualTo(FIELD_TYPE_VALUE);
+        assertThat(result.getField(FIELD_NAME)).isNull();
+    }
+
+    @Test
+    void should_not_add_created_at_or_updated_at_when_dates_are_null() {
+        ApiProduct apiProduct = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .environmentId("env-1")
+            .name("My Product")
+            .createdAt(null)
+            .updatedAt(null)
+            .build();
+        IndexableApiProduct indexable = new IndexableApiProduct(apiProduct, null);
+
+        Document result = cut.transform(indexable);
+
+        assertThat(result.getField(FIELD_NAME).stringValue()).isEqualTo("My Product");
+        assertThat(result.getFields(FIELD_CREATED_AT)).isEmpty();
+        assertThat(result.getFields(FIELD_UPDATED_AT)).isEmpty();
+    }
+
+    @Test
+    void should_add_created_at_and_updated_at_when_dates_are_set() {
+        ZonedDateTime created = ZonedDateTime.now().minusDays(1);
+        ZonedDateTime updated = ZonedDateTime.now();
+        ApiProduct apiProduct = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .environmentId("env-1")
+            .name("My Product")
+            .createdAt(created)
+            .updatedAt(updated)
+            .build();
+        IndexableApiProduct indexable = new IndexableApiProduct(apiProduct, null);
+
+        Document result = cut.transform(indexable);
+
+        assertThat(result.getFields(FIELD_CREATED_AT)).hasSize(1);
+        assertThat(result.getFields(FIELD_UPDATED_AT)).hasSize(1);
+    }
+
+    @Test
+    void should_strip_special_chars_in_name_sorted_for_collation() {
+        // SPECIAL_CHARS pattern: [|\-+!(){}^"~*?:&/] — strip these before collation
+        ApiProduct apiProduct = ApiProduct.builder().id(PRODUCT_ID).environmentId("env-1").name("API | Product (v1)").build();
+        IndexableApiProduct indexable = new IndexableApiProduct(apiProduct, null);
+
+        Document result = cut.transform(indexable);
+
+        IndexableField sortedField = result.getField(FIELD_NAME_SORTED);
+        assertThat(sortedField).isNotNull();
+        // Sorted value should be based on cleaned name (special chars removed), not raw
+        assertThat(sortedField.binaryValue()).isNotNull();
+    }
+
+    @Test
+    void should_handle_handle_for_indexable_api_product() {
+        assertThat(cut.handle(IndexableApiProduct.class)).isTrue();
+        assertThat(cut.handle(io.gravitee.rest.api.model.search.Indexable.class)).isFalse();
+    }
+
+    @Test
+    void should_transform_full_product_with_owner_and_description() {
+        ApiProduct apiProduct = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .environmentId("env-1")
+            .name("Full Product")
+            .description("A description")
+            .apiIds(Set.of("api-1"))
+            .createdAt(ZonedDateTime.now().minusDays(1))
+            .updatedAt(ZonedDateTime.now())
+            .build();
+        IndexableApiProduct indexable = new IndexableApiProduct(apiProduct, PRIMARY_OWNER);
+
+        Document result = cut.transform(indexable);
+
+        assertThat(result.getField(FIELD_ID).stringValue()).isEqualTo(PRODUCT_ID);
+        assertThat(result.getField(FIELD_NAME).stringValue()).isEqualTo("Full Product");
+        assertThat(result.getField(FIELD_DESCRIPTION).stringValue()).isEqualTo("A description");
+        assertThat(result.getField(IndexableApiProductDocumentTransformer.FIELD_OWNER).stringValue()).isEqualTo("Product Owner");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImplTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiProductSearchServiceImplTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String ORG_ID = "org-1";
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
+
+    private ApiProductSearchServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiProductSearchServiceImpl(searchEngineService, apiProductQueryService, apiProductPrimaryOwnerDomainService);
+    }
+
+    @Test
+    void should_return_empty_page_short_circuit_when_search_has_no_results() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(Set.of(), 0));
+        var queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+        var pageable = new PageableImpl(1, 10);
+
+        Page<ApiProduct> result = service.search(executionContext, queryBuilder, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getPageNumber()).isZero();
+        assertThat(result.getTotalElements()).isZero();
+        verify(searchEngineService).search(eq(executionContext), any());
+        verify(apiProductQueryService, org.mockito.Mockito.never()).findByEnvironmentIdAndIdIn(any(), any());
+    }
+
+    @Test
+    void should_apply_pagination_get_page_subset() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1", "id-2", "id-3", "id-4", "id-5"), 5));
+        ApiProduct p3 = ApiProduct.builder().id("id-3").name("P3").environmentId(ENV_ID).build();
+        when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-3", "id-4")))).thenReturn(
+            Set.of(p3, ApiProduct.builder().id("id-4").name("P4").environmentId(ENV_ID).build())
+        );
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(eq(ORG_ID), any())).thenReturn(null);
+        var queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+        var pageable = new PageableImpl(2, 2); // page 2, size 2 -> ids at index 2,3 = id-3, id-4
+
+        Page<ApiProduct> result = service.search(executionContext, queryBuilder, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo("id-3");
+        assertThat(result.getContent().get(1).getId()).isEqualTo("id-4");
+        assertThat(result.getPageNumber()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(5);
+    }
+
+    @Test
+    void should_throw_pagination_invalid_exception_when_page_number_less_than_one() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1"), 1));
+        var queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+        // Use a pageable that returns 0 (PageableImpl normalizes 0 to 1, so we use a custom one to test the guard)
+        Pageable pageable = new Pageable() {
+            @Override
+            public int getPageNumber() {
+                return 0;
+            }
+
+            @Override
+            public int getPageSize() {
+                return 10;
+            }
+        };
+
+        assertThatThrownBy(() -> service.search(executionContext, queryBuilder, pageable)).isInstanceOf(PaginationInvalidException.class);
+    }
+
+    @Test
+    void should_throw_pagination_invalid_exception_when_start_index_exceeds_total() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1", "id-2"), 2));
+        var queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+        var pageable = new PageableImpl(5, 10); // page 5, only 2 total
+
+        assertThatThrownBy(() -> service.search(executionContext, queryBuilder, pageable)).isInstanceOf(PaginationInvalidException.class);
+    }
+
+    @Test
+    void should_swallow_primary_owner_not_found_and_return_product_without_owner() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1"), 1));
+        ApiProduct apiProduct = ApiProduct.builder().id("id-1").name("P1").environmentId(ENV_ID).build();
+        when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-1")))).thenReturn(Set.of(apiProduct));
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, "id-1")).thenThrow(
+            new ApiProductPrimaryOwnerNotFoundException("id-1")
+        );
+
+        Page<ApiProduct> result = service.search(executionContext, QueryBuilder.create(IndexableApiProduct.class), new PageableImpl(1, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getPrimaryOwner()).isNull();
+        assertThat(result.getContent().get(0).getId()).isEqualTo("id-1");
+    }
+
+    @Test
+    void should_add_primary_owner_when_found() {
+        ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1"), 1));
+        ApiProduct apiProduct = ApiProduct.builder().id("id-1").name("P1").environmentId(ENV_ID).build();
+        PrimaryOwnerEntity owner = new PrimaryOwnerEntity("u1", "o@e.io", "Owner", PrimaryOwnerEntity.Type.USER);
+        when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-1")))).thenReturn(Set.of(apiProduct));
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, "id-1")).thenReturn(owner);
+
+        Page<ApiProduct> result = service.search(executionContext, QueryBuilder.create(IndexableApiProduct.class), new PageableImpl(1, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getPrimaryOwner()).isEqualTo(owner);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12966

## Description

This PR introduces a search capability to the API Product listing endpoint. A new endpoint: /environments/{envId}/api-products/_search, allowing users to filter API Products by name (case-insensitive). The search is executed before pagination so the returned page and total count reflect the filtered dataset.

The behavior is aligned with the existing API search functionality implemented for APIs (POST /apis/_search). When query is not provided or empty, the endpoint behaves exactly as before and returns all API Products.


```markdown
## Summary
Introduces search and indexation for API Products, aligned with the existing API search (POST /apis/_search).

## Changes

### Search endpoint
- **New endpoint:** `POST /environments/{envId}/api-products/_search`
- **Query (body):**
  - `query` (optional): Text filter on name (case-insensitive substring). Description and owner name are also searchable per OpenAPI.
  - `ids` (optional): Filter by exact API Product IDs.
- If neither `query` nor `ids` is provided (or both empty), returns all API Products in the environment (paginated).
- **Query params:** `page`, `perPage`, `sortBy` (`name` | `-name`, default `name`).
- **Response:** Same shape as list: `data`, `pagination`, `links`.
- **Permission:** `ENVIRONMENT_API_PRODUCT` READ.

### Indexation
- API Products are indexed on **create**, **update**, and **delete** via `ApiProductIndexerDomainService` and `IndexableApiProduct`.
- Enables search to run against the search index for better performance and consistency with APIs.

### Alignment with APIs
- Behavior and contract mirror `POST /apis/_search` (search before pagination, optional query/ids, sortBy, pagination).


