### PR TITLE
Add filter definition endpoint to the logs engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,12 @@ gravitee-apim-e2e/ui-test/screenshots/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# project's maven repo
+/.m2/repository
+/.mvn/jvm.config
+/.mvn/maven.config
+
+# Claude configurations
+CLAUDE.md
+.claude

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -99,6 +99,8 @@ import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -164,6 +166,7 @@ import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSett
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.definition.LogsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1007,6 +1010,16 @@ public class ResourceContextConfiguration {
     @Bean
     public GetMetricFacetSpecUseCase getMetricFacetSpecUseCase(AnalyticsDefinitionQueryService analyticsDefinitionQueryService) {
         return new GetMetricFacetSpecUseCase(analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public LogsDefinitionQueryService logsDefinitionQueryService() {
+        return new LogsDefinitionYAMLQueryService();
+    }
+
+    @Bean
+    public GetLogsFilterDefinitionsUseCase getLogsFilterDefinitionsUseCase(LogsDefinitionQueryService logsDefinitionQueryService) {
+        return new GetLogsFilterDefinitionsUseCase(logsDefinitionQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.installation.Environment
 import io.gravitee.rest.api.management.v2.rest.resource.installation.GraviteeLicenseResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.OrganizationResource;
 import io.gravitee.rest.api.management.v2.rest.resource.integration.IntegrationsResource;
+import io.gravitee.rest.api.management.v2.rest.resource.logs.LogsDefinitionResource;
 import io.gravitee.rest.api.management.v2.rest.resource.logs.LogsSearchResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.ApiServicesResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource;
@@ -82,6 +83,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(AnalyticsDefinitionResource.class);
         register(AnalyticsComputationResource.class);
         register(LogsSearchResource.class);
+        register(LogsDefinitionResource.class);
 
         // Resources deprecated at root level
         register(EndpointsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
+import io.gravitee.apim.core.observability.model.NumberRange;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpec;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMeasuresMapper.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.*;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.CustomInterval;
 import java.time.Instant;
@@ -101,8 +102,8 @@ public interface AnalyticsMeasuresMapper {
         return FilterSpec.Name.valueOf(filterName.name());
     }
 
-    default FilterSpec.Operator mapOperator(Operator operator) {
-        return FilterSpec.Operator.valueOf(operator.name());
+    default FilterOperator mapOperator(Operator operator) {
+        return FilterOperator.valueOf(operator.name());
     }
 
     default Instant toInstant(Object timeRangeBound) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsDefinitionMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.analytics_engine.model.NumberRange;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpec;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecRange;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecsResponse;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface LogsDefinitionMapper {
+    LogsDefinitionMapper INSTANCE = Mappers.getMapper(LogsDefinitionMapper.class);
+
+    LogsFilterSpec mapFilterSpec(io.gravitee.apim.core.logs_engine.model.LogsFilterSpec filterSpec);
+
+    List<LogsFilterSpec> mapFilterSpecs(List<io.gravitee.apim.core.logs_engine.model.LogsFilterSpec> filterSpecs);
+
+    @Mapping(source = "from", target = "min")
+    @Mapping(source = "to", target = "max")
+    LogsFilterSpecRange mapRange(NumberRange range);
+
+    default LogsFilterSpecsResponse toFilterSpecsResponse(List<io.gravitee.apim.core.logs_engine.model.LogsFilterSpec> filterSpecs) {
+        return new LogsFilterSpecsResponse().data(mapFilterSpecs(filterSpecs));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsDefinitionMapper.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
+import io.gravitee.apim.core.observability.model.NumberRange;
 import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecRange;
 import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecsResponse;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentLogsResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
+import io.gravitee.rest.api.management.v2.rest.resource.logs.LogsDefinitionResource;
 import io.gravitee.rest.api.management.v2.rest.resource.logs.LogsSearchResource;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.ResourceContext;
@@ -28,5 +29,10 @@ public class EnvironmentLogsResource {
     @Path("/search")
     public LogsSearchResource getLogsSearchResource() {
         return resourceContext.getResource(LogsSearchResource.class);
+    }
+
+    @Path("/definition")
+    public LogsDefinitionResource getLogsDefinitionResource() {
+        return resourceContext.getResource(LogsDefinitionResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsDefinitionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsDefinitionResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.logs;
+
+import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
+import io.gravitee.rest.api.management.v2.rest.mapper.LogsDefinitionMapper;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecsResponse;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class LogsDefinitionResource {
+
+    @Inject
+    GetLogsFilterDefinitionsUseCase getLogsFilterDefinitions;
+
+    @Path("/filters")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
+    public LogsFilterSpecsResponse getFilterDefinitions() {
+        return LogsDefinitionMapper.INSTANCE.toFilterSpecsResponse(getLogsFilterDefinitions.execute().specs());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -29,8 +29,55 @@ servers:
 tags:
   - name: logs
     description: Operations related to querying API connection logs
+  - name: definition
+    description: Operations related to querying logs filter definitions
 
 paths:
+  /environments/{envId}/logs/definition/filters:
+    get:
+      operationId: queryLogFilterDefinitions
+      summary: Query available filters for log search
+      description: |
+        Returns a list of available filters that can be applied to log searches, including their operators and value constraints.
+      tags:
+        - definition
+      parameters:
+        - $ref: "./openapi-analytics.yaml#/components/parameters/EnvId"
+      responses:
+        "200":
+          description: |
+            The response contains a list of available filters for log searches, including their supported operators, types, and optional enum values or ranges.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LogsFilterSpecsResponse"
+              examples:
+                log-filters:
+                  summary: Log Search Filters
+                  value:
+                    data:
+                      - name: "API"
+                        label: "API"
+                        type: "KEYWORD"
+                        operators: ["EQ", "IN"]
+                      - name: "HTTP_STATUS"
+                        label: "Status Code"
+                        type: "NUMBER"
+                        operators: ["EQ", "IN", "LTE", "GTE"]
+                        range:
+                          min: 100
+                          max: 599
+                      - name: "RESPONSE_TIME"
+                        label: "Response Time"
+                        type: "NUMBER"
+                        operators: ["GTE", "LTE"]
+        "500":
+          description: Internal server error while getting filter definitions.
+          content:
+            application/json:
+              schema:
+                $ref: "./openapi-analytics.yaml#/components/schemas/Error"
+
   /environments/{envId}/logs/search:
     post:
       operationId: searchApiLogs
@@ -385,3 +432,78 @@ components:
         - LTE
         - IN
       description: Filter operator
+
+    LogsFilterSpecsResponse:
+      type: object
+      description: The response contains a list of available filters for log searches.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/LogsFilterSpec"
+      example:
+        data:
+          - name: "API"
+            label: "API"
+            type: "KEYWORD"
+            operators: ["EQ", "IN"]
+          - name: "HTTP_STATUS"
+            label: "Status Code"
+            type: "NUMBER"
+            operators: ["EQ", "IN", "LTE", "GTE"]
+            range:
+              min: 100
+              max: 599
+
+    LogsFilterSpec:
+      type: object
+      required:
+        - name
+        - label
+        - type
+        - operators
+      description: Filter specification for filtering log searches. Describes a filter's name, type, supported operators, and optional constraints.
+      properties:
+        name:
+          $ref: "#/components/schemas/FilterName"
+        label:
+          type: string
+          description: Human-readable label for the filter
+          example: "API"
+        type:
+          type: string
+          enum:
+            - KEYWORD
+            - STRING
+            - NUMBER
+            - ENUM
+          description: Data type of the filter
+          example: "KEYWORD"
+        operators:
+          type: array
+          items:
+            $ref: "#/components/schemas/Operator"
+          description: List of supported operators for this filter
+          example: ["EQ", "IN"]
+        enumValues:
+          type: array
+          items:
+            type: string
+          description: Enum values (only applicable for enum type)
+        range:
+          type: object
+          properties:
+            min:
+              type: number
+              description: Minimum value
+              example: 100
+            max:
+              type: number
+              description: Maximum value
+              example: 599
+          description: Value range (only applicable for numeric types)
+      example:
+        name: "API"
+        label: "API"
+        type: "KEYWORD"
+        operators: ["EQ", "IN"]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProc
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.model.AnalyticsQueryContext;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.Facet;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
@@ -448,7 +449,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
         void should_forward_transformer_api_filter_to_es_query() {
             var apiFilter = new io.gravitee.apim.core.analytics_engine.model.Filter(
                 FilterSpec.Name.API,
-                FilterSpec.Operator.IN,
+                FilterOperator.IN,
                 Set.of("api-1")
             );
             when(queryFilterTransformer.transform(any(AnalyticsQueryContext.class), any())).thenReturn(List.of(apiFilter));
@@ -489,11 +490,7 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
         @Test
         void should_scope_api_filter_to_authorized_ids() {
             var authorizedIds = Set.of("api-1", "api-2");
-            var apiFilter = new io.gravitee.apim.core.analytics_engine.model.Filter(
-                FilterSpec.Name.API,
-                FilterSpec.Operator.IN,
-                authorizedIds
-            );
+            var apiFilter = new io.gravitee.apim.core.analytics_engine.model.Filter(FilterSpec.Name.API, FilterOperator.IN, authorizedIds);
             when(queryFilterTransformer.transform(any(AnalyticsQueryContext.class), any())).thenReturn(List.of(apiFilter));
 
             var queryContext = new QueryContext(ORGANIZATION, ENVIRONMENT);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsDefinitionResourceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.logs;
+
+import static assertions.MAPIAssertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpec;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.LogsFilterSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LogsDefinitionResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+
+    @BeforeEach
+    void setup() {
+        var environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/logs";
+    }
+
+    @Test
+    void should_return_filter_definitions() {
+        var response = rootTarget().path("definition").path("filters").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(LogsFilterSpecsResponse.class)
+            .extracting(LogsFilterSpecsResponse::getData)
+            .satisfies(filters -> assertThat(filters).hasSize(11));
+    }
+
+    @Test
+    void should_return_filter_definitions_with_correct_structure() {
+        var response = rootTarget().path("definition").path("filters").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(LogsFilterSpecsResponse.class)
+            .extracting(LogsFilterSpecsResponse::getData)
+            .satisfies(filters -> {
+                var apiFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("API"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(apiFilter.getLabel()).isEqualTo("API");
+                assertThat(apiFilter.getType()).isEqualTo(LogsFilterSpec.TypeEnum.KEYWORD);
+                assertThat(apiFilter.getOperators()).isNotEmpty();
+
+                var responseTimeFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("RESPONSE_TIME"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(responseTimeFilter.getLabel()).isEqualTo("Response Time");
+                assertThat(responseTimeFilter.getType()).isEqualTo(LogsFilterSpec.TypeEnum.NUMBER);
+                assertThat(responseTimeFilter.getOperators()).isNotEmpty();
+
+                var httpStatusFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("HTTP_STATUS"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(httpStatusFilter.getRange()).isNotNull();
+                assertThat(httpStatusFilter.getRange().getMin()).isEqualTo(100);
+                assertThat(httpStatusFilter.getRange().getMax()).isEqualTo(599);
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -16,9 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.spring;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
@@ -116,6 +114,8 @@ import io.gravitee.apim.core.license.crud_service.LicenseCrudService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -193,6 +193,7 @@ import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSett
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.definition.LogsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1142,6 +1143,16 @@ public class ResourceContextConfiguration {
     @Bean
     public GetMetricFacetSpecUseCase getMetricFacetSpecUseCase(AnalyticsDefinitionQueryService analyticsDefinitionQueryService) {
         return new GetMetricFacetSpecUseCase(analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public LogsDefinitionQueryService logsDefinitionQueryService() {
+        return new LogsDefinitionYAMLQueryService();
+    }
+
+    @Bean
+    public GetLogsFilterDefinitionsUseCase getLogsFilterDefinitionsUseCase(LogsDefinitionQueryService logsDefinitionQueryService) {
+        return new GetLogsFilterDefinitionsUseCase(logsDefinitionQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -93,6 +93,8 @@ import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainS
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
@@ -152,6 +154,7 @@ import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSett
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.definition.LogsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1191,6 +1194,16 @@ public class ResourceContextConfiguration {
     @Bean
     public GetMetricFacetSpecUseCase getMetricFacetSpecUseCase(AnalyticsDefinitionQueryService analyticsDefinitionQueryService) {
         return new GetMetricFacetSpecUseCase(analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public LogsDefinitionQueryService logsDefinitionQueryService() {
+        return new LogsDefinitionYAMLQueryService();
+    }
+
+    @Bean
+    public GetLogsFilterDefinitionsUseCase getLogsFilterDefinitionsUseCase(LogsDefinitionQueryService logsDefinitionQueryService) {
+        return new GetLogsFilterDefinitionsUseCase(logsDefinitionQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -85,6 +85,8 @@ import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryS
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
@@ -142,6 +144,7 @@ import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSett
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.logs_engine.definition.LogsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDSpecDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1083,6 +1086,16 @@ public class ResourceContextConfiguration {
     @Bean
     public GetMetricFacetSpecUseCase getMetricFacetSpecUseCase(AnalyticsDefinitionQueryService analyticsDefinitionQueryService) {
         return new GetMetricFacetSpecUseCase(analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public LogsDefinitionQueryService logsDefinitionQueryService() {
+        return new LogsDefinitionYAMLQueryService();
+    }
+
+    @Bean
+    public GetLogsFilterDefinitionsUseCase getLogsFilterDefinitionsUseCase(LogsDefinitionQueryService logsDefinitionQueryService) {
+        return new GetLogsFilterDefinitionsUseCase(logsDefinitionQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -24,10 +24,10 @@ import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.observability.model.NumberRange;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import java.util.List;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FacetSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FacetSpec.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.List;
 
 public record FacetSpec(Name name, String label, String type, List<Object> enumValues, NumberRange range) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FacetsRequest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FacetsRequest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/Filter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/Filter.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.observability.model.FilterOperator;
+
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record Filter(FilterSpec.Name name, FilterSpec.Operator operator, Object value) {}
+public record Filter(FilterSpec.Name name, FilterOperator operator, Object value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.analytics_engine.model;
 
 import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.apim.core.observability.model.FilterType;
+import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.List;
 
 public record FilterSpec(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -15,9 +15,18 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.observability.model.FilterType;
 import java.util.List;
 
-public record FilterSpec(Name name, String label, Type type, List<String> enumValues, NumberRange range, List<Operator> operators) {
+public record FilterSpec(
+    Name name,
+    String label,
+    FilterType type,
+    List<String> enumValues,
+    NumberRange range,
+    List<FilterOperator> operators
+) {
     public enum Name {
         API,
         APPLICATION,
@@ -60,19 +69,5 @@ public record FilterSpec(Name name, String label, Type type, List<String> enumVa
         MCP_PROXY_RESOURCE,
         MCP_PROXY_PROMPT,
         API_TYPE,
-    }
-
-    public enum Type {
-        STRING,
-        KEYWORD,
-        ENUM,
-        NUMBER,
-    }
-
-    public enum Operator {
-        EQ,
-        LTE,
-        GTE,
-        IN,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/TimeSeriesRequest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/TimeSeriesRequest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.analytics_engine.model;
 
+import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dashboard/model/DashboardWidgetRequestMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dashboard/model/DashboardWidgetRequestMapper.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import java.util.List;
 
@@ -140,9 +141,9 @@ public final class DashboardWidgetRequestMapper {
         }
     }
 
-    private static FilterSpec.Operator parseFilterOperator(String value) {
+    private static FilterOperator parseFilterOperator(String value) {
         try {
-            return FilterSpec.Operator.valueOf(value);
+            return FilterOperator.valueOf(value);
         } catch (IllegalArgumentException e) {
             throw new InvalidQueryException("Unknown filter operator: " + value);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsDefinition.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.logs_engine.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record LogsDefinition(LogsDefinitionSpec spec) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsDefinitionSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsDefinitionSpec.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.logs_engine.model;
+
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record LogsDefinitionSpec(List<LogsFilterSpec> filters) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsFilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsFilterSpec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.logs_engine.model;
+
+import io.gravitee.apim.core.analytics_engine.model.NumberRange;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record LogsFilterSpec(
+    FilterName name,
+    String label,
+    Type type,
+    List<String> enumValues,
+    NumberRange range,
+    List<Operator> operators
+) {
+    public enum Type {
+        STRING,
+        KEYWORD,
+        ENUM,
+        NUMBER,
+    }
+
+    public enum Operator {
+        EQ,
+        LTE,
+        GTE,
+        IN,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsFilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/LogsFilterSpec.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.apim.core.logs_engine.model;
 
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
 import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.apim.core.observability.model.FilterType;
+import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.List;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/query_service/LogsDefinitionQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/query_service/LogsDefinitionQueryService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.logs_engine.query_service;
+
+import io.gravitee.apim.core.logs_engine.model.LogsFilterSpec;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface LogsDefinitionQueryService {
+    List<LogsFilterSpec> getFilters();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/GetLogsFilterDefinitionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/GetLogsFilterDefinitionsUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.logs_engine.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.logs_engine.model.LogsFilterSpec;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+@UseCase
+public class GetLogsFilterDefinitionsUseCase {
+
+    private final LogsDefinitionQueryService definition;
+
+    public GetLogsFilterDefinitionsUseCase(LogsDefinitionQueryService definition) {
+        this.definition = definition;
+    }
+
+    public record Output(List<LogsFilterSpec> specs) {}
+
+    public Output execute() {
+        return new Output(definition.getFilters());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterOperator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterOperator.java
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.logs_engine.model;
-
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
-import io.gravitee.apim.core.observability.model.FilterOperator;
-import io.gravitee.apim.core.observability.model.FilterType;
-import java.util.List;
+package io.gravitee.apim.core.observability.model;
 
 /**
  * @author GraviteeSource Team
  */
-public record LogsFilterSpec(
-    FilterName name,
-    String label,
-    FilterType type,
-    List<String> enumValues,
-    NumberRange range,
-    List<FilterOperator> operators
-) {}
+public enum FilterOperator {
+    EQ,
+    LTE,
+    GTE,
+    IN,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterType.java
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.logs_engine.model;
-
-import io.gravitee.apim.core.analytics_engine.model.NumberRange;
-import io.gravitee.apim.core.observability.model.FilterOperator;
-import io.gravitee.apim.core.observability.model.FilterType;
-import java.util.List;
+package io.gravitee.apim.core.observability.model;
 
 /**
  * @author GraviteeSource Team
  */
-public record LogsFilterSpec(
-    FilterName name,
-    String label,
-    FilterType type,
-    List<String> enumValues,
-    NumberRange range,
-    List<FilterOperator> operators
-) {}
+public enum FilterType {
+    STRING,
+    KEYWORD,
+    ENUM,
+    NUMBER,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/NumberRange.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/NumberRange.java
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.analytics_engine.model;
+package io.gravitee.apim.core.observability.model;
 
 public record NumberRange(Number from, Number to) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.infra.domain_service.analytics_engine.definition;
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.gravitee.apim.core.analytics_engine.model.AnalyticsDefinition;
 import io.gravitee.apim.core.analytics_engine.model.AnalyticsDefinitionSpec;
 import io.gravitee.apim.core.analytics_engine.model.ApiSpec;
@@ -23,9 +22,9 @@ import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.infra.domain_service.observability.YAMLDefinitionLoader;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,23 +32,10 @@ public class AnalyticsDefinitionYAMLQueryService implements AnalyticsDefinitionQ
 
     private static final String ANALYTICS_DEFINITION_FILE = "analytics/definition/analytics-definition.yaml";
 
-    private static final YAMLMapper YAML = new YAMLMapper();
-
     private final AnalyticsDefinitionSpec spec;
 
     public AnalyticsDefinitionYAMLQueryService() {
-        spec = readYAMLDefinition().spec();
-    }
-
-    private static io.gravitee.apim.core.analytics_engine.model.AnalyticsDefinition readYAMLDefinition() {
-        try {
-            return YAML.readValue(
-                AnalyticsDefinitionYAMLQueryService.class.getClassLoader().getResourceAsStream(ANALYTICS_DEFINITION_FILE),
-                AnalyticsDefinition.class
-            );
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to read analytics definition file", e);
-        }
+        spec = YAMLDefinitionLoader.load(ANALYTICS_DEFINITION_FILE, AnalyticsDefinition.class).spec();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.analytics_engine.exception.InvalidQueryException;
 import io.gravitee.apim.core.analytics_engine.model.AnalyticsQueryContext;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.definition.model.v4.ApiType;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,7 +65,7 @@ public class ApiTypeFilterTransformer implements QueryFilterTransformer {
             .map(f -> resolveApiIds(context, f))
             .orElseGet(context::authorizedApiIds);
 
-        transformed.add(new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, apiIds));
+        transformed.add(new Filter(FilterSpec.Name.API, FilterOperator.IN, apiIds));
 
         return transformed;
     }
@@ -85,7 +86,7 @@ public class ApiTypeFilterTransformer implements QueryFilterTransformer {
 
     @SuppressWarnings("unchecked")
     private static List<ApiType> toApiTypes(Filter apiTypeFilter) {
-        if (apiTypeFilter.operator() == FilterSpec.Operator.IN) {
+        if (apiTypeFilter.operator() == FilterOperator.IN) {
             return ((Collection<String>) apiTypeFilter.value()).stream().map(ApiTypeFilterTransformer::mapApiType).toList();
         }
         return List.of(mapApiType((String) apiTypeFilter.value()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/definition/LogsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/definition/LogsDefinitionYAMLQueryService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.logs_engine.definition;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.gravitee.apim.core.logs_engine.model.LogsDefinition;
+import io.gravitee.apim.core.logs_engine.model.LogsDefinitionSpec;
+import io.gravitee.apim.core.logs_engine.model.LogsFilterSpec;
+import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Service
+public class LogsDefinitionYAMLQueryService implements LogsDefinitionQueryService {
+
+    private static final String LOGS_DEFINITION_FILE = "logs/definition/logs-definition.yaml";
+
+    private static final YAMLMapper YAML = new YAMLMapper();
+
+    private final LogsDefinitionSpec spec;
+
+    public LogsDefinitionYAMLQueryService() {
+        spec = readYAMLDefinition().spec();
+    }
+
+    private static LogsDefinition readYAMLDefinition() {
+        try (var stream = LogsDefinitionYAMLQueryService.class.getClassLoader().getResourceAsStream(LOGS_DEFINITION_FILE)) {
+            if (stream == null) {
+                throw new IllegalStateException("Logs definition file not found on classpath: " + LOGS_DEFINITION_FILE);
+            }
+            return YAML.readValue(stream, LogsDefinition.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to parse logs definition file: " + LOGS_DEFINITION_FILE, e);
+        }
+    }
+
+    @Override
+    public List<LogsFilterSpec> getFilters() {
+        return spec.filters();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/definition/LogsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/definition/LogsDefinitionYAMLQueryService.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.apim.infra.domain_service.logs_engine.definition;
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.gravitee.apim.core.logs_engine.model.LogsDefinition;
 import io.gravitee.apim.core.logs_engine.model.LogsDefinitionSpec;
 import io.gravitee.apim.core.logs_engine.model.LogsFilterSpec;
 import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
-import java.io.IOException;
+import io.gravitee.apim.infra.domain_service.observability.YAMLDefinitionLoader;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -32,23 +31,10 @@ public class LogsDefinitionYAMLQueryService implements LogsDefinitionQueryServic
 
     private static final String LOGS_DEFINITION_FILE = "logs/definition/logs-definition.yaml";
 
-    private static final YAMLMapper YAML = new YAMLMapper();
-
     private final LogsDefinitionSpec spec;
 
     public LogsDefinitionYAMLQueryService() {
-        spec = readYAMLDefinition().spec();
-    }
-
-    private static LogsDefinition readYAMLDefinition() {
-        try (var stream = LogsDefinitionYAMLQueryService.class.getClassLoader().getResourceAsStream(LOGS_DEFINITION_FILE)) {
-            if (stream == null) {
-                throw new IllegalStateException("Logs definition file not found on classpath: " + LOGS_DEFINITION_FILE);
-            }
-            return YAML.readValue(stream, LogsDefinition.class);
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to parse logs definition file: " + LOGS_DEFINITION_FILE, e);
-        }
+        spec = YAMLDefinitionLoader.load(LOGS_DEFINITION_FILE, LogsDefinition.class).spec();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/observability/YAMLDefinitionLoader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/observability/YAMLDefinitionLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.observability;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public final class YAMLDefinitionLoader {
+
+    private static final YAMLMapper YAML = new YAMLMapper();
+
+    private YAMLDefinitionLoader() {}
+
+    public static <T> T load(String classpathResource, Class<T> type) {
+        try (var stream = YAMLDefinitionLoader.class.getClassLoader().getResourceAsStream(classpathResource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Definition file not found on classpath: " + classpathResource);
+            }
+            return YAML.readValue(stream, type);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to parse definition file: " + classpathResource, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/logs/definition/logs-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/logs/definition/logs-definition.yaml
@@ -1,0 +1,72 @@
+spec:
+    filters:
+        - name: API
+          label: API
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: APPLICATION
+          label: Application
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: ENTRYPOINT
+          label: Entrypoint
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: PLAN
+          label: Plan
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: HTTP_METHOD
+          label: HTTP Method
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: HTTP_STATUS
+          label: Status Code
+          type: NUMBER
+          operators:
+              - EQ
+              - IN
+              - GTE
+              - LTE
+          range:
+              from: 100
+              to: 599
+        - name: MCP_METHOD
+          label: MCP Method
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+        - name: TRANSACTION_ID
+          label: Transaction ID
+          type: STRING
+          operators:
+              - EQ
+              - IN
+        - name: REQUEST_ID
+          label: Request ID
+          type: STRING
+          operators:
+              - EQ
+              - IN
+        - name: URI
+          label: URI
+          type: STRING
+          operators:
+              - EQ
+        - name: RESPONSE_TIME
+          label: Response Time
+          type: NUMBER
+          operators:
+              - GTE
+              - LTE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeFacetsUseCaseTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Instant;
 import java.util.List;
@@ -108,7 +109,7 @@ class ComputeFacetsUseCaseTest {
 
     @Test
     void should_apply_transformer_filters_to_query() {
-        var apiFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
+        var apiFilter = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(apiFilter));
 
         var useCase = new ComputeFacetsUseCase(
@@ -133,8 +134,8 @@ class ComputeFacetsUseCaseTest {
 
     @Test
     void should_chain_filters_from_multiple_transformers() {
-        var filter1 = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
-        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterSpec.Operator.IN, Set.of("app-1"));
+        var filter1 = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
+        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.IN, Set.of("app-1"));
 
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1));
         when(transformer2.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1, filter2));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeMeasuresUseCaseTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Instant;
 import java.util.List;
@@ -103,7 +104,7 @@ class ComputeMeasuresUseCaseTest {
 
     @Test
     void should_apply_transformer_filters_to_query() {
-        var apiFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
+        var apiFilter = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(apiFilter));
 
         var useCase = new ComputeMeasuresUseCase(queryContextProvider, validator, List.of(transformer1), contextLoader);
@@ -122,8 +123,8 @@ class ComputeMeasuresUseCaseTest {
 
     @Test
     void should_chain_filters_from_multiple_transformers() {
-        var filter1 = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
-        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterSpec.Operator.IN, Set.of("app-1"));
+        var filter1 = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
+        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.IN, Set.of("app-1"));
 
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1));
         when(transformer2.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1, filter2));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ComputeTimeSeriesUseCaseTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Duration;
 import java.time.Instant;
@@ -109,7 +110,7 @@ class ComputeTimeSeriesUseCaseTest {
 
     @Test
     void should_apply_transformer_filters_to_query() {
-        var apiFilter = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
+        var apiFilter = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(apiFilter));
 
         var useCase = new ComputeTimeSeriesUseCase(
@@ -134,8 +135,8 @@ class ComputeTimeSeriesUseCaseTest {
 
     @Test
     void should_chain_filters_from_multiple_transformers() {
-        var filter1 = new Filter(FilterSpec.Name.API, FilterSpec.Operator.IN, Set.of("api-1"));
-        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterSpec.Operator.IN, Set.of("app-1"));
+        var filter1 = new Filter(FilterSpec.Name.API, FilterOperator.IN, Set.of("api-1"));
+        var filter2 = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.IN, Set.of("app-1"));
 
         when(transformer1.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1));
         when(transformer2.transform(eq(ANALYTICS_CONTEXT), any())).thenReturn(List.of(filter1, filter2));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dashboard/model/DashboardWidgetRequestMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dashboard/model/DashboardWidgetRequestMapperTest.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -162,7 +163,7 @@ class DashboardWidgetRequestMapperTest {
 
             assertThat(result.filters()).hasSize(1);
             assertThat(result.filters().get(0).name()).isEqualTo(FilterSpec.Name.API);
-            assertThat(result.filters().get(0).operator()).isEqualTo(FilterSpec.Operator.EQ);
+            assertThat(result.filters().get(0).operator()).isEqualTo(FilterOperator.EQ);
             assertThat(result.filters().get(0).value()).isEqualTo("my-api-id");
         }
 
@@ -183,7 +184,7 @@ class DashboardWidgetRequestMapperTest {
 
             assertThat(result.metrics().get(0).filters()).hasSize(1);
             assertThat(result.metrics().get(0).filters().get(0).name()).isEqualTo(FilterSpec.Name.API_TYPE);
-            assertThat(result.metrics().get(0).filters().get(0).operator()).isEqualTo(FilterSpec.Operator.EQ);
+            assertThat(result.metrics().get(0).filters().get(0).operator()).isEqualTo(FilterOperator.EQ);
             assertThat(result.metrics().get(0).filters().get(0).value()).isEqualTo("LLM");
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
@@ -80,7 +81,7 @@ class ApiTypeFilterTransformerTest {
 
         assertThat(filters).hasSize(1);
         assertThat(filters.getFirst().name()).isEqualTo(FilterSpec.Name.API);
-        assertThat(filters.getFirst().operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filters.getFirst().operator()).isEqualTo(FilterOperator.IN);
         assertThat(filters.getFirst().value())
             .asInstanceOf(InstanceOfAssertFactories.collection(String.class))
             .containsExactlyInAnyOrderElementsOf(authorizedApiIds);
@@ -89,7 +90,7 @@ class ApiTypeFilterTransformerTest {
     @Test
     void should_preserve_existing_filters() {
         var context = buildContext(Set.of("api-1"), Map.of(ApiType.PROXY, Set.of("api-1")));
-        var existingFilter = new Filter(FilterSpec.Name.APPLICATION, FilterSpec.Operator.EQ, "app-1");
+        var existingFilter = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.EQ, "app-1");
 
         var filters = transformer.transform(context, List.of(existingFilter));
 
@@ -112,12 +113,12 @@ class ApiTypeFilterTransformerTest {
     void should_narrow_to_mcp_apis_with_eq_operator() {
         var context = buildContext(Set.of("api-1", "api-2", "api-3"), STANDARD_API_IDS_BY_TYPE);
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "MCP");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "MCP");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters).hasSize(1);
         assertThat(filters.getFirst().name()).isEqualTo(FilterSpec.Name.API);
-        assertThat(filters.getFirst().operator()).isEqualTo(FilterSpec.Operator.IN);
+        assertThat(filters.getFirst().operator()).isEqualTo(FilterOperator.IN);
         assertThat(filters.getFirst().value()).asInstanceOf(InstanceOfAssertFactories.collection(String.class)).containsExactly("api-2");
     }
 
@@ -125,7 +126,7 @@ class ApiTypeFilterTransformerTest {
     void should_narrow_to_multiple_api_types_with_in_operator() {
         var context = buildContext(Set.of("api-1", "api-2", "api-3"), STANDARD_API_IDS_BY_TYPE);
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.IN, List.of("LLM", "MCP"));
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.IN, List.of("LLM", "MCP"));
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters).hasSize(1);
@@ -139,8 +140,8 @@ class ApiTypeFilterTransformerTest {
     void should_remove_api_type_filter_from_output() {
         var context = buildContext(Set.of("api-1"), Map.of(ApiType.PROXY, Set.of("api-1")));
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "HTTP_PROXY");
-        var otherFilter = new Filter(FilterSpec.Name.APPLICATION, FilterSpec.Operator.EQ, "app-1");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "HTTP_PROXY");
+        var otherFilter = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.EQ, "app-1");
 
         var filters = transformer.transform(context, List.of(apiTypeFilter, otherFilter));
 
@@ -152,7 +153,7 @@ class ApiTypeFilterTransformerTest {
     @Test
     void should_return_empty_api_filter_when_api_type_present_but_no_authorized_apis() {
         var context = buildContext(Set.of());
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "MCP");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "MCP");
 
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
@@ -165,7 +166,7 @@ class ApiTypeFilterTransformerTest {
     void should_map_http_proxy_to_proxy_api_type() {
         var context = buildContext(Set.of("api-1"), Map.of(ApiType.PROXY, Set.of("api-1")));
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "HTTP_PROXY");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "HTTP_PROXY");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters.getFirst().value()).asInstanceOf(InstanceOfAssertFactories.collection(String.class)).containsExactly("api-1");
@@ -175,7 +176,7 @@ class ApiTypeFilterTransformerTest {
     void should_map_message_to_message_api_type() {
         var context = buildContext(Set.of("api-4"), Map.of(ApiType.MESSAGE, Set.of("api-4")));
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "MESSAGE");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "MESSAGE");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters.getFirst().value()).asInstanceOf(InstanceOfAssertFactories.collection(String.class)).containsExactly("api-4");
@@ -185,7 +186,7 @@ class ApiTypeFilterTransformerTest {
     void should_map_kafka_to_native_api_type() {
         var context = buildContext(Set.of("api-5"), Map.of(ApiType.NATIVE, Set.of("api-5")));
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "KAFKA");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "KAFKA");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters.getFirst().value()).asInstanceOf(InstanceOfAssertFactories.collection(String.class)).containsExactly("api-5");
@@ -194,7 +195,7 @@ class ApiTypeFilterTransformerTest {
     @Test
     void should_throw_on_unknown_api_type_value() {
         var context = buildContext(Set.of("api-1"));
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "UNKNOWN");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "UNKNOWN");
 
         assertThatThrownBy(() -> transformer.transform(context, List.of(apiTypeFilter)))
             .isInstanceOf(InvalidQueryException.class)
@@ -206,7 +207,7 @@ class ApiTypeFilterTransformerTest {
         var apiIdsByType = Map.of(ApiType.PROXY, Set.of("api-1"), ApiType.LLM_PROXY, Set.of("api-3"));
         var context = buildContext(Set.of("api-1", "api-3"), apiIdsByType);
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "MCP");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "MCP");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters.getFirst().value())
@@ -219,7 +220,7 @@ class ApiTypeFilterTransformerTest {
     void should_return_authorized_mcp_apis_only_when_multiple_types_exist() {
         var context = buildContext(Set.of("api-2", "api-3"), STANDARD_API_IDS_BY_TYPE);
 
-        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterSpec.Operator.EQ, "MCP");
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, "MCP");
         var filters = transformer.transform(context, List.of(apiTypeFilter));
 
         assertThat(filters.getFirst().value()).asInstanceOf(InstanceOfAssertFactories.collection(String.class)).containsExactly("api-2");


### PR DESCRIPTION
## Issue

[GKO-2419](https://gravitee.atlassian.net/browse/GKO-2419)

## Description

Add a new `GET /environments/{envId}/logs/definition/filters` endpoint that returns available log filters with their metadata (name, label, type, operators, range), and refactor shared observability types across the analytics and logs engines.

### New endpoint

- New OpenAPI spec additions in `openapi-logs.yaml` with `LogsFilterSpecsResponse` and `LogsFilterSpec` schemas
- YAML-backed definition service (`LogsDefinitionYAMLQueryService`) following the analytics engine pattern
- Domain models: `LogsFilterSpec` with `FilterType` and `FilterOperator` enums
- MapStruct mapper with `NumberRange(from/to)` to `LogsFilterSpecRange(min/max)` mapping
- 11 filter definitions: API, APPLICATION, ENTRYPOINT, PLAN, HTTP_METHOD, HTTP_STATUS, MCP_METHOD, TRANSACTION_ID, REQUEST_ID, URI, RESPONSE_TIME
- Integration tests verifying filter count and structure

### Refactoring: shared observability model

- Extract `FilterType` and `FilterOperator` enums into a shared `io.gravitee.apim.core.observability.model` package — both `analytics_engine.FilterSpec` and `logs_engine.LogsFilterSpec` now reference the same enums
- Move `NumberRange` from `analytics_engine` to the shared `observability.model` package since it's used by both engines
- Extract `YAMLDefinitionLoader` utility in the observability infra package to remove duplicated YAML classpath loading boilerplate from `AnalyticsDefinitionYAMLQueryService` and `LogsDefinitionYAMLQueryService`

### Response example

```json
{
  "data": [
    {
      "name": "API",
      "label": "API",
      "type": "KEYWORD",
      "operators": ["EQ", "IN"],
      "enumValues": []
    },
    {
      "name": "HTTP_STATUS",
      "label": "Status Code",
      "type": "NUMBER",
      "operators": ["EQ", "IN", "GTE", "LTE"],
      "enumValues": [],
      "range": { "min": 100, "max": 599 }
    },
    {
      "name": "RESPONSE_TIME",
      "label": "Response Time",
      "type": "NUMBER",
      "operators": ["GTE", "LTE"],
      "enumValues": []
    }
  ]
}
```

## Additional context

Follows the same architectural pattern as the analytics definition endpoint (`AnalyticsDefinitionResource` / `AnalyticsDefinitionYAMLQueryService`):
- OpenAPI spec → REST Resource → Use Case → YAML Query Service

[GKO-2419]: https://gravitee.atlassian.net/browse/GKO-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ