### PR TITLE
fix(analytics): add NumberRange to FilterSpecRange mapping

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -15,16 +15,19 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.analytics_engine.model.NumberRange;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecRange;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpecsResponse;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -54,6 +57,10 @@ public interface AnalyticsDefinitionMapper {
     default FacetSpecsResponse toFacetSpecsResponse(List<io.gravitee.apim.core.analytics_engine.model.FacetSpec> facetSpecs) {
         return new FacetSpecsResponse().data(mapFacetSpecs(facetSpecs));
     }
+
+    @Mapping(source = "from", target = "min")
+    @Mapping(source = "to", target = "max")
+    FilterSpecRange mapRange(NumberRange range);
 
     FilterSpec mapFilterSpec(io.gravitee.apim.core.analytics_engine.model.FilterSpec filterSpec);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/definition/AnalyticsDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/definition/AnalyticsDefinitionResourceTest.java
@@ -17,10 +17,16 @@ package io.gravitee.rest.api.management.v2.rest.resource.analytics.definition;
 
 import static assertions.MAPIAssertions.assertThat;
 
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricType;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Operator;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApiResourceTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -50,6 +56,31 @@ class AnalyticsDefinitionResourceTest extends ApiResourceTest {
     }
 
     @Test
+    void should_return_api_specs_with_correct_structure() {
+        var response = rootTarget().path("apis").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(ApiSpecsResponse.class)
+            .extracting(ApiSpecsResponse::getData)
+            .satisfies(apis -> {
+                var httpProxy = apis
+                    .stream()
+                    .filter(a -> a.getName().equals(ApiName.HTTP_PROXY))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(httpProxy.getLabel()).isEqualTo("HTTP Proxy");
+
+                var llm = apis
+                    .stream()
+                    .filter(a -> a.getName().equals(ApiName.LLM))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(llm.getLabel()).isEqualTo("LLM");
+            });
+    }
+
+    @Test
     void should_return_api_metrics() {
         var response = rootTarget().path("apis").path("HTTP_PROXY").path("metrics").request().get();
 
@@ -58,6 +89,29 @@ class AnalyticsDefinitionResourceTest extends ApiResourceTest {
             .asEntity(MetricSpecsResponse.class)
             .extracting(MetricSpecsResponse::getData)
             .satisfies(metrics -> assertThat(metrics).isNotEmpty());
+    }
+
+    @Test
+    void should_return_api_metrics_with_correct_structure() {
+        var response = rootTarget().path("apis").path("HTTP_PROXY").path("metrics").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(MetricSpecsResponse.class)
+            .extracting(MetricSpecsResponse::getData)
+            .satisfies(metrics -> {
+                var httpRequests = metrics
+                    .stream()
+                    .filter(m -> m.getName().equals(MetricName.HTTP_REQUESTS))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(httpRequests.getLabel()).isEqualTo("HTTP Requests");
+                assertThat(httpRequests.getType()).isEqualTo(MetricType.COUNTER);
+                assertThat(httpRequests.getApis()).contains(ApiName.HTTP_PROXY);
+                assertThat(httpRequests.getMeasures()).isNotEmpty();
+                assertThat(httpRequests.getFacets()).isNotEmpty();
+                assertThat(httpRequests.getFilters()).isNotEmpty();
+            });
     }
 
     @Test
@@ -72,6 +126,38 @@ class AnalyticsDefinitionResourceTest extends ApiResourceTest {
     }
 
     @Test
+    void should_return_metric_filters_with_correct_structure() {
+        var response = rootTarget().path("metrics").path("HTTP_REQUESTS").path("filters").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterSpecsResponse.class)
+            .extracting(FilterSpecsResponse::getData)
+            .satisfies(filters -> {
+                var apiFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("API"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(apiFilter.getLabel()).isEqualTo("API");
+                assertThat(apiFilter.getType()).isEqualTo(FilterSpec.TypeEnum.KEYWORD);
+                assertThat(apiFilter.getOperators()).containsExactlyInAnyOrder(Operator.EQ, Operator.IN);
+
+                var httpStatusFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("HTTP_STATUS"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(httpStatusFilter.getLabel()).isEqualTo("Status Code");
+                assertThat(httpStatusFilter.getType()).isEqualTo(FilterSpec.TypeEnum.NUMBER);
+                assertThat(httpStatusFilter.getOperators()).containsExactlyInAnyOrder(Operator.EQ, Operator.LTE, Operator.GTE);
+                assertThat(httpStatusFilter.getRange()).isNotNull();
+                assertThat(httpStatusFilter.getRange().getMin()).isEqualTo(100);
+                assertThat(httpStatusFilter.getRange().getMax()).isEqualTo(599);
+            });
+    }
+
+    @Test
     void should_return_metric_facets() {
         var response = rootTarget().path("metrics").path("HTTP_REQUESTS").path("facets").request().get();
 
@@ -83,23 +169,50 @@ class AnalyticsDefinitionResourceTest extends ApiResourceTest {
     }
 
     @Test
+    void should_return_metric_facets_with_correct_structure() {
+        var response = rootTarget().path("metrics").path("HTTP_REQUESTS").path("facets").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FacetSpecsResponse.class)
+            .extracting(FacetSpecsResponse::getData)
+            .satisfies(facets -> {
+                var apiFacet = facets
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("API"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(apiFacet.getLabel()).isEqualTo("API");
+                assertThat(apiFacet.getType()).isEqualTo(FacetSpec.TypeEnum.KEYWORD);
+
+                var httpStatusFacet = facets
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("HTTP_STATUS"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(httpStatusFacet.getLabel()).isEqualTo("Status Code");
+                assertThat(httpStatusFacet.getType()).isEqualTo(FacetSpec.TypeEnum.NUMBER);
+            });
+    }
+
+    @Test
     void should_return_error_for_unknown_metric_facets() {
         var response = rootTarget().path("metrics").path("FOO").path("facets").request().get();
 
-        assertThat(response).hasStatus(400);
+        assertThat(response).hasStatus(400).asError().hasHttpStatus(400).hasMessage("Invalid metric name");
     }
 
     @Test
     void should_return_error_for_unknown_metric_filters() {
-        var response = rootTarget().path("metrics").path("BAR").path("facets").request().get();
+        var response = rootTarget().path("metrics").path("BAR").path("filters").request().get();
 
-        assertThat(response).hasStatus(400);
+        assertThat(response).hasStatus(400).asError().hasHttpStatus(400).hasMessage("Invalid metric name");
     }
 
     @Test
     void should_return_error_for_unknown_api_metrics() {
         var response = rootTarget().path("apis").path("BAZ").path("metrics").request().get();
 
-        assertThat(response).hasStatus(400);
+        assertThat(response).hasStatus(400).asError().hasHttpStatus(400).hasMessage("Invalid api name");
     }
 }


### PR DESCRIPTION
## Issue

[GKO-2420](https://gravitee.atlassian.net/browse/GKO-2420)

## Description

- Added explicit `mapRange(NumberRange)` method to `AnalyticsDefinitionMapper` with `@Mapping` annotations to correctly map `from`→`min` and `to`→`max` field names between `NumberRange` and `FilterSpecRange`
- Added structural validation tests for API specs, metric specs, filter specs (including range values), and facet specs
- Fixed incorrect request path in `should_return_error_for_unknown_metric_filters` test (was hitting `/facets` instead of `/filters`)
- Improved error assertions to validate error messages, not just status codes

## Additional context

MapStruct could not automatically map between `NumberRange.from` → `FilterSpecRange.min` and `NumberRange.to` → `FilterSpecRange.max` because the field names differ. This caused the `range` field on filter specs (e.g., HTTP status code range 100–599) to have null `min`/`max` values in the API response.

[GKO-2420]: https://gravitee.atlassian.net/browse/GKO-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ