### PR TITLE
fix: race condition in HttpDynamicPropertiesServiceTest advanceTimeBy

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceTest.java
@@ -866,6 +866,15 @@ class HttpDynamicPropertiesServiceTest {
      * @param configuration the configuration needed to build the {@link CronTrigger}
      */
     private void advanceTimeBy(final int delay, HttpDynamicPropertiesService cut, HttpDynamicPropertiesServiceConfiguration configuration) {
+        // Allow I/O threads to complete any pending repeat re-subscriptions and schedule
+        // the next timer on the test scheduler before advancing virtual time.
+        // Without this, a race condition exists: the test scheduler can advance past the
+        // next timer's scheduled time before the I/O thread has had a chance to schedule it.
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         TimeProvider.overrideClock(
             Clock.fixed(Instant.ofEpochMilli(testScheduler.now(TimeUnit.MILLISECONDS) + delay), ZoneId.systemDefault())
         );


### PR DESCRIPTION
## Issue

No Jira ticket — fixing a flaky CI test.

## Description

- Fixed race condition in `HttpDynamicPropertiesServiceTest.advanceTimeBy()` that caused `should_publish_dynamic_properties_multiple_times` to intermittently fail on CI with `expected: 4, got: 3`.
- Added a 50ms `Thread.sleep` before advancing the `TestScheduler` to allow I/O threads to complete pending RxJava `.repeat()` re-subscriptions and schedule the next timer.

## Additional context

**Root cause:** `scheduleInBackground()` uses `Observable.timer(...).repeat()`. When a timer fires, `fetchProperties()` runs an HTTP call on I/O threads. After the event is published, `awaitCount(N)` returns on the test thread, but the `.repeat()` re-subscription (which schedules the *next* timer on the `TestScheduler`) is still in progress on the I/O thread. If `advanceTimeBy()` runs before that timer is scheduled, it's missed — resulting in fewer events than expected.

**Reproduction:** Spying on `EventManagerImpl.publishEvent()` with a 200ms delay on I/O threads (simulating CI thread contention) reliably produces `expected: 4, got: 3` — identical to the CI error.

**Fix:** A brief `Thread.sleep(50)` at the start of `advanceTimeBy()` gives I/O threads time to complete the re-subscription chain before virtual time advances. This is a standard pattern when mixing `TestScheduler` with real async I/O threads.