### PR TITLE
feat(kafka-explorer): add consumer groups list and detail pages

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
 
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
@@ -26,4 +28,6 @@ public interface KafkaClusterDomainService {
     TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
     TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
     BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
+    ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
+    ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroup.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+public record ConsumerGroup(String groupId, String state, int membersCount, long totalLag, int numTopics, KafkaNode coordinator) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupDetail.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupDetail.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record ConsumerGroupDetail(
+    String groupId,
+    String state,
+    KafkaNode coordinator,
+    String partitionAssignor,
+    List<ConsumerGroupMember> members,
+    List<ConsumerGroupOffset> offsets
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupMember.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupMember.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record ConsumerGroupMember(String memberId, String clientId, String host, List<MemberAssignment> assignments) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupOffset.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupOffset.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+public record ConsumerGroupOffset(String topic, int partition, long committedOffset, long endOffset, long lag) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupsPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/ConsumerGroupsPage.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record ConsumerGroupsPage(List<ConsumerGroup> data, long totalCount, int page, int perPage) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/MemberAssignment.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/MemberAssignment.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
+
+import java.util.List;
+
+public record MemberAssignment(String topicName, List<Integer> partitions) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
+
+@UseCase
+public class DescribeConsumerGroupUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public DescribeConsumerGroupUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var consumerGroupDetail = kafkaClusterDomainService.describeConsumerGroup(config, input.groupId());
+        return new Output(consumerGroupDetail);
+    }
+
+    public record Input(String clusterId, String environmentId, String groupId) {}
+
+    public record Output(ConsumerGroupDetail consumerGroupDetail) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
+
+@UseCase
+public class ListConsumerGroupsUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public ListConsumerGroupsUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var consumerGroupsPage = kafkaClusterDomainService.listConsumerGroups(config, input.nameFilter(), input.page(), input.perPage());
+        return new Output(consumerGroupsPage);
+    }
+
+    public record Input(String clusterId, String environmentId, String nameFilter, int page, int perPage) {}
+
+    public record Output(ConsumerGroupsPage consumerGroupsPage) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -18,6 +18,9 @@ package io.gravitee.rest.api.kafkaexplorer.mapper;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerLogDirEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroup;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
@@ -25,9 +28,12 @@ import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicPartitionDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ConsumerGroupSummary;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeConsumerGroupResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListConsumerGroupsResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.Pagination;
 import java.util.List;
@@ -70,4 +76,35 @@ public interface KafkaExplorerMapper {
                     .totalCount(topicsPage.totalCount())
             );
     }
+
+    ConsumerGroupSummary map(ConsumerGroup consumerGroup);
+
+    List<ConsumerGroupSummary> mapConsumerGroups(List<ConsumerGroup> consumerGroups);
+
+    default ListConsumerGroupsResponse map(ConsumerGroupsPage consumerGroupsPage, int page, int perPage) {
+        return new ListConsumerGroupsResponse()
+            .data(mapConsumerGroups(consumerGroupsPage.data()))
+            .pagination(
+                new Pagination()
+                    .page(page)
+                    .perPage(perPage)
+                    .pageCount((int) Math.ceil((double) consumerGroupsPage.totalCount() / perPage))
+                    .pageItemsCount(consumerGroupsPage.data().size())
+                    .totalCount(consumerGroupsPage.totalCount())
+            );
+    }
+
+    DescribeConsumerGroupResponse map(ConsumerGroupDetail consumerGroupDetail);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.ConsumerGroupMember map(
+        io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupMember member
+    );
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.MemberAssignment map(
+        io.gravitee.rest.api.kafkaexplorer.domain.model.MemberAssignment assignment
+    );
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.ConsumerGroupOffset map(
+        io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupOffset offset
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -18,14 +18,18 @@ package io.gravitee.rest.api.kafkaexplorer.resource;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeBrokerUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeConsumerGroupUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListConsumerGroupsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.mapper.KafkaExplorerMapper;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeConsumerGroupRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListConsumerGroupsRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -57,6 +61,12 @@ public class KafkaExplorerResource {
 
     @Inject
     private DescribeTopicUseCase describeTopicUseCase;
+
+    @Inject
+    private ListConsumerGroupsUseCase listConsumerGroupsUseCase;
+
+    @Inject
+    private DescribeConsumerGroupUseCase describeConsumerGroupUseCase;
 
     @POST
     @Path("/describe-cluster")
@@ -176,6 +186,75 @@ public class KafkaExplorerResource {
                 new DescribeBrokerUseCase.Input(request.getClusterId(), environmentId, request.getBrokerId())
             );
             return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.brokerInfo())).build();
+        } catch (KafkaExplorerException e) {
+            return Response.status(Response.Status.BAD_GATEWAY)
+                .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))
+                .build();
+        }
+    }
+
+    @POST
+    @Path("/list-consumer-groups")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @GraviteeLicenseFeature("apim-native-kafka-explorer")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = RolePermissionAction.READ) })
+    public Response listConsumerGroups(
+        ListConsumerGroupsRequest request,
+        @QueryParam("page") @DefaultValue("1") int page,
+        @QueryParam("perPage") @DefaultValue("25") int perPage
+    ) {
+        if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("clusterId is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (page < 1) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("page must be >= 1").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        try {
+            var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+            int page0Based = page - 1;
+            var result = listConsumerGroupsUseCase.execute(
+                new ListConsumerGroupsUseCase.Input(request.getClusterId(), environmentId, request.getNameFilter(), page0Based, perPage)
+            );
+            return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.consumerGroupsPage(), page, perPage)).build();
+        } catch (KafkaExplorerException e) {
+            return Response.status(Response.Status.BAD_GATEWAY)
+                .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))
+                .build();
+        }
+    }
+
+    @POST
+    @Path("/describe-consumer-group")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @GraviteeLicenseFeature("apim-native-kafka-explorer")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = RolePermissionAction.READ) })
+    public Response describeConsumerGroup(DescribeConsumerGroupRequest request) {
+        if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("clusterId is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (request.getGroupId() == null || request.getGroupId().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("groupId is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        try {
+            var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+            var result = describeConsumerGroupUseCase.execute(
+                new DescribeConsumerGroupUseCase.Input(request.getClusterId(), environmentId, request.getGroupId())
+            );
+            return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.consumerGroupDetail())).build();
         } catch (KafkaExplorerException e) {
             return Response.status(Response.Status.BAD_GATEWAY)
                 .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -115,6 +115,16 @@ public class KafkaExplorerResource {
                 .build();
         }
 
+        if (perPage < 1 || perPage > 100) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(
+                    new KafkaExplorerError()
+                        .message("perPage must be between 1 and 100")
+                        .technicalCode(TechnicalCode.INVALID_PARAMETERS.name())
+                )
+                .build();
+        }
+
         try {
             var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
             int page0Based = page - 1;
@@ -213,6 +223,16 @@ public class KafkaExplorerResource {
         if (page < 1) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(new KafkaExplorerError().message("page must be >= 1").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (perPage < 1 || perPage > 100) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(
+                    new KafkaExplorerError()
+                        .message("perPage must be between 1 and 100")
+                        .technicalCode(TechnicalCode.INVALID_PARAMETERS.name())
+                )
                 .build();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -164,6 +164,87 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/list-consumer-groups:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: List consumer groups of a Kafka cluster
+            description: |
+                Connects to a Kafka cluster and returns the list of consumer groups with their metadata.
+            operationId: listConsumerGroups
+            parameters:
+                - name: page
+                  in: query
+                  schema:
+                      type: integer
+                      default: 1
+                  description: Page number (1-based)
+                - name: perPage
+                  in: query
+                  schema:
+                      type: integer
+                      default: 10
+                  description: Number of consumer groups per page
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ListConsumerGroupsRequest"
+            responses:
+                "200":
+                    description: List of consumer groups
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ListConsumerGroupsResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
+    /kafka-explorer/describe-consumer-group:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: Describe a Kafka consumer group
+            description: |
+                Connects to a Kafka cluster and returns detailed information about a specific consumer group including members and offsets.
+            operationId: describeConsumerGroup
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DescribeConsumerGroupRequest"
+            responses:
+                "200":
+                    description: Consumer group detail
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DescribeConsumerGroupResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
 components:
     schemas:
         DescribeClusterRequest:
@@ -437,6 +518,126 @@ components:
                     type: integer
                     format: int64
                     description: Total size of this log directory in bytes
+
+        ListConsumerGroupsRequest:
+            type: object
+            required:
+                - clusterId
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                nameFilter:
+                    type: string
+                    description: Optional filter to match consumer group IDs (case-insensitive contains)
+
+        ListConsumerGroupsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConsumerGroupSummary"
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
+
+        ConsumerGroupSummary:
+            type: object
+            properties:
+                groupId:
+                    type: string
+                state:
+                    type: string
+                    description: Consumer group state (STABLE, EMPTY, REBALANCING, DEAD, etc.)
+                membersCount:
+                    type: integer
+                    format: int32
+                totalLag:
+                    type: integer
+                    format: int64
+                    description: Total lag across all partitions
+                numTopics:
+                    type: integer
+                    format: int32
+                    description: Number of topics the consumer group has committed offsets for
+                coordinator:
+                    $ref: "#/components/schemas/KafkaNode"
+
+        DescribeConsumerGroupRequest:
+            type: object
+            required:
+                - clusterId
+                - groupId
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                groupId:
+                    type: string
+                    description: ID of the consumer group to describe
+
+        DescribeConsumerGroupResponse:
+            type: object
+            properties:
+                groupId:
+                    type: string
+                state:
+                    type: string
+                coordinator:
+                    $ref: "#/components/schemas/KafkaNode"
+                partitionAssignor:
+                    type: string
+                members:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConsumerGroupMember"
+                offsets:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ConsumerGroupOffset"
+
+        ConsumerGroupMember:
+            type: object
+            properties:
+                memberId:
+                    type: string
+                clientId:
+                    type: string
+                host:
+                    type: string
+                assignments:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/MemberAssignment"
+
+        MemberAssignment:
+            type: object
+            properties:
+                topicName:
+                    type: string
+                partitions:
+                    type: array
+                    items:
+                        type: integer
+                        format: int32
+
+        ConsumerGroupOffset:
+            type: object
+            properties:
+                topic:
+                    type: string
+                partition:
+                    type: integer
+                    format: int32
+                committedOffset:
+                    type: integer
+                    format: int64
+                endOffset:
+                    type: integer
+                    format: int64
+                lag:
+                    type: integer
+                    format: int64
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCaseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupMember;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupOffset;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.MemberAssignment;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DescribeConsumerGroupUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private DescribeConsumerGroupUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new DescribeConsumerGroupUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_consumer_group_detail() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var expectedDetail = new ConsumerGroupDetail(
+            "my-group",
+            "STABLE",
+            new KafkaNode(0, "broker-host", 9092),
+            "range",
+            List.of(
+                new ConsumerGroupMember("member-1", "client-1", "/127.0.0.1", List.of(new MemberAssignment("my-topic", List.of(0, 1))))
+            ),
+            List.of(new ConsumerGroupOffset("my-topic", 0, 50, 100, 50), new ConsumerGroupOffset("my-topic", 1, 80, 100, 20))
+        );
+        clusterDomainService.givenConsumerGroupDetail(expectedDetail);
+
+        var result = useCase.execute(new DescribeConsumerGroupUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-group"));
+
+        assertThat(result.consumerGroupDetail()).isEqualTo(expectedDetail);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
+
+        assertThatThrownBy(() -> useCase.execute(new DescribeConsumerGroupUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-group")))
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroup;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ListConsumerGroupsUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private ListConsumerGroupsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new ListConsumerGroupsUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_consumer_groups_page() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var coordinator = new KafkaNode(0, "kafka-0", 9092);
+        var allGroups = List.of(
+            new ConsumerGroup("group-a", "STABLE", 2, 100L, 3, coordinator),
+            new ConsumerGroup("group-b", "EMPTY", 0, 0L, 0, coordinator)
+        );
+        clusterDomainService.givenConsumerGroups(allGroups);
+
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25));
+
+        assertThat(result.consumerGroupsPage().data()).hasSize(2);
+        assertThat(result.consumerGroupsPage().totalCount()).isEqualTo(2);
+        assertThat(result.consumerGroupsPage().page()).isEqualTo(0);
+        assertThat(result.consumerGroupsPage().perPage()).isEqualTo(25);
+    }
+
+    @Test
+    void should_filter_consumer_groups_by_name() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var coordinator = new KafkaNode(0, "kafka-0", 9092);
+        var allGroups = List.of(
+            new ConsumerGroup("my-group", "STABLE", 2, 100L, 3, coordinator),
+            new ConsumerGroup("other-group", "EMPTY", 0, 0L, 0, coordinator),
+            new ConsumerGroup("my-other-group", "STABLE", 1, 50L, 1, coordinator)
+        );
+        clusterDomainService.givenConsumerGroups(allGroups);
+
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", 0, 25));
+
+        assertThat(result.consumerGroupsPage().data()).hasSize(2);
+        assertThat(result.consumerGroupsPage().data().get(0).groupId()).isEqualTo("my-group");
+        assertThat(result.consumerGroupsPage().data().get(1).groupId()).isEqualTo("my-other-group");
+        assertThat(result.consumerGroupsPage().totalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
+
+        assertThatThrownBy(() -> useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25)))
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeBrokerUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeConsumerGroupUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListConsumerGroupsUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceImpl;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+abstract class AbstractKafkaExplorerResourceIntegrationTest {
+
+    protected static final String BROKER_SERVICE = "broker";
+    protected static final int PLAINTEXT_PORT = 9092;
+    protected static final int SSL_PORT = 9094;
+    protected static final int SASL_PLAINTEXT_PORT = 9095;
+    protected static final String CLUSTER_ID = "test-cluster";
+    protected static final String ENVIRONMENT_ID = "test-env";
+
+    protected static final DockerComposeContainer<?> kafka;
+    protected static KafkaExplorerResource resource;
+    protected static ClusterCrudServiceInMemory clusterCrudService;
+
+    static {
+        kafka = new DockerComposeContainer<>(new File("src/test/resources/docker/docker-compose.yml"))
+            .withExposedService(BROKER_SERVICE, PLAINTEXT_PORT, Wait.forHealthcheck().withStartupTimeout(Duration.ofSeconds(60)))
+            .withExposedService(BROKER_SERVICE, SSL_PORT)
+            .withExposedService(BROKER_SERVICE, SASL_PLAINTEXT_PORT);
+        kafka.start();
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        try {
+            resource = new KafkaExplorerResource();
+            clusterCrudService = new ClusterCrudServiceInMemory();
+            var clusterService = new KafkaClusterDomainServiceImpl();
+            var objectMapper = new ObjectMapper();
+            injectField(
+                resource,
+                "describeKafkaClusterUseCase",
+                new DescribeKafkaClusterUseCase(clusterCrudService, clusterService, objectMapper)
+            );
+            injectField(resource, "listTopicsUseCase", new ListTopicsUseCase(clusterCrudService, clusterService, objectMapper));
+            injectField(resource, "describeTopicUseCase", new DescribeTopicUseCase(clusterCrudService, clusterService, objectMapper));
+            injectField(resource, "describeBrokerUseCase", new DescribeBrokerUseCase(clusterCrudService, clusterService, objectMapper));
+            injectField(
+                resource,
+                "listConsumerGroupsUseCase",
+                new ListConsumerGroupsUseCase(clusterCrudService, clusterService, objectMapper)
+            );
+            injectField(
+                resource,
+                "describeConsumerGroupUseCase",
+                new DescribeConsumerGroupUseCase(clusterCrudService, clusterService, objectMapper)
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set up integration test", e);
+        }
+    }
+
+    @BeforeEach
+    void resetClusterCrudService() {
+        clusterCrudService.reset();
+    }
+
+    protected static String plaintextBootstrapServers() {
+        return kafka.getServiceHost(BROKER_SERVICE, PLAINTEXT_PORT) + ":" + kafka.getServicePort(BROKER_SERVICE, PLAINTEXT_PORT);
+    }
+
+    protected static String sslBootstrapServers() {
+        return kafka.getServiceHost(BROKER_SERVICE, SSL_PORT) + ":" + kafka.getServicePort(BROKER_SERVICE, SSL_PORT);
+    }
+
+    protected static String saslBootstrapServers() {
+        return kafka.getServiceHost(BROKER_SERVICE, SASL_PLAINTEXT_PORT) + ":" + kafka.getServicePort(BROKER_SERVICE, SASL_PLAINTEXT_PORT);
+    }
+
+    protected static void givenClusterWithConfig(Map<String, Object> config) {
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(config).build());
+    }
+
+    protected static void injectField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest.java
@@ -17,32 +17,15 @@ package io.gravitee.rest.api.kafkaexplorer.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerRequest;
-import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
-import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicRequest;
-import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
-import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsRequest;
-import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -53,33 +36,6 @@ class KafkaExplorerResourceIntegrationTest extends AbstractKafkaExplorerResource
 
     private static final String SASL_USERNAME = "admin";
     private static final String SASL_PASSWORD = "admin-secret";
-
-    @Nested
-    class Plaintext {
-
-        @Test
-        void should_return_200_with_cluster_info() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeClusterRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.describeCluster(request);
-
-            assertThat(response.getStatus()).isEqualTo(200);
-            var body = (DescribeClusterResponse) response.getEntity();
-            assertThat(body.getClusterId()).isNotBlank();
-            assertThat(body.getController()).isNotNull();
-            assertThat(body.getNodes()).isNotEmpty();
-            assertThat(body.getTotalTopics()).isGreaterThanOrEqualTo(0);
-            assertThat(body.getTotalPartitions()).isGreaterThanOrEqualTo(0);
-
-            var firstNode = body.getNodes().get(0);
-            assertThat(firstNode.getHost()).isNotBlank();
-            assertThat(firstNode.getPort()).isGreaterThan(0);
-            assertThat(firstNode.getLeaderPartitions()).isGreaterThanOrEqualTo(0);
-            assertThat(firstNode.getReplicaPartitions()).isGreaterThanOrEqualTo(0);
-        }
-    }
 
     @Nested
     class SaslPlaintext {
@@ -108,8 +64,6 @@ class KafkaExplorerResourceIntegrationTest extends AbstractKafkaExplorerResource
             var body = (DescribeClusterResponse) response.getEntity();
             assertThat(body.getClusterId()).isNotBlank();
             assertThat(body.getNodes()).isNotEmpty();
-            assertThat(body.getTotalTopics()).isGreaterThanOrEqualTo(0);
-            assertThat(body.getTotalPartitions()).isGreaterThanOrEqualTo(0);
         }
 
         @Test
@@ -227,273 +181,6 @@ class KafkaExplorerResourceIntegrationTest extends AbstractKafkaExplorerResource
             var response = resource.describeCluster(request);
 
             assertThat(response.getStatus()).isEqualTo(502);
-        }
-    }
-
-    @Nested
-    class UnreachableBroker {
-
-        @Test
-        void should_return_502_with_connection_failed() {
-            givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeClusterRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.describeCluster(request);
-
-            assertThat(response.getStatus()).isEqualTo(502);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
-        }
-    }
-
-    @Nested
-    class InvalidRequest {
-
-        @Test
-        void should_return_400_when_request_is_null() {
-            var response = resource.describeCluster(null);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_400_when_cluster_id_is_empty() {
-            var request = new DescribeClusterRequest().clusterId("");
-
-            var response = resource.describeCluster(request);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-        }
-    }
-
-    @Nested
-    class ListTopics {
-
-        private static final String TEST_TOPIC = "test-topic-for-integration";
-        private static final int TEST_MESSAGES_COUNT = 5;
-
-        @BeforeAll
-        static void createTestTopic() throws Exception {
-            var props = new Properties();
-            props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
-            try (var admin = AdminClient.create(props)) {
-                admin.createTopics(List.of(new NewTopic(TEST_TOPIC, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
-            }
-
-            var producerProps = new Properties();
-            producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
-            producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-            producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-            try (var producer = new KafkaProducer<String, String>(producerProps)) {
-                for (int i = 0; i < TEST_MESSAGES_COUNT; i++) {
-                    producer.send(new ProducerRecord<>(TEST_TOPIC, "key-" + i, "value-" + i)).get();
-                }
-            }
-        }
-
-        @Test
-        void should_return_200_with_topics() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.listTopics(request, 1, 10);
-
-            assertThat(response.getStatus()).isEqualTo(200);
-            var body = (ListTopicsResponse) response.getEntity();
-            assertThat(body.getData()).isNotNull();
-            assertThat(body.getData()).isNotEmpty();
-            assertThat(body.getData()).anyMatch(t -> TEST_TOPIC.equals(t.getName()));
-            assertThat(body.getPagination()).isNotNull();
-            assertThat(body.getPagination().getTotalCount()).isGreaterThan(0);
-            assertThat(body.getPagination().getPage()).isEqualTo(1);
-            assertThat(body.getPagination().getPerPage()).isEqualTo(10);
-            assertThat(body.getPagination().getPageItemsCount()).isEqualTo(body.getData().size());
-            assertThat(body.getPagination().getPageCount()).isGreaterThanOrEqualTo(1);
-        }
-
-        @Test
-        void should_return_topics_with_size_and_message_count() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new ListTopicsRequest().clusterId(CLUSTER_ID).nameFilter(TEST_TOPIC);
-
-            var response = resource.listTopics(request, 1, 10);
-
-            assertThat(response.getStatus()).isEqualTo(200);
-            var body = (ListTopicsResponse) response.getEntity();
-            assertThat(body.getData()).isNotEmpty();
-            var testTopic = body
-                .getData()
-                .stream()
-                .filter(t -> TEST_TOPIC.equals(t.getName()))
-                .findFirst();
-            assertThat(testTopic).isPresent();
-            assertThat(testTopic.get().getSize()).isNotNull().isGreaterThan(0);
-            assertThat(testTopic.get().getMessageCount()).isNotNull().isEqualTo((long) TEST_MESSAGES_COUNT);
-        }
-
-        @Test
-        void should_return_400_when_request_is_null() {
-            var response = resource.listTopics(null, 1, 10);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_400_when_page_is_less_than_1() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.listTopics(request, 0, 10);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_502_when_broker_unreachable() {
-            givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.listTopics(request, 1, 10);
-
-            assertThat(response.getStatus()).isEqualTo(502);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
-        }
-    }
-
-    @Nested
-    class DescribeTopic {
-
-        private static final String DESCRIBE_TOPIC = "describe-topic-test";
-
-        @BeforeAll
-        static void createTestTopic() throws Exception {
-            var props = new Properties();
-            props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
-            try (var admin = AdminClient.create(props)) {
-                admin.createTopics(List.of(new NewTopic(DESCRIBE_TOPIC, 2, (short) 1))).all().get(10, TimeUnit.SECONDS);
-            }
-        }
-
-        @Test
-        void should_return_200_with_topic_detail() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeTopicRequest().clusterId(CLUSTER_ID).topicName(DESCRIBE_TOPIC);
-
-            var response = resource.describeTopic(request);
-
-            assertThat(response.getStatus()).isEqualTo(200);
-            var body = (DescribeTopicResponse) response.getEntity();
-            assertThat(body.getName()).isEqualTo(DESCRIBE_TOPIC);
-            assertThat(body.getInternal()).isFalse();
-            assertThat(body.getPartitions()).hasSize(2);
-            assertThat(body.getPartitions().get(0).getId()).isGreaterThanOrEqualTo(0);
-            assertThat(body.getPartitions().get(0).getLeader()).isNotNull();
-            assertThat(body.getPartitions().get(0).getReplicas()).isNotEmpty();
-            assertThat(body.getPartitions().get(0).getIsr()).isNotEmpty();
-            assertThat(body.getConfigs()).isNotEmpty();
-            assertThat(body.getConfigs()).anyMatch(c -> c.getName() != null && !c.getName().isBlank());
-        }
-
-        @Test
-        void should_return_400_when_topic_name_missing() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeTopicRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.describeTopic(request);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_502_when_broker_unreachable() {
-            givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeTopicRequest().clusterId(CLUSTER_ID).topicName(DESCRIBE_TOPIC);
-
-            var response = resource.describeTopic(request);
-
-            assertThat(response.getStatus()).isEqualTo(502);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
-        }
-    }
-
-    @Nested
-    class DescribeBroker {
-
-        @Test
-        void should_return_200_with_broker_detail() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(0);
-
-            var response = resource.describeBroker(request);
-
-            assertThat(response.getStatus()).isEqualTo(200);
-            var body = (DescribeBrokerResponse) response.getEntity();
-            assertThat(body.getId()).isEqualTo(0);
-            assertThat(body.getHost()).isNotBlank();
-            assertThat(body.getPort()).isGreaterThan(0);
-            assertThat(body.getIsController()).isNotNull();
-            assertThat(body.getLeaderPartitions()).isGreaterThanOrEqualTo(0);
-            assertThat(body.getReplicaPartitions()).isGreaterThanOrEqualTo(0);
-            assertThat(body.getLogDirEntries()).isNotNull();
-            assertThat(body.getConfigs()).isNotNull().isNotEmpty();
-        }
-
-        @Test
-        void should_return_400_when_broker_id_is_null() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID);
-
-            var response = resource.describeBroker(request);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_400_when_broker_id_is_negative() {
-            givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(-1);
-
-            var response = resource.describeBroker(request);
-
-            assertThat(response.getStatus()).isEqualTo(400);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
-        }
-
-        @Test
-        void should_return_502_when_broker_unreachable() {
-            givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
-
-            var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(0);
-
-            var response = resource.describeBroker(request);
-
-            assertThat(response.getStatus()).isEqualTo(502);
-            var error = (KafkaExplorerError) response.getEntity();
-            assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeBroker.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeBroker.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_DescribeBroker extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    @Test
+    void should_return_200_with_broker_detail() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(0);
+
+        var response = resource.describeBroker(request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (DescribeBrokerResponse) response.getEntity();
+        assertThat(body.getId()).isEqualTo(0);
+        assertThat(body.getHost()).isNotBlank();
+        assertThat(body.getPort()).isGreaterThan(0);
+        assertThat(body.getIsController()).isNotNull();
+        assertThat(body.getLeaderPartitions()).isGreaterThanOrEqualTo(0);
+        assertThat(body.getReplicaPartitions()).isGreaterThanOrEqualTo(0);
+        assertThat(body.getLogDirEntries()).isNotNull();
+        assertThat(body.getConfigs()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void should_return_400_when_broker_id_is_null() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.describeBroker(request);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_broker_id_is_negative() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(-1);
+
+        var response = resource.describeBroker(request);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeBrokerRequest().clusterId(CLUSTER_ID).brokerId(0);
+
+        var response = resource.describeBroker(request);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeCluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeCluster.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_DescribeCluster extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    @Test
+    void should_return_200_with_cluster_info() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeClusterRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.describeCluster(request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (DescribeClusterResponse) response.getEntity();
+        assertThat(body.getClusterId()).isNotBlank();
+        assertThat(body.getController()).isNotNull();
+        assertThat(body.getNodes()).isNotEmpty();
+        assertThat(body.getTotalTopics()).isGreaterThanOrEqualTo(0);
+        assertThat(body.getTotalPartitions()).isGreaterThanOrEqualTo(0);
+
+        var firstNode = body.getNodes().getFirst();
+        assertThat(firstNode.getHost()).isNotBlank();
+        assertThat(firstNode.getPort()).isGreaterThan(0);
+        assertThat(firstNode.getLeaderPartitions()).isGreaterThanOrEqualTo(0);
+        assertThat(firstNode.getReplicaPartitions()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void should_return_400_when_request_is_null() {
+        var response = resource.describeCluster(null);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_cluster_id_is_empty() {
+        var request = new DescribeClusterRequest().clusterId("");
+
+        var response = resource.describeCluster(request);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeClusterRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.describeCluster(request);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeConsumerGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeConsumerGroup.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeConsumerGroupRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeConsumerGroupResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_DescribeConsumerGroup extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    private static final String CONSUMER_GROUP_ID = "describe-cg-integration-test-group";
+    private static final String TEST_TOPIC = "describe-cg-integration-test-topic";
+
+    @BeforeAll
+    static void createTopicAndConsumerGroup() throws Exception {
+        var adminProps = new Properties();
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        try (var admin = AdminClient.create(adminProps)) {
+            admin.createTopics(List.of(new NewTopic(TEST_TOPIC, 2, (short) 1))).all().get(10, TimeUnit.SECONDS);
+        }
+
+        var producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        try (var producer = new KafkaProducer<String, String>(producerProps)) {
+            for (int i = 0; i < 10; i++) {
+                producer.send(new ProducerRecord<>(TEST_TOPIC, "key-" + i, "value-" + i)).get();
+            }
+        }
+
+        var consumerProps = new Properties();
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, CONSUMER_GROUP_ID);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        try (var consumer = new KafkaConsumer<String, String>(consumerProps)) {
+            consumer.subscribe(List.of(TEST_TOPIC));
+            consumer.poll(Duration.ofSeconds(5));
+            consumer.commitSync();
+        }
+    }
+
+    @Test
+    void should_return_200_with_consumer_group_detail() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeConsumerGroupRequest().clusterId(CLUSTER_ID).groupId(CONSUMER_GROUP_ID);
+
+        var response = resource.describeConsumerGroup(request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (DescribeConsumerGroupResponse) response.getEntity();
+        assertThat(body.getGroupId()).isEqualTo(CONSUMER_GROUP_ID);
+        assertThat(body.getState()).isNotBlank();
+        assertThat(body.getCoordinator()).isNotNull();
+        assertThat(body.getOffsets()).isNotEmpty();
+        assertThat(body.getOffsets()).allMatch(o -> TEST_TOPIC.equals(o.getTopic()));
+    }
+
+    @Test
+    void should_return_400_when_request_is_null() {
+        var response = resource.describeConsumerGroup(null);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_group_id_missing() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeConsumerGroupRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.describeConsumerGroup(request);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeConsumerGroupRequest().clusterId(CLUSTER_ID).groupId(CONSUMER_GROUP_ID);
+
+        var response = resource.describeConsumerGroup(request);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeTopic.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_DescribeTopic.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeTopicResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_DescribeTopic extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    private static final String DESCRIBE_TOPIC = "describe-topic-test";
+
+    @BeforeAll
+    static void createTestTopic() throws Exception {
+        var props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        try (var admin = AdminClient.create(props)) {
+            admin.createTopics(List.of(new NewTopic(DESCRIBE_TOPIC, 2, (short) 1))).all().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void should_return_200_with_topic_detail() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeTopicRequest().clusterId(CLUSTER_ID).topicName(DESCRIBE_TOPIC);
+
+        var response = resource.describeTopic(request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (DescribeTopicResponse) response.getEntity();
+        assertThat(body.getName()).isEqualTo(DESCRIBE_TOPIC);
+        assertThat(body.getInternal()).isFalse();
+        assertThat(body.getPartitions()).hasSize(2);
+        assertThat(body.getPartitions().getFirst().getId()).isGreaterThanOrEqualTo(0);
+        assertThat(body.getPartitions().getFirst().getLeader()).isNotNull();
+        assertThat(body.getPartitions().getFirst().getReplicas()).isNotEmpty();
+        assertThat(body.getPartitions().getFirst().getIsr()).isNotEmpty();
+        assertThat(body.getConfigs()).isNotEmpty();
+        assertThat(body.getConfigs()).anyMatch(c -> c.getName() != null && !c.getName().isBlank());
+    }
+
+    @Test
+    void should_return_400_when_topic_name_missing() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeTopicRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.describeTopic(request);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new DescribeTopicRequest().clusterId(CLUSTER_ID).topicName(DESCRIBE_TOPIC);
+
+        var response = resource.describeTopic(request);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListConsumerGroupsRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListConsumerGroupsResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    private static final String CONSUMER_GROUP_ID = "list-cg-integration-test-group";
+
+    @BeforeAll
+    static void createConsumerGroup() {
+        var consumerProps = new Properties();
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, CONSUMER_GROUP_ID);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        try (var consumer = new KafkaConsumer<String, String>(consumerProps)) {
+            consumer.subscribe(List.of("__consumer_offsets"));
+            consumer.poll(Duration.ofSeconds(5));
+            consumer.commitSync();
+        }
+    }
+
+    @Test
+    void should_return_200_with_consumer_groups() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listConsumerGroups(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListConsumerGroupsResponse) response.getEntity();
+        assertThat(body.getData()).isNotNull();
+        assertThat(body.getData()).isNotEmpty();
+        assertThat(body.getPagination()).isNotNull();
+        assertThat(body.getPagination().getPage()).isEqualTo(1);
+        assertThat(body.getPagination().getPerPage()).isEqualTo(10);
+        assertThat(body.getPagination().getTotalCount()).isGreaterThan(0);
+    }
+
+    @Test
+    void should_filter_consumer_groups_by_name() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).nameFilter(CONSUMER_GROUP_ID);
+
+        var response = resource.listConsumerGroups(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListConsumerGroupsResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        assertThat(body.getData()).allMatch(g -> g.getGroupId().contains(CONSUMER_GROUP_ID));
+    }
+
+    @Test
+    void should_return_400_when_request_is_null() {
+        var response = resource.listConsumerGroups(null, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_page_is_less_than_1() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listConsumerGroups(request, 0, 10);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listConsumerGroups(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListTopics.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListTopics.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.ListTopicsResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    private static final String TEST_TOPIC = "test-topic-for-integration";
+    private static final int TEST_MESSAGES_COUNT = 5;
+
+    @BeforeAll
+    static void createTestTopic() throws Exception {
+        var props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        try (var admin = AdminClient.create(props)) {
+            admin.createTopics(List.of(new NewTopic(TEST_TOPIC, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+        }
+
+        var producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        try (var producer = new KafkaProducer<String, String>(producerProps)) {
+            for (int i = 0; i < TEST_MESSAGES_COUNT; i++) {
+                producer.send(new ProducerRecord<>(TEST_TOPIC, "key-" + i, "value-" + i)).get();
+            }
+        }
+    }
+
+    @Test
+    void should_return_200_with_topics() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listTopics(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListTopicsResponse) response.getEntity();
+        assertThat(body.getData()).isNotNull();
+        assertThat(body.getData()).isNotEmpty();
+        assertThat(body.getData()).anyMatch(t -> TEST_TOPIC.equals(t.getName()));
+        assertThat(body.getPagination()).isNotNull();
+        assertThat(body.getPagination().getTotalCount()).isGreaterThan(0);
+        assertThat(body.getPagination().getPage()).isEqualTo(1);
+        assertThat(body.getPagination().getPerPage()).isEqualTo(10);
+        assertThat(body.getPagination().getPageItemsCount()).isEqualTo(body.getData().size());
+        assertThat(body.getPagination().getPageCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void should_return_topics_with_size_and_message_count() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListTopicsRequest().clusterId(CLUSTER_ID).nameFilter(TEST_TOPIC);
+
+        var response = resource.listTopics(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListTopicsResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        var testTopic = body
+            .getData()
+            .stream()
+            .filter(t -> TEST_TOPIC.equals(t.getName()))
+            .findFirst();
+        assertThat(testTopic).isPresent();
+        assertThat(testTopic.get().getSize()).isNotNull().isGreaterThan(0);
+        assertThat(testTopic.get().getMessageCount()).isNotNull().isEqualTo((long) TEST_MESSAGES_COUNT);
+    }
+
+    @Test
+    void should_return_400_when_request_is_null() {
+        var response = resource.listTopics(null, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_page_is_less_than_1() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listTopics(request, 0, 10);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.listTopics(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.html
@@ -15,13 +15,13 @@
     limitations under the License.
 
 -->
-<mat-card class="brokers">
-  <mat-card-header>
-    <mat-card-title>Brokers</mat-card-title>
-  </mat-card-header>
-  <mat-card-content>
-    @if (controller(); as ctrl) {
-      <div class="brokers__cluster-info">
+<div class="brokers">
+  @if (controller(); as ctrl) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Brokers</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
         <div class="brokers__cluster-info-items">
           <div class="brokers__cluster-info-item">
             <span class="mat-caption">Cluster ID</span>
@@ -44,55 +44,61 @@
             <span class="mat-body-2">{{ totalPartitions() }}</span>
           </div>
         </div>
-      </div>
-    }
+      </mat-card-content>
+    </mat-card>
+  }
 
-    <h5 class="brokers__section-title">Broker Nodes</h5>
-    <table mat-table [dataSource]="nodes()">
-      <ng-container matColumnDef="id">
-        <th mat-header-cell *matHeaderCellDef>Node ID</th>
-        <td mat-cell *matCellDef="let node">
-          <span class="brokers__node-id">
-            {{ node.id }}
-            @if (node.id === controllerId()) {
-              <span class="brokers__controller-badge">Controller</span>
-            }
-          </span>
-        </td>
-      </ng-container>
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Broker Nodes</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="nodes()">
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef>Node ID</th>
+          <td mat-cell *matCellDef="let node">
+            <span class="brokers__node-id">
+              {{ node.id }}
+              @if (node.id === controllerId()) {
+                <span class="brokers__controller-badge">Controller</span>
+              }
+            </span>
+          </td>
+        </ng-container>
 
-      <ng-container matColumnDef="host">
-        <th mat-header-cell *matHeaderCellDef>Host</th>
-        <td mat-cell *matCellDef="let node">{{ node.host }}</td>
-      </ng-container>
+        <ng-container matColumnDef="host">
+          <th mat-header-cell *matHeaderCellDef>Host</th>
+          <td mat-cell *matCellDef="let node">{{ node.host }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="port">
-        <th mat-header-cell *matHeaderCellDef>Port</th>
-        <td mat-cell *matCellDef="let node">{{ node.port }}</td>
-      </ng-container>
+        <ng-container matColumnDef="port">
+          <th mat-header-cell *matHeaderCellDef>Port</th>
+          <td mat-cell *matCellDef="let node">{{ node.port }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="rack">
-        <th mat-header-cell *matHeaderCellDef>Rack</th>
-        <td mat-cell *matCellDef="let node">{{ node.rack || '-' }}</td>
-      </ng-container>
+        <ng-container matColumnDef="rack">
+          <th mat-header-cell *matHeaderCellDef>Rack</th>
+          <td mat-cell *matCellDef="let node">{{ node.rack || '-' }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="leaderPartitions">
-        <th mat-header-cell *matHeaderCellDef>Leader Partitions</th>
-        <td mat-cell *matCellDef="let node">{{ node.leaderPartitions }}</td>
-      </ng-container>
+        <ng-container matColumnDef="leaderPartitions">
+          <th mat-header-cell *matHeaderCellDef>Leader Partitions</th>
+          <td mat-cell *matCellDef="let node">{{ node.leaderPartitions }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="replicaPartitions">
-        <th mat-header-cell *matHeaderCellDef>Replica Partitions</th>
-        <td mat-cell *matCellDef="let node">{{ node.replicaPartitions }}</td>
-      </ng-container>
+        <ng-container matColumnDef="replicaPartitions">
+          <th mat-header-cell *matHeaderCellDef>Replica Partitions</th>
+          <td mat-cell *matCellDef="let node">{{ node.replicaPartitions }}</td>
+        </ng-container>
 
-      <ng-container matColumnDef="logDirSize">
-        <th mat-header-cell *matHeaderCellDef>Disk Usage</th>
-        <td mat-cell *matCellDef="let node">{{ node.logDirSize | gkeFileSize }}</td>
-      </ng-container>
+        <ng-container matColumnDef="logDirSize">
+          <th mat-header-cell *matHeaderCellDef>Disk Usage</th>
+          <td mat-cell *matCellDef="let node">{{ node.logDirSize | gkeFileSize }}</td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="brokers__row" (click)="brokerSelect.emit(row.id)"></tr>
-    </table>
-  </mat-card-content>
-</mat-card>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="brokers__row" (click)="brokerSelect.emit(row.id)"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.component.scss
@@ -15,6 +15,10 @@
  */
 
 .brokers {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
   mat-card-content {
     overflow-x: auto;
   }
@@ -36,13 +40,6 @@
     font-weight: 500;
     background-color: var(--mat-sys-primary-container, #e8def8);
     color: var(--mat-sys-on-primary-container, #1d192b);
-  }
-
-  &__cluster-info {
-    margin-top: 4px;
-    margin-bottom: 16px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid var(--mat-sys-outline-variant, #cac4d0);
   }
 
   &__cluster-info-items {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/brokers/brokers.harness.ts
@@ -20,7 +20,7 @@ export class BrokersHarness extends ComponentHarness {
   static hostSelector = 'gke-brokers';
 
   private readonly getTable = this.locatorFor(MatTableHarness);
-  private readonly getClusterInfo = this.locatorForOptional('.brokers__cluster-info');
+  private readonly getClusterInfo = this.locatorForOptional('.brokers__cluster-info-items');
 
   async getClusterInfoText() {
     const info = await this.getClusterInfo();

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gke-consumer-group-detail [groupDetail]="groupDetail()" [loading]="loading()" (back)="onBack()" (topicSelect)="onTopicSelect($event)" />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.spec.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ConsumerGroupDetailPageComponent } from './consumer-group-detail-page.component';
+import { ConsumerGroupDetailHarness } from './consumer-group-detail.harness';
+import { fakeConsumerGroupOffset, fakeDescribeConsumerGroupResponse } from '../models/kafka-cluster.fixture';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+
+describe('ConsumerGroupDetailPageComponent', () => {
+  let fixture: ComponentFixture<ConsumerGroupDetailPageComponent>;
+  let httpTesting: HttpTestingController;
+  let loader: HarnessLoader;
+
+  const router = { navigate: jest.fn() };
+  const route = { snapshot: { params: { groupId: 'my-group' } } };
+
+  beforeEach(async () => {
+    router.navigate.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [ConsumerGroupDetailPageComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        KafkaExplorerStore,
+        provideNoopAnimations(),
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+      ],
+    }).compileComponents();
+
+    httpTesting = TestBed.inject(HttpTestingController);
+    const store = TestBed.inject(KafkaExplorerStore);
+    store.baseURL.set('/api/v2');
+    store.clusterId.set('test-cluster-id');
+
+    fixture = TestBed.createComponent(ConsumerGroupDetailPageComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushGroup(response = fakeDescribeConsumerGroupResponse()) {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-consumer-group').flush(response);
+    fixture.detectChanges();
+  }
+
+  it('should call describeConsumerGroup on init with route param', () => {
+    const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-consumer-group');
+    expect(req.request.body).toEqual({ clusterId: 'test-cluster-id', groupId: 'my-group' });
+    req.flush(fakeDescribeConsumerGroupResponse());
+  });
+
+  it('should display group id', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    expect(await harness.getGroupId()).toBe('my-group');
+  });
+
+  it('should display state badge', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    expect(await harness.getState()).toBe('STABLE');
+  });
+
+  it('should display members table', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    const rows = await harness.getMembersRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['memberId']).toBe('member-1');
+    expect(rows[0]['clientId']).toBe('client-1');
+    expect(rows[0]['host']).toBe('/127.0.0.1');
+    expect(rows[0]['assignments']).toContain('my-topic');
+  });
+
+  it('should display offsets table', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    const rows = await harness.getOffsetsRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['topic']).toBe('my-topic');
+    expect(rows[0]['partition']).toBe('0');
+    expect(rows[0]['committedOffset']).toBe('50');
+    expect(rows[0]['endOffset']).toBe('100');
+    expect(rows[0]['lag']).toContain('50');
+  });
+
+  it('should show lag warning for offsets with lag > 0', async () => {
+    flushGroup(
+      fakeDescribeConsumerGroupResponse({
+        offsets: [fakeConsumerGroupOffset({ lag: 100 })],
+      }),
+    );
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    const rows = await harness.getOffsetsRows();
+    expect(rows[0]['lag']).toContain('behind');
+  });
+
+  it('should show loading bar while loading', async () => {
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    expect(await harness.isLoading()).toBe(true);
+
+    flushGroup();
+  });
+
+  it('should not show loading bar after loading completes', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should navigate back on back button click', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    await harness.clickBack();
+
+    expect(router.navigate).toHaveBeenCalledWith(['..'], { relativeTo: route });
+  });
+
+  it('should navigate to topic detail on topic link click', async () => {
+    flushGroup();
+
+    const harness = await loader.getHarness(ConsumerGroupDetailHarness);
+    await harness.clickOffsetTopicLink(0);
+
+    expect(router.navigate).toHaveBeenCalledWith(['../../topics', 'my-topic'], { relativeTo: route });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail-page.component.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ConsumerGroupDetailComponent } from './consumer-group-detail.component';
+import { DescribeConsumerGroupResponse } from '../models/kafka-cluster.model';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+import { KafkaExplorerService } from '../services/kafka-explorer.service';
+
+@Component({
+  selector: 'gke-consumer-group-detail-page',
+  standalone: true,
+  imports: [ConsumerGroupDetailComponent],
+  templateUrl: './consumer-group-detail-page.component.html',
+})
+export class ConsumerGroupDetailPageComponent implements OnInit {
+  store = inject(KafkaExplorerStore);
+  private readonly service = inject(KafkaExplorerService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  groupDetail = signal<DescribeConsumerGroupResponse | undefined>(undefined);
+  loading = signal(false);
+
+  ngOnInit() {
+    const groupId = this.route.snapshot.params['groupId'];
+    this.loading.set(true);
+    this.service
+      .describeConsumerGroup(this.store.baseURL(), this.store.clusterId(), groupId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: detail => {
+          this.groupDetail.set(detail);
+          this.loading.set(false);
+        },
+        error: err => {
+          this.store.error.set(err?.error?.message ?? 'Failed to load consumer group details');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  onBack() {
+    this.router.navigate(['..'], { relativeTo: this.route });
+  }
+
+  onTopicSelect(topicName: string) {
+    this.router.navigate(['../../topics', topicName], { relativeTo: this.route });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.html
@@ -1,0 +1,151 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="consumer-group-detail">
+  <div class="consumer-group-detail__header">
+    <button mat-icon-button (click)="back.emit()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+    <h3 class="consumer-group-detail__title">{{ groupDetail()?.groupId }}</h3>
+    @if (groupDetail()?.state; as state) {
+      <span class="consumer-group-detail__state-badge consumer-group-detail__state-badge--{{ state | lowercase }}">{{ state }}</span>
+    }
+  </div>
+
+  @if (loading()) {
+    <mat-progress-bar mode="indeterminate" />
+  }
+
+  @if (groupDetail(); as detail) {
+    <mat-card>
+      <mat-card-content>
+        <div class="consumer-group-detail__info-items">
+          <div class="consumer-group-detail__info-item">
+            <span class="mat-caption">Coordinator</span>
+            <span class="mat-body-2">{{ detail.coordinator.host }}:{{ detail.coordinator.port }} (node {{ detail.coordinator.id }})</span>
+          </div>
+          <div class="consumer-group-detail__info-item">
+            <span class="mat-caption">Partition Assignor</span>
+            <span class="mat-body-2">{{ detail.partitionAssignor }}</span>
+          </div>
+          <div class="consumer-group-detail__info-item">
+            <span class="mat-caption">Members</span>
+            <span class="mat-body-2">{{ detail.members.length }}</span>
+          </div>
+          <div class="consumer-group-detail__info-item">
+            <span class="mat-caption">Topics</span>
+            <span class="mat-body-2">{{ countDistinctTopics(detail.offsets) }}</span>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Members</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table mat-table [dataSource]="detail.members">
+          <ng-container matColumnDef="memberId">
+            <th mat-header-cell *matHeaderCellDef>Member ID</th>
+            <td mat-cell *matCellDef="let m">{{ m.memberId }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="clientId">
+            <th mat-header-cell *matHeaderCellDef>Client ID</th>
+            <td mat-cell *matCellDef="let m">{{ m.clientId }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="host">
+            <th mat-header-cell *matHeaderCellDef>Host</th>
+            <td mat-cell *matCellDef="let m">{{ m.host }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="assignments">
+            <th mat-header-cell *matHeaderCellDef>Assignments</th>
+            <td mat-cell *matCellDef="let m">
+              @for (a of m.assignments; track a.topicName) {
+                <span
+                  ><a
+                    class="consumer-group-detail__topic-link"
+                    tabindex="0"
+                    (click)="topicSelect.emit(a.topicName); $event.stopPropagation()"
+                    (keydown.enter)="topicSelect.emit(a.topicName); $event.stopPropagation()"
+                    >{{ a.topicName }}</a
+                  >[{{ a.partitions.join(', ') }}]</span
+                >
+              }
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="memberColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: memberColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Offsets</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table mat-table [dataSource]="detail.offsets">
+          <ng-container matColumnDef="topic">
+            <th mat-header-cell *matHeaderCellDef>Topic</th>
+            <td mat-cell *matCellDef="let o">
+              <a
+                class="consumer-group-detail__topic-link"
+                tabindex="0"
+                (click)="topicSelect.emit(o.topic); $event.stopPropagation()"
+                (keydown.enter)="topicSelect.emit(o.topic); $event.stopPropagation()"
+                >{{ o.topic }}</a
+              >
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="partition">
+            <th mat-header-cell *matHeaderCellDef>Partition</th>
+            <td mat-cell *matCellDef="let o">{{ o.partition }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="committedOffset">
+            <th mat-header-cell *matHeaderCellDef>Committed Offset</th>
+            <td mat-cell *matCellDef="let o">{{ o.committedOffset }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="endOffset">
+            <th mat-header-cell *matHeaderCellDef>End Offset</th>
+            <td mat-cell *matCellDef="let o">{{ o.endOffset }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="lag">
+            <th mat-header-cell *matHeaderCellDef>Lag</th>
+            <td mat-cell *matCellDef="let o">
+              {{ o.lag }}
+              @if (o.lag > 0) {
+                <span class="consumer-group-detail__lag-warning">behind</span>
+              }
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="offsetColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: offsetColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.scss
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.consumer-group-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__title {
+    margin: 0;
+  }
+
+  &__info-items {
+    display: flex;
+    gap: 32px;
+    flex-wrap: wrap;
+  }
+
+  &__info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__state-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-surface-variant, #e7e0ec);
+    color: var(--mat-sys-on-surface-variant, #49454f);
+
+    &--stable {
+      background-color: var(--mat-sys-tertiary-container, #e8f5e9);
+      color: var(--mat-sys-on-tertiary-container, #2e7d32);
+    }
+
+    &--empty {
+      background-color: var(--mat-sys-surface-variant, #e0e0e0);
+      color: var(--mat-sys-on-surface-variant, #616161);
+    }
+
+    &--rebalancing {
+      background-color: var(--mat-sys-error-container, #fff3e0);
+      color: var(--mat-sys-on-error-container, #e65100);
+    }
+
+    &--dead {
+      background-color: var(--mat-sys-error, #ffebee);
+      color: var(--mat-sys-on-error, #c62828);
+    }
+  }
+
+  &__topic-link {
+    cursor: pointer;
+  }
+
+  &__lag-warning {
+    display: inline-block;
+    margin-left: 4px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-error-container, #fff3e0);
+    color: var(--mat-sys-on-error-container, #e65100);
+  }
+
+  mat-card-content {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.component.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTableModule } from '@angular/material/table';
+
+import { ConsumerGroupOffset, DescribeConsumerGroupResponse } from '../models/kafka-cluster.model';
+
+@Component({
+  selector: 'gke-consumer-group-detail',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatTableModule, MatIconModule, MatButtonModule, MatProgressBarModule],
+  templateUrl: './consumer-group-detail.component.html',
+  styleUrls: ['./consumer-group-detail.component.scss'],
+})
+export class ConsumerGroupDetailComponent {
+  groupDetail = input<DescribeConsumerGroupResponse | undefined>();
+  loading = input(false);
+
+  back = output<void>();
+  topicSelect = output<string>();
+
+  memberColumns = ['memberId', 'clientId', 'host', 'assignments'];
+  offsetColumns = ['topic', 'partition', 'committedOffset', 'endOffset', 'lag'];
+
+  countDistinctTopics(offsets: ConsumerGroupOffset[]): number {
+    return new Set(offsets.map(o => o.topic)).size;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-group-detail/consumer-group-detail.harness.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class ConsumerGroupDetailHarness extends ComponentHarness {
+  static hostSelector = 'gke-consumer-group-detail';
+
+  private readonly getTables = this.locatorForAll(MatTableHarness);
+  private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getTitle = this.locatorFor('.consumer-group-detail__title');
+  private readonly getStateBadge = this.locatorForOptional('.consumer-group-detail__state-badge');
+
+  async getGroupId() {
+    const title = await this.getTitle();
+    return title.text();
+  }
+
+  async getState() {
+    const badge = await this.getStateBadge();
+    return badge ? badge.text() : null;
+  }
+
+  async isLoading() {
+    return (await this.getProgressBar()) !== null;
+  }
+
+  async clickBack() {
+    const button = await this.getBackButton();
+    await button.click();
+  }
+
+  async getMembersRows() {
+    const tables = await this.getTables();
+    if (tables.length < 1) return [];
+    const rows = await tables[0].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async getOffsetsRows() {
+    const tables = await this.getTables();
+    if (tables.length < 2) return [];
+    const rows = await tables[1].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async clickOffsetTopicLink(rowIndex: number) {
+    const tables = await this.getTables();
+    const allLinks = await this.locatorForAll('.consumer-group-detail__topic-link')();
+    // Each member row may have multiple assignment links; use a simpler approach:
+    // offset topic links start after all assignment topic links
+    // For simplicity, get the offset table rows count and index from the end
+    const offsetsRows = tables.length > 1 ? await tables[1].getRows() : [];
+    const offsetLinksStart = allLinks.length - offsetsRows.length;
+    const link = allLinks[offsetLinksStart + rowIndex];
+    if (link) {
+      await link.click();
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.html
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gke-consumer-groups
+  [consumerGroups]="consumerGroupsPage()?.data ?? []"
+  [totalElements]="consumerGroupsPage()?.pagination?.totalCount ?? 0"
+  [page]="(consumerGroupsPage()?.pagination?.page ?? 1) - 1"
+  [pageSize]="consumerGroupsPage()?.pagination?.perPage ?? 25"
+  [loading]="consumerGroupsLoading()"
+  (filterChange)="onFilterChange($event)"
+  (pageChange)="onPageChange($event)"
+  (groupSelect)="onGroupSelect($event)"
+/>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ConsumerGroupsPageComponent } from './consumer-groups-page.component';
+import { ConsumerGroupsHarness } from './consumer-groups.harness';
+import { fakeConsumerGroupSummary, fakeListConsumerGroupsResponse, fakePagination } from '../models/kafka-cluster.fixture';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+
+describe('ConsumerGroupsPageComponent', () => {
+  let fixture: ComponentFixture<ConsumerGroupsPageComponent>;
+  let httpTesting: HttpTestingController;
+  let loader: HarnessLoader;
+
+  const router = { navigate: jest.fn() };
+  const route = { snapshot: { params: {} } };
+
+  beforeEach(async () => {
+    router.navigate.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [ConsumerGroupsPageComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        KafkaExplorerStore,
+        provideNoopAnimations(),
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+      ],
+    }).compileComponents();
+
+    httpTesting = TestBed.inject(HttpTestingController);
+    const store = TestBed.inject(KafkaExplorerStore);
+    store.baseURL.set('/api/v2');
+    store.clusterId.set('test-cluster-id');
+
+    fixture = TestBed.createComponent(ConsumerGroupsPageComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushConsumerGroups(response = fakeListConsumerGroupsResponse()) {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups').flush(response);
+    fixture.detectChanges();
+  }
+
+  it('should call listConsumerGroups on init', () => {
+    const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups');
+    expect(req.request.body).toEqual({ clusterId: 'test-cluster-id' });
+    expect(req.request.params.get('page')).toBe('1');
+    expect(req.request.params.get('perPage')).toBe('25');
+    req.flush(fakeListConsumerGroupsResponse());
+  });
+
+  it('should render consumer groups in the table', async () => {
+    flushConsumerGroups();
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    const rows = await harness.getRowsData();
+    expect(rows.length).toBe(3);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        groupId: 'my-group',
+        state: 'STABLE',
+        membersCount: '2',
+      }),
+    );
+    expect(rows[1]['groupId']).toBe('orders-group');
+  });
+
+  it('should render an empty table when no consumer groups', async () => {
+    flushConsumerGroups(fakeListConsumerGroupsResponse({ data: [], pagination: fakePagination({ totalCount: 0, pageItemsCount: 0 }) }));
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    expect(await harness.getRowCount()).toBe(0);
+  });
+
+  it('should show progress bar when loading', async () => {
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    expect(await harness.isLoading()).toBe(true);
+
+    flushConsumerGroups();
+  });
+
+  it('should not show progress bar after loading completes', async () => {
+    flushConsumerGroups();
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should show paginator with correct range', async () => {
+    flushConsumerGroups(
+      fakeListConsumerGroupsResponse({
+        data: [fakeConsumerGroupSummary()],
+        pagination: fakePagination({ totalCount: 50, perPage: 10, pageItemsCount: 10 }),
+      }),
+    );
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    const rangeLabel = await harness.getRangeLabel();
+    expect(rangeLabel).toContain('1');
+    expect(rangeLabel).toContain('50');
+  });
+
+  it('should reload consumer groups after filter with debounce', fakeAsync(async () => {
+    flushConsumerGroups();
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    await harness.setFilter('my');
+    tick(300);
+
+    httpTesting
+      .expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups' && req.body.nameFilter === 'my')
+      .flush(fakeListConsumerGroupsResponse());
+  }));
+
+  it('should reload consumer groups on page change', async () => {
+    flushConsumerGroups(fakeListConsumerGroupsResponse({ pagination: fakePagination({ totalCount: 50, perPage: 10 }) }));
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    await harness.goToNextPage();
+
+    httpTesting
+      .expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups' && req.params.get('page') === '2')
+      .flush(fakeListConsumerGroupsResponse());
+  });
+
+  it('should navigate to consumer group detail on group select', async () => {
+    flushConsumerGroups();
+
+    const harness = await loader.getHarness(ConsumerGroupsHarness);
+    const rows = await harness.getRows();
+    await (await rows[0].host()).click();
+
+    expect(router.navigate).toHaveBeenCalledWith(['my-group'], { relativeTo: route });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups-page.component.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
+
+import { ConsumerGroupsComponent } from './consumer-groups.component';
+import { ListConsumerGroupsResponse } from '../models/kafka-cluster.model';
+import { KafkaExplorerStore } from '../services/kafka-explorer-store.service';
+import { KafkaExplorerService } from '../services/kafka-explorer.service';
+
+@Component({
+  selector: 'gke-consumer-groups-page',
+  standalone: true,
+  imports: [ConsumerGroupsComponent],
+  templateUrl: './consumer-groups-page.component.html',
+})
+export class ConsumerGroupsPageComponent implements OnInit {
+  store = inject(KafkaExplorerStore);
+  private readonly service = inject(KafkaExplorerService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  consumerGroupsPage = signal<ListConsumerGroupsResponse | undefined>(undefined);
+  consumerGroupsLoading = signal(false);
+
+  private currentFilter = '';
+  private currentPage = 0;
+  private currentPageSize = 25;
+  private readonly filterSubject = new Subject<string>();
+
+  ngOnInit() {
+    this.loadConsumerGroups(this.currentFilter, this.currentPage, this.currentPageSize);
+
+    this.filterSubject.pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef)).subscribe(filter => {
+      this.currentFilter = filter;
+      this.currentPage = 0;
+      this.loadConsumerGroups(filter, 0, this.currentPageSize);
+    });
+  }
+
+  onFilterChange(filter: string) {
+    this.filterSubject.next(filter);
+  }
+
+  onGroupSelect(groupId: string) {
+    this.router.navigate([groupId], { relativeTo: this.route });
+  }
+
+  onPageChange(event: { page: number; pageSize: number }) {
+    this.currentPage = event.page;
+    this.currentPageSize = event.pageSize;
+    this.loadConsumerGroups(this.currentFilter, event.page, event.pageSize);
+  }
+
+  private loadConsumerGroups(nameFilter: string, page: number, pageSize: number) {
+    this.consumerGroupsLoading.set(true);
+    this.service
+      .listConsumerGroups(this.store.baseURL(), this.store.clusterId(), nameFilter || undefined, page + 1, pageSize)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => {
+          this.consumerGroupsPage.set(response);
+          this.consumerGroupsLoading.set(false);
+        },
+        error: err => {
+          this.store.error.set(err?.error?.message ?? 'Failed to load consumer groups');
+          this.consumerGroupsLoading.set(false);
+        },
+      });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.html
@@ -1,0 +1,85 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="consumer-groups">
+  <mat-card-header>
+    <mat-card-title>Consumer Groups</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <mat-form-field class="consumer-groups__filter" appearance="outline">
+      <mat-label>Filter by group ID</mat-label>
+      <input matInput (input)="onFilterInput($event)" placeholder="Search consumer groups..." />
+    </mat-form-field>
+
+    @if (loading()) {
+      <mat-progress-bar mode="indeterminate" />
+    }
+
+    <table mat-table [dataSource]="consumerGroups()">
+      <ng-container matColumnDef="groupId">
+        <th mat-header-cell *matHeaderCellDef>Group ID</th>
+        <td mat-cell *matCellDef="let group">{{ group.groupId }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="state">
+        <th mat-header-cell *matHeaderCellDef>State</th>
+        <td mat-cell *matCellDef="let group">
+          <span class="consumer-groups__state-badge consumer-groups__state-badge--{{ group.state?.toLowerCase() }}">
+            {{ group.state }}
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="membersCount">
+        <th mat-header-cell *matHeaderCellDef>Members</th>
+        <td mat-cell *matCellDef="let group">{{ group.membersCount }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="numTopics">
+        <th mat-header-cell *matHeaderCellDef>Topics</th>
+        <td mat-cell *matCellDef="let group">{{ group.numTopics }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="coordinator">
+        <th mat-header-cell *matHeaderCellDef>Coordinator</th>
+        <td mat-cell *matCellDef="let group">{{ group.coordinator?.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="totalLag">
+        <th mat-header-cell *matHeaderCellDef>Total Lag</th>
+        <td mat-cell *matCellDef="let group">
+          @if (group.totalLag > 0) {
+            <span class="consumer-groups__lag-warning">{{ group.totalLag | number }}</span>
+          } @else {
+            {{ group.totalLag | number }}
+          }
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="consumer-groups__row" (click)="groupSelect.emit(row.groupId)"></tr>
+    </table>
+
+    <mat-paginator
+      [length]="totalElements()"
+      [pageIndex]="page()"
+      [pageSize]="pageSize()"
+      [pageSizeOptions]="[25, 50, 100]"
+      (page)="onPageEvent($event)"
+    />
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.scss
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.consumer-groups {
+  mat-card-content {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+
+  &__filter {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  &__state-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-surface-variant, #e7e0ec);
+    color: var(--mat-sys-on-surface-variant, #49454f);
+
+    &--stable {
+      background-color: var(--mat-sys-tertiary-container, #e8f5e9);
+      color: var(--mat-sys-on-tertiary-container, #2e7d32);
+    }
+
+    &--empty {
+      background-color: var(--mat-sys-surface-variant, #e0e0e0);
+      color: var(--mat-sys-on-surface-variant, #616161);
+    }
+
+    &--rebalancing {
+      background-color: var(--mat-sys-error-container, #fff3e0);
+      color: var(--mat-sys-on-error-container, #e65100);
+    }
+
+    &--dead {
+      background-color: var(--mat-sys-error, #ffebee);
+      color: var(--mat-sys-on-error, #c62828);
+    }
+  }
+
+  &__lag-warning {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    background-color: var(--mat-sys-error-container, #fff3e0);
+    color: var(--mat-sys-on-error-container, #e65100);
+  }
+
+  &__row {
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--mat-sys-surface-variant, #f5f5f5);
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.component.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule, DecimalPipe } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTableModule } from '@angular/material/table';
+
+import { ConsumerGroupSummary } from '../models/kafka-cluster.model';
+
+@Component({
+  selector: 'gke-consumer-groups',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatProgressBarModule,
+    DecimalPipe,
+  ],
+  templateUrl: './consumer-groups.component.html',
+  styleUrls: ['./consumer-groups.component.scss'],
+})
+export class ConsumerGroupsComponent {
+  consumerGroups = input<ConsumerGroupSummary[]>([]);
+  totalElements = input(0);
+  page = input(0);
+  pageSize = input(25);
+  loading = input(false);
+
+  filterChange = output<string>();
+  pageChange = output<{ page: number; pageSize: number }>();
+  groupSelect = output<string>();
+
+  displayedColumns = ['groupId', 'state', 'membersCount', 'numTopics', 'coordinator', 'totalLag'];
+
+  onFilterInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.filterChange.emit(value);
+  }
+
+  onPageEvent(event: PageEvent) {
+    this.pageChange.emit({ page: event.pageIndex, pageSize: event.pageSize });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/consumer-groups/consumer-groups.harness.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatPaginatorHarness } from '@angular/material/paginator/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class ConsumerGroupsHarness extends ComponentHarness {
+  static hostSelector = 'gke-consumer-groups';
+
+  private readonly getTable = this.locatorFor(MatTableHarness);
+  private readonly getFilterInput = this.locatorFor(MatInputHarness);
+  private readonly getPaginator = this.locatorFor(MatPaginatorHarness);
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+
+  async getRows() {
+    const table = await this.getTable();
+    return table.getRows();
+  }
+
+  async getRowsData() {
+    const rows = await this.getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async getRowCount() {
+    const rows = await this.getRows();
+    return rows.length;
+  }
+
+  async setFilter(value: string) {
+    const input = await this.getFilterInput();
+    await input.setValue(value);
+  }
+
+  async getRangeLabel() {
+    const paginator = await this.getPaginator();
+    return paginator.getRangeLabel();
+  }
+
+  async goToNextPage() {
+    const paginator = await this.getPaginator();
+    await paginator.goToNextPage();
+  }
+
+  async isLoading() {
+    const progressBar = await this.getProgressBar();
+    return progressBar !== null;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.html
@@ -38,6 +38,14 @@
         <a mat-button routerLink="topics" routerLinkActive="kafka-explorer__sidebar-btn--active" class="kafka-explorer__sidebar-btn">
           Topics
         </a>
+        <a
+          mat-button
+          routerLink="consumer-groups"
+          routerLinkActive="kafka-explorer__sidebar-btn--active"
+          class="kafka-explorer__sidebar-btn"
+        >
+          Consumer Groups
+        </a>
       </aside>
       <div class="kafka-explorer__content">
         <router-outlet />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
@@ -96,7 +96,7 @@ describe('KafkaExplorerComponent', () => {
     flushCluster();
 
     const labels = await harness.getSidebarLabels();
-    expect(labels).toEqual(['Brokers', 'Topics']);
+    expect(labels).toEqual(['Brokers', 'Topics', 'Consumer Groups']);
   });
 
   it('should display brokers section by default', async () => {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
@@ -18,6 +18,8 @@ import { Routes } from '@angular/router';
 import { KafkaExplorerComponent } from './kafka-explorer.component';
 import { BrokerDetailPageComponent } from '../broker-detail/broker-detail-page.component';
 import { BrokersPageComponent } from '../brokers/brokers-page.component';
+import { ConsumerGroupDetailPageComponent } from '../consumer-group-detail/consumer-group-detail-page.component';
+import { ConsumerGroupsPageComponent } from '../consumer-groups/consumer-groups-page.component';
 import { TopicDetailPageComponent } from '../topic-detail/topic-detail-page.component';
 import { TopicsPageComponent } from '../topics/topics-page.component';
 
@@ -31,6 +33,8 @@ export const KAFKA_EXPLORER_ROUTES: Routes = [
       { path: 'brokers/:brokerId', component: BrokerDetailPageComponent },
       { path: 'topics', component: TopicsPageComponent },
       { path: 'topics/:topicName', component: TopicDetailPageComponent },
+      { path: 'consumer-groups', component: ConsumerGroupsPageComponent },
+      { path: 'consumer-groups/:groupId', component: ConsumerGroupDetailPageComponent },
     ],
   },
 ];

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -17,11 +17,17 @@ import {
   BrokerDetail,
   BrokerLogDirEntry,
   DescribeBrokerResponse,
+  ConsumerGroupMember,
+  ConsumerGroupOffset,
+  ConsumerGroupSummary,
   DescribeClusterResponse,
+  DescribeConsumerGroupResponse,
   DescribeTopicResponse,
   KafkaNode,
   KafkaTopic,
+  ListConsumerGroupsResponse,
   ListTopicsResponse,
+  MemberAssignment,
   Pagination,
   TopicConfig,
   TopicPartitionDetail,
@@ -79,7 +85,7 @@ export function fakeKafkaTopic(overrides: Partial<KafkaTopic> = {}): KafkaTopic 
 export function fakePagination(overrides: Partial<Pagination> = {}): Pagination {
   return {
     page: 1,
-    perPage: 10,
+    perPage: 25,
     pageCount: 1,
     pageItemsCount: 3,
     totalCount: 3,
@@ -164,6 +170,81 @@ export function fakeDescribeBrokerResponse(overrides: Partial<DescribeBrokerResp
     configs: [
       fakeTopicConfig({ name: 'log.retention.hours', value: '168', source: 'STATIC_BROKER_CONFIG' }),
       fakeTopicConfig({ name: 'num.partitions', value: '1', source: 'DEFAULT_CONFIG' }),
+    ],
+    ...overrides,
+  };
+}
+
+export function fakeConsumerGroupSummary(overrides: Partial<ConsumerGroupSummary> = {}): ConsumerGroupSummary {
+  return {
+    groupId: 'my-group',
+    state: 'STABLE',
+    membersCount: 2,
+    totalLag: 150,
+    numTopics: 3,
+    coordinator: fakeKafkaNode({ id: 0 }),
+    ...overrides,
+  };
+}
+
+export function fakeListConsumerGroupsResponse(overrides: Partial<ListConsumerGroupsResponse> = {}): ListConsumerGroupsResponse {
+  return {
+    data: [
+      fakeConsumerGroupSummary({ groupId: 'my-group' }),
+      fakeConsumerGroupSummary({ groupId: 'orders-group', state: 'EMPTY', membersCount: 0, totalLag: 0 }),
+      fakeConsumerGroupSummary({ groupId: 'analytics-group', state: 'STABLE', membersCount: 3, totalLag: 500 }),
+    ],
+    pagination: fakePagination(),
+    ...overrides,
+  };
+}
+
+export function fakeMemberAssignment(overrides: Partial<MemberAssignment> = {}): MemberAssignment {
+  return {
+    topicName: 'my-topic',
+    partitions: [0, 1],
+    ...overrides,
+  };
+}
+
+export function fakeConsumerGroupMember(overrides: Partial<ConsumerGroupMember> = {}): ConsumerGroupMember {
+  return {
+    memberId: 'member-1',
+    clientId: 'client-1',
+    host: '/127.0.0.1',
+    assignments: [fakeMemberAssignment()],
+    ...overrides,
+  };
+}
+
+export function fakeConsumerGroupOffset(overrides: Partial<ConsumerGroupOffset> = {}): ConsumerGroupOffset {
+  return {
+    topic: 'my-topic',
+    partition: 0,
+    committedOffset: 50,
+    endOffset: 100,
+    lag: 50,
+    ...overrides,
+  };
+}
+
+export function fakeDescribeConsumerGroupResponse(overrides: Partial<DescribeConsumerGroupResponse> = {}): DescribeConsumerGroupResponse {
+  return {
+    groupId: 'my-group',
+    state: 'STABLE',
+    coordinator: fakeKafkaNode({ id: 0 }),
+    partitionAssignor: 'range',
+    members: [
+      fakeConsumerGroupMember({ memberId: 'member-1', clientId: 'client-1' }),
+      fakeConsumerGroupMember({
+        memberId: 'member-2',
+        clientId: 'client-2',
+        assignments: [fakeMemberAssignment({ topicName: 'my-topic', partitions: [2, 3] })],
+      }),
+    ],
+    offsets: [
+      fakeConsumerGroupOffset({ topic: 'my-topic', partition: 0, committedOffset: 50, endOffset: 100, lag: 50 }),
+      fakeConsumerGroupOffset({ topic: 'my-topic', partition: 1, committedOffset: 80, endOffset: 100, lag: 20 }),
     ],
     ...overrides,
   };

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -103,3 +103,46 @@ export interface DescribeBrokerResponse {
   logDirEntries: BrokerLogDirEntry[];
   configs: TopicConfig[];
 }
+
+export interface ConsumerGroupSummary {
+  groupId: string;
+  state: string;
+  membersCount: number;
+  totalLag: number;
+  numTopics: number;
+  coordinator: KafkaNode;
+}
+
+export interface ListConsumerGroupsResponse {
+  data: ConsumerGroupSummary[];
+  pagination: Pagination;
+}
+
+export interface ConsumerGroupMember {
+  memberId: string;
+  clientId: string;
+  host: string;
+  assignments: MemberAssignment[];
+}
+
+export interface MemberAssignment {
+  topicName: string;
+  partitions: number[];
+}
+
+export interface ConsumerGroupOffset {
+  topic: string;
+  partition: number;
+  committedOffset: number;
+  endOffset: number;
+  lag: number;
+}
+
+export interface DescribeConsumerGroupResponse {
+  groupId: string;
+  state: string;
+  coordinator: KafkaNode;
+  partitionAssignor: string;
+  members: ConsumerGroupMember[];
+  offsets: ConsumerGroupOffset[];
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -17,7 +17,14 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DescribeBrokerResponse, DescribeClusterResponse, DescribeTopicResponse, ListTopicsResponse } from '../models/kafka-cluster.model';
+import {
+  DescribeBrokerResponse,
+  DescribeClusterResponse,
+  DescribeTopicResponse,
+  ListTopicsResponse,
+  DescribeConsumerGroupResponse,
+  ListConsumerGroupsResponse,
+} from '../models/kafka-cluster.model';
 
 @Injectable({
   providedIn: 'root',
@@ -29,7 +36,7 @@ export class KafkaExplorerService {
     return this.http.post<DescribeClusterResponse>(`${baseURL}/kafka-explorer/describe-cluster`, { clusterId });
   }
 
-  listTopics(baseURL: string, clusterId: string, nameFilter?: string, page = 1, perPage = 10): Observable<ListTopicsResponse> {
+  listTopics(baseURL: string, clusterId: string, nameFilter?: string, page = 1, perPage = 25): Observable<ListTopicsResponse> {
     return this.http.post<ListTopicsResponse>(
       `${baseURL}/kafka-explorer/list-topics`,
       { clusterId, nameFilter },
@@ -45,5 +52,25 @@ export class KafkaExplorerService {
 
   describeBroker(baseURL: string, clusterId: string, brokerId: number): Observable<DescribeBrokerResponse> {
     return this.http.post<DescribeBrokerResponse>(`${baseURL}/kafka-explorer/describe-broker`, { clusterId, brokerId });
+  }
+
+  listConsumerGroups(
+    baseURL: string,
+    clusterId: string,
+    nameFilter?: string,
+    page = 1,
+    perPage = 25,
+  ): Observable<ListConsumerGroupsResponse> {
+    return this.http.post<ListConsumerGroupsResponse>(
+      `${baseURL}/kafka-explorer/list-consumer-groups`,
+      { clusterId, nameFilter },
+      {
+        params: { page: page.toString(), perPage: perPage.toString() },
+      },
+    );
+  }
+
+  describeConsumerGroup(baseURL: string, clusterId: string, groupId: string): Observable<DescribeConsumerGroupResponse> {
+    return this.http.post<DescribeConsumerGroupResponse>(`${baseURL}/kafka-explorer/describe-consumer-group`, { clusterId, groupId });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.html
@@ -19,7 +19,7 @@
   [topics]="topicsPage()?.data ?? []"
   [totalElements]="topicsPage()?.pagination?.totalCount ?? 0"
   [page]="(topicsPage()?.pagination?.page ?? 1) - 1"
-  [pageSize]="topicsPage()?.pagination?.perPage ?? 10"
+  [pageSize]="topicsPage()?.pagination?.perPage ?? 25"
   [loading]="topicsLoading()"
   (filterChange)="onTopicsFilterChange($event)"
   (pageChange)="onTopicsPageChange($event)"

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.spec.ts
@@ -72,7 +72,7 @@ describe('TopicsPageComponent', () => {
     const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-topics');
     expect(req.request.body).toEqual({ clusterId: 'test-cluster-id' });
     expect(req.request.params.get('page')).toBe('1');
-    expect(req.request.params.get('perPage')).toBe('10');
+    expect(req.request.params.get('perPage')).toBe('25');
     req.flush(fakeListTopicsResponse());
   });
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/topics/topics-page.component.ts
@@ -41,7 +41,7 @@ export class TopicsPageComponent implements OnInit {
 
   private currentFilter = '';
   private currentPage = 0;
-  private currentPageSize = 10;
+  private currentPageSize = 25;
   private readonly filterSubject = new Subject<string>();
 
   ngOnInit() {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
@@ -31,4 +31,8 @@ export * from './lib/topic-detail/topic-detail.component';
 export * from './lib/topic-detail/topic-detail-page.component';
 export * from './lib/broker-detail/broker-detail.component';
 export * from './lib/broker-detail/broker-detail-page.component';
+export * from './lib/consumer-groups/consumer-groups.component';
+export * from './lib/consumer-groups/consumer-groups-page.component';
+export * from './lib/consumer-group-detail/consumer-group-detail.component';
+export * from './lib/consumer-group-detail/consumer-group-detail-page.component';
 export * from './lib/pipes/file-size.pipe';

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
@@ -22,4 +22,6 @@ export * from './lib/brokers/brokers.harness';
 export * from './lib/topics/topics.harness';
 export * from './lib/topic-detail/topic-detail.harness';
 export * from './lib/broker-detail/broker-detail.harness';
+export * from './lib/consumer-groups/consumer-groups.harness';
+export * from './lib/consumer-group-detail/consumer-group-detail.harness';
 export * from './lib/models/kafka-cluster.fixture';


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12789


## Summary
- Add consumer groups list page with pagination, filtering, and columns: Group ID, State, Members, Num Topics, Coordinator, Total Lag
- Add consumer group detail page with info card (Coordinator, Partition Assignor, Members, Topics), members table, and offsets table with clickable topic links
- Add backend endpoints: `listConsumerGroups` and `describeConsumerGroup` with domain models, use cases, and OpenAPI spec
- Change default page size from 10 to 25 across all paginated pages (topics + consumer groups)
- Refactor brokers page into info card + table card layout (consistent with consumer group detail)
- Split integration tests into separate files per endpoint for better organization

## Video
https://github.com/user-attachments/assets/bd0d9bfd-801a-40bb-921e-4c4c57c1264a
