### PR TITLE
fix: inconsistency with tab permission check

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
@@ -78,7 +78,7 @@ export class PortalNavigationService {
       displayName: 'Subscription Form',
       routerLink: 'subscription-form',
       icon: 'gio:list-check',
-      permissions: ['environment-settings-r', 'environment-settings-u'],
+      permissions: ['environment-metadata-r', 'environment-metadata-u'],
     },
   ];
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12948

## Description

Fixed a permission mismatch for the "Subscription Form" navigation item in PortalNavigationService. The menu item was guarded by environment-settings-* permissions, while the route guard required environment-metadata-*. This caused the tab to be visible but non-navigable for users without metadata permissions. Aligned the navigation service permissions with the route definition.

## Additional context

Tab is now not visible if you don't have either `'environment-metadata-r'` or `'environment-metadata-u'` permissions 

