### PR TITLE
feat: enable _search for api-product

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSearchQuery.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSearchQuery.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-export * from './apiProduct';
-export * from './apiProductSearchQuery';
-export * from './apiProductSortByParam';
-export * from './apiProductsResponse';
-export * from './createApiProduct';
-export * from './updateApiProduct';
+export interface ApiProductSearchQuery {
+  /**
+   * Filter by name (case-insensitive substring match).
+   */
+  query?: string;
+  /**
+   * Filter by exact API Product IDs.
+   */
+  ids?: string[];
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSortByParam.spec.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSortByParam.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toApiProductSortByParam } from './apiProductSortByParam';
+
+describe('toApiProductSortByParam', () => {
+  it('should return "name" when given "name"', () => {
+    expect(toApiProductSortByParam('name')).toBe('name');
+  });
+
+  it('should return "-name" when given "-name"', () => {
+    expect(toApiProductSortByParam('-name')).toBe('-name');
+  });
+
+  it('should return undefined when given undefined', () => {
+    expect(toApiProductSortByParam(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when given empty string', () => {
+    expect(toApiProductSortByParam('')).toBeUndefined();
+  });
+
+  it('should return version and -version when given', () => {
+    expect(toApiProductSortByParam('version')).toBe('version');
+    expect(toApiProductSortByParam('-version')).toBe('-version');
+  });
+
+  it('should return apis and -apis when given', () => {
+    expect(toApiProductSortByParam('apis')).toBe('apis');
+    expect(toApiProductSortByParam('-apis')).toBe('-apis');
+  });
+
+  it('should return owner and -owner when given', () => {
+    expect(toApiProductSortByParam('owner')).toBe('owner');
+    expect(toApiProductSortByParam('-owner')).toBe('-owner');
+  });
+
+  it('should return undefined for invalid sort values', () => {
+    expect(toApiProductSortByParam('invalidSort')).toBeUndefined();
+    expect(toApiProductSortByParam('createdAt')).toBeUndefined();
+  });
+});

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSortByParam.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProductSortByParam.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ApiProductSortByParam = 'name' | '-name' | 'version' | '-version' | 'apis' | '-apis' | 'owner' | '-owner';
+
+const ALLOWED_SORT_BY: ApiProductSortByParam[] = ['name', '-name', 'version', '-version', 'apis', '-apis', 'owner', '-owner'];
+
+/**
+ * Returns the given string as ApiProductSortByParam if it is allowed, otherwise undefined.
+ * Use this to avoid sending invalid sort values to the backend.
+ */
+export function toApiProductSortByParam(sortBy: string | undefined): ApiProductSortByParam | undefined {
+  if (!sortBy) {
+    return undefined;
+  }
+  return ALLOWED_SORT_BY.includes(sortBy as ApiProductSortByParam) ? (sortBy as ApiProductSortByParam) : undefined;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/create/api-product-create.component.ts
@@ -26,6 +26,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 
 import { CreateApiProduct } from '../../../entities/management-api-v2/api-product';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
@@ -43,6 +44,7 @@ interface CreateApiProductForm {
   templateUrl: './api-product-create.component.html',
   styleUrls: ['./api-product-create.component.scss'],
   standalone: true,
+  providers: [{ provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher }],
   imports: [
     CommonModule,
     ReactiveFormsModule,
@@ -67,7 +69,6 @@ export class ApiProductCreateComponent {
       nonNullable: true,
       validators: [Validators.required, Validators.maxLength(512), Validators.minLength(1)],
       asyncValidators: [apiProductNameUniqueAsyncValidator(this.apiProductV2Service)],
-      updateOn: 'blur',
     }),
     version: new FormControl('', {
       nonNullable: true,

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isObject } from 'angular';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -31,7 +32,6 @@ import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { Constants } from '../../../entities/Constants';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
-import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
 
 describe('ApiProductListComponent', () => {
   let fixture: ComponentFixture<ApiProductListComponent>;
@@ -39,6 +39,7 @@ describe('ApiProductListComponent', () => {
   let httpTestingController: HttpTestingController;
   let _router: Router;
   let queryParams$: BehaviorSubject<Record<string, string>>;
+  let navigateSpy: jest.SpyInstance;
 
   const fakeSnackBarService = {
     error: jest.fn(),
@@ -57,7 +58,9 @@ describe('ApiProductListComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: { queryParams: {} },
+            get snapshot() {
+              return { queryParams: queryParams$.value };
+            },
             queryParams: queryParams$.asObservable(),
           },
         },
@@ -68,6 +71,19 @@ describe('ApiProductListComponent', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
     _router = TestBed.inject(Router);
+
+    // When router.navigate is called with queryParams, sync them to our mock so the component receives the update
+    const originalNavigate = _router.navigate.bind(_router);
+    navigateSpy = jest.spyOn(_router, 'navigate').mockImplementation((commands, extras) => {
+      if (extras?.queryParams && isObject(extras.queryParams)) {
+        const params: Record<string, string> = {};
+        for (const [k, v] of Object.entries(extras.queryParams)) {
+          if (v != null && v !== '') params[k] = String(v);
+        }
+        queryParams$.next({ ...queryParams$.value, ...params });
+      }
+      return originalNavigate(commands, extras);
+    });
   });
 
   afterEach(() => {
@@ -140,12 +156,72 @@ describe('ApiProductListComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
     req.flush({ message: 'Error loading products' }, { status: 500, statusText: 'Internal Server Error' });
     fixture.detectChanges();
     await fixture.whenStable();
 
     expect(fakeSnackBarService.error).toHaveBeenCalled();
+  });
+
+  it('should use default sort (sortBy=name) when URL has no order param', async () => {
+    queryParams$.next({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    expect(req.request.params.get('sortBy')).toEqual('name');
+    req.flush({ data: [], pagination: { totalCount: 0 } });
+    await fixture.whenStable();
+  });
+
+  it('should add order=name to URL when missing after first load', async () => {
+    queryParams$.next({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    req.flush({ data: [], pagination: { totalCount: 0 } });
+    await fixture.whenStable();
+
+    // Router spy syncs queryParams on navigate, which may trigger a second request after debounce (100ms)
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    const pending = httpTestingController.match(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    pending.forEach(r => r.flush({ data: [], pagination: { totalCount: 0 } }));
+    await fixture.whenStable();
+
+    const orderCall = navigateSpy.mock.calls.find(call => call[1]?.queryParams?.order === 'name');
+    expect(orderCall).toBeDefined();
+  });
+
+  it('should propagate sortBy from component sort state to _search request', async () => {
+    // order=-name → queryParamsToFilters → toSort → { active: 'name', direction: 'desc' } → toOrder → '-name'
+    queryParams$.next({ order: '-name' });
+    try {
+      fixture.detectChanges();
+    } catch (e: unknown) {
+      if ((e as Error)?.message?.includes('NG0100') === false) throw e;
+    }
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    expect(req.request.params.get('sortBy')).toEqual('-name');
+    expect(req.request.params.get('page')).toEqual('1');
+    expect(req.request.params.get('perPage')).toEqual('10');
+    req.flush({ data: [], pagination: { totalCount: 0 } });
+    await fixture.whenStable();
   });
 
   it('should update filters and reload data when query params change', async () => {
@@ -158,17 +234,36 @@ describe('ApiProductListComponent', () => {
     };
     await initComponent([apiProduct]);
 
-    const navigateSpy = jest.spyOn(_router, 'navigate');
-    const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
-    await tableWrapper.setSearchValue('test');
+    // Flush any second request from component syncing order: 'name' to URL
+    await new Promise(resolve => setTimeout(resolve, 150));
+    const pendingAfterInit = httpTestingController.match(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    pendingAfterInit.forEach(r => r.flush({ data: [apiProduct], pagination: { totalCount: 1 } }));
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance;
+    comp.onFiltersChanged({
+      searchTerm: 'test',
+      pagination: { index: 1, size: 10 },
+      sort: { active: 'name', direction: 'asc' },
+    });
 
     expect(navigateSpy).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: expect.objectContaining({ q: 'test' }) }));
+    const navigateCallWithSearch = navigateSpy.mock.calls.find(c => c[1]?.queryParams?.q === 'test');
+    expect(navigateCallWithSearch).toBeDefined();
+    const queryParams = navigateCallWithSearch![1].queryParams;
+    expect(['q', 'page', 'size', 'order'].every(k => Object.prototype.hasOwnProperty.call(queryParams, k))).toBe(true);
 
-    // Simulate router having updated query params (router is the source of truth)
-    queryParams$.next({ q: 'test' });
+    // Router spy synced queryParams when navigate was called - wait for debounce (100ms) so the request is sent
     await new Promise(resolve => setTimeout(resolve, 150));
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual({ query: 'test' });
     req.flush({ data: [], pagination: { totalCount: 0 } });
+    fixture.detectChanges();
     await fixture.whenStable();
   });
 
@@ -215,19 +310,33 @@ describe('ApiProductListComponent', () => {
     };
     await initComponent([apiProduct]);
 
-    const navigateSpy = jest.spyOn(_router, 'navigate');
-    const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
-    await tableWrapper.setSearchValue('nonexistent-search-term');
+    // Flush any second request from component syncing order: 'name' to URL
+    await new Promise(resolve => setTimeout(resolve, 150));
+    const pendingAfterInit = httpTestingController.match(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    pendingAfterInit.forEach(r => r.flush({ data: [apiProduct], pagination: { totalCount: 1 } }));
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance;
+    comp.onFiltersChanged({
+      searchTerm: 'nonexistent-search-term',
+      pagination: { index: 1, size: 10 },
+      sort: { active: 'name', direction: 'asc' },
+    });
 
     expect(navigateSpy).toHaveBeenCalledWith(
       [],
       expect.objectContaining({ queryParams: expect.objectContaining({ q: 'nonexistent-search-term' }) }),
     );
 
-    queryParams$.next({ q: 'nonexistent-search-term' });
+    // Router spy synced queryParams when navigate was called - wait for debounce (100ms) so the request is sent
     await new Promise(resolve => setTimeout(resolve, 150));
 
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual({ query: 'nonexistent-search-term' });
     req.flush({ data: [], pagination: { totalCount: 0 } });
     fixture.detectChanges();
     await fixture.whenStable();
@@ -241,8 +350,13 @@ describe('ApiProductListComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products?page=1&perPage=10`);
-    expect(req.request.method).toEqual('GET');
+    const req = httpTestingController.expectOne(
+      r => r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`) && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual({});
+    expect(req.request.params.get('page')).toEqual('1');
+    expect(req.request.params.get('perPage')).toEqual('10');
+    expect(req.request.params.get('sortBy')).toEqual('name');
     req.flush({ data: apiProducts, pagination: { totalCount: apiProducts.length } });
     fixture.detectChanges();
     await fixture.whenStable();

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -26,17 +26,17 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioAvatarModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { isObject } from 'angular';
 import { isEqual } from 'lodash';
 
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
-import { filtersToQueryParams, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
+import { filtersToQueryParams, toOrder, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
-import { ApiProduct, ApiProductsResponse } from '../../../entities/management-api-v2/api-product';
+import { ApiProduct, ApiProductsResponse, ApiProductSearchQuery } from '../../../entities/management-api-v2/api-product';
 
 const FILTERS_DEBOUNCE_MS = 100;
 const DEFAULT_FILTERS: ApiProductListTableWrapperFilters = {
@@ -48,11 +48,13 @@ const EMPTY_API_PRODUCTS_RESPONSE: ApiProductsResponse = {
   pagination: { totalCount: 0 },
 };
 
+const DEFAULT_SORT = { active: 'name', direction: 'asc' as const };
+
 function queryParamsToFilters(queryParams: Record<string, string>): ApiProductListTableWrapperFilters {
   const searchTerm = queryParams.q ?? DEFAULT_FILTERS.searchTerm;
   const index = queryParams.page ? Number(queryParams.page) : DEFAULT_FILTERS.pagination.index;
   const size = queryParams.size ? Number(queryParams.size) : DEFAULT_FILTERS.pagination.size;
-  const sort = queryParams.order ? toSort(queryParams.order, { active: 'name', direction: 'asc' }) : undefined;
+  const sort = queryParams.order ? toSort(queryParams.order, DEFAULT_SORT) : undefined;
   return {
     searchTerm,
     sort,
@@ -127,10 +129,27 @@ export class ApiProductListComponent {
       switchMap((filters: ApiProductListTableWrapperFilters) => {
         const page = filters.pagination?.index || 1;
         const perPage = filters.pagination?.size || 10;
-        return this.apiProductV2Service.list(page, perPage).pipe(
+        const sortBy = filters.sort ? toOrder(filters.sort) : 'name';
+        const searchQuery: ApiProductSearchQuery = {};
+        const query = filters.searchTerm?.trim();
+        if (query) {
+          searchQuery.query = query;
+        }
+        return this.apiProductV2Service.search(searchQuery, sortBy, page, perPage).pipe(
           catchError(error => {
             this.snackBarService.error(this.getErrorMessage(error, 'An error occurred while loading API Products'));
             return of(EMPTY_API_PRODUCTS_RESPONSE);
+          }),
+          tap(() => {
+            const q = this.activatedRoute.snapshot.queryParams as Record<string, string>;
+            if (q['order'] == null || q['order'] === '') {
+              this.router.navigate([], {
+                relativeTo: this.activatedRoute,
+                queryParams: { ...q, order: 'name' },
+                queryParamsHandling: 'merge',
+                replaceUrl: true,
+              });
+            }
           }),
           map((response: ApiProductsResponse) => ({
             tableDS: this.toApiProductsTableDS(response.data || []),
@@ -188,10 +207,13 @@ export class ApiProductListComponent {
       ...this.filters(),
       ...filters,
     };
+    const queryParams = filtersToQueryParams(mergedFilters);
+    if (queryParams.order == null || queryParams.order === '') {
+      queryParams.order = 'name';
+    }
     this.router.navigate([], {
       relativeTo: this.activatedRoute,
-      queryParams: filtersToQueryParams(mergedFilters),
-      queryParamsHandling: 'merge',
+      queryParams,
     });
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
@@ -112,6 +112,88 @@ describe('ApiProductV2Service', () => {
     });
   });
 
+  describe('search', () => {
+    it('should call the API with default params and empty body', done => {
+      const response = { data: [fakeApiProduct()], pagination: { totalCount: 1 } };
+
+      apiProductV2Service.search().subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        expect(result.data?.[0].name).toEqual('Payments API Product');
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/_search?page=1&perPage=10`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+      req.flush(response);
+    });
+
+    it('should call the API with query and sortBy', done => {
+      const response = { data: [fakeApiProduct()], pagination: { totalCount: 1 } };
+
+      apiProductV2Service.search({ query: 'Payments' }, '-name', 2, 25).subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/_search?page=2&perPage=25&sortBy=-name`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ query: 'Payments' });
+      req.flush(response);
+    });
+
+    it('should call the API with ids filter', done => {
+      const response = { data: [fakeApiProduct()], pagination: { totalCount: 1 } };
+
+      apiProductV2Service.search({ ids: ['product-1', 'product-2'] }, 'name', 1, 10).subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/_search?page=1&perPage=10&sortBy=name`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ ids: ['product-1', 'product-2'] });
+      req.flush(response);
+    });
+
+    it('should call the API with sortBy version', done => {
+      const response = { data: [fakeApiProduct()], pagination: { totalCount: 1 } };
+
+      apiProductV2Service.search({}, 'version', 1, 10).subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/_search?page=1&perPage=10&sortBy=version`,
+        method: 'POST',
+      });
+      req.flush(response);
+    });
+
+    it('should not send invalid sortBy to the backend', done => {
+      const response = { data: [fakeApiProduct()], pagination: { totalCount: 1 } };
+
+      apiProductV2Service.search({}, 'invalidSort' as any, 1, 10).subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/_search?page=1&perPage=10`,
+        method: 'POST',
+      });
+      expect(req.request.params.has('sortBy')).toBe(false);
+      req.flush(response);
+    });
+  });
+
   describe('get', () => {
     it('should call the API', done => {
       const fakeProduct = fakeApiProduct({ id: 'product-123' });

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -18,7 +18,14 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { ApiProduct, ApiProductsResponse, CreateApiProduct, UpdateApiProduct } from '../entities/management-api-v2/api-product';
+import {
+  ApiProduct,
+  ApiProductSearchQuery,
+  ApiProductsResponse,
+  CreateApiProduct,
+  toApiProductSortByParam,
+  UpdateApiProduct,
+} from '../entities/management-api-v2/api-product';
 
 @Injectable({
   providedIn: 'root',
@@ -49,6 +56,26 @@ export class ApiProductV2Service {
   list(page = 1, perPage = 10): Observable<ApiProductsResponse> {
     const params = new HttpParams().set('page', page.toString()).set('perPage', perPage.toString());
     return this.http.get<ApiProductsResponse>(`${this.constants.env.v2BaseURL}/api-products`, { params });
+  }
+
+  /**
+   * Search API Products by name or IDs (same as APIs list)
+   * Calls POST /environments/{envId}/api-products/_search
+   * @param searchQuery - Optional query (text search on name/description/owner) and/or ids
+   * @param sortBy - Sort by name, version, apis, or owner; prefix "-" for desc. Invalid values are ignored.
+   * @param page - Page number (starting from 1)
+   * @param perPage - Number of items per page (1-100)
+   * @returns Observable of ApiProductsResponse with paginated data
+   */
+  search(searchQuery: ApiProductSearchQuery = {}, sortBy?: string, page = 1, perPage = 10): Observable<ApiProductsResponse> {
+    let params = new HttpParams().set('page', page.toString()).set('perPage', perPage.toString());
+    const validSortBy = toApiProductSortByParam(sortBy);
+    if (validSortBy) {
+      params = params.set('sortBy', validSortBy);
+    }
+    return this.http.post<ApiProductsResponse>(`${this.constants.env.v2BaseURL}/api-products/_search`, searchQuery, {
+      params,
+    });
   }
 
   /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiProductSortByParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiProductSortByParam.java
@@ -27,7 +27,13 @@ public class ApiProductSortByParam {
 
     public enum ApiProductSortByEnum {
         NAME_ASC("name", "name", true),
-        NAME_DESC("-name", "name", false);
+        NAME_DESC("-name", "name", false),
+        VERSION_ASC("version", "version", true),
+        VERSION_DESC("-version", "version", false),
+        APIS_ASC("apis", "apiCount", true),
+        APIS_DESC("-apis", "apiCount", false),
+        OWNER_ASC("owner", "ownerName", true),
+        OWNER_DESC("-owner", "ownerName", false);
 
         private final String paramValue;
         private final String fieldName;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -256,13 +256,19 @@ paths:
             default: 10
         - name: sortBy
           in: query
-          description: Sort by name. Use "name" for ascending, "-name" for descending. Default is name ascending.
+          description: Sort by name, version, apis (API count), or owner. Prefix with "-" for descending. Default is name ascending.
           required: false
           schema:
             type: string
             enum:
               - name
               - "-name"
+              - version
+              - "-version"
+              - apis
+              - "-apis"
+              - owner
+              - "-owner"
             default: name
       requestBody:
         required: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
@@ -50,7 +50,12 @@ public class IndexableApiProductDocumentTransformer implements DocumentTransform
     public static final String FIELD_DESCRIPTION_LOWERCASE = "description_lowercase";
     public static final String FIELD_DESCRIPTION_SPLIT = "description_split";
     public static final String FIELD_OWNER = "ownerName";
+    public static final String FIELD_OWNER_SORTED = "ownerName_sorted";
     public static final String FIELD_OWNER_LOWERCASE = "ownerName_lowercase";
+    public static final String FIELD_VERSION = "version";
+    public static final String FIELD_VERSION_SORTED = "version_sorted";
+    public static final String FIELD_API_COUNT = "apiCount";
+    public static final String FIELD_API_COUNT_SORTED = "apiCount_sorted";
     public static final String FIELD_CREATED_AT = "createdAt";
     public static final String FIELD_UPDATED_AT = "updatedAt";
 
@@ -81,6 +86,13 @@ public class IndexableApiProductDocumentTransformer implements DocumentTransform
         doc.add(new StringField(FIELD_NAME_LOWERCASE, apiProduct.getName().toLowerCase(), Field.Store.NO));
         doc.add(new TextField(FIELD_NAME_SPLIT, apiProduct.getName(), Field.Store.NO));
 
+        String version = apiProduct.getVersion() != null ? apiProduct.getVersion() : "";
+        doc.add(new SortedDocValuesField(FIELD_VERSION_SORTED, toSortedValue(version)));
+
+        int apiCount = apiProduct.getApiIds() != null ? apiProduct.getApiIds().size() : 0;
+        String apiCountSorted = String.format("%06d", Math.min(apiCount, 999999));
+        doc.add(new SortedDocValuesField(FIELD_API_COUNT_SORTED, new BytesRef(apiCountSorted)));
+
         if (apiProduct.getDescription() != null) {
             doc.add(new StringField(FIELD_DESCRIPTION, apiProduct.getDescription(), Field.Store.NO));
             doc.add(new StringField(FIELD_DESCRIPTION_LOWERCASE, apiProduct.getDescription().toLowerCase(), Field.Store.NO));
@@ -96,6 +108,7 @@ public class IndexableApiProductDocumentTransformer implements DocumentTransform
 
         if (primaryOwner != null && primaryOwner.displayName() != null) {
             doc.add(new StringField(FIELD_OWNER, primaryOwner.displayName(), Field.Store.NO));
+            doc.add(new SortedDocValuesField(FIELD_OWNER_SORTED, toSortedValue(primaryOwner.displayName())));
             doc.add(new StringField(FIELD_OWNER_LOWERCASE, primaryOwner.displayName().toLowerCase(), Field.Store.NO));
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
@@ -98,6 +98,18 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
                 apiProduct -> apiProduct.getName() != null ? apiProduct.getName() : "",
                 String.CASE_INSENSITIVE_ORDER
             );
+            case "version" -> Comparator.comparing(
+                apiProduct -> apiProduct.getVersion() != null ? apiProduct.getVersion() : "",
+                String.CASE_INSENSITIVE_ORDER
+            );
+            case "apiCount" -> Comparator.comparingInt(apiProduct -> apiProduct.getApiIds() != null ? apiProduct.getApiIds().size() : 0);
+            case "ownerName" -> Comparator.comparing(
+                apiProduct ->
+                    apiProduct.getPrimaryOwner() != null && apiProduct.getPrimaryOwner().displayName() != null
+                        ? apiProduct.getPrimaryOwner().displayName()
+                        : "",
+                String.CASE_INSENSITIVE_ORDER
+            );
             case "createdAt" -> Comparator.comparing(
                 apiProduct -> apiProduct.getCreatedAt() != null ? apiProduct.getCreatedAt() : ZonedDateTime.now().minusYears(100),
                 Comparator.naturalOrder()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12795

```markdown
## Summary
Enables the API Product list in the Console to use the `_search` endpoint, so users can filter by name and sort by name (asc/desc). The list now calls `POST /environments/{envId}/api-products/_search` with optional `query`, `sortBy`, `page`, and `perPage`.

## Changes
- List data source: Replaced `ApiProductV2Service.list()` with `ApiProductV2Service.search(searchQuery, sortBy, page, perPage)`.
- Search: Search term from the list filter is sent as `query` in the request body (name/description/owner on backend).
- Sort: Only name sort is supported; `sortBy` is sent as `name` or `-name`. APIs, Version, and Owner columns no longer have sort headers.
- Types: Added `ApiProductSearchQuery` and `ApiProductSortByParam` + `toApiProductSortByParam()` to match backend and avoid invalid `sortBy` values.
```

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

