### PR TITLE
feat: adjust look and feel of subscribe to api in nextgen portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.html
@@ -15,14 +15,7 @@
     limitations under the License.
 
 -->
-<div class="plan-list__container" [appIsNarrow]="'plan-list__container--narrow'" [appIsMobile]="'plan-list__container--mobile'">
-  @for (plan of plans; track plan.id) {
-    <app-plan-card
-      [id]="plan.id"
-      [plan]="plan"
-      [selected]="selectedPlanId() === plan.id"
-      [apiType]="api.type"
-      (selectPlan)="selectPlan.emit(plan)"
-    />
-  }
+<div class="step-header__badge">{{ stepNumber() }}</div>
+<div class="step-header__content">
+  <ng-content />
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.scss
@@ -14,42 +14,30 @@
  * limitations under the License.
  */
 
+@use '../../../../../scss/theme';
+
 :host {
   display: flex;
-  flex-flow: column;
-  gap: 24px;
-}
-
-.no-applications {
-  display: flex;
-  flex-flow: column;
   align-items: center;
-  padding: 56px 0;
-  gap: 8px;
+  gap: 16px;
+  padding: 16px;
+
+  background: #{theme.$card-background-color};
+  border-bottom: #{theme.$border-width} solid #{theme.$border-color};
 }
 
-.applications {
-  display: grid;
-  margin-top: 30px;
-  gap: 32px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.step-header__badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: #{theme.$border-width} solid #{theme.$border-color};
+}
 
-  &--narrow {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  &--mobile {
-    grid-template-columns: 1fr;
-  }
-
-  &__description {
-    display: -webkit-box;
-    overflow: hidden;
-    max-height: 98px;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 4;
-    line-clamp: 4;
-    text-overflow: ellipsis;
-    word-wrap: break-word;
-  }
+.step-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component.ts
@@ -13,46 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.subscribe-to-api-checkout {
-  &__container {
-    display: flex;
-    flex-direction: column;
-    padding-top: 32px;
-    gap: 16px;
-  }
+import { Component, input } from '@angular/core';
 
-  &__top-row {
-    display: flex;
-    flex-direction: row;
-    gap: 32px;
-
-    @media (width <= 768px) {
-      flex-direction: column;
-    }
-  }
-
-  &__subscription-info {
-    min-width: 38%;
-  }
-
-  &__api-key-card {
-    flex: 1 1 100%;
-    min-width: 0;
-  }
-
-  &__api-key-mode {
-    display: flex;
-    flex-flow: column;
-    gap: 16px;
-
-    &__radio-cards {
-      display: flex;
-      gap: 16px;
-    }
-  }
-
-  &__form {
-    padding-top: 16px;
-    width: 100%;
-  }
+@Component({
+  selector: 'app-subscribe-to-api-step-header',
+  templateUrl: './subscribe-to-api-step-header.component.html',
+  styleUrl: './subscribe-to-api-step-header.component.scss',
+})
+export class SubscribeToApiStepHeaderComponent {
+  stepNumber = input.required<number>();
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.html
@@ -16,7 +16,7 @@
 
 -->
 @if (!!applications.length) {
-  <div class="applications">
+  <div class="applications" [appIsNarrow]="'applications--narrow'" [appIsMobile]="'applications--mobile'">
     @for (application of applications; track application.id) {
       <app-radio-card
         [value]="application"
@@ -33,22 +33,14 @@
       </app-radio-card>
     }
   </div>
-  <div class="pagination">
-    <div class="m3-body-medium">
-      {{ pagination.start }} - {{ pagination.end }} <span i18n="@@paginationOf">of</span> {{ pagination.totalApplications }}
-    </div>
-    <button mat-icon-button [disabled]="pagination.start <= 1" (click)="previousPage.emit()" aria-label="Previous page of applications">
-      <mat-icon class="breadcrumb-icon">chevron_left</mat-icon>
-    </button>
-    <button
-      mat-icon-button
-      [disabled]="pagination.end >= pagination.totalApplications"
-      (click)="nextPage.emit()"
-      aria-label="Next page of applications"
-    >
-      <mat-icon class="breadcrumb-icon">chevron_right</mat-icon>
-    </button>
-  </div>
+  <app-pagination
+    [totalResults]="pagination.totalApplications"
+    [currentPage]="pagination.currentPage"
+    [pageSize]="pagination.pageSize"
+    [pageSizeOptions]="pageSizeOptions"
+    (selectPage)="pageChange.emit($event)"
+    (selectPageSize)="pageSizeChange.emit($event)"
+  />
 } @else {
   <div class="no-applications">
     <div class="m3-title-medium" i18n="@@subscribeToApiNoApplicationsFound">No application found</div>

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { signal, WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import {
+  ApplicationsPagination,
+  DEFAULT_APPLICATIONS_PAGE_SIZE,
+  SubscribeToApiChooseApplicationComponent,
+} from './subscribe-to-api-choose-application.component';
+import { fakeApplication } from '../../../../entities/application/application.fixture';
+import { ObservabilityBreakpointService } from '../../../../services/observability-breakpoint.service';
+
+class MockObservabilityBreakpointService {
+  static mockIsNarrow: WritableSignal<boolean> = signal(false);
+  static mockIsMobile: WritableSignal<boolean> = signal(false);
+
+  get isNarrow() {
+    return MockObservabilityBreakpointService.mockIsNarrow.asReadonly();
+  }
+
+  get isMobile() {
+    return MockObservabilityBreakpointService.mockIsMobile.asReadonly();
+  }
+}
+
+describe('SubscribeToApiChooseApplicationComponent', () => {
+  let component: SubscribeToApiChooseApplicationComponent;
+  let fixture: ComponentFixture<SubscribeToApiChooseApplicationComponent>;
+
+  const DEFAULT_PAGINATION: ApplicationsPagination = { currentPage: 1, totalApplications: 0, pageSize: DEFAULT_APPLICATIONS_PAGE_SIZE };
+
+  beforeEach(async () => {
+    MockObservabilityBreakpointService.mockIsNarrow = signal(false);
+    MockObservabilityBreakpointService.mockIsMobile = signal(false);
+
+    await TestBed.configureTestingModule({
+      imports: [SubscribeToApiChooseApplicationComponent, NoopAnimationsModule],
+      providers: [{ provide: ObservabilityBreakpointService, useClass: MockObservabilityBreakpointService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubscribeToApiChooseApplicationComponent);
+    component = fixture.componentInstance;
+    component.pagination = DEFAULT_PAGINATION;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit selectApplication when an application is selected', () => {
+    const app = fakeApplication({ id: 'app-1', name: 'App One' });
+    component.applications = [{ ...app, disabled: false }];
+    fixture.detectChanges();
+
+    let emitted: unknown;
+    component.selectApplication.subscribe(a => (emitted = a));
+
+    component.selectApplication.emit(app);
+
+    expect(emitted).toEqual(app);
+  });
+
+  it('should emit pageChange when page changes', () => {
+    let emittedPage: number | undefined;
+    component.pageChange.subscribe(p => (emittedPage = p));
+
+    component.pageChange.emit(2);
+
+    expect(emittedPage).toBe(2);
+  });
+
+  it('should emit pageSizeChange when page size changes', () => {
+    let emittedSize: number | undefined;
+    component.pageSizeChange.subscribe(s => (emittedSize = s));
+
+    component.pageSizeChange.emit(12);
+
+    expect(emittedSize).toBe(12);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.ts
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { MatIconButton } from '@angular/material/button';
-import { MatIcon } from '@angular/material/icon';
 
+import { PaginationComponent } from '../../../../components/pagination/pagination.component';
 import { RadioCardComponent } from '../../../../components/radio-card/radio-card.component';
+import { MobileClassDirective } from '../../../../directives/mobile-class.directive';
+import { NarrowClassDirective } from '../../../../directives/narrow-class.directive';
 import { Application } from '../../../../entities/application/application';
 import { ApplicationVM } from '../subscribe-to-api.component';
+
+export const APPLICATIONS_PAGE_SIZE_OPTIONS: number[] = [6, 12, 24, 48, 96];
+export const DEFAULT_APPLICATIONS_PAGE_SIZE = 6;
 
 export interface ApplicationsPagination {
   currentPage: number;
   totalApplications: number;
-  start: number;
-  end: number;
+  pageSize: number;
 }
 
 @Component({
   selector: 'app-subscribe-to-api-choose-application',
-  imports: [RadioCardComponent, MatIcon, MatIconButton],
+  imports: [RadioCardComponent, PaginationComponent, MobileClassDirective, NarrowClassDirective],
   templateUrl: './subscribe-to-api-choose-application.component.html',
   styleUrl: './subscribe-to-api-choose-application.component.scss',
 })
@@ -42,14 +45,16 @@ export class SubscribeToApiChooseApplicationComponent {
   selectedApplication?: Application;
 
   @Input()
-  pagination: ApplicationsPagination = { currentPage: 0, totalApplications: 0, start: 0, end: 0 };
+  pagination: ApplicationsPagination = { currentPage: 0, totalApplications: 0, pageSize: DEFAULT_APPLICATIONS_PAGE_SIZE };
 
   @Output()
   selectApplication = new EventEmitter<ApplicationVM>();
 
   @Output()
-  previousPage = new EventEmitter();
+  pageChange = new EventEmitter<number>();
 
   @Output()
-  nextPage = new EventEmitter();
+  pageSizeChange = new EventEmitter<number>();
+
+  protected readonly pageSizeOptions = APPLICATIONS_PAGE_SIZE_OPTIONS;
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.harness.ts
@@ -19,8 +19,12 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 export class SubscribeToApiChooseApplicationHarness extends ComponentHarness {
   public static hostSelector = 'app-subscribe-to-api-choose-application';
   protected locateNoApplications = this.locatorFor('.no-applications');
-  protected locateNextPage = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Next page of applications"]' }));
-  protected locatePreviousPage = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Previous page of applications"]' }));
+  protected locateNextPage = this.locatorFor(
+    MatButtonHarness.with({ selector: '[aria-label="Next page of results"].pagination__nav-button' }),
+  );
+  protected locatePreviousPage = this.locatorFor(
+    MatButtonHarness.with({ selector: '[aria-label="Previous page of results"].pagination__nav-button' }),
+  );
 
   public async noApplicationsMessageShown(): Promise<boolean> {
     return await this.locateNoApplications()

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.scss
@@ -62,11 +62,14 @@
 
 .plan-list__container {
   display: grid;
-  margin-top: 30px;
-  gap: 32px;
+  gap: 16px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 
-  @media (width <= 768px) {
+  &--narrow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  &--mobile {
     grid-template-columns: 1fr;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 import { Component, computed, EventEmitter, Input, Output, Signal, WritableSignal } from '@angular/core';
-import { MatIcon } from '@angular/material/icon';
 
-import { BannerComponent } from '../../../../components/banner/banner.component';
 import { PlanCardComponent } from '../../../../components/subscribe/plan-card/plan-card.component';
+import { MobileClassDirective } from '../../../../directives/mobile-class.directive';
+import { NarrowClassDirective } from '../../../../directives/narrow-class.directive';
 import { Api } from '../../../../entities/api/api';
 import { Plan } from '../../../../entities/plan/plan';
 
 @Component({
   selector: 'app-subscribe-to-api-choose-plan',
-  imports: [PlanCardComponent, BannerComponent, MatIcon],
+  imports: [PlanCardComponent, MobileClassDirective, NarrowClassDirective],
   templateUrl: './subscribe-to-api-choose-plan.component.html',
   styleUrl: './subscribe-to-api-choose-plan.component.scss',
 })

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
@@ -15,95 +15,99 @@
     limitations under the License.
 
 -->
-<mat-card class="subscribe-to-api" appearance="outlined">
-  @if (currentStep() === 1) {
-    <mat-card-header class="subscribe-to-api__header">
-      <div class="m3-title-large" i18n="@@subscribeChoosePlan">Choose a plan</div>
-      <div class="m3-body-medium" i18n="@@subscribeChoosePlanDescription">Select the plan that best suit for your needs.</div>
-    </mat-card-header>
-    <mat-card-content>
-      @if (plans$ | async; as plans) {
-        @if (plans.length) {
-          <app-subscribe-to-api-choose-plan
-            [plans]="plans"
-            [selectedPlan]="currentPlan"
-            [api]="api"
-            (selectPlan)="currentPlan.set($event)"
-          />
-        }
-      } @else {
-        <app-loader />
-      }
-    </mat-card-content>
-  } @else if (currentStep() === 2) {
-    <mat-card-header class="subscribe-to-api__header">
-      <div class="m3-title-large" i18n="@@subscribeChooseApplication">Choose an application</div>
-      <div class="m3-body-medium" i18n="@@subscribeChooseApplicationDescription">
-        An application represents a developer's project that interacts with the API. It acts as a means to manage access control to APIs via
-        subscriptions.
-      </div>
-    </mat-card-header>
-    <mat-card-content>
-      @if (applicationsData$ | async; as applicationsData) {
-        <app-subscribe-to-api-choose-application
-          [applications]="applicationsData.applications"
-          [selectedApplication]="currentApplication()"
-          [pagination]="applicationsData.pagination"
-          (selectApplication)="currentApplication.set($event)"
-          (previousPage)="onPreviousApplicationPage()"
-          (nextPage)="onNextApplicationPage()"
-        />
-      } @else {
-        <app-loader />
-      }
-    </mat-card-content>
-  } @else if (currentStep() === 3) {
-    <mat-card-header class="subscribe-to-api__header">
-      <div class="m3-title-large" i18n="@@subscribeConfigureConsumer">Configure Consumer</div>
-    </mat-card-header>
-    <mat-card-content>
-      <app-consumer-configuration
-        (consumerConfigurationFormDataChange)="consumerConfigurationFormChanges($event)"
-        [consumerConfigurationFormValues]="consumerConfigurationFormData().value"
-      />
-    </mat-card-content>
-  } @else if (currentStep() === 4) {
-    <mat-card-header class="subscribe-to-api__header">
-      <div class="m3-title-large" i18n="@@subscribeCheckout">Checkout</div>
-      @if (currentPlan()?.security === 'KEY_LESS') {
-        <div class="m3-body-medium" i18n="@@subscribeChooseApplicationDescription">
-          This plan does not need any subscription to consume the API.
+<div>
+  <mat-card class="subscribe-to-api" appearance="outlined">
+    @if (currentStep() === SubscribeStep.PLAN_SELECTION) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.PLAN_SELECTION)">
+        <div class="next-gen-h5" i18n="@@subscribeChoosePlan">Choose a plan</div>
+        <div class="next-gen-body" i18n="@@subscribeChoosePlanDescription">
+          A plan lets an application access an API. Once subscribed and approved, the application gets credentials to use it.
         </div>
-      }
-    </mat-card-header>
-    <mat-card-content class="subscribe-to-api__checkout">
-      @if (currentPlan(); as plan) {
-        @if (checkoutData$ | async; as checkoutData) {
-          <app-subscribe-to-api-checkout
-            [api]="api"
-            [application]="currentApplication()"
-            [plan]="plan"
-            [message]="message"
-            [subscriptionForm]="subscriptionForm()"
-            [apiKeyMode]="applicationApiKeyMode"
-            [showApiKeyModeSelection]="showApiKeyModeSelection()"
-            [applicationApiKeySubscriptions]="checkoutData.applicationApiKeySubscriptions"
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        @if (plans$ | async; as plans) {
+          @if (plans.length) {
+            <app-subscribe-to-api-choose-plan
+              [plans]="plans"
+              [selectedPlan]="currentPlan"
+              [api]="api"
+              (selectPlan)="currentPlan.set($event)"
+            />
+          }
+        } @else {
+          <app-loader />
+        }
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.APP_SELECTION) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.APP_SELECTION)">
+        <div class="next-gen-h5" i18n="@@subscribeChooseApplication">Choose an application</div>
+        <div class="next-gen-body" i18n="@@subscribeChooseApplicationDescription">
+          An application represents a developer's project that interacts with the API. It acts as a means to manage access control to APIs
+          via subscriptions.
+        </div>
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        @if (applicationsData$ | async; as applicationsData) {
+          <app-subscribe-to-api-choose-application
+            [applications]="applicationsData.applications"
+            [selectedApplication]="currentApplication()"
+            [pagination]="applicationsData.pagination"
+            (selectApplication)="currentApplication.set($event)"
+            (pageChange)="onApplicationPageChange($event)"
+            (pageSizeChange)="onApplicationPageSizeChange($event)"
           />
         } @else {
           <app-loader />
         }
-      }
-      @if (hasSubscriptionError) {
-        <div class="m3-title-medium error-message" i18n="@@subscribeToApiGeneralErrorMessage">
-          There was an error with your subscription and it could not be processed. Try again, and if the issue persists, contact your portal
-          administrator.
-        </div>
-      }
-    </mat-card-content>
-  }
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.PUSH_DETAILS) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.PUSH_DETAILS)">
+        <div class="next-gen-h5" i18n="@@subscribeConfigureConsumer">Configure Consumer</div>
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        <app-consumer-configuration
+          (consumerConfigurationFormDataChange)="consumerConfigurationFormChanges($event)"
+          [consumerConfigurationFormValues]="consumerConfigurationFormData().value"
+        />
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.REVIEW) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.REVIEW)">
+        <div class="next-gen-h5" i18n="@@subscribeReview">Review</div>
+        @if (currentPlan()?.security === 'KEY_LESS') {
+          <div class="next-gen-body" i18n="@@subscribeChooseApplicationDescription">
+            This plan does not need any subscription to consume the API.
+          </div>
+        }
+      </app-subscribe-to-api-step-header>
+      <mat-card-content class="subscribe-to-api__review">
+        @if (currentPlan(); as plan) {
+          @if (checkoutData$ | async; as checkoutData) {
+            <app-subscribe-to-api-checkout
+              [api]="api"
+              [application]="currentApplication()"
+              [plan]="plan"
+              [message]="message"
+              [apiKeyMode]="applicationApiKeyMode"
+              [showApiKeyModeSelection]="showApiKeyModeSelection()"
+              [applicationApiKeySubscriptions]="checkoutData.applicationApiKeySubscriptions"
+              [subscriptionForm]="subscriptionForm()"
+            />
+          } @else {
+            <app-loader />
+          }
+        }
+        @if (hasSubscriptionError) {
+          <div class="m3-title-medium error-message" i18n="@@subscribeToApiGeneralErrorMessage">
+            There was an error with your subscription and it could not be processed. Try again, and if the issue persists, contact your
+            portal administrator.
+          </div>
+        }
+      </mat-card-content>
+    }
+  </mat-card>
   <mat-card-actions class="subscribe-to-api__actions">
     <div>
-      @if (currentStep() > 1) {
+      @if (activeSteps().indexOf(currentStep()) > 0) {
         <button
           (click)="goToPreviousStep()"
           mat-stroked-button
@@ -113,10 +117,12 @@
         >
           Previous
         </button>
+      } @else if (cancelFn()) {
+        <button mat-stroked-button color="primary" (click)="cancelFn()!()" i18n="@@subscribeToApiCancel">Cancel</button>
       }
     </div>
     <div>
-      @if (currentStep() < 4) {
+      @if (currentStep() !== SubscribeStep.REVIEW) {
         <div class="subscribe-to-api__actions__next">
           @if (currentApplication()) {
             <div class="m3-body-medium subscribe-to-api__actions__selected-application">
@@ -129,17 +135,11 @@
               </mat-chip>
             </div>
           }
-          <button
-            (click)="goToNextStep()"
-            mat-flat-button
-            class="secondary-button"
-            [disabled]="stepIsInvalid()"
-            i18n="@@subscribeToApiNext"
-          >
+          <button (click)="goToNextStep()" mat-flat-button color="primary" [disabled]="stepIsInvalid()" i18n="@@subscribeToApiNext">
             Next
           </button>
         </div>
-      } @else if (currentStep() === 4 && currentPlan()?.security !== 'KEY_LESS') {
+      } @else if (currentStep() === SubscribeStep.REVIEW && currentPlan()?.security !== 'KEY_LESS') {
         <button (click)="subscribe()" mat-flat-button class="secondary-button" [disabled]="stepIsInvalid() || subscriptionInProgress()">
           @if (subscriptionInProgress()) {
             <span i18n="@@subscribeToApiSubscribingInProgress">Subscribing...</span>
@@ -150,4 +150,4 @@
       }
     </div>
   </mat-card-actions>
-</mat-card>
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.scss
@@ -16,15 +16,7 @@
 @use '../../../scss/theme';
 
 .subscribe-to-api {
-  margin-top: 34px;
-
-  &__header {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  &__checkout {
+  &__review {
     display: flex;
     flex-flow: column;
     gap: 32px;
@@ -41,6 +33,10 @@
     }
 
     &__selected-application {
+      --mat-chip-elevated-container-color: #{theme.$chip-background};
+      --mat-chip-container-shape-radius: #{theme.$chip-shape};
+      --mat-chip-outline-width: 0;
+
       display: flex;
       align-items: center;
       gap: 8px;

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
@@ -178,7 +178,7 @@ describe('SubscribeToApiComponent', () => {
         await goToNextStep();
         fixture.detectChanges();
 
-        expect(getTitle()).toEqual('Checkout');
+        expect(getTitle()).toEqual('Review');
         const checkout = await harnessLoader.getHarness(SubscribeToApiCheckoutHarness);
         const subscribeButton = await getSubscribeButton();
         expect(await checkout.isSubscriptionFormVisible()).toEqual(false);
@@ -223,10 +223,10 @@ describe('SubscribeToApiComponent', () => {
         await goToNextStep();
 
         fixture.detectChanges();
-        expect(getTitle()).toEqual('Checkout');
+        expect(getTitle()).toEqual('Review');
       });
     });
-    describe('Step 3 -- Checkout', () => {
+    describe('Step 2 -- Review', () => {
       describe('V4 Proxy', () => {
         beforeEach(async () => {
           await init(true, fakeApi({ id: API_ID, type: 'PROXY', definitionVersion: 'V4', entrypoints: [ENTRYPOINT] }));
@@ -236,7 +236,7 @@ describe('SubscribeToApiComponent', () => {
           await goToNextStep();
           fixture.detectChanges();
         });
-        it('should see checkout information', async () => {
+        it('should see review information', async () => {
           expect(fixture.debugElement.query(By.css('app-subscription-info'))).toBeTruthy();
           const apiAccess = await harnessLoader.getHarness(ApiAccessHarness);
           expect(apiAccess).toBeTruthy();
@@ -266,7 +266,7 @@ describe('SubscribeToApiComponent', () => {
           await goToNextStep();
           fixture.detectChanges();
         });
-        it('should see checkout information', async () => {
+        it('should see review information', async () => {
           expect(fixture.debugElement.query(By.css('app-subscription-info'))).toBeTruthy();
           const apiAccess = await harnessLoader.getHarness(ApiAccessHarness);
           expect(apiAccess).toBeTruthy();
@@ -322,7 +322,7 @@ describe('SubscribeToApiComponent', () => {
           fixture.detectChanges();
         });
 
-        it('should not allow checkout', async () => {
+        it('should not allow proceeding without an application', async () => {
           const step2 = await harnessLoader.getHarness(SubscribeToApiChooseApplicationHarness);
           expect(step2).toBeTruthy();
           expect(await step2.noApplicationsMessageShown()).toEqual(true);
@@ -398,7 +398,7 @@ describe('SubscribeToApiComponent', () => {
           await goToNextStep();
 
           fixture.detectChanges();
-          expect(getTitle()).toEqual('Checkout');
+          expect(getTitle()).toEqual('Review');
         });
 
         it('should list pages of applications and go to next step', async () => {
@@ -438,7 +438,7 @@ describe('SubscribeToApiComponent', () => {
           await goToNextStep();
 
           fixture.detectChanges();
-          expect(getTitle()).toEqual('Checkout');
+          expect(getTitle()).toEqual('Review');
         });
 
         it('should disable applications with valid subscriptions', async () => {
@@ -465,7 +465,7 @@ describe('SubscribeToApiComponent', () => {
       });
     });
 
-    describe('Step 3 -- Checkout', () => {
+    describe('Step 3 -- Review', () => {
       describe('When terms and conditions need to be accepted', () => {
         const PAGE = fakePage({
           id: GENERAL_CONDITIONS_ID,
@@ -878,7 +878,7 @@ describe('SubscribeToApiComponent', () => {
       });
     });
 
-    describe('Step 3 -- Checkout', () => {
+    describe('Step 3 -- Review', () => {
       beforeEach(async () => {
         await selectPlan(OAUTH2_PLAN_ID);
         await selectApplication();
@@ -1033,7 +1033,7 @@ describe('SubscribeToApiComponent', () => {
       });
     });
 
-    describe('Step 3 -- Checkout', () => {
+    describe('Step 3 -- Review', () => {
       beforeEach(async () => {
         await selectPlan(JWT_PLAN_ID);
         await selectApplication();
@@ -1141,7 +1141,7 @@ describe('SubscribeToApiComponent', () => {
       });
     });
 
-    describe('Step 3 -- Checkout', () => {
+    describe('Step 3 -- Review', () => {
       beforeEach(async () => {
         await selectPlan(MTLS_PLAN_ID);
         await selectApplication(APP_ID_WITH_CLIENT_CERTIFICATE);
@@ -1155,6 +1155,35 @@ describe('SubscribeToApiComponent', () => {
 
         expectPostCreateSubscription({ plan: MTLS_PLAN_ID, application: APP_ID_WITH_CLIENT_CERTIFICATE });
       });
+    });
+  });
+
+  describe('cancelFn input', () => {
+    it('should NOT show a Cancel button when cancelFn is not provided', async () => {
+      await init(false);
+      const cancelBtn = await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ text: 'Cancel' }));
+      expect(cancelBtn).toBeNull();
+    });
+
+    it('should show a Cancel button when cancelFn is provided', async () => {
+      await init(false);
+      fixture.componentRef.setInput('cancelFn', () => {});
+      fixture.detectChanges();
+
+      const cancelBtn = await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ text: 'Cancel' }));
+      expect(cancelBtn).toBeTruthy();
+    });
+
+    it('should call cancelFn when Cancel button is clicked', async () => {
+      await init(false);
+      const cancelFnSpy = jest.fn();
+      fixture.componentRef.setInput('cancelFn', cancelFnSpy);
+      fixture.detectChanges();
+
+      const cancelBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+      await cancelBtn.click();
+
+      expect(cancelFnSpy).toHaveBeenCalled();
     });
   });
 
@@ -1192,7 +1221,7 @@ describe('SubscribeToApiComponent', () => {
 
   function expectGetApplications(page: number = 1, applicationsResponse: ApplicationsResponse = fakeApplicationsResponse()) {
     httpTestingController
-      .expectOne(`${TESTING_BASE_URL}/applications?page=${page}&size=9&forSubscription=true`)
+      .expectOne(`${TESTING_BASE_URL}/applications?page=${page}&size=6&forSubscription=true`)
       .flush(applicationsResponse);
   }
 
@@ -1242,7 +1271,7 @@ describe('SubscribeToApiComponent', () => {
   }
 
   function getTitle(): string {
-    return fixture.debugElement.query(By.css('.m3-title-large')).nativeElement.textContent;
+    return fixture.debugElement.query(By.css('.next-gen-h5')).nativeElement.textContent;
   }
 
   async function selectPlan(planId: string): Promise<void> {

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, computed, DestroyRef, inject, Input, OnInit, Signal, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, Input, OnInit, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
-import { MatCard, MatCardActions, MatCardContent, MatCardHeader } from '@angular/material/card';
+import { MatCard, MatCardActions, MatCardContent } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
@@ -27,6 +27,7 @@ import { of } from 'rxjs/internal/observable/of';
 
 import { GMD_FORM_STATE_STORE, provideGmdFormStore } from '@gravitee/gravitee-markdown';
 
+import { SubscribeToApiStepHeaderComponent } from './components/subscribe-to-api-step-header/subscribe-to-api-step-header.component';
 import {
   TermsAndConditionsDialogComponent,
   TermsAndConditionsDialogData,
@@ -34,6 +35,7 @@ import {
 import { SubscribeToApiCheckoutComponent } from './subscribe-to-api-checkout/subscribe-to-api-checkout.component';
 import {
   ApplicationsPagination,
+  DEFAULT_APPLICATIONS_PAGE_SIZE,
   SubscribeToApiChooseApplicationComponent,
 } from './subscribe-to-api-choose-application/subscribe-to-api-choose-application.component';
 import { SubscribeToApiChoosePlanComponent } from './subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component';
@@ -53,6 +55,13 @@ import { PageService } from '../../../services/page.service';
 import { PlanService } from '../../../services/plan.service';
 import { PortalService } from '../../../services/portal.service';
 import { SubscriptionService } from '../../../services/subscription.service';
+
+export enum SubscribeStep {
+  PLAN_SELECTION = 'PLAN_SELECTION',
+  APP_SELECTION = 'APP_SELECTION',
+  PUSH_DETAILS = 'PUSH_DETAILS',
+  REVIEW = 'REVIEW',
+}
 
 export interface ApplicationVM extends Application {
   disabled?: boolean;
@@ -76,8 +85,8 @@ interface CheckoutData {
     SubscribeToApiCheckoutComponent,
     SubscribeToApiChoosePlanComponent,
     SubscribeToApiChooseApplicationComponent,
+    SubscribeToApiStepHeaderComponent,
     MatCardActions,
-    MatCardHeader,
     MatCardContent,
     MatButton,
     LoaderComponent,
@@ -102,12 +111,32 @@ export class SubscribeToApiComponent implements OnInit {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly matDialog = inject(MatDialog);
   private readonly currentApplicationsPage = new BehaviorSubject(1);
+  private readonly currentApplicationsPageSize = new BehaviorSubject(DEFAULT_APPLICATIONS_PAGE_SIZE);
 
   @Input() api!: Api;
+  cancelFn = input<() => void>();
 
-  currentStep = signal(1);
+  readonly SubscribeStep = SubscribeStep;
+
+  currentStep = signal<SubscribeStep>(SubscribeStep.PLAN_SELECTION);
   currentPlan = signal<Plan | undefined>(undefined);
   currentApplication = signal<Application | undefined>(undefined);
+
+  activeSteps = computed<SubscribeStep[]>(() => {
+    const plan = this.currentPlan();
+    const steps: SubscribeStep[] = [SubscribeStep.PLAN_SELECTION];
+
+    if (plan?.security !== 'KEY_LESS') {
+      steps.push(SubscribeStep.APP_SELECTION);
+      if (plan?.mode === 'PUSH') {
+        steps.push(SubscribeStep.PUSH_DETAILS);
+      }
+    }
+
+    steps.push(SubscribeStep.REVIEW);
+    return steps;
+  });
+
   message = signal<string>('');
   applicationApiKeyMode = signal<'EXCLUSIVE' | 'SHARED' | 'UNSPECIFIED' | null>(null);
   subscriptionInProgress = signal<boolean>(false);
@@ -135,20 +164,23 @@ export class SubscribeToApiComponent implements OnInit {
   });
   formIsValid = this.store.formValid;
   stepIsInvalid: Signal<boolean> = computed(() => {
-    if (this.currentStep() === 1) {
-      return this.currentPlan() === undefined;
-    } else if (this.currentStep() === 2) {
-      return this.currentApplication() === undefined;
-    } else if (this.currentStep() === 3) {
-      return !this.consumerConfigurationFormData().isValid;
-    } else if (this.currentStep() === 4) {
-      if (this.showApiKeyModeSelection() && !this.applicationApiKeyMode()) {
-        return true;
+    switch (this.currentStep()) {
+      case SubscribeStep.PLAN_SELECTION:
+        return this.currentPlan() === undefined;
+      case SubscribeStep.APP_SELECTION:
+        return this.currentApplication() === undefined;
+      case SubscribeStep.PUSH_DETAILS:
+        return !this.consumerConfigurationFormData().isValid;
+      case SubscribeStep.REVIEW: {
+        if (this.showApiKeyModeSelection() && !this.applicationApiKeyMode()) {
+          return true;
+        }
+        const showSubscriptionForm = this.subscriptionForm()?.gmdContent && this.currentPlan()?.security !== 'KEY_LESS';
+        return showSubscriptionForm ? !this.formIsValid() : false;
       }
-      const showSubscriptionForm = this.subscriptionForm()?.gmdContent && this.currentPlan()?.security !== 'KEY_LESS';
-      return showSubscriptionForm ? !this.formIsValid() : false;
+      default:
+        return false;
     }
-    return false;
   });
 
   ngOnInit(): void {
@@ -158,9 +190,11 @@ export class SubscribeToApiComponent implements OnInit {
     );
 
     this.applicationsData$ = this.subscriptionService.list({ apiIds: [this.api.id], statuses: ['PENDING', 'ACCEPTED'], size: -1 }).pipe(
-      combineLatestWith(this.currentApplicationsPage),
-      switchMap(([subscriptions, page]) => this.getApplicationsData$(page, subscriptions)),
-      catchError(_ => of({ applications: [], pagination: { currentPage: 0, totalApplications: 0, start: 0, end: 0 } })),
+      combineLatestWith(this.currentApplicationsPage, this.currentApplicationsPageSize),
+      switchMap(([subscriptions, page, pageSize]) => this.getApplicationsData$(page, pageSize, subscriptions)),
+      catchError(_ =>
+        of({ applications: [], pagination: { currentPage: 0, totalApplications: 0, pageSize: DEFAULT_APPLICATIONS_PAGE_SIZE } }),
+      ),
     );
 
     this.checkoutData$ = this.handleCheckoutData$(this.api).pipe(
@@ -178,34 +212,33 @@ export class SubscribeToApiComponent implements OnInit {
     this.consumerConfigurationFormData.set(data);
   }
 
+  stepNumberOf(step: SubscribeStep): number {
+    return this.activeSteps().indexOf(step) + 1;
+  }
+
   goToNextStep(): void {
-    if (this.currentPlan()?.mode !== 'PUSH' && this.currentStep() === 2) {
-      this.currentStep.set(4);
-    } else if (this.currentPlan()?.security === 'KEY_LESS' && this.currentStep() === 1) {
-      this.currentStep.set(4);
-    } else if (this.currentStep() < 4) {
-      this.currentStep.update(currentStep => currentStep + 1);
+    const steps = this.activeSteps();
+    const currentIndex = steps.indexOf(this.currentStep());
+    if (currentIndex < steps.length - 1) {
+      this.currentStep.set(steps[currentIndex + 1]);
     }
   }
 
   goToPreviousStep(): void {
-    if (this.currentPlan()?.mode !== 'PUSH' && this.currentPlan()?.security !== 'KEY_LESS' && this.currentStep() === 4) {
-      this.currentStep.set(2);
-    } else if (this.currentPlan()?.security === 'KEY_LESS' && this.currentStep() === 4) {
-      this.currentStep.set(1);
-    } else if (this.currentStep() > 1) {
-      this.currentStep.update(currentStep => currentStep - 1);
+    const steps = this.activeSteps();
+    const currentIndex = steps.indexOf(this.currentStep());
+    if (currentIndex > 0) {
+      this.currentStep.set(steps[currentIndex - 1]);
     }
   }
 
-  onNextApplicationPage() {
-    this.currentApplicationsPage.next(this.currentApplicationsPage.getValue() + 1);
+  onApplicationPageChange(page: number) {
+    this.currentApplicationsPage.next(page);
   }
 
-  onPreviousApplicationPage() {
-    if (this.currentApplicationsPage.getValue() > 1) {
-      this.currentApplicationsPage.next(this.currentApplicationsPage.getValue() - 1);
-    }
+  onApplicationPageSizeChange(pageSize: number) {
+    this.currentApplicationsPageSize.next(pageSize);
+    this.currentApplicationsPage.next(1);
   }
 
   subscribe() {
@@ -268,15 +301,14 @@ export class SubscribeToApiComponent implements OnInit {
     return consumerConfiguration;
   }
 
-  private getApplicationsData$(page: number, subscriptionsResponse: SubscriptionsResponse): Observable<ApplicationsData> {
-    return this.applicationService.list(page, 9, true).pipe(
+  private getApplicationsData$(page: number, pageSize: number, subscriptionsResponse: SubscriptionsResponse): Observable<ApplicationsData> {
+    return this.applicationService.list(page, pageSize, true).pipe(
       map(response => ({
         applications: this.addApplicationDisabledState(response, subscriptionsResponse),
         pagination: {
           currentPage: response.metadata?.pagination?.current_page ?? 0,
           totalApplications: response.metadata?.pagination?.total ?? 0,
-          start: response.metadata?.pagination?.first ?? 0,
-          end: response.metadata?.pagination?.last ?? 0,
+          pageSize,
         },
       })),
       tap(({ applications }) => {
@@ -326,7 +358,7 @@ export class SubscribeToApiComponent implements OnInit {
 
     return applicationsResponse.data.map(application => {
       if (this.applicationHasExistingValidSubscriptionsForPlan(application, subscriptions.data)) {
-        return { ...application, disabled: true, disabledMessage: 'A pending or accepted subscription already exists for this plan' };
+        return { ...application, disabled: true, disabledMessage: 'A subscription already exists for this plan' };
       }
       if (this.applicationInSharedKeyModeHasExistingValidApiKeySubscriptionsForApi(application, subscriptions)) {
         return {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
@@ -16,10 +16,14 @@
 
 -->
 <div class="content">
-  <a [routerLink]="['/documentation', navId()]" [queryParams]="{ pageId: pageId() }" class="documentation-subscribe__back-link">
-    <span class="material-icons">arrow_back</span>
-    <span i18n="@@documentationSubscribeBack">Back to Documentation</span>
+  <a
+    [routerLink]="['/documentation', navId()]"
+    [queryParams]="{ pageId: pageId() }"
+    class="documentation-subscribe__back-link internal-link"
+  >
+    <mat-icon>arrow_backward</mat-icon>
+    <span i18n="@@documentationSubscribeBack">Back to API</span>
   </a>
-  <div class="next-gen-h3"><span i18n="@@documentationSubscribeCTA">Subscribe to an API:</span> {{ api().name }}</div>
-  <app-subscribe-to-api [api]="api()" />
+  <div class="next-gen-h3"><span i18n="@@documentationSubscribeCTA">Subscribe to the API:</span> {{ api().name }}</div>
+  <app-subscribe-to-api [api]="api()" [cancelFn]="cancel" />
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
@@ -23,6 +23,4 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  text-decoration: none;
-  color: app-theme.$default-text-color;
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Component, inject, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Router, RouterModule } from '@angular/router';
 
 import { Api } from '../../../../entities/api/api';
 import { SubscribeToApiComponent } from '../../../api/subscribe-to-api/subscribe-to-api.component';
 
 @Component({
   selector: 'app-documentation-subscribe',
-  imports: [RouterModule, SubscribeToApiComponent],
+  imports: [RouterModule, SubscribeToApiComponent, MatIconModule],
   templateUrl: './documentation-subscribe.component.html',
   styleUrls: ['./documentation-subscribe.component.scss'],
 })
@@ -29,4 +30,8 @@ export class DocumentationSubscribeComponent {
   api = input.required<Api>();
   navId = input.required<string>();
   pageId = input<string>();
+
+  private router = inject(Router);
+
+  cancel = () => this.router.navigate(['/documentation', this.navId(), 'api', this.api().id]);
 }

--- a/gravitee-apim-portal-webui-next/src/components/radio-card/radio-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/radio-card/radio-card.component.html
@@ -22,7 +22,7 @@
         @if (displayPicture) {
           <app-picture [hashValue]="pictureHashValue" [size]="40" [picture]="pictureUrl" />
         }
-        <div aria-label="Title" class="m3-title-medium">{{ title }}</div>
+        <div aria-label="Title" class="next-gen-h5">{{ title }}</div>
       </div>
       @if (disabled) {
         <div class="radio-card__header-content__disable-icon">

--- a/gravitee-apim-portal-webui-next/src/components/radio-card/radio-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/radio-card/radio-card.component.scss
@@ -67,12 +67,15 @@
   --mat-radio-selected-hover-icon-color: #{theme.$primary-main-color} !important;
   --mat-radio-selected-icon-color: #{theme.$primary-main-color} !important;
   --mat-radio-selected-pressed-icon-color: #{theme.$primary-main-color} !important;
+  --mat-card-outlined-container-color: #{theme.$card-background-color};
 
   padding: 0;
   border: 2px solid #{theme.$tertiary-main-color};
 }
 
 .radio-card.disabled {
+  --mat-card-outlined-container-color: #{theme.$card-background-color};
+
   cursor: not-allowed;
 
   .radio-card__header-content__title {

--- a/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.html
@@ -23,25 +23,29 @@
   [title]="plan().name"
   (selectItem)="onSelectPlan()"
 >
-  <div class="m3-body-medium">Plan includes:</div>
-  <ul class="plan-card__content">
-    <li class="m3-body-medium">Authentication: {{ authentication() }}</li>
+  @if (plan().description) {
+    <p class="next-gen-body">{{ plan().description }}</p>
+  }
+  <mat-chip-set class="plan-card__badges">
+    @if (authentication()) {
+      <mat-chip>{{ authentication() }}</mat-chip>
+    }
+    @if (plan().validation === 'AUTO') {
+      <mat-chip i18n="@@planCardNoApproval">No approval</mat-chip>
+    } @else {
+      <mat-chip i18n="@@planCardRequiresApproval">Requires approval</mat-chip>
+    }
     @if (!!plan().usage_configuration?.quota?.limit) {
-      <li class="m3-body-medium">
-        Quota: up to {{ plan().usage_configuration?.quota?.limit ?? 0 }} hits /
+      <mat-chip>
+        Quota: up to {{ plan().usage_configuration?.quota?.limit }} hits /
         {{ plan().usage_configuration?.quota ?? {} | toPeriodTimeUnitLabelPipe }}
-      </li>
+      </mat-chip>
     }
     @if (!!plan().usage_configuration?.rate_limit?.limit) {
-      <li class="m3-body-medium">
-        Rate-limit: up to {{ plan().usage_configuration?.rate_limit?.limit ?? 0 }} hits /
+      <mat-chip>
+        Rate-limit: up to {{ plan().usage_configuration?.rate_limit?.limit }} hits /
         {{ plan().usage_configuration?.rate_limit ?? {} | toPeriodTimeUnitLabelPipe }}
-      </li>
+      </mat-chip>
     }
-  </ul>
-  @if (plan().security !== 'KEY_LESS') {
-    <div class="m3-body-medium">
-      {{ plan().validation === 'AUTO' ? 'The subscription is automatic.' : 'The subscription is under admin review.' }}
-    </div>
-  }
+  </mat-chip-set>
 </app-radio-card>

--- a/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.scss
@@ -37,14 +37,16 @@
   &__content {
     min-height: 80px;
   }
-}
 
-.plan-card.selected {
-  border: 1px solid #{theme.$tertiary-main-color};
-  background-color: #{theme.$banner-background-color};
-}
+  &__badges {
+    --mat-chip-elevated-container-color: #{theme.$chip-background};
+    --mat-chip-container-shape-radius: #{theme.$chip-shape};
+    --mat-chip-outline-width: 0;
 
-.plan-card.disabled {
-  cursor: not-allowed;
-  opacity: 0.2;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 16px;
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { PlanCardComponent } from './plan-card.component';
+import { fakePlan } from '../../../entities/plan/plan.fixture';
+
+describe('PlanCardComponent', () => {
+  let component: PlanCardComponent;
+  let fixture: ComponentFixture<PlanCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlanCardComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlanCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('plan', fakePlan({ security: 'API_KEY', mode: 'STANDARD' }));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('authentication()', () => {
+    it('should return null for PUSH mode plan', () => {
+      fixture.componentRef.setInput('plan', fakePlan({ mode: 'PUSH' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBeNull();
+    });
+
+    it('should return SASL/SSL PLAIN label for NATIVE API with API_KEY security', () => {
+      component.apiType = 'NATIVE';
+      fixture.componentRef.setInput('plan', fakePlan({ security: 'API_KEY', mode: 'STANDARD' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBe('SASL/SSL with SASL mechanisms PLAIN, SCRAM-256, and SCRAM-512');
+    });
+
+    it('should return SASL/SSL OAUTHBEARER label for NATIVE API with JWT security', () => {
+      component.apiType = 'NATIVE';
+      fixture.componentRef.setInput('plan', fakePlan({ security: 'JWT', mode: 'STANDARD' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBe('SASL/SSL with SASL mechanism OAUTHBEARER');
+    });
+
+    it('should return SASL/SSL OAUTHBEARER label for NATIVE API with OAUTH2 security', () => {
+      component.apiType = 'NATIVE';
+      fixture.componentRef.setInput('plan', fakePlan({ security: 'OAUTH2', mode: 'STANDARD' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBe('SASL/SSL with SASL mechanism OAUTHBEARER');
+    });
+
+    it('should return SSL for NATIVE API with KEY_LESS security (default case)', () => {
+      component.apiType = 'NATIVE';
+      fixture.componentRef.setInput('plan', fakePlan({ security: 'KEY_LESS', mode: 'STANDARD' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBe('SSL');
+    });
+
+    it('should return standard security label for non-NATIVE API', () => {
+      component.apiType = 'PROXY';
+      fixture.componentRef.setInput('plan', fakePlan({ security: 'API_KEY', mode: 'STANDARD' }));
+      fixture.detectChanges();
+
+      expect(component.authentication()).toBe('API Key');
+    });
+  });
+
+  describe('onSelectPlan()', () => {
+    it('should emit selectPlan when not disabled', () => {
+      const plan = fakePlan({ security: 'API_KEY', mode: 'STANDARD' });
+      fixture.componentRef.setInput('plan', plan);
+      component.disabled = false;
+      fixture.detectChanges();
+
+      let emitted: unknown;
+      component.selectPlan.subscribe(p => (emitted = p));
+
+      component.onSelectPlan();
+
+      expect(emitted).toEqual(plan);
+    });
+
+    it('should NOT emit selectPlan when disabled', () => {
+      fixture.componentRef.setInput('plan', fakePlan());
+      component.disabled = true;
+      fixture.detectChanges();
+
+      let emitted = false;
+      component.selectPlan.subscribe(() => (emitted = true));
+
+      component.onSelectPlan();
+
+      expect(emitted).toBeFalsy();
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscribe/plan-card/plan-card.component.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 import { Component, computed, EventEmitter, input, Input, Output } from '@angular/core';
+import { MatChipsModule } from '@angular/material/chips';
 
 import { ApiType } from '../../../entities/api/api';
-import { getPlanSecurityTypeLabel, Plan, PlanSecurityEnum } from '../../../entities/plan/plan';
+import { getPlanSecurityTypeLabel, Plan, PlanMode, PlanSecurityEnum } from '../../../entities/plan/plan';
 import { ToPeriodTimeUnitLabelPipe } from '../../../pipe/time-unit.pipe';
 import { RadioCardComponent } from '../../radio-card/radio-card.component';
 
 @Component({
   selector: 'app-plan-card',
-  imports: [ToPeriodTimeUnitLabelPipe, RadioCardComponent],
+  imports: [ToPeriodTimeUnitLabelPipe, RadioCardComponent, MatChipsModule],
   templateUrl: './plan-card.component.html',
   providers: [ToPeriodTimeUnitLabelPipe],
   styleUrl: './plan-card.component.scss',
@@ -42,11 +43,14 @@ export class PlanCardComponent {
 
   plan = input.required<Plan>();
 
-  authentication = computed(() => {
+  authentication = computed<string | null>(() => {
+    if (this.plan().mode === PlanMode.PUSH) {
+      return null;
+    }
     if (this.apiType === 'NATIVE') {
       return this.getNativeSecurityLabel(this.plan().security);
     }
-    return getPlanSecurityTypeLabel(this.plan().security);
+    return getPlanSecurityTypeLabel(this.plan().security) || null;
   });
 
   onSelectPlan() {

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.scss
@@ -48,8 +48,8 @@
 
     &__subsections {
       display: flex;
-      flex-wrap: wrap;
-      gap: 15px 100px;
+      flex-direction: column;
+      gap: 15px;
     }
 
     &__grid {

--- a/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/subscription-comment-dialog/subscription-comment-dialog.component.html
@@ -26,7 +26,7 @@
     <div class="m3-body-medium">{{ data.plan.comment_question }}</div>
   } @else {
     <div class="m3-body-medium" i18n="@@subscribeToApiCommentSubtitle">
-      Please provide a brief explanation of why you want to use this API
+      Briefly explain why you need this API so the owner can review your request.
     </div>
   }
   <form [formGroup]="commentForm">

--- a/gravitee-apim-portal-webui-next/src/directives/narrow-class.directive.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/directives/narrow-class.directive.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, signal, WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { NarrowClassDirective } from './narrow-class.directive';
+import { ObservabilityBreakpointService } from '../services/observability-breakpoint.service';
+
+@Component({
+  template: `<div [appIsNarrow]="'table-narrow'" (triggerBreakpoint)="onBreakpoint($event)">Test Element</div>`,
+  standalone: true,
+  imports: [NarrowClassDirective],
+})
+class TestHostWithOutputComponent {
+  lastBreakpoint: 'narrow' | null | undefined;
+  onBreakpoint(value: 'narrow' | null) {
+    this.lastBreakpoint = value;
+  }
+}
+
+class MockObservabilityBreakpointService {
+  static mockIsNarrow: WritableSignal<boolean>;
+
+  get isNarrow() {
+    return MockObservabilityBreakpointService.mockIsNarrow.asReadonly();
+  }
+}
+
+@Component({
+  template: `<div [appIsNarrow]="'table-narrow'">Test Element</div>`,
+  standalone: true,
+  imports: [NarrowClassDirective],
+})
+class TestHostComponent {}
+
+describe('NarrowClassDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    // Reset the static signal before each test
+    MockObservabilityBreakpointService.mockIsNarrow = signal(false);
+
+    await TestBed.configureTestingModule({
+      // Import the host component (which imports the directive)
+      imports: [TestHostComponent],
+      providers: [
+        // Provide the mock service
+        {
+          provide: ObservabilityBreakpointService,
+          useClass: MockObservabilityBreakpointService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    // Find the element the directive is applied to
+    element = fixture.debugElement.query(By.directive(NarrowClassDirective)).nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    const directive = fixture.debugElement.query(By.directive(NarrowClassDirective));
+    expect(directive).toBeTruthy();
+  });
+
+  it('should NOT have the "table-narrow" class when isNarrow is false', () => {
+    // Set signal value
+    MockObservabilityBreakpointService.mockIsNarrow.set(false);
+
+    // Trigger change detection
+    fixture.detectChanges();
+
+    // Assert
+    expect(element.classList.contains('table-narrow')).toBeFalsy();
+  });
+
+  it('SHOULD have the "table-narrow" class when isNarrow is true', () => {
+    // Set signal value
+    MockObservabilityBreakpointService.mockIsNarrow.set(true);
+
+    // Trigger change detection
+    fixture.detectChanges();
+
+    // Assert
+    expect(element.classList.contains('table-narrow')).toBeTruthy();
+  });
+
+  it('should reactively toggle the class when the signal changes', () => {
+    // Start as false
+    MockObservabilityBreakpointService.mockIsNarrow.set(false);
+    fixture.detectChanges();
+    expect(element.classList.contains('table-narrow')).toBeFalsy();
+
+    // Change to true
+    MockObservabilityBreakpointService.mockIsNarrow.set(true);
+    fixture.detectChanges();
+    expect(element.classList.contains('table-narrow')).toBeTruthy();
+
+    // Change back to false
+    MockObservabilityBreakpointService.mockIsNarrow.set(false);
+    fixture.detectChanges();
+    expect(element.classList.contains('table-narrow')).toBeFalsy();
+  });
+});
+
+describe('NarrowClassDirective - triggerBreakpoint output', () => {
+  let fixture: ComponentFixture<TestHostWithOutputComponent>;
+  let hostComponent: TestHostWithOutputComponent;
+
+  beforeEach(async () => {
+    MockObservabilityBreakpointService.mockIsNarrow = signal(false);
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostWithOutputComponent],
+      providers: [{ provide: ObservabilityBreakpointService, useClass: MockObservabilityBreakpointService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostWithOutputComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should emit "narrow" when isNarrow becomes true', () => {
+    MockObservabilityBreakpointService.mockIsNarrow.set(true);
+    fixture.detectChanges();
+
+    expect(hostComponent.lastBreakpoint).toBe('narrow');
+  });
+
+  it('should emit null when isNarrow becomes false after being true', () => {
+    MockObservabilityBreakpointService.mockIsNarrow.set(true);
+    fixture.detectChanges();
+
+    MockObservabilityBreakpointService.mockIsNarrow.set(false);
+    fixture.detectChanges();
+
+    expect(hostComponent.lastBreakpoint).toBeNull();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/directives/narrow-class.directive.ts
+++ b/gravitee-apim-portal-webui-next/src/directives/narrow-class.directive.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, inject, input, computed, ElementRef, Renderer2, effect, output } from '@angular/core';
+
+import { ObservabilityBreakpointService } from '../services/observability-breakpoint.service';
+
+/**
+ * Conditionally applies a CSS class to the host element when the viewport is detected as narrow
+ * by the `ObservabilityBreakpointService`.
+ *
+ * @usage
+ * <div [appIsNarrow]="'my-narrow-class'">...</div>
+ *
+ * @param appIsNarrow The string name of the CSS class to apply when the state is narrow.
+ */
+@Directive({
+  selector: '[appIsNarrow]',
+  standalone: true,
+})
+export class NarrowClassDirective {
+  public appIsNarrow = input<string>();
+
+  triggerBreakpoint = output<'narrow' | null>();
+
+  private el = inject(ElementRef);
+  private renderer = inject(Renderer2);
+  private isNarrowState = inject(ObservabilityBreakpointService).isNarrow;
+  private activeNarrowClass = computed(() => {
+    return this.isNarrowState() ? this.appIsNarrow() : null;
+  });
+
+  constructor() {
+    effect(onCleanup => {
+      const className = this.activeNarrowClass();
+      if (className) {
+        this.renderer.addClass(this.el.nativeElement, className);
+        this.triggerBreakpoint.emit('narrow');
+      }
+      onCleanup(() => {
+        if (className) {
+          this.renderer.removeClass(this.el.nativeElement, className);
+          this.triggerBreakpoint.emit(null);
+        }
+      });
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
@@ -34,6 +34,7 @@ $error-main-color: var(--gio-app-error-main-color);
 
 // -- Shapes --
 $container-shape: 8px;
+$chip-shape: 16px;
 
 // Dimensions
 $inner-content-width: 1440px;
@@ -116,7 +117,7 @@ $table-body-background-color: var(--gio-app-table-body-container-color, $card-ba
 $table-header-headline-color: var(--gio-app-table-header-headline-color, $default-text-color);
 
 // -- Other Components --
-$chip-background: var(--gio-app-chip-container-color, $card-background-color);
+$chip-background: var(--gio-app-chip-container-color, #e1e5ed);
 $select-panel-background-color: color-mix(in srgb, $banner-background-color 12%, $card-background-color);
 $calendar-background-color: color-mix(in srgb, $banner-background-color 50%, $card-background-color);
 $primary-highlight-color: color-mix(in srgb, $primary-main-color 8%, white 92%);

--- a/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/observability-breakpoint.service.ts
@@ -30,4 +30,14 @@ export class ObservabilityBreakpointService {
       shareReplay({ refCount: true, bufferSize: 1 }),
     );
   readonly isMobile = toSignal(this.isMobile$);
+
+  // Using Breakpoints.XSmall + Small + Medium for narrow viewports (max-width: 1279.98px)
+  // This covers phones, small tablets, and medium tablets — cards grid switches to 2-col below this threshold
+  readonly isNarrow$ = inject(BreakpointObserver)
+    .observe([Breakpoints.XSmall, Breakpoints.Small, Breakpoints.Medium])
+    .pipe(
+      map(state => state.matches),
+      shareReplay({ refCount: true, bufferSize: 1 }),
+    );
+  readonly isNarrow = toSignal(this.isNarrow$);
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-63

## Description

This PR adjusts the look and feel of the "Subscribe to API" flow in the next-gen portal. It touches the multi-step subscription wizard — plan selection, application selection, and review — updating the visual structure, layout, and styling to align with the new design. 

**Adjusted the content and styling of the "Subscribe to API" flow components**:

- SubscribeToApiChoosePlanComponent
- SubscribeToApiChooseApplicationComponent
- SubscribeToApiCheckoutComponent (renamed to SubscribeToApiReviewComponent)
- SubscribeToApiComponent

**New common components introduced**:

- SubscribeToApiStepHeaderComponent

**Other adjustments:**

- ObservabilityBreakpointService — added isNarrow signal
- PlanCardComponent — minor styling updates
- RadioCardComponent — minor content update
- SubscriptionInfoComponent — minor styling update
- SubscriptionCommentDialogComponent — minor content update
- DocumentationSubscribeComponent — updated to reflect new subscription flow structure

**Open items / To be confirmed**

Content:

- [x] Confirm if we should keep common Review page for all type of APIs or create dedicated one "Calling the API" for keyless plan like on Figma
- [x] Confirm Review page content - should we leave current parameters or we want to reorganize it?
- [x] Decide how to display security info for push plans -> currently no chip is displayed

Styling:

- [x] Confirm selected/disabled card background color — Figma defines #f4f7fd but it resolves to transparent
- [x] Confirm if --mat-chip-container-shape-radius: 16px is needed for chip styling in plan card
- [x] Cancel/Previous  button styling - confirm if should keep current button with border + blue text vs Figma
- [x] Confirm: Selected Application styling - should we make it identical to Security Plan chips (no border?)

Technical:

- [x] ~~Consider reusing BannerComponent for the step header~~ -> skip as per Ivan comment
- [x] ~~Consider reusing CardsGridComponent from [#15436](https://github.com/gravitee-io/gravitee-api-management/pull/15436) for plan and application grids~~ -> skip as per Ivan comment


**Video:**

https://github.com/user-attachments/assets/71f4f4cf-4ca7-4bcb-af48-94c9228f74b3

**Screenshots:**
<img width="2498" height="1289" alt="Screenshot 2026-03-06 at 10 11 30" src="https://github.com/user-attachments/assets/0a86cd77-d907-4a9f-924d-972ff8f05b3b" />
<img width="972" height="1302" alt="Screenshot 2026-03-06 at 10 11 41" src="https://github.com/user-attachments/assets/5f25a49d-6308-4c07-bc96-7880971232e8" />
<img width="518" height="1297" alt="Screenshot 2026-03-06 at 10 11 53" src="https://github.com/user-attachments/assets/2ce9767d-3c39-4b82-90be-fced85e88af7" />
