### PR TITLE
feat: add confirmation dialog for updating scheduled alerts

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
@@ -23,6 +23,9 @@
         <h1 ng-if="!$ctrl.updateMode">[{{ $ctrl.titlePrefix }}] Create a new alert</h1>
         <a ng-click="$ctrl.backToAlerts()">Back to alerts</a>
       </div>
+      <div class="gv-forms-header" ng-if="$ctrl.updateMode && $ctrl.alert.updated_at">
+        <span class="gv-subtitle"> Last updated at {{ $ctrl.alert.updated_at | date:'medium' }} </span>
+      </div>
 
       <div class="gv-page-draft-banner" ng-if="$ctrl.status.available_plugins === 0">
         <ng-md-icon icon="warning" class="gv-warning"></ng-md-icon>
@@ -271,7 +274,8 @@
           <md-button
             ng-if="$ctrl.hasPermissionForCurrentScope('alert-u') && $ctrl.updateMode"
             class="md-raised md-primary"
-            type="submit"
+            type="button"
+            ng-click="$ctrl.onUpdate($ctrl.alert)"
             ng-disabled="$ctrl.status.available_plugins === 0 || $ctrl.formAlert.$invalid || $ctrl.formAlert.$pristine"
           >
             Update


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- Display a confirmation dialog when updating an alert that has a scheduled duration (duration + timeUnit condition), warning the user that saving will reset the evaluation schedule
- Show the "Last updated at" timestamp on the alert edit page in both AngularJS and Angular views

Demo:

https://github.com/user-attachments/assets/e7545049-91f4-4959-a062-815b307e5c38



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

