### PR TITLE
feat: Added api product subscription changes

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -16,6 +16,8 @@
 
 import { PrimaryOwner } from '../api';
 
+export type ApiProductDeploymentState = 'NEED_REDEPLOY' | 'DEPLOYED';
+
 export interface ApiProduct {
   /**
    * API Product's unique identifier.
@@ -49,5 +51,10 @@ export interface ApiProduct {
    * The primary owner of the API Product.
    */
   primaryOwner?: PrimaryOwner;
+  /**
+   * Indicates whether the API Product is in sync with the latest deployment.
+   */
+  deploymentState?: ApiProductDeploymentState;
+
   _links?: { [key: string]: string };
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/verifyApiProductDeploy.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/verifyApiProductDeploy.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
-export * from './verifyApiProductDeploy';
+export interface VerifyApiProductDeployResponse {
+  ok?: boolean;
+  reason?: string;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.guard.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.guard.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { firstValueFrom, of, throwError } from 'rxjs';
+
+import { ApiProductsGuard } from './api-products.guard';
+
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { CONSTANTS_TESTING } from '../../shared/testing';
+import { Constants } from '../../entities/Constants';
+
+describe('ApiProductsGuard', () => {
+  const API_PRODUCT_ID = 'product-guard-test';
+
+  let permissionService: GioPermissionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        GioPermissionService,
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    permissionService = TestBed.inject(GioPermissionService);
+  });
+
+  afterEach(() => {
+    TestBed.inject(HttpTestingController).verify();
+    jest.clearAllMocks();
+  });
+
+  const fakeRoute = { params: { apiProductId: API_PRODUCT_ID } } as unknown as ActivatedRouteSnapshot;
+  const fakeState = {} as RouterStateSnapshot;
+
+  describe('loadPermissions', () => {
+    it('loads API product permissions and returns true', async () => {
+      const loadSpy = jest.spyOn(permissionService, 'loadApiProductPermissions').mockReturnValue(of(undefined));
+
+      const result = await TestBed.runInInjectionContext(() =>
+        firstValueFrom(ApiProductsGuard.loadPermissions(fakeRoute, fakeState) as ReturnType<typeof of>),
+      );
+
+      expect(loadSpy).toHaveBeenCalledWith(API_PRODUCT_ID);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when permission load fails', async () => {
+      jest.spyOn(permissionService, 'loadApiProductPermissions').mockReturnValue(throwError(() => ({ error: { message: 'Forbidden' } })));
+
+      const result = await TestBed.runInInjectionContext(() =>
+        firstValueFrom(ApiProductsGuard.loadPermissions(fakeRoute, fakeState) as ReturnType<typeof of>),
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearPermissions', () => {
+    it('clears API product permissions on deactivation', () => {
+      const clearSpy = jest.spyOn(permissionService, 'clearApiProductPermissions');
+
+      TestBed.runInInjectionContext(() => {
+        ApiProductsGuard.clearPermissions(null, fakeRoute, fakeState, fakeState);
+      });
+
+      expect(clearSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.guard.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.guard.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateFn, CanDeactivateFn } from '@angular/router';
+import { catchError, map } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+
+export const ApiProductsGuard: {
+  loadPermissions: CanActivateFn;
+  clearPermissions: CanDeactivateFn<unknown>;
+} = {
+  loadPermissions: (route: ActivatedRouteSnapshot) => {
+    return inject(GioPermissionService)
+      .loadApiProductPermissions(route.params['apiProductId'])
+      .pipe(
+        map(() => true),
+        catchError(() => of(false)),
+      );
+  },
+
+  clearPermissions: () => {
+    inject(GioPermissionService).clearApiProductPermissions();
+    return true;
+  },
+};

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -16,6 +16,8 @@
 
 import { Routes } from '@angular/router';
 
+import { ApiProductsGuard } from './api-products.guard';
+
 export const API_PRODUCTS_ROUTES: Routes = [
   {
     path: '',
@@ -39,6 +41,8 @@ export const API_PRODUCTS_ROUTES: Routes = [
   {
     path: ':apiProductId',
     loadComponent: () => import('./navigation/api-product-navigation.component').then(m => m.ApiProductNavigationComponent),
+    canActivate: [ApiProductsGuard.loadPermissions],
+    canDeactivate: [ApiProductsGuard.clearPermissions],
     children: [
       {
         path: '',
@@ -52,6 +56,38 @@ export const API_PRODUCTS_ROUTES: Routes = [
       {
         path: 'apis',
         loadComponent: () => import('./apis/api-product-apis.component').then(m => m.ApiProductApisComponent),
+      },
+      {
+        path: 'consumers',
+        redirectTo: 'consumers/plans',
+        pathMatch: 'full',
+      },
+      {
+        path: 'consumers/plans',
+        loadComponent: () => import('./plans/list/api-product-plan-list.component').then(m => m.ApiProductPlanListComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-r'],
+          },
+        },
+      },
+      {
+        path: 'consumers/plans/new',
+        loadComponent: () => import('./plans/edit/api-product-plan-edit.component').then(m => m.ApiProductPlanEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-c'],
+          },
+        },
+      },
+      {
+        path: 'consumers/plans/:planId',
+        loadComponent: () => import('./plans/edit/api-product-plan-edit.component').then(m => m.ApiProductPlanEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-plan-r'],
+          },
+        },
       },
     ],
   },

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -89,6 +89,26 @@ export const API_PRODUCTS_ROUTES: Routes = [
           },
         },
       },
+      {
+        path: 'consumers/subscriptions',
+        loadComponent: () =>
+          import('./subscriptions/list/api-product-subscription-list.component').then(m => m.ApiProductSubscriptionListComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-subscription-r'],
+          },
+        },
+      },
+      {
+        path: 'consumers/subscriptions/:subscriptionId',
+        loadComponent: () =>
+          import('./subscriptions/edit/api-product-subscription-edit.component').then(m => m.ApiProductSubscriptionEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-subscription-r'],
+          },
+        },
+      },
     ],
   },
 ];

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.harness.ts
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
-export * from './verifyApiProductDeploy';
+export class ApiProductConfirmDeploymentDialogHarness extends ComponentHarness {
+  static hostSelector = 'api-product-confirm-deployment-dialog';
+
+  async clickDeploy(): Promise<void> {
+    const btn = await this.locatorFor(MatButtonHarness.with({ text: 'Deploy' }))();
+    return btn.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<span matDialogTitle>Deploy your API Product</span>
+
+<mat-dialog-content class="content">
+  <p class="mat-body-2">You are about to deploy your API Product to the gateway. All subscribed consumers will be affected.</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+  <button color="primary" mat-raised-button aria-label="Deploy the API Product" data-testid="deploy_button" (click)="onDeploy()">
+    Deploy
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { ApiProductConfirmDeploymentDialogComponent } from './api-product-confirm-deployment-dialog.component';
+import { ApiProductConfirmDeploymentDialogHarness } from './api-product-confirm-deployment-dialog.component.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+describe('ApiProductConfirmDeploymentDialogComponent', () => {
+  const API_PRODUCT_ID = 'api-product-deploy-test';
+
+  let fixture: ComponentFixture<ApiProductConfirmDeploymentDialogComponent>;
+  let harness: ApiProductConfirmDeploymentDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRefClose: jest.Mock;
+  const snackBarService = { success: jest.fn(), error: jest.fn() };
+
+  beforeEach(async () => {
+    dialogRefClose = jest.fn();
+    await TestBed.configureTestingModule({
+      imports: [ApiProductConfirmDeploymentDialogComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: SnackBarService, useValue: snackBarService },
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+        { provide: MAT_DIALOG_DATA, useValue: { apiProductId: API_PRODUCT_ID } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductConfirmDeploymentDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductConfirmDeploymentDialogHarness);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should close dialog and show success snackbar on successful deploy', async () => {
+    await harness.clickDeploy();
+
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments`, method: 'POST' })
+      .flush({ id: API_PRODUCT_ID, name: 'Product', version: '1.0' });
+    await fixture.whenStable();
+
+    expect(dialogRefClose).toHaveBeenCalled();
+    expect(snackBarService.success).toHaveBeenCalledWith('API Product successfully deployed.');
+  });
+
+  it('should show error snackbar and keep dialog open when deploy fails', async () => {
+    await harness.clickDeploy();
+
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments`, method: 'POST' })
+      .flush({ message: 'Deployment not allowed' }, { status: 400, statusText: 'Bad Request' });
+    await fixture.whenStable();
+
+    expect(snackBarService.error).toHaveBeenCalled();
+    expect(dialogRefClose).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { catchError, EMPTY, tap } from 'rxjs';
+
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+export interface ApiProductConfirmDeploymentDialogData {
+  apiProductId: string;
+}
+
+export type ApiProductConfirmDeploymentDialogResult = void;
+
+@Component({
+  selector: 'api-product-confirm-deployment-dialog',
+  templateUrl: './api-product-confirm-deployment-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule],
+})
+export class ApiProductConfirmDeploymentDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<ApiProductConfirmDeploymentDialogComponent, ApiProductConfirmDeploymentDialogResult>>(MatDialogRef);
+  private readonly dialogData = inject<ApiProductConfirmDeploymentDialogData>(MAT_DIALOG_DATA);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  onDeploy(): void {
+    this.apiProductV2Service
+      .deploy(this.dialogData.apiProductId)
+      .pipe(
+        tap(() => {
+          this.dialogRef.close();
+          this.snackBarService.success('API Product successfully deployed.');
+        }),
+        catchError(err => {
+          this.snackBarService.error(`An error occurred while deploying the API Product.\n${err.error?.message ?? err.message}.`);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.scss
@@ -13,11 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
-export * from './verifyApiProductDeploy';

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.ts
@@ -25,6 +25,7 @@ export interface ApiProductTabMenuItem {
 @Component({
   selector: 'api-product-navigation-tabs',
   templateUrl: './api-product-navigation-tabs.component.html',
+  styleUrls: ['./api-product-navigation-tabs.component.scss'],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterModule, MatTabsModule],

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -16,7 +16,7 @@
 
 -->
 
-@if (currentApiProduct$ | async; as currentApiProduct) {
+@if (currentApiProduct(); as currentApiProduct) {
   <div class="api-product-navigation">
     <div class="api-product-navigation__menu">
       <gio-submenu class="api-product-navigation__submenu">
@@ -47,7 +47,38 @@
       }
 
       <div class="api-product-navigation__content__view">
-        <router-outlet></router-outlet>
+        @if (banners().length > 0) {
+          <div class="api-product-navigation__content__view__banners">
+            @for (banner of banners(); track banner.title) {
+              <gio-banner [type]="banner.type">
+                {{ banner.title }}
+                @if (banner.action) {
+                  <div gioBannerAction>
+                    <button mat-stroked-button color="basic" (click)="banner.action.onClick()" [disabled]="isActionDisabled()">
+                      {{ banner.action.btnText }}
+                    </button>
+                  </div>
+                }
+                @if (banner.body) {
+                  <div gioBannerBody [innerHTML]="banner.body"></div>
+                }
+              </gio-banner>
+            }
+          </div>
+        }
+        @if (selectedItemHeader(); as header) {
+          <div class="api-product-navigation__content__view__section-header">
+            <div class="mat-h2">{{ header.title }}</div>
+            @if (header.subtitle) {
+              <div class="api-product-navigation__content__view__section-header__subtitle">{{ header.subtitle }}</div>
+            }
+          </div>
+        }
+        @if (selectedItemWithTabs(); as itemWithTabs) {
+          <api-product-navigation-tabs [tabMenuItems]="itemWithTabs.tabs"><router-outlet></router-outlet></api-product-navigation-tabs>
+        } @else {
+          <router-outlet></router-outlet>
+        }
       </div>
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.scss
@@ -48,7 +48,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       &__name {
         @include mat.m2-typography-level($typography, subtitle-1);
         margin: 0;
-        padding: 16px 20px;
+        padding: 1rem 1.25rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -61,7 +61,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       align-items: center;
 
       &__icon {
-        margin-right: 8px;
+        margin-right: 0.5rem;
         color: $textColor;
         width: 1.25rem;
         height: 1.25rem;
@@ -70,7 +70,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
   }
 
   &__breadcrumb {
-    padding: 16px 32px 0 32px;
+    padding: 1rem 2rem 0 2rem;
 
     &__item {
       display: contents;
@@ -88,7 +88,19 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       flex-direction: column;
       flex: 1 1 auto;
       height: 100%;
-      margin: 12px 24px 0 24px;
+      margin: 0.75rem 1.5rem 0 1.5rem;
+
+      &__section-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-bottom: 1.5rem;
+
+        &__subtitle {
+          color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+          @include mat.m2-typography-level($typography, 'body-2');
+        }
+      }
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -28,6 +26,8 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { Constants } from '../../../entities/Constants';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductNavigationComponent', () => {
   const API_PRODUCT_ID = 'product-1';
@@ -39,9 +39,21 @@ describe('ApiProductNavigationComponent', () => {
   };
 
   let fixture: ComponentFixture<ApiProductNavigationComponent>;
-  let _loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
   const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  function flushRequests(product: ApiProduct, verifyOk = true, verifyReason?: string): void {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`).flush(product);
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments/_verify`)
+      .flush({ ok: verifyOk, ...(verifyReason ? { reason: verifyReason } : {}) });
+  }
+
+  function createFixture(): void {
+    fixture = TestBed.createComponent(ApiProductNavigationComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -49,6 +61,7 @@ describe('ApiProductNavigationComponent', () => {
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -59,11 +72,6 @@ describe('ApiProductNavigationComponent', () => {
         },
       ],
     }).compileComponents();
-
-    fixture = TestBed.createComponent(ApiProductNavigationComponent);
-    _loader = TestbedHarnessEnvironment.loader(fixture);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
   });
 
   afterEach(() => {
@@ -72,16 +80,15 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should create', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should display API product name when loaded', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    expect(req.request.method).toBe('GET');
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -89,8 +96,8 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should display Configuration menu item', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush(fakeApiProduct);
+    createFixture();
+    flushRequests(fakeApiProduct);
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -98,10 +105,95 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should show snackbar on load error', async () => {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    req.flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    createFixture();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`)
+      .flush({ message: 'Not found' }, { status: 404, statusText: 'Not Found' });
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/deployments/_verify`)
+      .flush({ ok: true });
     await fixture.whenStable();
 
     expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+
+  it('should not show out-of-sync banner when API Product is deployed', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'DEPLOYED' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('out of sync');
+  });
+
+  it('should show out-of-sync banner with Deploy button when NEED_REDEPLOY and license ok', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+    expect(fixture.nativeElement.textContent).toContain('Deploy API Product');
+  });
+
+  it('should show out-of-sync banner without Deploy button when user lacks update permission', async () => {
+    TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: [] });
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+    expect(fixture.nativeElement.textContent).not.toContain('Deploy API Product');
+  });
+
+  it('should show cannot-be-deployed banner with body when license check fails', async () => {
+    createFixture();
+    flushRequests(fakeApiProduct, false, 'API Product deployment requires a universe license.');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product cannot be deployed.');
+    expect(fixture.nativeElement.innerHTML).toContain('API Product deployment requires a universe license.');
+  });
+
+  it('should re-fetch api product and show banner after planStateVersion changes', async () => {
+    createFixture();
+    flushRequests({ ...fakeApiProduct, deploymentState: 'DEPLOYED' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('out of sync');
+
+    TestBed.inject(ApiProductV2Service).notifyPlanStateChanged();
+    fixture.detectChanges();
+
+    flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
+  });
+
+  describe('Consumers menu item visibility', () => {
+    it('should show consumers menu item when user has api product plan read permission', async () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-plan-r'] });
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Consumers');
+    });
+
+    it('should hide consumers menu item when user lacks api product plan read permission', async () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-definition-r'] });
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('Consumers');
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -52,8 +52,6 @@ export interface MenuItem {
   displayName: string;
   routerLink: string;
   icon?: string;
-  tabs?: ApiProductTabMenuItem[];
-  header?: { title: string; subtitle?: string };
 }
 
 type TopBanner = {

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -160,7 +160,6 @@ export class ApiProductNavigationComponent {
     }
 
     const banners: TopBanner[] = [];
-    const canUpdateApiProduct = this.permissionService.hasAnyMatching(['api_product-definition-u']);
 
     if (apiProduct.deploymentState === 'NEED_REDEPLOY' && verifyDeployResponse.ok) {
       banners.push(

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -14,30 +14,75 @@
  * limitations under the License.
  */
 
-import { AsyncPipe } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { GioBreadcrumbModule, GioIconsModule, GioMenuModule, GioMenuService, GioSubmenuModule } from '@gravitee/ui-particles-angular';
-import { catchError, filter, map, of, startWith, switchMap } from 'rxjs';
+import {
+  GIO_DIALOG_WIDTH,
+  GioBannerModule,
+  GioBannerTypes,
+  GioBreadcrumbModule,
+  GioIconsModule,
+  GioMenuModule,
+  GioMenuService,
+  GioSubmenuModule,
+} from '@gravitee/ui-particles-angular';
+import { catchError, combineLatest, filter, map, of, startWith, switchMap, tap } from 'rxjs';
 
+import {
+  ApiProductConfirmDeploymentDialogComponent,
+  ApiProductConfirmDeploymentDialogData,
+  ApiProductConfirmDeploymentDialogResult,
+} from './api-product-confirm-deployment-dialog/api-product-confirm-deployment-dialog.component';
+import {
+  ApiProductNavigationTabsComponent,
+  ApiProductTabMenuItem,
+} from './api-product-navigation-tabs/api-product-navigation-tabs.component';
+
+import { VerifyApiProductDeployResponse } from '../../../entities/management-api-v2/api-product';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 export interface MenuItem {
   displayName: string;
   routerLink: string;
   icon?: string;
+  tabs?: ApiProductTabMenuItem[];
+  header?: { title: string; subtitle?: string };
 }
+
+type TopBanner = {
+  title: string;
+  body?: string;
+  type: GioBannerTypes;
+  action?: {
+    btnText: string;
+    onClick: () => void;
+  };
+};
 
 @Component({
   selector: 'api-product-navigation',
   templateUrl: './api-product-navigation.component.html',
   styleUrls: ['./api-product-navigation.component.scss'],
   standalone: true,
-  imports: [AsyncPipe, RouterModule, GioSubmenuModule, GioIconsModule, GioBreadcrumbModule, GioMenuModule, MatIconModule, MatTooltipModule],
+  imports: [
+    RouterModule,
+    GioSubmenuModule,
+    GioIconsModule,
+    GioBreadcrumbModule,
+    GioMenuModule,
+    GioBannerModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    ApiProductNavigationTabsComponent,
+  ],
 })
 export class ApiProductNavigationComponent {
   private readonly router = inject(Router);
@@ -45,13 +90,17 @@ export class ApiProductNavigationComponent {
   private readonly gioMenuService = inject(GioMenuService);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
 
-  readonly subMenuItems: MenuItem[] = [
-    { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
-    { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
-  ];
+  readonly isActionDisabled = signal(false);
+  private readonly reloadCount = signal(0);
+  readonly subMenuItems = computed(() => {
+    this.navTrigger();
+    return this.buildSubMenuItems();
+  });
   readonly hasBreadcrumb = toSignal(this.gioMenuService.reduced$, { initialValue: false });
-
   private readonly navTrigger = toSignal(
     this.router.events.pipe(
       filter((event): event is NavigationEnd => event instanceof NavigationEnd),
@@ -59,28 +108,130 @@ export class ApiProductNavigationComponent {
     ),
     { initialValue: null },
   );
+
+  private readonly apiProductData = toSignal(
+    combineLatest([
+      this.activatedRoute.params.pipe(map(p => p['apiProductId'] ?? null)),
+      toObservable(this.reloadCount),
+      toObservable(this.apiProductV2Service.planStateVersion),
+    ]).pipe(
+      switchMap(([apiProductId]) => {
+        if (!apiProductId) {
+          return of([null, { ok: true }] as [null, VerifyApiProductDeployResponse]);
+        }
+        return combineLatest([
+          this.apiProductV2Service.get(apiProductId).pipe(
+            catchError(error => {
+              this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+              return of(null);
+            }),
+          ),
+          this.apiProductV2Service
+            .verifyDeploy(apiProductId)
+            .pipe(catchError(() => of({ ok: false, reason: 'Could not verify deployment compatibility.' }))),
+        ]);
+      }),
+    ),
+    { initialValue: [null, { ok: true }] as [null, VerifyApiProductDeployResponse] },
+  );
+
   readonly menuItemsWithActive = computed(() => {
     this.navTrigger();
-    return this.subMenuItems.map(item => ({
+    return this.subMenuItems().map(item => ({
       ...item,
       active: this.isItemActive(item),
     }));
   });
 
-  readonly currentApiProduct$ = this.activatedRoute.params.pipe(
-    map(p => p['apiProductId'] ?? null),
-    switchMap(apiProductId => {
-      if (apiProductId) {
-        return this.apiProductV2Service.get(apiProductId).pipe(
-          catchError(error => {
-            this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
-            return of(null);
-          }),
-        );
-      }
-      return of(null);
-    }),
-  );
+  readonly selectedItemWithTabs = computed(() => {
+    this.navTrigger();
+    return this.subMenuItems().find(item => this.isItemActive(item) && (item.tabs?.length ?? 0) > 0) ?? null;
+  });
+
+  readonly selectedItemHeader = computed(() => {
+    this.navTrigger();
+    return this.subMenuItems().find(item => this.isItemActive(item) && item.header)?.header ?? null;
+  });
+
+  readonly currentApiProduct = computed(() => this.apiProductData()[0]);
+
+  readonly banners = computed<TopBanner[]>(() => {
+    const [apiProduct, verifyDeployResponse] = this.apiProductData();
+    if (!apiProduct) {
+      return [];
+    }
+
+    const banners: TopBanner[] = [];
+    const canUpdateApiProduct = this.permissionService.hasAnyMatching(['api_product-definition-u']);
+
+    if (apiProduct.deploymentState === 'NEED_REDEPLOY' && verifyDeployResponse.ok) {
+      banners.push(
+        canUpdateApiProduct
+          ? {
+              title: 'This API Product is out of sync.',
+              type: 'warning',
+              action: {
+                btnText: 'Deploy API Product',
+                onClick: () => {
+                  this.isActionDisabled.set(true);
+                  this.matDialog
+                    .open<
+                      ApiProductConfirmDeploymentDialogComponent,
+                      ApiProductConfirmDeploymentDialogData,
+                      ApiProductConfirmDeploymentDialogResult
+                    >(ApiProductConfirmDeploymentDialogComponent, {
+                      data: { apiProductId: apiProduct.id },
+                      role: 'alertdialog',
+                      id: 'gioApiProductConfirmDeploymentDialog',
+                      width: GIO_DIALOG_WIDTH.MEDIUM,
+                    })
+                    .afterClosed()
+                    .pipe(
+                      tap(() => {
+                        this.isActionDisabled.set(false);
+                        this.reloadCount.update(count => count + 1);
+                      }),
+                      takeUntilDestroyed(this.destroyRef),
+                    )
+                    .subscribe();
+                },
+              },
+            }
+          : {
+              title: 'This API Product is out of sync.',
+              type: 'warning',
+            },
+      );
+    }
+
+    if (!verifyDeployResponse.ok) {
+      banners.push({
+        title: 'This API Product cannot be deployed.',
+        body: verifyDeployResponse.reason ?? 'Deployment is not allowed.',
+        type: 'error',
+      });
+    }
+
+    return banners;
+  });
+
+  private buildSubMenuItems(): MenuItem[] {
+    const items: MenuItem[] = [
+      { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
+      { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
+    ];
+    if (this.permissionService.hasAnyMatching(['api_product-plan-r'])) {
+      items.push({
+        displayName: 'Consumers',
+        routerLink: 'consumers/plans',
+        icon: 'gio:cloud-consumers',
+        header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
+        tabs: [{ displayName: 'Plans', routerLink: 'consumers/plans' }],
+      });
+    }
+
+    return items;
+  }
 
   private isItemActive(item: MenuItem): boolean {
     if (!item.routerLink) {

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -52,6 +52,8 @@ export interface MenuItem {
   displayName: string;
   routerLink: string;
   icon?: string;
+  tabs?: ApiProductTabMenuItem[];
+  header?: { title: string; subtitle?: string };
 }
 
 type TopBanner = {
@@ -160,6 +162,7 @@ export class ApiProductNavigationComponent {
     }
 
     const banners: TopBanner[] = [];
+    const canUpdateApiProduct = this.permissionService.hasAnyMatching(['api_product-definition-u']);
 
     if (apiProduct.deploymentState === 'NEED_REDEPLOY' && verifyDeployResponse.ok) {
       banners.push(
@@ -217,13 +220,21 @@ export class ApiProductNavigationComponent {
       { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
       { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
     ];
-    if (this.permissionService.hasAnyMatching(['api_product-plan-r'])) {
+    if (this.permissionService.hasAnyMatching(['api_product-plan-r', 'api_product-subscription-r'])) {
+      const tabs: ApiProductTabMenuItem[] = [];
+      if (this.permissionService.hasAnyMatching(['api_product-plan-r'])) {
+        tabs.push({ displayName: 'Plans', routerLink: 'consumers/plans' });
+      }
+      if (this.permissionService.hasAnyMatching(['api_product-subscription-r'])) {
+        tabs.push({ displayName: 'Subscriptions', routerLink: 'consumers/subscriptions' });
+      }
+      const defaultRouterLink = tabs.length > 0 ? tabs[0].routerLink : 'consumers/plans';
       items.push({
         displayName: 'Consumers',
-        routerLink: 'consumers/plans',
+        routerLink: defaultRouterLink,
         icon: 'gio:cloud-consumers',
         header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
-        tabs: [{ displayName: 'Plans', routerLink: 'consumers/plans' }],
+        tabs,
       });
     }
 
@@ -234,11 +245,22 @@ export class ApiProductNavigationComponent {
     if (!item.routerLink) {
       return false;
     }
-    return this.router.isActive(this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }), {
-      paths: 'subset',
-      queryParams: 'subset',
-      fragment: 'ignored',
-      matrixParams: 'ignored',
-    });
+    const routingOptions = {
+      paths: 'subset' as const,
+      queryParams: 'subset' as const,
+      fragment: 'ignored' as const,
+      matrixParams: 'ignored' as const,
+    };
+    const baseActive = this.router.isActive(
+      this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }),
+      routingOptions,
+    );
+    if (item.tabs?.length) {
+      const anyTabActive = item.tabs.some(tab =>
+        this.router.isActive(this.router.createUrlTree([tab.routerLink], { relativeTo: this.activatedRoute }), routingOptions),
+      );
+      return baseActive || anyTabActive;
+    }
+    return baseActive;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -22,8 +22,8 @@
   </span>
 </div>
 
-@if (planMenuItem()) {
-  <form autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
+@if (planForm() && planMenuItem()) {
+  <form autocomplete="off" gioFormFocusInvalid [formGroup]="planForm()!" (ngSubmit)="onSubmit()">
     <mat-card>
       <api-plan-form
         #apiPlanForm

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -22,7 +22,7 @@
   </span>
 </div>
 
-@if (planMenuItem())  {
+@if (planMenuItem()) {
   <form autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
     <mat-card>
       <api-plan-form

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -22,8 +22,8 @@
   </span>
 </div>
 
-@if (planForm() && planMenuItem()) {
-  <form autocomplete="off" gioFormFocusInvalid [formGroup]="planForm()!" (ngSubmit)="onSubmit()">
+@if (planMenuItem())  {
+  <form autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
     <mat-card>
       <api-plan-form
         #apiPlanForm

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -29,6 +29,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing'
 import { fakePlanV4 } from '../../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductPlanEditComponent', () => {
   const API_PRODUCT_ID = 'product-xyz';
@@ -38,6 +39,7 @@ describe('ApiProductPlanEditComponent', () => {
   let harness: ApiProductPlanEditComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
+  let notifyPlanStateChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function setup(
@@ -71,6 +73,7 @@ describe('ApiProductPlanEditComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
+    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductPlanEditComponentHarness);
   }
@@ -281,10 +284,80 @@ describe('ApiProductPlanEditComponent', () => {
       tick();
       fixture.detectChanges();
       httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
+
+      expect(fixture.componentInstance['isReadOnly']()).toBe(true);
+      expect(fixture.nativeElement.querySelector('gio-save-bar')).toBeNull();
+    }));
+  });
+
+  describe('deploy banner notification', () => {
+    it('notifies plan state changed after creating a plan so deploy banner is triggered', fakeAsync(async () => {
+      await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
+      tick();
+      fixture.detectChanges();
+
+      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans` })
+        .flush(fakePlanV4({ id: 'new-plan', status: 'STAGING' }));
       tick();
       fixture.detectChanges();
 
       expect(await harness.isSaveBarVisible()).toBe(false);
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after updating a plan so deploy banner is triggered', fakeAsync(async () => {
+      await setup({ planId: PLAN_ID });
+      const plan = fakePlanV4({ id: PLAN_ID, name: 'Original', status: 'PUBLISHED', security: { type: 'API_KEY' } });
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}`).flush(plan);
+      tick();
+      fixture.detectChanges();
+
+      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}`).flush(plan);
+      tick();
+
+      httpTestingController
+        .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}` })
+        .flush({ ...plan });
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('does not notify plan state changed when save fails', fakeAsync(async () => {
+      await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
+      tick();
+      fixture.detectChanges();
+
+      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      fixture.componentInstance['onSubmit']();
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans` })
+        .flush({ message: 'Plan creation failed' }, { status: 500, statusText: 'Server Error' });
+      tick();
+
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+
+      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
     }));
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -284,9 +284,10 @@ describe('ApiProductPlanEditComponent', () => {
       tick();
       fixture.detectChanges();
       httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
 
-      expect(fixture.componentInstance['isReadOnly']()).toBe(true);
-      expect(fixture.nativeElement.querySelector('gio-save-bar')).toBeNull();
+      expect(await harness.isSaveBarVisible()).toBe(false);
     }));
   });
 
@@ -295,8 +296,13 @@ describe('ApiProductPlanEditComponent', () => {
       await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
       tick();
       fixture.detectChanges();
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
 
-      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      const planValue = fakePlanV4({ name: 'New Plan', security: { type: 'JWT' }, status: 'STAGING' });
+      fixture.componentInstance['planForm'].patchValue({ plan: planValue });
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
       fixture.componentInstance['onSubmit']();
       tick();
       fixture.detectChanges();
@@ -306,9 +312,6 @@ describe('ApiProductPlanEditComponent', () => {
         .flush(fakePlanV4({ id: 'new-plan', status: 'STAGING' }));
       tick();
       fixture.detectChanges();
-
-      expect(await harness.isSaveBarVisible()).toBe(false);
-      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
 
       expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
     }));
@@ -321,7 +324,7 @@ describe('ApiProductPlanEditComponent', () => {
       tick();
       fixture.detectChanges();
 
-      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
       fixture.componentInstance['onSubmit']();
       tick();
       fixture.detectChanges();
@@ -344,8 +347,13 @@ describe('ApiProductPlanEditComponent', () => {
       await setup({ queryParams: { selectedPlanMenuItem: 'JWT' } });
       tick();
       fixture.detectChanges();
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
 
-      jest.spyOn(fixture.componentInstance['planForm']()!, 'invalid', 'get').mockReturnValue(false);
+      const planValue = fakePlanV4({ name: 'New Plan', security: { type: 'JWT' }, status: 'STAGING' });
+      fixture.componentInstance['planForm'].patchValue({ plan: planValue });
+      jest.spyOn(fixture.componentInstance['planForm'], 'invalid', 'get').mockReturnValue(false);
       fixture.componentInstance['onSubmit']();
       tick();
       fixture.detectChanges();
@@ -354,8 +362,6 @@ describe('ApiProductPlanEditComponent', () => {
         .expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans` })
         .flush({ message: 'Plan creation failed' }, { status: 500, statusText: 'Server Error' });
       tick();
-
-      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/jwt/schema`).forEach(r => r.flush({}));
 
       expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
     }));

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
@@ -23,6 +23,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { GioFormFocusInvalidModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
 import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
@@ -52,6 +53,7 @@ export class ApiProductPlanEditComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
   private readonly planService = inject(ApiProductPlanV2Service);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly permissionService = inject(GioPermissionService);
   private readonly snackBarService = inject(SnackBarService);
 
@@ -76,7 +78,12 @@ export class ApiProductPlanEditComponent {
     combineLatest([toObservable(this.apiProductId), toObservable(this.planId)]).pipe(
       switchMap(([apiProductId, planId]) => {
         if (!planId) return of(undefined as Plan | undefined);
-        return this.planService.get(apiProductId, planId).pipe(catchError(err => this.handleError(err)));
+        return this.planService.get(apiProductId, planId).pipe(
+          catchError(error => {
+            this.snackBarService.error(error.error?.message ?? 'An error occurred.');
+            return EMPTY;
+          }),
+        );
       }),
     ),
     { initialValue: null as Plan | undefined | null },
@@ -114,8 +121,14 @@ export class ApiProductPlanEditComponent {
 
     savePlan$
       .pipe(
-        tap(() => this.snackBarService.success('Configuration successfully saved!')),
-        catchError(err => this.handleError(err, 'An error occurred while saving configuration.')),
+        tap(() => {
+          this.snackBarService.success('Configuration successfully saved!');
+          this.apiProductV2Service.notifyPlanStateChanged();
+        }),
+        catchError(error => {
+          this.snackBarService.error(error.error?.message ?? 'An error occurred while saving configuration.');
+          return EMPTY;
+        }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => {

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
@@ -36,6 +36,7 @@ import { ApiPlansResponse, Plan, PLAN_STATUS, fakePlanV4 } from '../../../../ent
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { Constants } from '../../../../entities/Constants';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 
 describe('ApiProductPlanListComponent', () => {
   const API_PRODUCT_ID = 'product-abc';
@@ -46,6 +47,7 @@ describe('ApiProductPlanListComponent', () => {
   let planListHarness: PlanListComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
+  let notifyPlanStateChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function init(permissions: string[] = ['api_product-plan-u', 'api_product-plan-r', 'api_product-plan-c']) {
@@ -87,6 +89,7 @@ describe('ApiProductPlanListComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
+    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
     loader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     planListHarness = await loader.getHarness(PlanListComponentHarness);
@@ -397,31 +400,147 @@ describe('ApiProductPlanListComponent', () => {
     }));
   });
 
-  describe('clicking a plan navigates to edit route', () => {
-    it('navigates to plan edit route when plan name is clicked', fakeAsync(async () => {
+  describe('deploy banner notification', () => {
+    it('notifies plan state changed after publish so deploy banner is triggered', fakeAsync(async () => {
       await init();
       fixture.detectChanges();
-      const plan = fakePlanV4({ status: 'PUBLISHED', security: { type: 'JWT' } });
+
+      const plan = fakePlanV4({ name: 'New Plan', status: 'STAGING', security: { type: 'API_KEY' } });
       flushPlansList([plan]);
       tick();
       fixture.detectChanges();
 
-      await planListHarness.clickPlanName();
+      await planListHarness.selectStatusFilter(/STAGING/);
+      tick();
+      fixture.detectChanges();
 
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['./', plan.id], expect.objectContaining({ relativeTo: expect.anything() }));
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#publishPlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Publish' })).then(btn => btn.click());
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_publish`)
+        .flush({ ...plan, status: 'PUBLISHED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'PUBLISHED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
-    it('navigates to plan edit route when edit button is clicked', fakeAsync(async () => {
+    it('notifies plan state changed after deprecate so deploy banner is triggered', fakeAsync(async () => {
       await init();
       fixture.detectChanges();
-      const plan = fakePlanV4({ status: 'PUBLISHED', security: { type: 'JWT' } });
+
+      const plan = fakePlanV4({ name: 'Active Plan', status: 'PUBLISHED', security: { type: 'JWT' } });
       flushPlansList([plan]);
       tick();
       fixture.detectChanges();
 
-      await planListHarness.clickEditPlanButton();
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Deprecate the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#deprecatePlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Deprecate' })).then(btn => btn.click());
 
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['./', plan.id], expect.objectContaining({ relativeTo: expect.anything() }));
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_deprecate`)
+        .flush({ ...plan, status: 'DEPRECATED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'DEPRECATED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after close so deploy banner is triggered', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+
+      const plan = fakePlanV4({ name: 'Close Me', status: 'PUBLISHED', security: { type: 'API_KEY' } });
+      flushPlansList([plan]);
+      tick();
+      fixture.detectChanges();
+
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Close the plan"]' })).then(btn => btn.click());
+      const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+      await confirmDialog.confirm();
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_close`)
+        .flush({ ...plan, status: 'CLOSED' });
+      fixture.detectChanges();
+      flushPlansList([{ ...plan, status: 'CLOSED' }]);
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('notifies plan state changed after reorder so deploy banner is triggered', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+      const plan1 = fakePlanV4({ id: 'p1', name: 'First', order: 1, status: 'PUBLISHED', security: { type: 'API_KEY' } });
+      const plan2 = fakePlanV4({ id: 'p2', name: 'Second', order: 2, status: 'PUBLISHED', security: { type: 'JWT' } });
+      flushPlansList([plan1, plan2]);
+      tick();
+      fixture.detectChanges();
+
+      const dropEvent = { previousIndex: 0, currentIndex: 1 } as CdkDragDrop<string[]>;
+      fixture.componentInstance['onPlanReordered'](dropEvent);
+      tick();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan1.id}` })
+        .flush({ ...plan1, order: 2 });
+      tick();
+      tick(); // allow reload() to schedule the list request
+      fixture.detectChanges();
+
+      // Reload is triggered by triggerReload(); flush the second (reload) list request
+      const listUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`;
+      const listReq = httpTestingController.expectOne(req => req.method === 'GET' && req.urlWithParams === listUrl);
+      listReq.flush({ data: [plan2, { ...plan1, order: 2 }] });
+      fixture.detectChanges();
+
+      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('does not notify plan state changed when publish fails', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+
+      const plan = fakePlanV4({ name: 'New Plan', status: 'STAGING', security: { type: 'API_KEY' } });
+      flushPlansList([plan]);
+      tick();
+      fixture.detectChanges();
+
+      await planListHarness.selectStatusFilter(/STAGING/);
+      tick();
+      fixture.detectChanges();
+
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then(btn => btn.click());
+      const dialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#publishPlanDialog' }));
+      await dialog.getHarness(MatButtonHarness.with({ text: 'Publish' })).then(btn => btn.click());
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${plan.id}/_publish`)
+        .flush({ message: 'Publish failed' }, { status: 500, statusText: 'Server Error' });
+      fixture.detectChanges();
+
+      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('selecting a plan type navigates to create route', () => {
+    it('navigates to new plan route with selected plan type as query param', fakeAsync(async () => {
+      await init();
+      fixture.detectChanges();
+      flushPlansList([]);
+      tick();
+      fixture.detectChanges();
+
+      await planListHarness.clickAddPlanMenuItem('API Key');
+
+      expect(routerNavigateSpy).toHaveBeenCalledWith(
+        ['./new'],
+        expect.objectContaining({ queryParams: { selectedPlanMenuItem: 'API_KEY' } }),
+      );
     }));
   });
 
@@ -451,10 +570,11 @@ describe('ApiProductPlanListComponent', () => {
       tick(); // allow reload() to schedule the list request
       fixture.detectChanges();
 
-      // Reload is triggered by triggerReload(); flush the second (reload) list request
-      const listUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`;
-      const listReq = httpTestingController.expectOne(req => req.method === 'GET' && req.urlWithParams === listUrl);
-      listReq.flush({ data: [plan2, { ...plan1, order: 2 }] });
+      httpTestingController
+        .expectOne(
+          `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans?page=1&perPage=9999&statuses=${PLAN_STATUS.join(',')}&fields=-flow`,
+        )
+        .flush({ data: [plan2, { ...plan1, order: 2 }] });
       fixture.detectChanges();
 
       const rowCells = await planListHarness.getRowCells();

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
@@ -36,10 +36,6 @@ import { Plan, PLAN_STATUS, PlanStatus } from '../../../../entities/management-a
 import { PlanActionEvent, PlanListComponent, PlanDS } from '../../../api/component/plan/plan-list/plan-list.component';
 
 const API_PRODUCT_PLAN_TYPES = ['API_KEY', 'JWT', 'MTLS'] as const;
-const INITIAL_API_PLAN_STATUS: { name: PlanStatus; number: number | null }[] = PLAN_STATUS.map(status => ({
-  name: status,
-  number: null,
-}));
 
 @Component({
   selector: 'api-product-plan-list',
@@ -61,7 +57,6 @@ export class ApiProductPlanListComponent {
   private readonly snackBarService = inject(SnackBarService);
 
   private readonly filterOverride = signal<PlanStatus | null>(null);
-  private readonly reloadTrigger$ = new Subject<void>();
 
   private readonly apiProductId = toSignal(this.activatedRoute.paramMap.pipe(map(p => p.get('apiProductId') ?? '')), { initialValue: '' });
   private readonly initialStatusFromRoute = toSignal(
@@ -69,18 +64,6 @@ export class ApiProductPlanListComponent {
     { initialValue: 'PUBLISHED' as PlanStatus },
   );
   protected readonly selectedStatus = computed(() => this.filterOverride() ?? this.initialStatusFromRoute());
-
-  private readonly plansData = toSignal(this.buildPlansStream(), {
-    initialValue: {
-      plans: [] as PlanDS[],
-      apiPlanStatus: INITIAL_API_PLAN_STATUS,
-      loading: true,
-    },
-  });
-
-  protected readonly plansTableDS = computed(() => this.plansData()?.plans ?? []);
-  protected readonly isLoadingData = computed(() => this.plansData()?.loading ?? true);
-  protected readonly apiPlanStatus = computed(() => this.plansData()?.apiPlanStatus ?? INITIAL_API_PLAN_STATUS);
   protected readonly isReadOnly = computed(() => !this.permissionService.hasAnyMatching(['api_product-plan-u']));
 
   private readonly plansResource = rxResource({

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
@@ -28,6 +28,7 @@ import {
 import { MatDialog } from '@angular/material/dialog';
 
 import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { ApiProductV2Service } from '../../../../services-ngx/api-product-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ConstantsService, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
@@ -35,6 +36,10 @@ import { Plan, PLAN_STATUS, PlanStatus } from '../../../../entities/management-a
 import { PlanActionEvent, PlanListComponent, PlanDS } from '../../../api/component/plan/plan-list/plan-list.component';
 
 const API_PRODUCT_PLAN_TYPES = ['API_KEY', 'JWT', 'MTLS'] as const;
+const INITIAL_API_PLAN_STATUS: { name: PlanStatus; number: number | null }[] = PLAN_STATUS.map(status => ({
+  name: status,
+  number: null,
+}));
 
 @Component({
   selector: 'api-product-plan-list',
@@ -49,12 +54,14 @@ export class ApiProductPlanListComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
   private readonly plansService = inject(ApiProductPlanV2Service);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly constantsService = inject(ConstantsService);
   private readonly permissionService = inject(GioPermissionService);
   private readonly matDialog = inject(MatDialog);
   private readonly snackBarService = inject(SnackBarService);
 
   private readonly filterOverride = signal<PlanStatus | null>(null);
+  private readonly reloadTrigger$ = new Subject<void>();
 
   private readonly apiProductId = toSignal(this.activatedRoute.paramMap.pipe(map(p => p.get('apiProductId') ?? '')), { initialValue: '' });
   private readonly initialStatusFromRoute = toSignal(
@@ -62,6 +69,18 @@ export class ApiProductPlanListComponent {
     { initialValue: 'PUBLISHED' as PlanStatus },
   );
   protected readonly selectedStatus = computed(() => this.filterOverride() ?? this.initialStatusFromRoute());
+
+  private readonly plansData = toSignal(this.buildPlansStream(), {
+    initialValue: {
+      plans: [] as PlanDS[],
+      apiPlanStatus: INITIAL_API_PLAN_STATUS,
+      loading: true,
+    },
+  });
+
+  protected readonly plansTableDS = computed(() => this.plansData()?.plans ?? []);
+  protected readonly isLoadingData = computed(() => this.plansData()?.loading ?? true);
+  protected readonly apiPlanStatus = computed(() => this.plansData()?.apiPlanStatus ?? INITIAL_API_PLAN_STATUS);
   protected readonly isReadOnly = computed(() => !this.permissionService.hasAnyMatching(['api_product-plan-u']));
 
   private readonly plansResource = rxResource({
@@ -166,7 +185,10 @@ export class ApiProductPlanListComponent {
         }),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.triggerReload());
+      .subscribe(() => {
+        this.apiProductV2Service.notifyPlanStateChanged();
+        this.triggerReload();
+      });
   }
 
   protected onPublishPlan(plan: Plan): void {
@@ -194,6 +216,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(published => {
         this.snackBarService.success(`The plan ${published.name} has been published with success.`);
+        this.apiProductV2Service.notifyPlanStateChanged();
         this.triggerReload();
       });
   }
@@ -223,6 +246,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(deprecated => {
         this.snackBarService.success(`The plan ${deprecated.name} has been deprecated with success.`);
+        this.apiProductV2Service.notifyPlanStateChanged();
         this.triggerReload();
       });
   }
@@ -255,6 +279,7 @@ export class ApiProductPlanListComponent {
       )
       .subscribe(closed => {
         this.snackBarService.success(`The plan ${closed.name} has been closed with success.`);
+        this.apiProductV2Service.notifyPlanStateChanged();
         this.triggerReload();
       });
   }

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="form" (ngSubmit)="onClose()">
+  <h2 mat-dialog-title>Transfer your subscription</h2>
+
+  <mat-dialog-content>
+    @if (plans().length > 0) {
+      @if (showGeneralConditionsMsg) {
+        <div>Plans with general conditions cannot be used</div>
+      }
+      <mat-radio-group formControlName="selectedPlanId" aria-label="Select a plan" class="transfer-dialog__radio-group">
+        @for (plan of plans(); track plan.id) {
+          <mat-radio-button [value]="plan.id" [disabled]="!!plan.generalConditions">{{ plan.name }}</mat-radio-button>
+        }
+      </mat-radio-group>
+    } @else {
+      <div>No transferable plans available</div>
+    }
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button type="button" [mat-dialog-close]="undefined">Cancel</button>
+    @if (plans().length > 0) {
+      <button color="primary" type="submit" mat-raised-button aria-label="Transfer subscription" [disabled]="form.invalid">Transfer</button>
+    }
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.scss
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: block;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.subscription-transfer {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  &__radio-group {
+    display: flex;
+    flex-direction: column;
+    margin: 15px 0;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { catchError, map, of } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+
+import { ApiProductPlanV2Service } from '../../../../../services-ngx/api-product-plan-v2.service';
+import { PlanSecurityType } from '../../../../../entities/management-api-v2';
+
+export interface ApiProductSubscriptionTransferDialogData {
+  apiProductId: string;
+  currentPlanId: string;
+  securityType: PlanSecurityType;
+}
+
+export interface ApiProductSubscriptionTransferDialogResult {
+  selectedPlanId: string;
+}
+
+interface PlanVM {
+  id: string;
+  name: string;
+  generalConditions: string;
+}
+
+@Component({
+  selector: 'api-product-subscription-transfer-dialog',
+  templateUrl: './api-product-subscription-transfer-dialog.component.html',
+  styleUrls: ['./api-product-subscription-transfer-dialog.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, MatButtonModule, MatDialogModule, MatRadioModule],
+})
+export class ApiProductSubscriptionTransferDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<ApiProductSubscriptionTransferDialogComponent, ApiProductSubscriptionTransferDialogResult>>(MatDialogRef);
+  private readonly data = inject<ApiProductSubscriptionTransferDialogData>(MAT_DIALOG_DATA);
+  private readonly planService = inject(ApiProductPlanV2Service);
+
+  protected readonly form = new UntypedFormGroup({
+    selectedPlanId: new UntypedFormControl('', Validators.required),
+  });
+
+  protected readonly plans = toSignal(
+    this.planService.list(this.data.apiProductId, [this.data.securityType], ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+      map(response =>
+        response.data
+          .filter(plan => plan.id !== this.data.currentPlanId)
+          .map((plan): PlanVM => ({ id: plan.id, name: plan.name, generalConditions: plan.generalConditions })),
+      ),
+      catchError(() => of([] as PlanVM[])),
+    ),
+    { initialValue: [] as PlanVM[] },
+  );
+
+  protected get showGeneralConditionsMsg(): boolean {
+    return this.plans().some(p => !!p.generalConditions);
+  }
+
+  protected onClose(): void {
+    this.dialogRef.close({ selectedPlanId: this.form.getRawValue().selectedPlanId });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.html
@@ -1,0 +1,284 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div id="subscription-edit" class="subscription">
+  <div class="subscription__nav">
+    <button mat-button aria-label="Go back to your subscriptions" [routerLink]="'../'">
+      <mat-icon svgIcon="gio:nav-arrow-left"></mat-icon> Go back to your subscriptions
+    </button>
+  </div>
+
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Subscription details</mat-card-title>
+    </mat-card-header>
+
+    @if (subscription(); as sub) {
+      <mat-card-content>
+        <dl class="gio-description-list">
+          <dt>ID</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.id" data-testid="subscription-id">
+            {{ sub.id || '-' }}
+          </dd>
+
+          <dt>Plan</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.plan.label" data-testid="subscription-plan">
+            {{ sub.plan.label || '-' }}
+          </dd>
+
+          <dt>Status</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.status" data-testid="subscription-status">
+            {{ sub.status || '-' }}
+          </dd>
+
+          @if (sub.consumerStatus) {
+            <dt>Consumer status</dt>
+            <dd gioClipboardCopyWrapper [contentToCopy]="sub.consumerStatus" data-testid="subscription-consumer-status">
+              {{ sub.consumerStatus }}
+            </dd>
+          }
+
+          @if (sub.failureCause) {
+            <dt>Failure Cause</dt>
+            <dd gioClipboardCopyWrapper [contentToCopy]="sub.failureCause" data-testid="subscription-failure-cause">
+              {{ sub.failureCause }}
+            </dd>
+          }
+
+          <dt>Subscribed by</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.subscribedBy" data-testid="subscription-subscribed-by">
+            {{ sub.subscribedBy || '-' }}
+          </dd>
+
+          <dt>Application</dt>
+          <dd data-testid="subscription-application">
+            <div class="subtitle-2">{{ sub.application?.label || '-' }}</div>
+            <div class="mat-body-2">{{ sub.application?.description }}</div>
+          </dd>
+
+          <dt>Publisher message to subscriber</dt>
+          <dd data-testid="subscription-publisher-message">
+            {{ sub.publisherMessage || '-' }}
+          </dd>
+
+          <dt>Subscriber message to publisher</dt>
+          <dd data-testid="subscription-subscriber-message">
+            {{ sub.subscriberMessage || '-' }}
+          </dd>
+
+          <dt>Created at</dt>
+          <dd data-testid="subscription-created-at">
+            {{ (sub.createdAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Updated at</dt>
+          <dd data-testid="subscription-updated-at">
+            {{ (sub.updatedAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Processed at</dt>
+          <dd data-testid="subscription-processed-at">
+            {{ (sub.processedAt | date: 'medium') || '-' }}
+          </dd>
+
+          @if (sub.status !== 'REJECTED') {
+            <dt>Starting at</dt>
+            <dd data-testid="subscription-starting-at">
+              {{ (sub.startingAt | date: 'medium') || '-' }}
+            </dd>
+            <dt>Paused at</dt>
+            <dd data-testid="subscription-paused-at">
+              {{ (sub.pausedAt | date: 'medium') || '-' }}
+            </dd>
+            <dt>Ending at</dt>
+            <dd data-testid="subscription-ending-at">
+              {{ (sub.endingAt | date: 'medium') || '-' }}
+            </dd>
+          }
+
+          <dt>Closed at</dt>
+          <dd data-testid="subscription-closed-at">
+            {{ (sub.closedAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Domain</dt>
+          <dd data-testid="subscription-domain">
+            {{ sub.domain || '-' }}
+          </dd>
+        </dl>
+      </mat-card-content>
+
+      <mat-card-actions>
+        @if (sub.status === 'PAUSED' || sub.status === 'ACCEPTED' || sub.status === 'PENDING') {
+          <div class="subscription__footer" *gioPermission="{ anyOf: ['api_product-subscription-u'] }">
+            @if (sub.status === 'PAUSED' || sub.status === 'ACCEPTED') {
+              <button mat-stroked-button (click)="transferSubscription()">
+                <mat-icon svgIcon="gio:data-transfer-both"></mat-icon>
+                Transfer
+              </button>
+              @if (sub.status === 'ACCEPTED') {
+                <button mat-stroked-button (click)="pauseSubscription()">
+                  <mat-icon svgIcon="gio:pause-circle"></mat-icon>
+                  Pause
+                </button>
+              }
+              @if (sub.status === 'PAUSED') {
+                <button mat-stroked-button (click)="resumeSubscription()">
+                  <mat-icon svgIcon="gio:play-circle"></mat-icon>
+                  Resume
+                </button>
+              }
+              <button mat-stroked-button (click)="changeEndDate()">
+                <mat-icon svgIcon="gio:calendar"></mat-icon>
+                Change end date
+              </button>
+              @if (sub.consumerStatus === 'FAILURE') {
+                <button mat-stroked-button (click)="resumeFailureSubscription()">
+                  <mat-icon svgIcon="gio:play-circle"></mat-icon>
+                  Resume from failure
+                </button>
+              }
+              <button mat-raised-button color="warn" (click)="closeSubscription()">
+                <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                Close subscription
+              </button>
+            } @else {
+              <button mat-raised-button color="primary" (click)="validateSubscription()">Validate subscription</button>
+              <button mat-stroked-button (click)="rejectSubscription()">Reject subscription</button>
+            }
+          </div>
+        }
+      </mat-card-actions>
+    }
+  </mat-card>
+
+  @if (
+    apiKeys().length > 0 &&
+    (subscription()?.status === 'PENDING' || (subscription()?.status !== 'REJECTED' && subscription()?.plan?.securityType === 'API_KEY'))
+  ) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>{{ hasSharedApiKeyMode() ? 'Shared API Keys' : 'API Keys' }}</mat-card-title>
+        @if (hasSharedApiKeyMode()) {
+          <mat-card-subtitle>
+            This subscription uses a shared API Key. You can renew or revoke the shared API Key at the application level.
+          </mat-card-subtitle>
+        }
+      </mat-card-header>
+
+      <div class="subscription__api-keys__table-wrapper">
+        <gio-table-wrapper
+          [disableSearchInput]="true"
+          [length]="apiKeys().length"
+          [filters]="filters()"
+          (filtersChange)="onFiltersChanged($event)"
+          [paginationPageSizeOptions]="[25, 50, 100]"
+        >
+          <table
+            mat-table
+            [dataSource]="apiKeys()"
+            matSort
+            [matSortActive]="filters().sort?.active ?? ''"
+            [matSortDirection]="filters().sort?.direction ?? ''"
+            class="card__table"
+            aria-label="API Keys Table"
+          >
+            <ng-container matColumnDef="active-icon">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="isValid"></th>
+              <td mat-cell *matCellDef="let apiKey">
+                <mat-icon
+                  [matTooltip]="apiKey.isValid ? 'Valid' : 'Revoked or Expired'"
+                  [ngClass]="{
+                    activeIcon: apiKey.isValid,
+                    revokedIcon: !apiKey.isValid,
+                  }"
+                  [svgIcon]="apiKey.isValid ? 'gio:check-circled-outline' : 'gio:x-circle'"
+                ></mat-icon>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="key">
+              <th mat-header-cell *matHeaderCellDef>Key</th>
+              <td mat-cell *matCellDef="let apiKey">
+                <mat-form-field class="apiKeyCell">
+                  <input matInput [value]="apiKey.key" readonly />
+                  <gio-clipboard-copy-icon matSuffix [contentToCopy]="apiKey.key"></gio-clipboard-copy-icon>
+                </mat-form-field>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="createdAt">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="createdAt">Created at</th>
+              <td mat-cell *matCellDef="let apiKey">{{ apiKey.createdAt | date: 'medium' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="endDate">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="endDate">Revoked/Expired at</th>
+              <td mat-cell *matCellDef="let apiKey">{{ (apiKey.endDate | date: 'medium') || '-' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef></th>
+              <td mat-cell *matCellDef="let apiKey">
+                @if (!hasSharedApiKeyMode() && (subscription()?.status === 'ACCEPTED' || subscription()?.status === 'PENDING')) {
+                  <div *gioPermission="{ anyOf: ['api_product-subscription-u'] }" class="subscription__api-keys__actions">
+                    @if (apiKey.isValid && subscription()?.status === 'ACCEPTED') {
+                      <button (click)="revokeApiKey(apiKey)" mat-button aria-label="Button to revoke an API Key" matTooltip="Revoke">
+                        <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                      </button>
+                      <button (click)="expireApiKey(apiKey)" mat-button aria-label="Button to expire an API Key" matTooltip="Expire">
+                        <mat-icon svgIcon="gio:clock-outline"></mat-icon>
+                      </button>
+                    }
+                    @if (!apiKey.isValid) {
+                      <button
+                        (click)="reactivateApiKey(apiKey)"
+                        mat-button
+                        aria-label="Button to reactivate an API Key"
+                        matTooltip="Reactivate"
+                      >
+                        <mat-icon svgIcon="gio:rotate-cw"></mat-icon>
+                      </button>
+                    }
+                  </div>
+                }
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+            <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+              <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No API keys!</td>
+            </tr>
+          </table>
+        </gio-table-wrapper>
+      </div>
+
+      @if (!hasSharedApiKeyMode() && subscription()?.status === 'ACCEPTED') {
+        <mat-card-actions>
+          <div class="subscription__api-keys__footer" *gioPermission="{ anyOf: ['api_product-subscription-u'] }">
+            <button mat-stroked-button (click)="renewApiKey()">
+              <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+              Renew
+            </button>
+          </div>
+        </mat-card-actions>
+      }
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.scss
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/gio-layout' as gio-layout;
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.subscription {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__footer {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__api-keys {
+    &__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    &__footer {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    &__table-wrapper {
+      .apiKeyCell {
+        width: 100%;
+      }
+
+      .activeIcon {
+        color: mat.m2-get-color-from-palette(gio.$mat-success-palette, darker20);
+      }
+
+      .revokedIcon {
+        color: mat.m2-get-color-from-palette(gio.$mat-error-palette, default);
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.spec.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+import { set } from 'lodash';
+
+import { ApiProductSubscriptionEditComponent } from './api-product-subscription-edit.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Constants } from '../../../../entities/Constants';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { fakeBasePlan, fakeSubscription, Subscription } from '../../../../entities/management-api-v2';
+import { fakeApiKey } from '../../../../entities/management-api-v2/api-key';
+
+const API_PRODUCT_ID = 'product-1';
+const SUBSCRIPTION_ID = 'sub-1';
+const PLAN_ID = 'plan-1';
+const APP_ID = 'app-1';
+
+function buildSubscription(overrides: Partial<Subscription> = {}): Subscription {
+  return fakeSubscription({
+    id: SUBSCRIPTION_ID,
+    plan: fakeBasePlan({ id: PLAN_ID, security: { type: 'API_KEY' } }),
+    status: 'ACCEPTED',
+    application: {
+      id: APP_ID,
+      name: 'My App',
+      description: 'Test app',
+      domain: 'https://example.com',
+      type: 'SIMPLE',
+      primaryOwner: { id: 'owner-1', displayName: 'Owner One' },
+      apiKeyMode: 'UNSPECIFIED',
+    },
+    ...overrides,
+  });
+}
+
+describe('ApiProductSubscriptionEditComponent', () => {
+  let fixture: ComponentFixture<ApiProductSubscriptionEditComponent>;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const snackBarService = { error: jest.fn(), success: jest.fn() };
+
+  async function init(permissions: string[] = ['api_product-subscription-r', 'api_product-subscription-u']) {
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionEditComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        { provide: SnackBarService, useValue: snackBarService },
+        {
+          provide: Constants,
+          useFactory: () => {
+            const constants = { ...CONSTANTS_TESTING };
+            set(constants, 'env.settings.plan.security.customApiKey.enabled', true);
+            return constants;
+          },
+        },
+        {
+          provide: InteractivityChecker,
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID }),
+            paramMap: of(convertToParamMap({ apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID })),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID } },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductSubscriptionEditComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  function expectSubscriptionRequest(subscription = buildSubscription()) {
+    const req = httpTestingController.expectOne(r => {
+      if (!r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`)) return false;
+      const expands = r.params.get('expands');
+      return expands === 'plan,application,subscribedBy';
+    });
+    req.flush(subscription);
+    return subscription;
+  }
+
+  function expectApiKeysRequest() {
+    const req = httpTestingController.expectOne(r =>
+      r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys`),
+    );
+    req.flush({ data: [fakeApiKey({ key: 'test-key-1', revoked: false, expired: false })], pagination: { totalCount: 1 } });
+  }
+
+  describe('subscription details display', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should display subscription details', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('[data-testid="subscription-id"]')?.textContent).toContain(SUBSCRIPTION_ID);
+      expect(compiled.querySelector('[data-testid="subscription-status"]')?.textContent).toContain('ACCEPTED');
+    });
+
+    it('should display action buttons for accepted subscription', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButton = await loader.getHarness(MatButtonHarness.with({ text: /Close subscription/ }));
+      expect(closeButton).toBeTruthy();
+    });
+  });
+
+  describe('close subscription', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should close subscription on confirm', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButton = await loader.getHarness(MatButtonHarness.with({ text: /Close subscription/ }));
+      await closeButton.click();
+
+      const closeDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#confirmCloseSubscriptionDialog' }));
+      const confirmBtn = await closeDialog.getHarness(MatButtonHarness.with({ text: /^Close$/ }));
+      await confirmBtn.click();
+
+      const closeReq = httpTestingController.expectOne(
+        r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_close`,
+      );
+      expect(closeReq.request.method).toBe('POST');
+      closeReq.flush(buildSubscription({ status: 'CLOSED' }));
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // After close, refreshSubscription triggers a reload: GET subscription then GET api-keys (plan is API_KEY)
+      expectSubscriptionRequest(buildSubscription({ status: 'CLOSED' }));
+      expectApiKeysRequest();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription closed');
+    });
+  });
+
+  describe('pending subscription', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should show validate and reject buttons for pending subscription', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest(buildSubscription({ status: 'PENDING' }));
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const validateButton = await loader.getHarness(MatButtonHarness.with({ text: /Validate subscription/ }));
+      const rejectButton = await loader.getHarness(MatButtonHarness.with({ text: /Reject subscription/ }));
+      expect(validateButton).toBeTruthy();
+      expect(rejectButton).toBeTruthy();
+    });
+  });
+
+  describe('read-only mode', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r']);
+    });
+
+    it('should not show action buttons without update permission', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Close subscription/ }));
+      expect(closeButtons.length).toBe(0);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.ts
@@ -1,0 +1,650 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { catchError, EMPTY, map, of, switchMap, tap } from 'rxjs';
+import { DatePipe, NgClass } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  GIO_DIALOG_WIDTH,
+  GioClipboardModule,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioIconsModule,
+} from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { filter } from 'rxjs/operators';
+
+import { ApiProductSubscriptionV2Service } from '../../../../services-ngx/api-product-subscription-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../../entities/Constants';
+import {
+  PlanMode,
+  PlanSecurityType,
+  Subscription as ApiSubscription,
+  SubscriptionConsumerConfiguration,
+  SubscriptionConsumerStatus,
+  SubscriptionStatus,
+} from '../../../../entities/management-api-v2';
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import {
+  ApiPortalSubscriptionChangeEndDateDialogComponent,
+  ApiPortalSubscriptionChangeEndDateDialogData,
+  ApiPortalSubscriptionChangeEndDateDialogResult,
+} from '../../../api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component';
+import {
+  ApiPortalSubscriptionAcceptDialogData,
+  ApiPortalSubscriptionAcceptDialogResult,
+  ApiPortalSubscriptionValidateDialogComponent,
+} from '../../../api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component';
+import {
+  ApiPortalSubscriptionRejectDialogComponent,
+  ApiPortalSubscriptionRejectDialogResult,
+} from '../../../api/subscriptions/components/dialogs/reject/api-portal-subscription-reject-dialog.component';
+import {
+  ApiPortalSubscriptionRenewDialogComponent,
+  ApiPortalSubscriptionRenewDialogData,
+  ApiPortalSubscriptionRenewDialogResult,
+} from '../../../api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component';
+import {
+  ApiPortalSubscriptionExpireApiKeyDialogComponent,
+  ApiPortalSubscriptionExpireApiKeyDialogData,
+  ApiPortalSubscriptionExpireApiKeyDialogResult,
+} from '../../../api/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component';
+import {
+  ApiProductSubscriptionTransferDialogComponent,
+  ApiProductSubscriptionTransferDialogData,
+  ApiProductSubscriptionTransferDialogResult,
+} from '../components/dialogs/api-product-subscription-transfer-dialog.component';
+import { ApiSubscriptionsModule } from '../../../api/subscriptions/api-subscriptions.module';
+
+interface SubscriptionDetailVM {
+  id: string;
+  plan: { id: string; label: string; securityType: PlanSecurityType; mode: PlanMode };
+  status: SubscriptionStatus;
+  consumerStatus: SubscriptionConsumerStatus;
+  subscribedBy: string;
+  application?: { id: string; label: string; name: string; description: string };
+  publisherMessage?: string;
+  subscriberMessage?: string;
+  failureCause?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  endingAt?: Date;
+  pausedAt?: Date;
+  processedAt?: Date;
+  startingAt?: Date;
+  closedAt?: Date;
+  domain?: string;
+  consumerConfiguration?: SubscriptionConsumerConfiguration;
+  metadata?: { [key: string]: string };
+}
+
+interface ApiKeyVM {
+  id: string;
+  key: string;
+  createdAt: Date;
+  endDate: Date;
+  isValid: boolean;
+}
+
+@Component({
+  selector: 'api-product-subscription-edit',
+  templateUrl: './api-product-subscription-edit.component.html',
+  styleUrls: ['./api-product-subscription-edit.component.scss'],
+  standalone: true,
+  imports: [
+    RouterModule,
+    DatePipe,
+    NgClass,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+    GioClipboardModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    ApiSubscriptionsModule,
+  ],
+})
+export class ApiProductSubscriptionEditComponent {
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly subscriptionService = inject(ApiProductSubscriptionV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly constants = inject<Constants>(Constants);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly apiProductId = toSignal(this.activatedRoute.params.pipe(map(param => param['apiProductId'] ?? '')), { initialValue: '' });
+  private readonly subscriptionId = toSignal(this.activatedRoute.params.pipe(map(param => param['subscriptionId'] ?? '')), { initialValue: '' });
+  private readonly refreshSubscription = signal(0);
+
+  protected readonly displayedColumns = ['active-icon', 'key', 'createdAt', 'endDate', 'actions'];
+
+  protected readonly subscription = signal<SubscriptionDetailVM | null>(null);
+  protected readonly apiKeys = signal<ApiKeyVM[]>([]);
+  protected readonly apiKeysTotalCount = signal(0);
+  protected readonly hasSharedApiKeyMode = signal(false);
+  protected readonly filters = signal<GioTableWrapperFilters>({
+    searchTerm: '',
+    pagination: { index: 1, size: 25 },
+    sort: { active: 'isValid', direction: 'desc' },
+  });
+
+  private readonly canUseCustomApiKey = computed(() => {
+    const sub = this.subscription();
+    return sub?.plan?.securityType === 'API_KEY' && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled === true;
+  });
+
+  private readonly loadTrigger = computed(() => ({
+    apiProductId: this.apiProductId(),
+    subscriptionId: this.subscriptionId(),
+    refresh: this.refreshSubscription(),
+  }));
+
+  private readonly subscriptionData$ = toObservable(this.loadTrigger).pipe(
+    switchMap(({ apiProductId, subscriptionId }) => {
+      if (!apiProductId || !subscriptionId) return EMPTY;
+      return this.subscriptionService.getById(apiProductId, subscriptionId, ['plan', 'application', 'subscribedBy']).pipe(
+        tap(sub => this.applySubscriptionToState(sub)),
+        switchMap(sub =>
+          sub.plan?.security?.type === 'API_KEY' ? this.subscriptionService.listApiKeys(apiProductId, subscriptionId, 1, 10) : of(null),
+        ),
+        tap(apiKeysResponse => {
+          if (apiKeysResponse) {
+            this.apiKeysTotalCount.set(apiKeysResponse.pagination?.totalCount ?? 0);
+            this.apiKeys.set(
+              apiKeysResponse.data.map(apiKey => ({
+                id: apiKey.id,
+                key: apiKey.key,
+                createdAt: apiKey.createdAt,
+                endDate: apiKey.revoked ? apiKey.revokedAt : apiKey.expireAt,
+                isValid: !apiKey.revoked && !apiKey.expired,
+              })),
+            );
+          }
+        }),
+        catchError(err => {
+          this.snackBarService.error(err.message ?? 'Failed to load subscription');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      );
+    }),
+  );
+
+  protected readonly subscriptionData = toSignal(this.subscriptionData$, { initialValue: undefined });
+
+  protected validateSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionValidateDialogComponent, ApiPortalSubscriptionAcceptDialogData, ApiPortalSubscriptionAcceptDialogResult>(
+        ApiPortalSubscriptionValidateDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {
+            apiId: this.apiProductId(),
+            applicationId: sub.application.id,
+            canUseCustomApiKey: this.canUseCustomApiKey(),
+            sharedApiKeyMode: this.hasSharedApiKeyMode(),
+            isFederated: false,
+          },
+          role: 'alertdialog',
+          id: 'validateSubscriptionDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result =>
+          this.subscriptionService.accept(sub.id, this.apiProductId(), {
+            ...(result.customApiKey ? { customApiKey: result.customApiKey } : {}),
+            ...(result.message ? { reason: result.message } : {}),
+            ...(result.start ? { startingAt: result.start } : {}),
+            ...(result.end ? { endingAt: result.end } : {}),
+          }),
+        ),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(updated => {
+        if (updated.status === 'ACCEPTED') {
+          this.snackBarService.success('Subscription validated');
+        } else {
+          this.snackBarService.error(`Subscription ${updated.status.toLowerCase()}`);
+        }
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected rejectSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionRejectDialogComponent, unknown, ApiPortalSubscriptionRejectDialogResult>(
+        ApiPortalSubscriptionRejectDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {},
+          role: 'alertdialog',
+          id: 'rejectSubscriptionDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.reject(sub.id, this.apiProductId(), result.reason)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription rejected');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected transferSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiProductSubscriptionTransferDialogComponent,
+        ApiProductSubscriptionTransferDialogData,
+        ApiProductSubscriptionTransferDialogResult
+      >(ApiProductSubscriptionTransferDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          apiProductId: this.apiProductId(),
+          securityType: sub.plan.securityType,
+          currentPlanId: sub.plan.id,
+        },
+        role: 'alertdialog',
+        id: 'transferSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.transfer(this.apiProductId(), sub.id, result.selectedPlanId)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription successfully transferred');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected pauseSubscription(): void {
+    const sub = this.subscription();
+    let content = 'The application will not be able to consume this API product anymore.';
+    if (sub.plan.securityType === 'API_KEY' && !this.hasSharedApiKeyMode()) {
+      content += '<br/>All Api-keys associated to this subscription will be paused and unusable.';
+    }
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Pause your subscription', content, confirmButton: 'Pause' },
+        role: 'alertdialog',
+        id: 'confirmPauseSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.pause(sub.id, this.apiProductId())),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription paused');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected resumeSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Resume your subscription',
+          content: 'The application will be able to consume your API Product.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.resume(sub.id, this.apiProductId())),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription resumed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected resumeFailureSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Resume your failed subscription',
+          content: 'The application will be able to consume your API Product.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeFailureSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.resumeFailure(sub.id, this.apiProductId())),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription resumed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected changeEndDate(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionChangeEndDateDialogComponent,
+        ApiPortalSubscriptionChangeEndDateDialogData,
+        ApiPortalSubscriptionChangeEndDateDialogResult
+      >(ApiPortalSubscriptionChangeEndDateDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          currentEndDate: sub.endingAt,
+          applicationName: sub.application.name,
+          securityType: sub.plan.securityType,
+          isApiProduct: true,
+        },
+        role: 'alertdialog',
+        id: 'changeEndDateDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result =>
+          this.subscriptionService.update(this.apiProductId(), sub.id, {
+            startingAt: sub.startingAt,
+            endingAt: result.endDate,
+            consumerConfiguration: sub.consumerConfiguration,
+            metadata: sub.metadata,
+          }),
+        ),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('End date successfully changed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected closeSubscription(): void {
+    const sub = this.subscription();
+    let content = `${sub.application.name} will no longer be able to consume your API Product.`;
+    if (sub.plan.securityType === 'API_KEY' && !this.hasSharedApiKeyMode()) {
+      content += '<br/>All API keys associated to this subscription will be closed and unusable.';
+    }
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Close your subscription', content, confirmButton: 'Close' },
+        role: 'alertdialog',
+        id: 'confirmCloseSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.close(sub.id, this.apiProductId())),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription closed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected renewApiKey(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionRenewDialogComponent, ApiPortalSubscriptionRenewDialogData, ApiPortalSubscriptionRenewDialogResult>(
+        ApiPortalSubscriptionRenewDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {
+            apiId: this.apiProductId(),
+            applicationId: sub.application.id,
+            canUseCustomApiKey: this.canUseCustomApiKey(),
+          },
+          role: 'alertdialog',
+          id: 'renewApiKeysDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.renewApiKey(this.apiProductId(), sub.id, result.customApiKey)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key renewed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected revokeApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Revoke your API Key', content: "Revoke your subscription's API Key", confirmButton: 'Revoke' },
+        role: 'alertdialog',
+        id: 'revokeApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.revokeApiKey(this.apiProductId(), sub.id, apiKey.id)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key revoked');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected expireApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionExpireApiKeyDialogComponent,
+        ApiPortalSubscriptionExpireApiKeyDialogData,
+        ApiPortalSubscriptionExpireApiKeyDialogResult
+      >(ApiPortalSubscriptionExpireApiKeyDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: { expirationDate: apiKey.endDate },
+        role: 'alertdialog',
+        id: 'expireApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.expireApiKey(this.apiProductId(), sub.id, apiKey.id, result.expirationDate)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key expiration validated');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected reactivateApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Reactivate your API Key',
+          content: 'Reactivate your revoked or expired API Key',
+          confirmButton: 'Reactivate',
+        },
+        role: 'alertdialog',
+        id: 'reactivateApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.reactivateApiKey(this.apiProductId(), sub.id, apiKey.id)),
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key reactivated');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected onFiltersChanged(event: GioTableWrapperFilters): void {
+    if (this.apiKeys().length < this.apiKeysTotalCount() || event.pagination.size <= this.apiKeysTotalCount()) {
+      this.loadApiKeys(event.pagination.index, event.pagination.size);
+    }
+  }
+
+  private applySubscriptionToState(subscription: ApiSubscription): void {
+    const plan = subscription.plan;
+    const application = subscription.application;
+    if (!plan || !application) {
+      return;
+    }
+    const primaryOwnerDisplayName = application.primaryOwner?.displayName ?? '';
+    this.subscription.set({
+      id: subscription.id,
+      plan: {
+        id: plan.id,
+        label: plan.security?.type ? `${plan.name} (${plan.security.type})` : plan.name,
+        securityType: plan.security?.type,
+        mode: plan.security?.type ? 'STANDARD' : 'PUSH',
+      },
+      application: {
+        id: application.id,
+        label: `${application.name} (${primaryOwnerDisplayName}) - Type: ${application.type ?? ''}`,
+        name: application.name,
+        description: application.description,
+      },
+      status: subscription.status,
+      consumerStatus: subscription.consumerStatus,
+      failureCause: subscription.failureCause,
+      subscribedBy: subscription.subscribedBy?.displayName,
+      publisherMessage: subscription.publisherMessage,
+      subscriberMessage: subscription.consumerMessage,
+      createdAt: subscription.createdAt,
+      updatedAt: subscription.updatedAt,
+      pausedAt: subscription.pausedAt,
+      startingAt: subscription.startingAt,
+      endingAt: subscription.endingAt,
+      processedAt: subscription.processedAt,
+      closedAt: subscription.closedAt,
+      domain: application.domain || undefined,
+      consumerConfiguration: subscription.consumerConfiguration,
+      metadata: subscription.metadata,
+    });
+    if (plan.security?.type === 'API_KEY' && subscription.status !== 'REJECTED') {
+      this.hasSharedApiKeyMode.set(application.apiKeyMode === 'SHARED');
+    }
+  }
+
+  private loadApiKeys(page: number, perPage: number): void {
+    this.subscriptionService
+      .listApiKeys(this.apiProductId(), this.subscriptionId(), page, perPage)
+      .pipe(
+        catchError(err => {
+          this.snackBarService.error(err.message);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(response => {
+        this.apiKeysTotalCount.set(response.pagination?.totalCount ?? 0);
+        this.apiKeys.set(
+          response.data.map(apiKey => ({
+            id: apiKey.id,
+            key: apiKey.key,
+            createdAt: apiKey.createdAt,
+            endDate: apiKey.revoked ? apiKey.revokedAt : apiKey.expireAt,
+            isValid: !apiKey.revoked && !apiKey.expired,
+          })),
+        );
+      });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.html
@@ -1,0 +1,196 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="subscriptions__header">
+  <div class="subscriptions__header__title">
+    <h2>Manage your subscriptions</h2>
+  </div>
+
+  @if (!isLoadingData()) {
+    <div class="subscriptions__header__buttons">
+      <button
+        *gioPermission="{ anyOf: ['api_product-subscription-r'] }"
+        mat-raised-button
+        type="button"
+        [disabled]="true"
+        aria-label="Export subscriptions list"
+        (click)="exportAsCSV()"
+      >
+        <mat-icon svgIcon="gio:upload"></mat-icon>Export as CSV
+      </button>
+      <button
+        *gioPermission="{ anyOf: ['api_product-subscription-c'] }"
+        mat-raised-button
+        type="button"
+        color="primary"
+        aria-label="Create a subscription"
+        (click)="createSubscription()"
+      >
+        <mat-icon svgIcon="gio:plus"></mat-icon>Create a subscription
+      </button>
+    </div>
+  }
+</div>
+
+<mat-card class="subscriptions__filters" [formGroup]="filtersForm">
+  <mat-card-content>
+    <div class="subscriptions__filters__inputs">
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Plan</mat-label>
+        <mat-select formControlName="planIds" [multiple]="true">
+          @for (plan of plans(); track plan.id) {
+            <mat-option [value]="plan.id">{{ plan.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Application</mat-label>
+        <gio-form-tags-input
+          [placeholder]="'Search for an application'"
+          formControlName="applicationIds"
+          [autocompleteOptions]="searchApplications"
+          [displayValueWith]="displayApplication"
+          [useAutocompleteOptionValueOnly]="true"
+        ></gio-form-tags-input>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Status</mat-label>
+        <mat-select formControlName="statuses" [multiple]="true">
+          @for (status of statuses; track status.id) {
+            <mat-option [value]="status.id">{{ status.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>API Key</mat-label>
+        <input matInput formControlName="apiKey" />
+      </mat-form-field>
+    </div>
+    <div class="subscriptions__filters__buttons">
+      <button mat-raised-button type="button" color="secondary" aria-label="Reset filters" (click)="resetFilters()">
+        <mat-icon svgIcon="gio:refresh-cw"></mat-icon>Reset filters
+      </button>
+    </div>
+  </mat-card-content>
+
+  <gio-table-wrapper
+    [disableSearchInput]="true"
+    [length]="nbTotalSubscriptions()"
+    [filters]="filters()?.tableWrapper"
+    (filtersChange)="onFiltersChanged($event)"
+  >
+    <table
+      mat-table
+      [dataSource]="subscriptionsTableDS()"
+      class="subscriptions__table"
+      id="subscriptionsTable"
+      aria-label="Subscriptions table"
+    >
+      <ng-container matColumnDef="securityType">
+        <th mat-header-cell *matHeaderCellDef id="securityType">Security type</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.securityType }}
+          @if (element.isSharedApiKey) {
+            <span class="gio-badge-accent" matTooltip="Use shared API keys">Shared</span>
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="plan">
+        <th mat-header-cell *matHeaderCellDef id="plan">Plan</th>
+        <td mat-cell *matCellDef="let element">{{ element.plan }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="application">
+        <th mat-header-cell *matHeaderCellDef id="application">Application</th>
+        <td mat-cell *matCellDef="let element">{{ element.application }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="createdAt">
+        <th mat-header-cell *matHeaderCellDef id="createdAt">Created at</th>
+        <td mat-cell *matCellDef="let element">{{ element.createdAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="processedAt">
+        <th mat-header-cell *matHeaderCellDef id="processedAt">Processed at</th>
+        <td mat-cell *matCellDef="let element">{{ element.processedAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="startingAt">
+        <th mat-header-cell *matHeaderCellDef id="startingAt">Start at</th>
+        <td mat-cell *matCellDef="let element">{{ element.startingAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="endAt">
+        <th mat-header-cell *matHeaderCellDef id="endAt">End at</th>
+        <td mat-cell *matCellDef="let element">{{ element.endAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef id="status">Status</th>
+        <td mat-cell *matCellDef="let element">
+          <span [class]="'gio-badge-' + element.statusBadge">{{ element.status }}</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="subscriptions__table__actions">
+            @if (canUpdate()) {
+              <button
+                mat-icon-button
+                aria-label="Edit the subscription"
+                matTooltip="Edit the subscription"
+                [routerLink]="'./' + element.id"
+              >
+                <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+              </button>
+            } @else {
+              <button
+                *gioPermission="{ anyOf: ['api_product-subscription-r'] }"
+                mat-icon-button
+                aria-label="View the subscription details"
+                matTooltip="View the subscription details"
+                [routerLink]="'./' + element.id"
+              >
+                <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              </button>
+            }
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        @if (!isLoadingData() && subscriptionsTableDS().length === 0) {
+          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">There is no subscription (yet).</td>
+        }
+        @if (isLoadingData()) {
+          <td class="mat-mdc-cell mdc-data-table__cell loader" [attr.colspan]="displayedColumns.length">
+            <gio-loader></gio-loader>
+          </td>
+        }
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.scss
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.subscriptions {
+  &__header {
+    display: flex;
+    align-items: center;
+
+    &__buttons {
+      flex: 1;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 0.5rem;
+
+      & button {
+        margin: 0;
+      }
+    }
+  }
+
+  &__filters {
+    display: flex;
+    flex-direction: column;
+
+    &__inputs {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+
+      &__field {
+        flex: 1;
+      }
+    }
+  }
+
+  &__table {
+    width: 100%;
+    @include mat.elevation(3);
+
+    &__actions {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+    }
+
+    .mat-column-actions {
+      width: 0;
+    }
+
+    .mat-column-securityType {
+      white-space: nowrap;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.spec.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ApiProductSubscriptionListComponent } from './api-product-subscription-list.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Constants } from '../../../../entities/Constants';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiPlansResponse, ApiSubscriptionsResponse, fakePlanV4, fakeSubscription } from '../../../../entities/management-api-v2';
+
+describe('ApiProductSubscriptionListComponent', () => {
+  const API_PRODUCT_ID = 'product-abc';
+  const PLAN_ID = 'plan-1';
+  const APPLICATION_ID = 'app-1';
+
+  const aSubscription = fakeSubscription({
+    id: 'sub-1',
+    plan: fakePlanV4({ id: PLAN_ID, name: 'My API Key Plan', security: { type: 'API_KEY' } }),
+    status: 'ACCEPTED',
+    application: {
+      id: APPLICATION_ID,
+      name: 'Test App',
+      primaryOwner: { id: 'owner-1', displayName: 'App Owner' },
+      type: 'SIMPLE',
+      apiKeyMode: 'UNSPECIFIED',
+    },
+  });
+
+  const plansResponse: ApiPlansResponse = {
+    data: [fakePlanV4({ id: PLAN_ID, name: 'My API Key Plan', security: { type: 'API_KEY' }, status: 'PUBLISHED' })],
+  };
+
+  const subscriptionsResponse: ApiSubscriptionsResponse = {
+    data: [aSubscription],
+    pagination: { totalCount: 1 },
+  };
+
+  let fixture: ComponentFixture<ApiProductSubscriptionListComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let queryParams$: BehaviorSubject<Record<string, string>>;
+
+  const snackBarService = { error: jest.fn(), success: jest.fn() };
+
+  async function init(
+    permissions: string[] = ['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c'],
+    initialQueryParams: Record<string, string> = {},
+  ) {
+    queryParams$ = new BehaviorSubject<Record<string, string>>(initialQueryParams);
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionListComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        { provide: SnackBarService, useValue: snackBarService },
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        {
+          provide: InteractivityChecker,
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ apiProductId: API_PRODUCT_ID })),
+            queryParams: queryParams$.asObservable(),
+            queryParamMap: queryParams$.pipe(map(p => convertToParamMap(p))),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID }, queryParams: initialQueryParams },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductSubscriptionListComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    // When the component calls router.navigate(..., { queryParams }), the real Router does not
+    // update our mock ActivatedRoute. Spy on navigate and push queryParams to queryParams$ so
+    // that filters (derived from queryParams) update and the component's flow runs as in production.
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockImplementation(((...args: unknown[]) => {
+      const options = args[1] as { queryParams?: Record<string, unknown> } | undefined;
+      if (options?.queryParams) {
+        const strParams: Record<string, string> = {};
+        Object.entries(options.queryParams).forEach(([k, v]) => {
+          if (v !== undefined && v !== null) strParams[k] = String(v);
+        });
+        queryParams$.next(strParams);
+      }
+      return Promise.resolve(true);
+    }) as Router['navigate']);
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  function expectPlansRequest() {
+    const req = httpTestingController.expectOne(r =>
+      r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans`),
+    );
+    req.flush(plansResponse);
+  }
+
+  function expectSubscriptionsRequest(expectedPage?: string) {
+    const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+    const req = httpTestingController.expectOne(r => {
+      if (!r.url.startsWith(baseUrl) || r.url.includes('/_export')) return false;
+      if (r.params.get('expands') !== 'application,plan') return false;
+      if (expectedPage != null && r.params.get('page') !== expectedPage) return false;
+      return true;
+    });
+    req.flush(subscriptionsResponse);
+  }
+
+  describe('list display', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should show subscriptions in table', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0); // Let toObservable(filters) effect emit
+      tick(400); // debounceTime(400) then subscriptions request is sent
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(MatTableHarness);
+      const rows = await table.getRows();
+      expect(rows.length).toBe(1);
+    }));
+
+    it('should show loading indicator initially', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('gio-loader')).toBeTruthy();
+
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+    }));
+  });
+
+  describe('with update permission', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c']);
+    });
+
+    it('should show edit button for subscriptions', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(MatTableHarness);
+      const rows = await table.getRows();
+      expect(rows.length).toBe(1);
+    }));
+
+    it('should show create subscription button', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create a subscription/ }));
+      expect(createButton).toBeTruthy();
+    }));
+  });
+
+  describe('without update permission', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r']);
+    });
+
+    it('should not show create subscription button', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const buttons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Create a subscription/ }));
+      expect(buttons.length).toBe(0);
+    }));
+  });
+
+  describe('reset filters', () => {
+    it('should reset filters and reload subscriptions', fakeAsync(async () => {
+      // Start with page=2 so that after reset (page=1) the filters change and a second request is sent
+      await init(['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c'], { page: '2' });
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest('2');
+      fixture.detectChanges();
+
+      const resetButton = await loader.getHarness(MatButtonHarness.with({ text: /Reset filters/ }));
+      await resetButton.click();
+      // Router.navigate spy pushes queryParams to queryParams$ so filters update and subscriptions reload
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest('1');
+      fixture.detectChanges();
+    }));
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
@@ -1,0 +1,396 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Params, Router, RouterModule } from '@angular/router';
+import { catchError, debounceTime, distinctUntilChanged, EMPTY, filter, map, Observable, of, switchMap, tap } from 'rxjs';
+import { isEqual, now, omitBy, isNil } from 'lodash';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { AutocompleteOptions, GioFormTagsInputModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { DatePipe } from '@angular/common';
+
+import { ApiProductSubscriptionV2Service } from '../../../../services-ngx/api-product-subscription-v2.service';
+import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { ApplicationService } from '../../../../services-ngx/application.service';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { SubscriptionStatus } from '../../../../entities/subscription/subscription';
+import { Plan } from '../../../../entities/management-api-v2';
+import {
+  ApiPortalSubscriptionCreationDialogComponent,
+  ApiPortalSubscriptionCreationDialogData,
+  ApiPortalSubscriptionCreationDialogResult,
+} from '../../../api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component';
+import { ApiSubscriptionsModule } from '../../../api/subscriptions/api-subscriptions.module';
+
+type SubscriptionsTableDS = {
+  id: string;
+  securityType: string;
+  isSharedApiKey: boolean;
+  plan: string;
+  application: string;
+  createdAt: Date;
+  processedAt: Date;
+  startingAt: Date;
+  endAt: Date;
+  status: string;
+  statusBadge: string;
+};
+
+export type SubscriptionsFiltersValue = {
+  planIds: string[] | null;
+  applicationIds: string[] | null;
+  statuses: SubscriptionStatus[];
+  apiKey: string | undefined;
+};
+
+type SubscriptionsFiltersForm = {
+  planIds: FormControl<string[] | null>;
+  applicationIds: FormControl<string[] | null>;
+  statuses: FormControl<SubscriptionStatus[]>;
+  apiKey: FormControl<string | undefined>;
+};
+
+@Component({
+  selector: 'api-product-subscription-list',
+  templateUrl: './api-product-subscription-list.component.html',
+  styleUrls: ['./api-product-subscription-list.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    RouterModule,
+    ReactiveFormsModule,
+    DatePipe,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatTableModule,
+    MatTooltipModule,
+    GioFormTagsInputModule,
+    GioIconsModule,
+    GioLoaderModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    ApiSubscriptionsModule,
+  ],
+})
+export class ApiProductSubscriptionListComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly subscriptionService = inject(ApiProductSubscriptionV2Service);
+  private readonly planService = inject(ApiProductPlanV2Service);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly displayedColumns = [
+    'securityType',
+    'plan',
+    'application',
+    'createdAt',
+    'processedAt',
+    'startingAt',
+    'endAt',
+    'status',
+    'actions',
+  ];
+
+  protected readonly statuses: { id: SubscriptionStatus; name: string; badge: string }[] = [
+    { id: 'ACCEPTED', name: 'Accepted', badge: 'success' },
+    { id: 'CLOSED', name: 'Closed', badge: 'neutral' },
+    { id: 'PAUSED', name: 'Paused', badge: 'accent' },
+    { id: 'PENDING', name: 'Pending', badge: 'warning' },
+    { id: 'REJECTED', name: 'Rejected', badge: 'warning' },
+    { id: 'RESUMED', name: 'Resumed', badge: 'neutral' },
+  ];
+
+  private readonly apiProductId = this.activatedRoute.snapshot.params['apiProductId'];
+
+  // Source of truth: The URL query parameters
+  protected readonly filters = toSignal(
+    this.activatedRoute.queryParams.pipe(
+      map(params => this.parseFiltersFromQueryParams(params)),
+      distinctUntilChanged(isEqual),
+    ),
+  );
+
+  protected readonly filtersForm: FormGroup<SubscriptionsFiltersForm> = this.buildFiltersForm();
+
+  protected readonly plans = toSignal(
+    this.planService.list(this.apiProductId, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+      map(response => response.data.filter(plan => plan.security?.type !== 'KEY_LESS')),
+      catchError(() => of([] as Plan[])),
+    ),
+    { initialValue: [] as Plan[] },
+  );
+
+  protected readonly canUpdate = computed(() => this.permissionService.hasAnyMatching(['api_product-subscription-u']));
+
+  private readonly subscriptionsData = toSignal(
+    toObservable(this.filters).pipe(
+      debounceTime(400),
+      distinctUntilChanged(isEqual),
+      tap(() => this.isLoadingData.set(true)),
+      switchMap(filters =>
+        this.subscriptionService
+          .list(
+            this.apiProductId,
+            `${filters.tableWrapper.pagination.index}`,
+            `${filters.tableWrapper.pagination.size}`,
+            filters.subscriptionsFilters.statuses,
+            filters.subscriptionsFilters.applicationIds,
+            filters.subscriptionsFilters.planIds,
+            filters.subscriptionsFilters.apiKey,
+            ['application', 'plan'],
+          )
+          .pipe(
+            catchError(() => {
+              this.snackBarService.error('Unable to load subscriptions, please try again');
+              return of({ data: [], pagination: { totalCount: 0 } });
+            }),
+          ),
+      ),
+      tap(() => this.isLoadingData.set(false)),
+    ),
+  );
+
+  protected readonly subscriptionsTableDS = computed<SubscriptionsTableDS[]>(() => {
+    const data = this.subscriptionsData()?.data ?? [];
+    return data.map(subscription => {
+      const statusEntry = this.statuses.find(s => s.id === subscription.status);
+      return {
+        id: subscription.id,
+        application: `${subscription.application?.name} (${subscription.application?.primaryOwner?.displayName})`,
+        createdAt: subscription.createdAt,
+        endAt: subscription.endingAt,
+        securityType: subscription.plan?.security?.type ?? 'UNKNOWN',
+        isSharedApiKey: subscription.plan?.security?.type === 'API_KEY' && subscription.application?.apiKeyMode === 'SHARED',
+        plan: subscription.plan?.name,
+        processedAt: subscription.processedAt,
+        startingAt: subscription.startingAt,
+        status: statusEntry?.name,
+        statusBadge: statusEntry?.badge,
+      };
+    });
+  });
+
+  protected readonly nbTotalSubscriptions = computed(() => this.subscriptionsData()?.pagination?.totalCount ?? 0);
+  protected readonly isLoadingData = signal(true);
+
+  // Sync Form -> URL (side effect: navigation)
+  private readonly syncFormToUrl = effect(() => {
+    this.filtersForm.valueChanges.pipe(distinctUntilChanged(isEqual), takeUntilDestroyed(this.destroyRef)).subscribe(formValues => {
+      this.navigateToFilters(
+        {
+          ...this.filters().subscriptionsFilters,
+          ...formValues,
+        },
+        {
+          ...this.filters().tableWrapper,
+          pagination: { ...this.filters().tableWrapper.pagination, index: 1 },
+        },
+      );
+    });
+  });
+
+  // Sync URL -> Form (e.g. on back/forward) without triggering navigation (emitEvent: false)
+  private readonly syncUrlToForm = effect(() => {
+    const filters = this.filters();
+    if (filters) {
+      this.filtersForm.patchValue(filters.subscriptionsFilters, { emitEvent: false });
+    }
+  });
+
+  // Initial sync of planIds once plans are loaded
+  private readonly hasSyncedPlanIdsWhenPlansLoaded = signal(false);
+  private readonly syncPlanIdsWhenPlansLoaded = effect(() => {
+    const plans = this.plans();
+    if (plans.length > 0 && !this.hasSyncedPlanIdsWhenPlansLoaded()) {
+      this.hasSyncedPlanIdsWhenPlansLoaded.set(true);
+      const filters = this.filters();
+      this.filtersForm.get('planIds')?.setValue(filters?.subscriptionsFilters.planIds ?? null, { emitEvent: false });
+    }
+  });
+
+  private navigateToFilters(subscriptionsFilters: SubscriptionsFiltersValue, tableWrapper: GioTableWrapperFilters) {
+    const params = omitBy(
+      {
+        page: tableWrapper.pagination.index,
+        size: tableWrapper.pagination.size,
+        status: subscriptionsFilters.statuses?.join(','),
+        plan: subscriptionsFilters.planIds?.join(','),
+        application: subscriptionsFilters.applicationIds?.join(','),
+        apiKey: subscriptionsFilters.apiKey,
+      },
+      isNil,
+    );
+
+    if (!isEqual(this.activatedRoute.snapshot.queryParams, params)) {
+      this.router.navigate(['.'], {
+        relativeTo: this.activatedRoute,
+        queryParams: params,
+      });
+    }
+  }
+
+  protected exportAsCSV(): void {
+    const filters = this.filters();
+    this.subscriptionService
+      .exportAsCSV(
+        this.apiProductId,
+        '1',
+        `${this.nbTotalSubscriptions()}`,
+        filters.subscriptionsFilters.statuses,
+        filters.subscriptionsFilters.applicationIds,
+        filters.subscriptionsFilters.planIds,
+        filters.subscriptionsFilters.apiKey,
+      )
+      .pipe(
+        tap(blob => {
+          let fileName = `subscriptions-api-product-${this.apiProductId}-${now()}.csv`;
+          fileName = fileName.replace(/[\s]/gi, '-').replace(/[^\w]/gi, '-');
+          const anchor = document.createElement('a');
+          anchor.download = fileName;
+          anchor.href = (window.webkitURL || window.URL).createObjectURL(blob);
+          anchor.click();
+        }),
+        catchError(() => {
+          this.snackBarService.error('An error occurred while exporting the subscriptions.');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  protected createSubscription(): void {
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionCreationDialogComponent,
+        ApiPortalSubscriptionCreationDialogData,
+        ApiPortalSubscriptionCreationDialogResult
+      >(ApiPortalSubscriptionCreationDialogComponent, {
+        role: 'alertdialog',
+        id: 'createSubscriptionDialog',
+        data: {
+          isFederatedApi: false,
+          availableSubscriptionEntrypoints: [],
+          plans: this.plans().filter(plan => plan.status === 'PUBLISHED'),
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => {
+          const toCreate = result.subscriptionToCreate;
+          if (result.apiKeyMode) {
+            toCreate.apiKeyMode = result.apiKeyMode;
+          }
+          return this.subscriptionService.create(this.apiProductId, toCreate);
+        }),
+        catchError(err => {
+          this.snackBarService.error(err?.error?.message ?? err?.message ?? 'Failed to create subscription');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(subscription => {
+        this.snackBarService.success('Subscription successfully created');
+        this.router.navigate(['.', subscription.id], { relativeTo: this.activatedRoute });
+      });
+  }
+
+  protected onFiltersChanged(filters: GioTableWrapperFilters): void {
+    this.navigateToFilters(this.filters().subscriptionsFilters, filters);
+  }
+
+  protected resetFilters(): void {
+    this.navigateToFilters(
+      {
+        planIds: null,
+        applicationIds: null,
+        statuses: ['ACCEPTED', 'PAUSED', 'PENDING'],
+        apiKey: undefined,
+      },
+      { searchTerm: '', pagination: { index: 1, size: 10 } },
+    );
+  }
+
+  protected readonly searchApplications: (searchTerm: string) => Observable<AutocompleteOptions> = (searchTerm: string) => {
+    return this.applicationService.list(undefined, searchTerm, 'name', 1, 20).pipe(
+      map(page =>
+        (page.data ?? []).map(app => ({
+          value: app.id,
+          label: `${app.name} (${app.owner?.displayName ?? ''})`,
+        })),
+      ),
+    );
+  };
+
+  protected readonly displayApplication: (value: string) => Observable<string> = (value: string) => {
+    return this.applicationService.getById(value).pipe(
+      map(application => `${application.name} (${application.owner?.displayName ?? ''})`),
+      catchError(() => of(value)),
+    );
+  };
+
+  private parseFiltersFromQueryParams(qp: Params) {
+    const initialPageNumber = qp?.['page'] ? Number(qp['page']) : 1;
+    const initialPageSize = qp?.['size'] ? Number(qp['size']) : 10;
+    const initialPlanIds: string[] | null = qp?.['plan'] ? qp['plan'].split(',') : null;
+    const initialApplicationIds: string[] | null = qp?.['application'] ? qp['application'].split(',') : null;
+    const initialStatuses: SubscriptionStatus[] = qp?.['status'] ? qp['status'].split(',') : ['ACCEPTED', 'PAUSED', 'PENDING'];
+    const initialApiKey: string | undefined = qp?.['apiKey'] ?? undefined;
+
+    return {
+      tableWrapper: { searchTerm: '', pagination: { index: initialPageNumber, size: initialPageSize } },
+      subscriptionsFilters: {
+        planIds: initialPlanIds,
+        applicationIds: initialApplicationIds,
+        statuses: initialStatuses,
+        apiKey: initialApiKey,
+      },
+    };
+  }
+
+  private buildFiltersForm(): FormGroup<SubscriptionsFiltersForm> {
+    const initialFilters = this.parseFiltersFromQueryParams(this.activatedRoute.snapshot.queryParams);
+    const { subscriptionsFilters } = initialFilters;
+    return new FormGroup<SubscriptionsFiltersForm>({
+      planIds: new FormControl<string[] | null>(subscriptionsFilters.planIds),
+      applicationIds: new FormControl<string[] | null>(subscriptionsFilters.applicationIds),
+      statuses: new FormControl<SubscriptionStatus[]>(subscriptionsFilters.statuses),
+      apiKey: new FormControl<string | undefined>(subscriptionsFilters.apiKey),
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
@@ -49,10 +49,6 @@ describe('PlanListComponent', () => {
   async function create(
     inputs: Partial<{
       plans: PlanDS[];
-      isReadOnly: boolean;
-      showDeployOnColumn: boolean;
-      canAddPlan: boolean;
-      isV2Api: boolean;
       context: PlanListContext;
       filterState: PlanFilterState;
     }> = {},
@@ -129,11 +125,6 @@ describe('PlanListComponent', () => {
     it('add plan menu lists only the provided plan types', async () => {
       await create({ context: { isReadOnly: false }, plans: [] });
       const texts = await harness.getAddPlanMenuItems();
-      await create({ isReadOnly: false, plans: [] });
-      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Add new plan"]' })).then(btn => btn.click());
-      const menu = await loader.getHarness(MatMenuHarness);
-      const items = await menu.getItems();
-      const texts = await parallel(() => items.map(i => i.getText()));
       expect(texts).toEqual(['API Key', 'JWT', 'mTLS']);
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
@@ -129,6 +129,11 @@ describe('PlanListComponent', () => {
     it('add plan menu lists only the provided plan types', async () => {
       await create({ context: { isReadOnly: false }, plans: [] });
       const texts = await harness.getAddPlanMenuItems();
+      await create({ isReadOnly: false, plans: [] });
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Add new plan"]' })).then(btn => btn.click());
+      const menu = await loader.getHarness(MatMenuHarness);
+      const items = await menu.getItems();
+      const texts = await parallel(() => items.map(i => i.getText()));
       expect(texts).toEqual(['API Key', 'JWT', 'mTLS']);
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.spec.ts
@@ -49,6 +49,10 @@ describe('PlanListComponent', () => {
   async function create(
     inputs: Partial<{
       plans: PlanDS[];
+      isReadOnly: boolean;
+      showDeployOnColumn: boolean;
+      canAddPlan: boolean;
+      isV2Api: boolean;
       context: PlanListContext;
       filterState: PlanFilterState;
     }> = {},

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.ts
@@ -15,6 +15,7 @@
  */
 import { Component, computed, input, output } from '@angular/core';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import { RouterModule } from '@angular/router';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
@@ -55,6 +56,7 @@ export interface PlanListContext {
   standalone: true,
   imports: [
     CommonModule,
+    RouterModule,
     DragDropModule,
     MatTableModule,
     MatButtonModule,
@@ -103,6 +105,7 @@ export class PlanListComponent {
       cols.push('deploy-on');
     }
     cols.push('actions');
+    if (!ctx.isReadOnly) {
       cols.unshift('drag-icon');
     }
     return cols;

--- a/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/plan-list/plan-list.component.ts
@@ -103,7 +103,6 @@ export class PlanListComponent {
       cols.push('deploy-on');
     }
     cols.push('actions');
-    if (!ctx.isReadOnly) {
       cols.unshift('drag-icon');
     }
     return cols;

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
@@ -21,7 +21,8 @@
   <mat-dialog-content class="change-end-date__dialog-content">
     <div class="change-end-date__content">
       <div class="change-end-date__warning">
-        Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this API.
+        Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this
+        {{ data.isApiProduct ? 'API product' : 'API' }}.
       </div>
       <div *ngIf="data.securityType === 'API_KEY'">All API Keys after the new end date will be revoked.</div>
       <mat-form-field>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.ts
@@ -23,6 +23,8 @@ export interface ApiPortalSubscriptionChangeEndDateDialogData {
   applicationName: string;
   securityType: PlanSecurityType;
   currentEndDate: Date;
+  /** When true, wording uses "API product" instead of "API". Used when opened from API Product context. */
+  isApiProduct?: boolean;
 }
 export interface ApiPortalSubscriptionChangeEndDateDialogResult {
   endDate: Date;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.spec.ts
@@ -21,7 +21,9 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { of } from 'rxjs';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 import { ApplicationSubscriptionListModule } from './application-subscription-list.module';
@@ -269,6 +271,56 @@ describe('ApplicationSubscriptionListComponent', () => {
       expect(rowCells[0][2]).toContain('Api Name - 1');
       expect(rowCells[0][2]).toContain('API Product');
       expect(rowCells[0][7]).toBe('Accepted');
+    }));
+
+    it('should show API product in close confirmation when subscription is API Product', fakeAsync(async () => {
+      const subscription = fakeSubscriptionPage({
+        referenceType: 'API_PRODUCT',
+        referenceId: 'product-id',
+        application: APPLICATION_ID,
+        plan: PLAN_ID,
+      });
+      await initComponent([subscription], undefined, [...DEFAULT_PERMISSIONS, 'application-subscription-d']);
+
+      const matDialog = fixture.debugElement.injector.get(MatDialog);
+      const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+      const listComp = fixture.componentInstance.subscriptionListComponent;
+      const apiProductRow = listComp.subscriptionsTableDS[0];
+      listComp.closeSubscription(apiProductRow);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content: expect.stringContaining('API product'),
+          }),
+        }),
+      );
+      openSpy.mockRestore();
+    }));
+
+    it('should show API in close confirmation when subscription is API', fakeAsync(async () => {
+      const subscription = fakeSubscriptionPage({ api: API_ID, application: APPLICATION_ID, plan: PLAN_ID });
+      await initComponent([subscription], undefined, [...DEFAULT_PERMISSIONS, 'application-subscription-d']);
+
+      const matDialog = fixture.debugElement.injector.get(MatDialog);
+      const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+      const listComp = fixture.componentInstance.subscriptionListComponent;
+      const apiRow = listComp.subscriptionsTableDS[0];
+      listComp.closeSubscription(apiRow);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content: expect.stringContaining('consume this API anymore'),
+          }),
+        }),
+      );
+      expect((openSpy.mock.calls[0][1] as { data: { content: string } }).data.content).not.toContain('API product');
+      openSpy.mockRestore();
     }));
   });
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
@@ -229,9 +229,10 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
 
   public closeSubscription(subscription: SubscriptionsTableDS) {
     const applicationId = this.activatedRoute.snapshot.params.applicationId;
+    const referenceLabel = subscription.referenceTypeLabel === 'API Product' ? 'API product' : 'API';
 
     let content =
-      'Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this API anymore.';
+      `Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this ${referenceLabel} anymore.`;
     if (subscription.securityType === PlanSecurityType.API_KEY && subscription.isSharedApiKey) {
       content += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
     }

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
@@ -19,8 +19,10 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { InteractivityChecker } from '@angular/cdk/a11y';
+import { of } from 'rxjs';
 
 import { ApplicationSubscriptionComponent } from './application-subscription.component';
 import { ApplicationSubscriptionHarness } from './application-subscription.harness';
@@ -201,6 +203,57 @@ describe('ApplicationSubscriptionComponent', () => {
       url: `${CONSTANTS_TESTING.env.baseURL}/applications/${applicationId}/subscriptions/${subscriptionId}`,
       method: 'DELETE',
     });
+  });
+
+  it('should show API product in close confirmation when subscription is API Product', async () => {
+    const matDialog = fixture.debugElement.injector.get(MatDialog);
+    const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+    const apiProductSubscription = fakeSubscription({
+      id: subscriptionId,
+      referenceType: 'API_PRODUCT',
+      apiProduct: {
+        id: 'product-id',
+        name: 'My API Product',
+        version: '1.0',
+        owner: { id: 'owner-id', displayName: 'Product Owner' },
+      },
+      plan: { id: 'planId', name: 'Free Plan', security: 'API_KEY' },
+    });
+    fixture.componentInstance.closeSubscription(fakeApplication({ id: applicationId }), apiProductSubscription);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining('API product'),
+        }),
+      }),
+    );
+    openSpy.mockRestore();
+  });
+
+  it('should show API in close confirmation when subscription is API', async () => {
+    const matDialog = fixture.debugElement.injector.get(MatDialog);
+    const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+    const apiSubscription = fakeSubscription({
+      id: subscriptionId,
+      api: { id: 'api-1', name: 'Test API', version: '1.0', definitionVersion: 'V2', owner: { id: 'o1', displayName: 'Owner' } },
+      plan: { id: 'planId', name: 'Free Plan', security: 'API_KEY' },
+    });
+    fixture.componentInstance.closeSubscription(fakeApplication({ id: applicationId }), apiSubscription);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining('consume this API anymore'),
+        }),
+      }),
+    );
+    expect((openSpy.mock.calls[0][1] as { data: { content: string } }).data.content).not.toContain('API product');
+    openSpy.mockRestore();
   });
 
   const expectApplicationGetRequest = (application: Application): void => {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
@@ -97,9 +97,10 @@ export class ApplicationSubscriptionComponent {
 
   public closeSubscription(application: Application, subscription: Subscription) {
     const applicationId = this.activatedRoute.snapshot.params.applicationId;
+    const referenceLabel = subscription.referenceType === 'API_PRODUCT' ? 'API product' : 'API';
 
     let content =
-      'Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this API anymore.';
+      `Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this ${referenceLabel} anymore.`;
     if (subscription.plan.security === PlanSecurityType.API_KEY && application.api_key_mode !== ApiKeyMode.SHARED) {
       content += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
     }

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.spec.ts
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiProductSubscriptionV2Service } from './api-product-subscription-v2.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import {
+  AcceptSubscription,
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  fakeSubscription,
+  VerifySubscription,
+} from '../entities/management-api-v2';
+import { fakeApiKey } from '../entities/management-api-v2/api-key';
+
+describe('ApiProductSubscriptionV2Service', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ApiProductSubscriptionV2Service;
+  const API_PRODUCT_ID = 'api-product-id';
+  const SUBSCRIPTION_ID = 'subscription-id';
+  const PLAN_ID = 'plan-id';
+  const APPLICATION_ID = 'application-id';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ApiProductSubscriptionV2Service);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list', () => {
+    it('should call the API with defaults', done => {
+      const response: ApiSubscriptionsResponse = { data: [fakeSubscription()] };
+
+      service.list(API_PRODUCT_ID).subscribe(r => {
+        expect(r.data).toEqual([fakeSubscription()]);
+        done();
+      });
+
+      const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+      const req = httpTestingController.expectOne(
+        r =>
+          r.method === 'GET' &&
+          r.url.startsWith(baseUrl) &&
+          !r.url.includes('_export') &&
+          r.params.get('page') === '1' &&
+          r.params.get('perPage') === '10',
+      );
+      req.flush(response);
+    });
+
+    it('should list with all query params', done => {
+      const response: ApiSubscriptionsResponse = { data: [fakeSubscription()] };
+
+      service
+        .list(API_PRODUCT_ID, '1', '10', ['ACCEPTED', 'CLOSED'], ['app1', 'app2'], ['plan1', 'plan2'], 'my-key', ['plan', 'application'])
+        .subscribe(r => {
+          expect(r).toEqual(response);
+          done();
+        });
+
+      const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+      const req = httpTestingController.expectOne(r => {
+        if (r.method !== 'GET' || !r.url.startsWith(baseUrl) || r.url.includes('_export')) return false;
+        const p = r.params;
+        return (
+          p.get('page') === '1' &&
+          p.get('perPage') === '10' &&
+          p.get('statuses') === 'ACCEPTED,CLOSED' &&
+          p.get('applicationIds') === 'app1,app2' &&
+          p.get('planIds') === 'plan1,plan2' &&
+          p.get('apiKey') === 'my-key' &&
+          p.get('expands') === 'plan,application'
+        );
+      });
+      req.flush(response);
+    });
+  });
+
+  describe('getById', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.getById(API_PRODUCT_ID, SUBSCRIPTION_ID, ['plan', 'application']).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const url = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`;
+      const req = httpTestingController.expectOne(
+        r => r.method === 'GET' && r.url.startsWith(url) && r.params.get('expands') === 'plan,application',
+      );
+      req.flush(subscription);
+    });
+  });
+
+  describe('create', () => {
+    it('should call the API', done => {
+      const createSubscription: CreateSubscription = { planId: PLAN_ID, applicationId: APPLICATION_ID };
+      const subscription = fakeSubscription();
+
+      service.create(API_PRODUCT_ID, createSubscription).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(createSubscription);
+      req.flush(subscription);
+    });
+  });
+
+  describe('close', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.close(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_close`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('accept', () => {
+    it('should call the API', done => {
+      const acceptSubscription: AcceptSubscription = { reason: 'ok' };
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.accept(SUBSCRIPTION_ID, API_PRODUCT_ID, acceptSubscription).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_accept`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(acceptSubscription);
+      req.flush(subscription);
+    });
+  });
+
+  describe('reject', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.reject(SUBSCRIPTION_ID, API_PRODUCT_ID, 'Not approved').subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_reject`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ reason: 'Not approved' });
+      req.flush(subscription);
+    });
+  });
+
+  describe('pause', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.pause(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_pause`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('resume', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.resume(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_resume`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('transfer', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      const newPlanId = 'new-plan-id';
+
+      service.transfer(API_PRODUCT_ID, SUBSCRIPTION_ID, newPlanId).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_transfer`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ planId: newPlanId });
+      req.flush(subscription);
+    });
+  });
+
+  describe('verify', () => {
+    it('should call the API', done => {
+      const verifySubscription: VerifySubscription = { applicationId: APPLICATION_ID, apiKey: 'my-api-key' };
+
+      service.verify(API_PRODUCT_ID, verifySubscription).subscribe(r => {
+        expect(r).toBeDefined();
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/_verify`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(verifySubscription);
+      req.flush({ ok: true });
+    });
+  });
+
+  describe('listApiKeys', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.listApiKeys(API_PRODUCT_ID, SUBSCRIPTION_ID).subscribe(r => {
+        expect(r.data).toContain(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys?page=1&perPage=10`,
+          method: 'GET',
+        })
+        .flush({ data: [apiKey] });
+    });
+  });
+
+  describe('renewApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.renewApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, 'custom-key').subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/_renew`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ customApiKey: 'custom-key' });
+      req.flush(apiKey);
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.revokeApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}/_revoke`,
+          method: 'POST',
+        })
+        .flush(apiKey);
+    });
+  });
+
+  describe('expireApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+      const expireAt = new Date('2025-12-31');
+
+      service.expireApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id, expireAt).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual({ expireAt });
+      req.flush(apiKey);
+    });
+  });
+
+  describe('reactivateApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.reactivateApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}/_reactivate`,
+          method: 'POST',
+        })
+        .flush(apiKey);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import {
+  AcceptSubscription,
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  Subscription,
+  UpdateSubscription,
+  VerifySubscription,
+  VerifySubscriptionResponse,
+} from '../entities/management-api-v2';
+import { ApiKey, SubscriptionApiKeysResponse } from '../entities/management-api-v2/api-key';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiProductSubscriptionV2Service {
+  private readonly http = inject(HttpClient);
+  private readonly constants = inject<Constants>(Constants);
+
+  list(
+    apiProductId: string,
+    page = '1',
+    perPage = '10',
+    statuses?: string[],
+    applicationIds?: string[],
+    planIds?: string[],
+    apiKey?: string,
+    expands?: ('plan' | 'application')[],
+  ): Observable<ApiSubscriptionsResponse> {
+    return this.http.get<ApiSubscriptionsResponse>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions`, {
+      params: {
+        page,
+        perPage,
+        ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
+        ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
+        ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
+        ...(apiKey ? { apiKey } : {}),
+        ...(expands ? { expands: expands.join(',') } : {}),
+      },
+    });
+  }
+
+  exportAsCSV(
+    apiProductId: string,
+    page = '1',
+    perPage = '10',
+    statuses?: string[],
+    applicationIds?: string[],
+    planIds?: string[],
+    apiKey?: string,
+  ): Observable<Blob> {
+    return this.http.get(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/_export`, {
+      responseType: 'blob',
+      params: {
+        page,
+        perPage,
+        ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
+        ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
+        ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
+        ...(apiKey ? { apiKey } : {}),
+      },
+    });
+  }
+
+  getById(apiProductId: string, subscriptionId: string, expands: string[] = []): Observable<Subscription> {
+    return this.http.get<Subscription>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}`, {
+      params: { ...(expands.length > 0 ? { expands: expands.join(',') } : {}) },
+    });
+  }
+
+  create(apiProductId: string, createSubscription: CreateSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions`, createSubscription);
+  }
+
+  update(apiProductId: string, subscriptionId: string, updateSubscription: UpdateSubscription): Observable<Subscription> {
+    return this.http.put<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}`,
+      updateSubscription,
+    );
+  }
+
+  transfer(apiProductId: string, subscriptionId: string, planId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_transfer`,
+      { planId },
+    );
+  }
+
+  pause(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_pause`,
+      {},
+    );
+  }
+
+  resume(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_resume`,
+      {},
+    );
+  }
+
+  resumeFailure(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_resumeFailure`,
+      {},
+    );
+  }
+
+  close(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_close`,
+      {},
+    );
+  }
+
+  accept(subscriptionId: string, apiProductId: string, acceptSubscription: AcceptSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_accept`,
+      acceptSubscription,
+    );
+  }
+
+  reject(subscriptionId: string, apiProductId: string, reason: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_reject`,
+      { reason },
+    );
+  }
+
+  verify(apiProductId: string, verifySubscription: VerifySubscription): Observable<VerifySubscriptionResponse> {
+    return this.http.post(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/_verify`, verifySubscription);
+  }
+
+  listApiKeys(apiProductId: string, subscriptionId: string, page = 1, perPage = 10): Observable<SubscriptionApiKeysResponse> {
+    return this.http.get<SubscriptionApiKeysResponse>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys`,
+      { params: { page, perPage } },
+    );
+  }
+
+  renewApiKey(apiProductId: string, subscriptionId: string, customApiKey: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/_renew`,
+      { customApiKey },
+    );
+  }
+
+  revokeApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_revoke`,
+      {},
+    );
+  }
+
+  expireApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string, expireAt: Date): Observable<ApiKey> {
+    return this.http.put<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}`,
+      { expireAt },
+    );
+  }
+
+  reactivateApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_reactivate`,
+      {},
+    );
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -40,6 +40,10 @@ export class ApiProductV2Service {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
+  notifyPlanStateChanged(): void {
+    this._planStateVersion.update(v => v + 1);
+  }
+
   /**
    * Notifies subscribers that plan state has changed. Must be called after any operation that
    * modifies plans: create, update, publish, deprecate, close, reorder, or delete.

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
@@ -25,16 +25,29 @@ import {
   CreateApiProduct,
   toApiProductSortByParam,
   UpdateApiProduct,
+  VerifyApiProductDeployResponse
 } from '../entities/management-api-v2/api-product';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ApiProductV2Service {
+  private readonly _planStateVersion = signal(0);
+  readonly planStateVersion = this._planStateVersion.asReadonly();
+
   constructor(
     private readonly http: HttpClient,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
+
+  /**
+   * Notifies subscribers that plan state has changed. Must be called after any operation that
+   * modifies plans: create, update, publish, deprecate, close, reorder, or delete.
+   * Keeps the navigation banner (e.g. NEED_REDEPLOY) in sync with the latest plan state.
+   */
+  notifyPlanStateChanged(): void {
+    this._planStateVersion.update(v => v + 1);
+  }
 
   /**
    * Create a new API Product
@@ -144,6 +157,28 @@ export class ApiProductV2Service {
   }
 
   /**
+   * Deploy an API Product to gateway instances
+   * Calls POST /environments/{envId}/api-products/{apiProductId}/deployments
+   * @param apiProductId - The API Product ID
+   * @returns Observable of the deployed API Product
+   */
+  deploy(apiProductId: string): Observable<ApiProduct> {
+    return this.http.post<ApiProduct>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/deployments`, {});
+  }
+
+  /**
+   * Check whether an API Product can be deployed (license check)
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/deployments/_verify
+   * @param apiProductId - The API Product ID
+   * @returns Observable with ok boolean and optional reason
+   */
+  verifyDeploy(apiProductId: string): Observable<VerifyApiProductDeployResponse> {
+    return this.http.get<VerifyApiProductDeployResponse>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/deployments/_verify`,
+    );
+  }
+
+  /**
    * Verify if an API Product name is unique
    * Calls POST /environments/{envId}/api-products/_verify
    * @param name - The API Product name to verify
@@ -153,5 +188,15 @@ export class ApiProductV2Service {
     return this.http.post<{ ok: boolean; reason?: string }>(`${this.constants.env.v2BaseURL}/api-products/_verify`, {
       name,
     });
+  }
+
+  /**
+   * Get the current user's permissions for a given API Product
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/members/permissions
+   * @param apiProductId - The API Product ID
+   * @returns Observable of permission map (e.g. { PLAN: ['C','R','U','D'] })
+   */
+  getPermissions(apiProductId: string): Observable<Record<string, string>> {
+    return this.http.get<Record<string, string>>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members/permissions`);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -40,10 +40,6 @@ export class ApiProductV2Service {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
-  notifyPlanStateChanged(): void {
-    this._planStateVersion.update(v => v + 1);
-  }
-
   /**
    * Notifies subscribers that plan state has changed. Must be called after any operation that
    * modifies plans: create, update, publish, deprecate, close, reorder, or delete.

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { inject, Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 import { intersection, toLower } from 'lodash';
 import { map, shareReplay } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
@@ -45,8 +45,6 @@ export const GioTestingRolesScopePermissionProvider = new InjectionToken<GioTest
 
 @Injectable({ providedIn: 'root' })
 export class GioPermissionService {
-  private readonly apiProductV2Service = inject(ApiProductV2Service);
-
   private currentOrganizationPermissions: string[] = [];
   private currentApiPermissions: string[] = [];
   private currentEnvironmentPermissions: string[] = [];

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
@@ -28,11 +28,12 @@ import { ApplicationService } from '../../../services-ngx/application.service';
 import { IntegrationsService } from '../../../services-ngx/integrations.service';
 import { GroupV2Service } from '../../../services-ngx/group-v2.service';
 import { ClusterService } from '../../../services-ngx/cluster.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 
 export type GioTestingPermission = string[];
 
 export type GioTestingRoleScopePermission = {
-  roleScope: 'API' | 'APPLICATION' | 'CLUSTER';
+  roleScope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT';
   id: string;
   permissions: string[];
 };
@@ -50,6 +51,7 @@ export class GioPermissionService {
   private currentApplicationPermissions: string[] = [];
   private currentIntegrationPermissions: string[] = [];
   private currentClusterPermissions: string[] = [];
+  private currentApiProductPermissions: string[] = [];
   private permissions: string[] = [];
   private roleScopePermissionsCache = new Map<string, Observable<string[]>>();
 
@@ -65,6 +67,7 @@ export class GioPermissionService {
     private readonly integrationService: IntegrationsService,
     private readonly clusterService: ClusterService,
     private readonly groupService: GroupV2Service,
+    private readonly apiProductV2Service: ApiProductV2Service,
   ) {
     if (this.gioTestingPermission) {
       this._setPermissions(this.gioTestingPermission);
@@ -171,6 +174,16 @@ export class GioPermissionService {
     );
   }
 
+  loadApiProductPermissions(apiProductId: string): Observable<void> {
+    return this.apiProductV2Service.getPermissions(apiProductId).pipe(
+      map(apiProductPermissions => {
+        this.currentApiProductPermissions = Object.entries(apiProductPermissions).flatMap(([key, crudValues]) =>
+          crudValues.split('').map(crudValue => toLower(`API_PRODUCT-${key}-${crudValue}`)),
+        );
+      }),
+    );
+  }
+
   public fetchGroupPermissions(groupId: string): Observable<string[]> {
     return this.groupService
       .getPermissions(groupId)
@@ -188,11 +201,11 @@ export class GioPermissionService {
    * A Cache is used to store previously fetched permissions to optimize performance and reduce redundant API calls.
    * The Cache is cleared with scope clear methods in the service.
    *
-   * @param {('API'|'APPLICATON'|'CLUSTER')} roleScope - The scope of the role.
+   * @param {('API'|'APPLICATION'|'CLUSTER'|'API_PRODUCT')} roleScope - The scope of the role.
    * @param {string} id - The unique identifier associated with the role.
    * @return {Observable<string[]>} An observable that emits an array of string permissions corresponding to the specified role and ID.
    */
-  getPermissionsByRoleScope(roleScope: 'API' | 'APPLICATION' | 'CLUSTER', id: string): Observable<string[]> {
+  getPermissionsByRoleScope(roleScope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT', id: string): Observable<string[]> {
     const cacheKey = `${roleScope}:${id}`;
 
     if (this.roleScopePermissionsCache.has(cacheKey)) {
@@ -216,6 +229,9 @@ export class GioPermissionService {
         break;
       case 'CLUSTER':
         permissions$ = this.clusterService.getPermissions(id).pipe(map(mapToStringPermissions));
+        break;
+      case 'API_PRODUCT':
+        permissions$ = this.apiProductV2Service.getPermissions(id).pipe(map(mapToStringPermissions));
         break;
       default:
         permissions$ = of([]);
@@ -243,6 +259,7 @@ export class GioPermissionService {
       intersection(this.currentApplicationPermissions, permissions).length > 0 ||
       intersection(this.currentIntegrationPermissions, permissions).length > 0 ||
       intersection(this.currentClusterPermissions, permissions).length > 0 ||
+      intersection(this.currentApiProductPermissions, permissions).length > 0 ||
       intersection(this.permissions, permissions).length > 0
     );
   }
@@ -254,6 +271,11 @@ export class GioPermissionService {
   clearApiPermissions() {
     this.currentApiPermissions = [];
     this.clearRoleScopePermissionsCache('API');
+  }
+
+  clearApiProductPermissions() {
+    this.currentApiProductPermissions = [];
+    this.clearRoleScopePermissionsCache('API_PRODUCT');
   }
 
   clearApplicationPermissions() {
@@ -270,7 +292,7 @@ export class GioPermissionService {
     this.clearRoleScopePermissionsCache('CLUSTER');
   }
 
-  clearRoleScopePermissionsCache(scope: 'API' | 'APPLICATION' | 'CLUSTER') {
+  clearRoleScopePermissionsCache(scope: 'API' | 'APPLICATION' | 'CLUSTER' | 'API_PRODUCT') {
     Array.from(this.roleScopePermissionsCache.keys())
       .filter(key => key.startsWith(`${scope}:`))
       .forEach(key => this.roleScopePermissionsCache.delete(key));
@@ -286,6 +308,7 @@ export class GioPermissionService {
       ...this.currentEnvironmentPermissions,
       ...this.currentApiPermissions,
       ...this.currentApplicationPermissions,
+      ...this.currentApiProductPermissions,
       ...this.permissions,
     ];
 

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { inject, Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 import { intersection, toLower } from 'lodash';
 import { map, shareReplay } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
@@ -45,6 +45,8 @@ export const GioTestingRolesScopePermissionProvider = new InjectionToken<GioTest
 
 @Injectable({ providedIn: 'root' })
 export class GioPermissionService {
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+
   private currentOrganizationPermissions: string[] = [];
   private currentApiPermissions: string[] = [];
   private currentEnvironmentPermissions: string[] = [];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12796

## Description

## API Product Subscription Changes

| Area | What Changed |
|------|--------------|
| List | Subscription list with filters (plan, application, status, API key), Create button, click row to open detail. |
| Detail | Full subscription view (plan, application, status, dates, messages) and action buttons based on status. |
| Lifecycle | PENDING: Validate, Reject. ACCEPTED/PAUSED: Transfer, Pause, Resume, Change end date, Close, Resume from failure (if FAILURE). |
| API keys | Table of keys, plus Renew, Revoke, Expire, Reactivate. Shared mode shows a note only. |
| Transfer | Dialog to move a subscription to another plan (same security type). Plans with general conditions disabled. |
| Service | ApiProductSubscriptionV2Service wraps v2 /api-products/{id}/subscriptions endpoints. |
| Permissions | r: view, c: create, u: lifecycle/API key actions. |
| Routes | consumers/subscriptions (list), consumers/subscriptions/:subscriptionId (detail). |
| Navigation | Subscriptions tab added under Consumers (next to Plans). |

https://github.com/user-attachments/assets/3de05de2-2f1a-48eb-95f1-a162ccba3bb5
