### PR TITLE
fix(api-product): use lambda wrapper for ApiProduct event subscription in DefaultApiReactor

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -112,7 +112,7 @@ import lombok.Getter;
  * @author GraviteeSource Team
  */
 @CustomLog
-public class DefaultApiReactor extends AbstractApiReactor implements EventListener<ApiProductEventType, ApiProductChangedEvent> {
+public class DefaultApiReactor extends AbstractApiReactor {
 
     private static final Set<LogEntry<? extends HttpExecutionContextInternal>> DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES = Set.of(
         LogEntryFactory.cached("serverId", DefaultExecutionContext.class, context -> context.getInternalAttribute(ATTR_INTERNAL_SERVER_ID)),
@@ -163,6 +163,7 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
     private final ApiProductRegistry apiProductRegistry;
     private final ApiProductPlanPolicyManagerFactory apiProductPlanPolicyManagerFactory;
     private PolicyManager apiProductPlanPolicyManager;
+    private EventListener<ApiProductEventType, ApiProductChangedEvent> apiProductEventListener;
 
     /**
      * Backward-compatible constructor for Message Reactor and other plugins that extend DefaultApiReactor.
@@ -646,9 +647,10 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
 
         Completable.concat(services.stream().map(ApiService::start).collect(Collectors.toList())).blockingAwait();
 
-        // Subscribe to API Product events for security chain refresh
+        // Subscribe to API Product events for security chain refresh.
         if (apiProductRegistry != null) {
-            eventManager.subscribeForEvents(this, ApiProductEventType.class);
+            apiProductEventListener = event -> onApiProductEvent(event);
+            eventManager.subscribeForEvents(apiProductEventListener, ApiProductEventType.class);
             log.debug("API reactor [{}] subscribed to API Product events", api.getId());
         }
 
@@ -669,7 +671,7 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
      */
     public void restartApiProductPlanPolicyManager() {
         if (lifecycleState != Lifecycle.State.STARTED) {
-            log.debug("Cannot refresh security chain for API [{}] - reactor is not started (state: {})", api.getId(), lifecycleState);
+            log.debug("API [{}] skipping security chain refresh — reactor not started (state: {})", api.getId(), lifecycleState);
             return;
         }
         try {
@@ -684,7 +686,7 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
                 }
             }
             refreshSecurityChain();
-            log.debug("Security chain refreshed for API [{}] due to API Product change", api.getId());
+            log.debug("API [{}] security chain refreshed after API Product change", api.getId());
         } catch (Exception e) {
             log.warn("Failed to refresh security chain for API [{}] on API Product change", api.getId(), e);
             // Don't throw - keep using old chain to avoid breaking running API
@@ -692,27 +694,16 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
     }
 
     /**
-     * Handle API Product events (DEPLOY/UPDATE/UNDEPLOY).
      * Refreshes security chain if this API is affected by the product change.
      */
-    @Override
-    public void onEvent(Event<ApiProductEventType, ApiProductChangedEvent> event) {
+    private void onApiProductEvent(Event<ApiProductEventType, ApiProductChangedEvent> event) {
         ApiProductChangedEvent payload = event.content();
         if (payload != null && payload.getApiIds() != null && payload.getApiIds().contains(api.getId())) {
-            log.debug(
-                "API [{}] affected by API Product [{}] {} event, refreshing security chain",
-                api.getId(),
-                payload.getProductId(),
-                event.type()
-            );
+            log.debug("API [{}] received ApiProductChangedEvent ({}) for product [{}]", api.getId(), event.type(), payload.getProductId());
             restartApiProductPlanPolicyManager();
         }
     }
 
-    /**
-     * Refresh the security chain.
-     * Rebuilds the chain with latest api product plan definitions from the registry.
-     */
     private void refreshSecurityChain() {
         HttpSecurityChain chain;
         if (apiProductRegistry != null && apiProductPlanPolicyManager != null) {
@@ -753,9 +744,10 @@ public class DefaultApiReactor extends AbstractApiReactor implements EventListen
         this.lifecycleState = Lifecycle.State.STOPPING;
 
         try {
-            // Unsubscribe from API Product events
-            if (apiProductRegistry != null) {
-                eventManager.unsubscribeForEvents(this, ApiProductEventType.class);
+            // Unsubscribe the lambda listener created at start time.
+            if (apiProductRegistry != null && apiProductEventListener != null) {
+                eventManager.unsubscribeForEvents(apiProductEventListener, ApiProductEventType.class);
+                apiProductEventListener = null;
                 log.debug("API reactor [{}] unsubscribed from API Product events", api.getId());
             }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -26,6 +26,7 @@ import static io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactor.REQ
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -50,6 +52,8 @@ import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.core.component.CompositeComponentProvider;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.api.ApiType;
@@ -942,6 +946,37 @@ class DefaultApiReactorTest {
         assertThat(accessPointHttpAcceptor.innerHttpsAcceptors())
             .extracting(HttpAcceptor::host, HttpAcceptor::path)
             .containsOnly(Tuple.tuple("host1", "path/"), Tuple.tuple("host2", "path/"));
+    }
+
+    @Test
+    void shouldSubscribeAndUnsubscribeWithSameLambdaListener() throws Exception {
+        ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> captor = ArgumentCaptor.forClass(EventListener.class);
+        verify(eventManager).subscribeForEvents(captor.capture(), eq(ApiProductEventType.class));
+        EventListener<ApiProductEventType, ApiProductChangedEvent> subscribedListener = captor.getValue();
+
+        assertThat(subscribedListener).isNotSameAs(cut);
+
+        cut.doStop();
+
+        verify(eventManager).unsubscribeForEvents(subscribedListener, ApiProductEventType.class);
+    }
+
+    @Test
+    void shouldNotLoseNewListenerWhenOldReactorStops() throws Exception {
+        ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> captor1 = ArgumentCaptor.forClass(EventListener.class);
+        verify(eventManager).subscribeForEvents(captor1.capture(), eq(ApiProductEventType.class));
+        EventListener<ApiProductEventType, ApiProductChangedEvent> oldListener = captor1.getValue();
+
+        buildApiReactor();
+        ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> captor2 = ArgumentCaptor.forClass(EventListener.class);
+        verify(eventManager, times(2)).subscribeForEvents(captor2.capture(), eq(ApiProductEventType.class));
+        EventListener<ApiProductEventType, ApiProductChangedEvent> newListener = captor2.getAllValues().get(1);
+
+        assertThat(newListener).isNotSameAs(oldListener);
+
+        cut.doStop();
+        verify(eventManager).unsubscribeForEvents(oldListener, ApiProductEventType.class);
+        verify(eventManager, never()).unsubscribeForEvents(newListener, ApiProductEventType.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12945

## Description

`DefaultApiReactor` previously implemented `EventListener` directly and subscribed itself (`this`) 
to `EventManager` for `ApiProductChangedEvent`. Because `equals()`/`hashCode()` on `DefaultApiReactor` 
are based on the API ID, two reactor instances for the same API were considered equal by the 
`EventManager`'s internal `Set`.

During a reactor replacement (old stopped, new started), the old reactor's `unsubscribe()` call 
silently removed the new reactor's subscription from the `Set` — leaving the new reactor deaf to 
`ApiProductChangedEvent`. As a result, the security chain was never refreshed after an API Product 
change, causing API key authentication to return `401 Unauthorized`.

**Fix:** Instead of subscribing `this`, `doStart()` now creates a dedicated lambda and stores it in 
`apiProductEventListener`. Each reactor instance gets a unique lambda object (default Java object 
identity), so `unsubscribe()` on the old reactor cannot affect the new reactor's subscription.

This pattern already exists in the codebase —> `ApiManagerImpl` line 101 uses a lambda for `SecretDiscoveryEvent`.

## Additional context

**Root cause flow:**
1. API Product deployed → `ApiProductSynchronizer` publishes `ApiProductChangedEvent`
2. New reactor subscribed, but old reactor's `doStop()` removes it from `EventManager` Set (collision)
3. New reactor never receives the event → security chain stays stale (missing product plans)
4. API key validation fails plan lookup → `401 Unauthorized`


**Verified:** Post-fix confirm all reactors receive `ApiProductChangedEvent` 
and API key authentication succeeds across all APIs in the product.

------

Working video (via script) :


https://github.com/user-attachments/assets/2f5d1724-2d7a-45cb-82d4-61618419bb61

testing case :

T0: created api product with 3 apis, made plan, subscription, (all), tested...working
T1: removed api1's all plans
T2: tried creating new api-product, with same 3 apis.....earlier : only 2 worked, now : all working
T3: removed api2's all plans
T4: tried creating new api-product, with same 3 apis.....earlier :only 1 worked, now : all working