### PR TITLE
tests(e2e): always pull latest image

### DIFF
--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -19,6 +19,7 @@ version: '3.8'
 services:
   management_api:
     image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-management_api
     restart: always
     links:
@@ -51,6 +52,7 @@ services:
 
   gateway:
     image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-gateway
     restart: always
     links:

--- a/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
@@ -19,6 +19,7 @@ version: '3.8'
 services:
   management_api:
     image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-management_api
     restart: always
     depends_on:
@@ -49,6 +50,7 @@ services:
 
   gateway-server:
     image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-gateway-bridge-server
     restart: always
     ports:
@@ -85,6 +87,7 @@ services:
 
   gateway:
     image: ${APIM_CLIENT_REGISTRY:-graviteeio}/apim-gateway:${APIM_CLIENT_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-gateway-bridge-client
     restart: always
     depends_on:

--- a/gravitee-apim-e2e/docker/common/docker-compose-uis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-uis.yml
@@ -41,6 +41,7 @@ services:
 
   management_ui:
     image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-management_ui
     restart: always
     ports:
@@ -60,6 +61,7 @@ services:
 
   portal_ui:
     image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_TAG:-3}
+    pull_policy: always
     container_name: gravitee-apim-e2e-portal_ui
     restart: always
     ports:


### PR DESCRIPTION
## Issue

N/A

## Description

Always pull apim images to not use the CI cache. Before, it could end in an unresolvable image