### PR TITLE
feat: use api search with pagination for API product APIs list

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/apiSearchQuery.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/apiSearchQuery.ts
@@ -24,6 +24,10 @@ export interface ApiSearchQuery {
    * List of ids to find
    */
   ids?: string[];
+  /**
+   * When provided, restricts search to APIs belonging to this API Product.
+   */
+  apiProductId?: string;
   definitionVersion?: DefinitionVersion;
   definitionVersions?: DefinitionVersion[];
   apiTypes?: string[];

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -31,6 +31,7 @@
     [length]="apisTableDSUnpaginatedLength"
     [searchLabel]="searchLabel"
     (filtersChange)="onFiltersChanged($event)"
+    [paginationPageSizeOptions]="[25, 50, 100, 200]"
   >
     <table mat-table [dataSource]="apisTableDS">
       <ng-container matColumnDef="picture">

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
@@ -34,6 +34,34 @@ import { Api, fakeProxyApiV4 } from '../../../entities/management-api-v2';
 import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { Constants } from '../../../entities/Constants';
+
+function expectApisSearchRequest(
+  httpTestingController: HttpTestingController,
+  apis: Api[],
+  options?: { apiProductId?: string; query?: string; page?: number; perPage?: number; totalCount?: number },
+) {
+  const { apiProductId = 'product-1', query, page = 1, perPage = 5, totalCount = apis.length } = options ?? {};
+  const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search`;
+  const req = httpTestingController.expectOne((r: { method: string; urlWithParams?: string; url?: string }) => {
+    const url = r.urlWithParams ?? r.url ?? '';
+    return r.method === 'POST' && url.startsWith(baseUrl) && url.includes(`page=${page}`) && url.includes(`perPage=${perPage}`);
+  });
+  expect(req.request.body).toEqual({
+    apiProductId,
+    ...(query ? { query } : {}),
+  });
+  req.flush({
+    data: apis,
+    pagination: {
+      page,
+      perPage,
+      pageCount: Math.ceil((totalCount || 1) / perPage),
+      pageItemsCount: apis.length,
+      totalCount,
+    },
+  });
+  return req;
+}
 
 describe('ApiProductApisComponent', () => {
   let fixture: ComponentFixture<ApiProductApisComponent>;
@@ -135,14 +163,14 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should display empty state when no APIs in product', async () => {
-    await initComponent({ ...fakeApiProduct, apiIds: [] });
+    await initComponent([]);
 
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
     expect(await emptyState.getText()).toContain('There are no APIs in this API Product (yet).');
   });
 
   it('should display table with API rows when product has APIs', async () => {
-    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+    await initComponent([fakeApi1, fakeApi2]);
 
     const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
     const rows = await table.getRows();
@@ -164,13 +192,7 @@ describe('ApiProductApisComponent', () => {
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
     expect(await emptyState.getText()).toContain('Loading...');
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(fakeApiProduct);
-
-    const api1Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`);
-    api1Req.flush(fakeApi1);
-    const api2Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`);
-    api2Req.flush(fakeApi2);
+    expectApisSearchRequest(httpTestingController, [fakeApi1, fakeApi2]);
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -180,11 +202,11 @@ describe('ApiProductApisComponent', () => {
     expect(rows.length).toBe(2);
   });
 
-  it('should handle error when loading API product', async () => {
+  it('should handle error when loading APIs', async () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    const req = httpTestingController.expectOne((r: { url: string }) => r.url.includes('/apis/_search'));
     req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' });
     fixture.detectChanges();
     await fixture.whenStable();
@@ -193,7 +215,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should have Add API button', async () => {
-    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+    await initComponent([fakeApi1]);
 
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
     expect(await addButton.getText()).toContain('Add API');
@@ -202,7 +224,7 @@ describe('ApiProductApisComponent', () => {
   it('should open Add API dialog when Add API clicked', async () => {
     const matDialog = TestBed.inject(MatDialog);
     const dialogOpenSpy = jest.spyOn(matDialog, 'open');
-    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+    await initComponent([fakeApi1]);
 
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
     await addButton.click();
@@ -223,41 +245,143 @@ describe('ApiProductApisComponent', () => {
     );
   });
 
-  it('should filter APIs by search term', async () => {
-    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+  it('should filter APIs by search term', fakeAsync(async () => {
+    initComponentFakeAsync([fakeApi1, fakeApi2]);
 
     const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
     await tableWrapper.setSearchValue('Orders');
-    await fixture.whenStable();
+    tick(450);
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(fakeApiProduct);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`).flush(fakeApi1);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`).flush(fakeApi2);
+    expectApisSearchRequest(httpTestingController, [fakeApi2], { query: 'Orders' });
 
     fixture.detectChanges();
-    await fixture.whenStable();
+    tick();
 
     const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
     const rows = await table.getRows();
     expect(rows.length).toBe(1);
     const rowCells = await rows[0].getCellTextByIndex();
     expect(rowCells[1]).toContain('Orders API');
-  });
+  }));
 
-  async function initComponent(apiProduct: ApiProduct, apis: Api[] = []) {
+  it('should show pagination and load next page', fakeAsync(async () => {
+    const api3 = fakeProxyApiV4({
+      id: 'api-3',
+      name: 'API 3',
+      listeners: [{ type: 'HTTP', paths: [{ path: '/api3' }], entrypoints: [{ type: 'http-proxy' }] }],
+    });
+    const api4 = fakeProxyApiV4({
+      id: 'api-4',
+      name: 'API 4',
+      listeners: [{ type: 'HTTP', paths: [{ path: '/api4' }], entrypoints: [{ type: 'http-proxy' }] }],
+    });
+    const api5 = fakeProxyApiV4({
+      id: 'api-5',
+      name: 'API 5',
+      listeners: [{ type: 'HTTP', paths: [{ path: '/api5' }], entrypoints: [{ type: 'http-proxy' }] }],
+    });
+    const page1Apis = [fakeApi1, fakeApi2, api3, api4, api5];
+    const page2Apis = [
+      fakeProxyApiV4({
+        id: 'api-6',
+        name: 'Shipping API',
+        apiVersion: '1.0',
+        listeners: [{ type: 'HTTP', paths: [{ path: '/shipping' }], entrypoints: [{ type: 'http-proxy' }] }],
+      }),
+    ];
+    const totalCount = 6;
+
+    initComponentFakeAsync(page1Apis, { totalCount });
+
+    const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
+    const paginator = await tableWrapper.getPaginator();
+    expect(await paginator.getRangeLabel()).toContain('6');
+
+    await paginator.goToNextPage();
+    tick(450);
+
+    expectApisSearchRequest(httpTestingController, page2Apis, { page: 2, totalCount });
+
+    fixture.detectChanges();
+    tick();
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(1);
+    const rowCells0 = await rows[0].getCellTextByIndex();
+    expect(rowCells0[1]).toContain('Shipping API');
+  }));
+
+  it('should search with pagination and load page when changing page after search', fakeAsync(async () => {
+    queryParams$.next({ page: '1', size: '1', q: '' });
+    const page1SearchResult = [fakeApi2];
+    const page2SearchResult = [
+      fakeProxyApiV4({
+        id: 'api-3',
+        name: 'Orders Extended API',
+        apiVersion: '1.0',
+        listeners: [{ type: 'HTTP', paths: [{ path: '/orders-ext' }], entrypoints: [{ type: 'http-proxy' }] }],
+      }),
+    ];
+    const totalCount = 2;
+
+    initComponentFakeAsync([fakeApi1, fakeApi2], { perPage: 1 });
+
+    const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
+    await tableWrapper.setSearchValue('Order');
+    tick(450);
+
+    expectApisSearchRequest(httpTestingController, page1SearchResult, {
+      query: 'Order',
+      totalCount,
+      perPage: 1,
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    const paginator = await tableWrapper.getPaginator();
+    await paginator.goToNextPage();
+    tick(450);
+
+    expectApisSearchRequest(httpTestingController, page2SearchResult, {
+      query: 'Order',
+      page: 2,
+      totalCount,
+      perPage: 1,
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
+    const rows = await table.getRows();
+    expect(rows.length).toBe(1);
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[1]).toContain('Orders Extended API');
+  }));
+
+  async function initComponent(apis: Api[] = []) {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(apiProduct);
-
-    for (const api of apis) {
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`);
-      req.flush(api);
-    }
+    expectApisSearchRequest(httpTestingController, apis);
 
     fixture.detectChanges();
     await fixture.whenStable();
+  }
+
+  /** Sync init for fakeAsync tests - whenStable() hangs in fakeAsync zone */
+  function initComponentFakeAsync(
+    apis: Api[] = [],
+    options?: { apiProductId?: string; query?: string; page?: number; perPage?: number; totalCount?: number },
+  ) {
+    fixture.detectChanges();
+    tick(150); // debounceTime(100) on queryParams
+
+    expectApisSearchRequest(httpTestingController, apis, options);
+
+    fixture.detectChanges();
+    tick();
   }
 });

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -40,7 +40,7 @@ function expectApisSearchRequest(
   apis: Api[],
   options?: { apiProductId?: string; query?: string; page?: number; perPage?: number; totalCount?: number },
 ) {
-  const { apiProductId = 'product-1', query, page = 1, perPage = 5, totalCount = apis.length } = options ?? {};
+  const { apiProductId = 'product-1', query, page = 1, perPage = 25, totalCount = apis.length } = options ?? {};
   const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search`;
   const req = httpTestingController.expectOne((r: { method: string; urlWithParams?: string; url?: string }) => {
     const url = r.urlWithParams ?? r.url ?? '';

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -22,8 +22,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { combineLatest, EMPTY, Observable, forkJoin, of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 import {
   GIO_DIALOG_WIDTH,
@@ -39,11 +39,11 @@ import {
   ApiProductAddApiDialogResult,
 } from './add-api-dialog/api-product-add-api-dialog.component';
 
-import { Api } from '../../../entities/management-api-v2';
+import { Api, ApiSearchQuery, ApisResponse, apiSortByParamFromString } from '../../../entities/management-api-v2';
+import { filtersToQueryParams, toOrder, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { getApiContextPath } from '../../../shared/utils/api-access.util';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
-import { filtersToQueryParams } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -61,16 +61,18 @@ export type ApiProductApiTableDS = {
 interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
 
 const DEFAULT_FILTERS: ApiProductApisTableWrapperFilters = {
-  pagination: { index: 1, size: 10 },
+  pagination: { index: 1, size: 5 },
   searchTerm: '',
 };
 
 function queryParamsToFilters(queryParams: Record<string, string>): ApiProductApisTableWrapperFilters {
-  const searchTerm = queryParams['q'] ?? DEFAULT_FILTERS.searchTerm;
-  const index = queryParams['page'] ? Number(queryParams['page']) : DEFAULT_FILTERS.pagination.index;
-  const size = queryParams['size'] ? Number(queryParams['size']) : DEFAULT_FILTERS.pagination.size;
+  const searchTerm = queryParams.q ?? DEFAULT_FILTERS.searchTerm;
+  const index = queryParams.page ? Number(queryParams.page) : DEFAULT_FILTERS.pagination.index;
+  const size = queryParams.size ? Number(queryParams.size) : DEFAULT_FILTERS.pagination.size;
+  const sort = queryParams.order ? toSort(queryParams.order, { active: 'name', direction: 'asc' }) : undefined;
   return {
     searchTerm,
+    sort,
     pagination: { index, size },
   };
 }
@@ -102,9 +104,11 @@ export class ApiProductApisComponent implements OnInit {
   });
 
   /** Filters derived from router query params (single source of truth) */
-  readonly filters = toSignal(this.activatedRoute.queryParams.pipe(map(params => queryParamsToFilters(params as Record<string, string>))), {
+  readonly filters = toSignal(this.activatedRoute.queryParams.pipe(map(params => queryParamsToFilters(params))), {
     initialValue: queryParamsToFilters(this.activatedRoute.snapshot.queryParams as Record<string, string>),
   });
+
+  private readonly reloadTrigger$ = new Subject<void>();
 
   private static readonly LOAD_API_PRODUCT_ERROR = 'An error occurred while loading the API Product';
 
@@ -121,7 +125,7 @@ export class ApiProductApisComponent implements OnInit {
         tap(value => {
           const message = typeof successMessage === 'function' ? successMessage(value) : successMessage;
           this.snackBarService.success(message);
-          this.reloadTable();
+          this.reloadTrigger$.next();
         }),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -135,56 +139,42 @@ export class ApiProductApisComponent implements OnInit {
   private initApisTableSubscription(): void {
     combineLatest([
       this.activatedRoute.queryParams.pipe(
-        map(params => queryParamsToFilters(params as Record<string, string>)),
         debounceTime(100),
+        map(params => queryParamsToFilters(params)),
         distinctUntilChanged(isEqual),
       ),
       toObservable(this.apiProductId, { injector: this.injector }).pipe(filter(id => !!id)),
+      this.reloadTrigger$.pipe(startWith(undefined)),
     ])
       .pipe(
         map(([filters, apiProductId]) => ({ filters, apiProductId })),
-        switchMap(({ filters, apiProductId }) => this.loadApisForProduct(apiProductId).pipe(map(apis => ({ filters, apis })))),
-        tap(({ filters, apis }) => this.processAndDisplayApis(filters, apis)),
+        switchMap(({ filters, apiProductId }) => this.loadApisForProduct(apiProductId, filters)),
+        tap(apisResponse => this.processAndDisplayApis(apisResponse)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
 
-  private loadApisForProduct(apiProductId: string): Observable<(Api | null)[]> {
+  private loadApisForProduct(apiProductId: string, filters: ApiProductApisTableWrapperFilters): Observable<ApisResponse> {
     this.isLoadingData = true;
-    return this.apiProductV2Service.get(apiProductId).pipe(
-      catchError(this.handleError(ApiProductApisComponent.LOAD_API_PRODUCT_ERROR, of(null))),
-      switchMap(apiProduct => {
-        if (!apiProduct?.apiIds?.length) {
-          return of([]);
-        }
-        const apiObservables = apiProduct.apiIds.map(apiId => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
-        return forkJoin(apiObservables).pipe(catchError(this.handleError('An error occurred while loading APIs', of([]))));
-      }),
-    );
+    const searchBody: ApiSearchQuery = {
+      apiProductId,
+      query: filters.searchTerm || undefined,
+    };
+    const order = toOrder(filters.sort) ?? 'name';
+    return this.apiV2Service
+      .search(searchBody, apiSortByParamFromString(order), filters.pagination?.index ?? 1, filters.pagination?.size ?? 5)
+      .pipe(
+        catchError(
+          this.handleError('An error occurred while loading APIs', of({ data: [], pagination: { totalCount: 0 } } as ApisResponse)),
+        ),
+      );
   }
 
-  private processAndDisplayApis(filters: ApiProductApisTableWrapperFilters, apis: (Api | null)[]): void {
-    let filteredApis = apis.filter((api): api is Api => api !== null);
-    const searchTerm = filters.searchTerm?.toLowerCase() || '';
-
-    if (searchTerm) {
-      filteredApis = filteredApis.filter(
-        api =>
-          api.name?.toLowerCase().includes(searchTerm) ||
-          getApiContextPath(api)?.toLowerCase().includes(searchTerm) ||
-          api.apiVersion?.toLowerCase().includes(searchTerm),
-      );
-    }
-
-    const page = filters.pagination?.index || 1;
-    const perPage = filters.pagination?.size || 10;
-    const startIndex = (page - 1) * perPage;
-    const endIndex = startIndex + perPage;
-    const paginatedApis = filteredApis.slice(startIndex, endIndex);
-
-    this.apisTableDS = this.toApisTableDS(paginatedApis);
-    this.apisTableDSUnpaginatedLength = filteredApis.length;
+  private processAndDisplayApis(apisResponse: ApisResponse): void {
+    const apis = apisResponse?.data ?? [];
+    this.apisTableDS = this.toApisTableDS(apis);
+    this.apisTableDSUnpaginatedLength = apisResponse?.pagination?.totalCount ?? apis.length;
     this.isLoadingData = false;
   }
 
@@ -210,15 +200,6 @@ export class ApiProductApisComponent implements OnInit {
       queryParams: filtersToQueryParams(mergedFilters),
       queryParamsHandling: 'merge',
     });
-  }
-
-  private reloadTable(): void {
-    this.loadApisForProduct(this.apiProductId())
-      .pipe(
-        tap(apis => this.processAndDisplayApis(this.filters(), apis)),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
   }
 
   onAddApi(): void {

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -61,7 +61,7 @@ export type ApiProductApiTableDS = {
 interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
 
 const DEFAULT_FILTERS: ApiProductApisTableWrapperFilters = {
-  pagination: { index: 1, size: 5 },
+  pagination: { index: 1, size: 25 },
   searchTerm: '',
 };
 
@@ -163,7 +163,7 @@ export class ApiProductApisComponent implements OnInit {
     };
     const order = toOrder(filters.sort) ?? 'name';
     return this.apiV2Service
-      .search(searchBody, apiSortByParamFromString(order), filters.pagination?.index ?? 1, filters.pagination?.size ?? 5)
+      .search(searchBody, apiSortByParamFromString(order), filters.pagination?.index ?? 1, filters.pagination?.size ?? 25)
       .pipe(
         catchError(
           this.handleError('An error occurred while loading APIs', of({ data: [], pagination: { totalCount: 0 } } as ApisResponse)),

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
@@ -90,7 +90,7 @@ export class GioTableWrapperComponent implements AfterViewInit, OnChanges {
 
   /** Pagination available page size options */
   @Input()
-  paginationPageSizeOptions = [25, 50, 100, 200];
+  paginationPageSizeOptions = [5, 10, 25, 100];
 
   // Combine the paginator, sort and filter into a single output
   // Alway sent initial filters values

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
@@ -90,7 +90,7 @@ export class GioTableWrapperComponent implements AfterViewInit, OnChanges {
 
   /** Pagination available page size options */
   @Input()
-  paginationPageSizeOptions = [5, 10, 25, 100];
+  paginationPageSizeOptions = [25, 50, 100, 200];
 
   // Combine the paginator, sort and filter into a single output
   // Alway sent initial filters values

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ALLOW_IN_API_PRODUCTS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_PRODUCT_IDS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
@@ -39,7 +40,6 @@ import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiHostsUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiPathsUseCase;
-import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
@@ -153,9 +153,6 @@ public class ApisResource extends AbstractResource {
 
     @Inject
     private OAIToImportApiUseCase oaiToImportApiUseCase;
-
-    @Inject
-    private ApiProductQueryService apiProductQueryService;
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -304,15 +301,10 @@ public class ApisResource extends AbstractResource {
             apiQueryBuilder.setQuery(apiSearchQuery.getQuery());
         }
 
+        // apiProductId: filter by Lucene field "api_product_ids" (indexed on each API doc at write time).
+        // Single TermQuery instead of loading hundreds of API IDs from DB - scales with product size.
         if (!Strings.isNullOrEmpty(apiSearchQuery.getApiProductId())) {
-            var apiProductOpt = apiProductQueryService.findById(apiSearchQuery.getApiProductId());
-            if (apiProductOpt.isEmpty() || apiProductOpt.get().getApiIds() == null || apiProductOpt.get().getApiIds().isEmpty()) {
-                return new ApisResponse()
-                    .data(List.of())
-                    .pagination(PaginationInfo.computePaginationInfo(0, 0, paginationParam))
-                    .links(computePaginationLinks(0, paginationParam));
-            }
-            apiQueryBuilder.addFilter(FIELD_TYPE_VALUE, new ArrayList<>(apiProductOpt.get().getApiIds()));
+            apiQueryBuilder.addFilter(FIELD_API_PRODUCT_IDS, List.of(apiSearchQuery.getApiProductId()));
         } else if (Objects.nonNull(apiSearchQuery.getIds()) && !apiSearchQuery.getIds().isEmpty()) {
             apiQueryBuilder.addFilter(FIELD_TYPE_VALUE, apiSearchQuery.getIds());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiHostsUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiPathsUseCase;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
@@ -94,6 +95,8 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -150,6 +153,9 @@ public class ApisResource extends AbstractResource {
 
     @Inject
     private OAIToImportApiUseCase oaiToImportApiUseCase;
+
+    @Inject
+    private ApiProductQueryService apiProductQueryService;
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -298,7 +304,16 @@ public class ApisResource extends AbstractResource {
             apiQueryBuilder.setQuery(apiSearchQuery.getQuery());
         }
 
-        if (Objects.nonNull(apiSearchQuery.getIds()) && !apiSearchQuery.getIds().isEmpty()) {
+        if (!Strings.isNullOrEmpty(apiSearchQuery.getApiProductId())) {
+            var apiProductOpt = apiProductQueryService.findById(apiSearchQuery.getApiProductId());
+            if (apiProductOpt.isEmpty() || apiProductOpt.get().getApiIds() == null || apiProductOpt.get().getApiIds().isEmpty()) {
+                return new ApisResponse()
+                    .data(List.of())
+                    .pagination(PaginationInfo.computePaginationInfo(0, 0, paginationParam))
+                    .links(computePaginationLinks(0, paginationParam));
+            }
+            apiQueryBuilder.addFilter(FIELD_TYPE_VALUE, new ArrayList<>(apiProductOpt.get().getApiIds()));
+        } else if (Objects.nonNull(apiSearchQuery.getIds()) && !apiSearchQuery.getIds().isEmpty()) {
             apiQueryBuilder.addFilter(FIELD_TYPE_VALUE, apiSearchQuery.getIds());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4008,6 +4008,10 @@ components:
                     example:
                         - apiId-1
                         - apiId-2
+                apiProductId:
+                    type: string
+                    description: When provided, restricts search to APIs belonging to this API Product. Takes precedence over ids when both are present.
+                    example: api-product-123
                 definitionVersion:
                     $ref: "#/components/schemas/DefinitionVersion"
                 definitionVersions:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
@@ -19,6 +19,8 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.ApiMetadataDecodeContext;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.model.PrimaryOwnerApiTemplateData;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
@@ -27,7 +29,9 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.Indexer;
 import io.gravitee.apim.core.search.model.IndexableApi;
 import java.util.Date;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 
 @DomainService
@@ -37,22 +41,34 @@ public class ApiIndexerDomainService {
     private final ApiMetadataDecoderDomainService apiMetadataDecoderDomainService;
     private final ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
     private final ApiCategoryQueryService apiCategoryQueryService;
+    private final ApiProductQueryService apiProductQueryService;
     private final Indexer indexer;
 
     public ApiIndexerDomainService(
         ApiMetadataDecoderDomainService apiMetadataDecoderDomainService,
         ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService,
         ApiCategoryQueryService apiCategoryQueryService,
+        ApiProductQueryService apiProductQueryService,
         Indexer indexer
     ) {
         this.apiMetadataDecoderDomainService = apiMetadataDecoderDomainService;
         this.apiPrimaryOwnerDomainService = apiPrimaryOwnerDomainService;
         this.apiCategoryQueryService = apiCategoryQueryService;
+        this.apiProductQueryService = apiProductQueryService;
         this.indexer = indexer;
     }
 
     public void index(Context context, Api apiToIndex, PrimaryOwnerEntity primaryOwner) {
+        // Send IndexableApi (includes apiProductIds from findByApiId) to Lucene - each API doc gets api_product_ids field
         indexer.index(context.toIndexationContext(), toIndexableApi(apiToIndex, primaryOwner));
+    }
+
+    /**
+     * Re-index an API using context (fetches primary owner internally).
+     * Used when re-indexing APIs after product membership changes - e.g. API added/removed from product.
+     */
+    public void index(Context context, Api apiToIndex) {
+        indexer.index(context.toIndexationContext(), toIndexableApi(context.toIndexationContext(), apiToIndex));
     }
 
     public void delete(Context context, Api apiToDelete) {
@@ -108,7 +124,13 @@ public class ApiIndexerDomainService {
                 .build()
         );
         var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(apiToIndex);
-        return new IndexableApi(apiToIndex, primaryOwner, metadata, categoryKeys);
+        // Inverse lookup: which products contain this API? Stored in Lucene as api_product_ids for efficient search.
+        Set<String> apiProductIds = apiProductQueryService
+            .findByApiId(apiToIndex.getId())
+            .stream()
+            .map(ApiProduct::getId)
+            .collect(Collectors.toSet());
+        return new IndexableApi(apiToIndex, primaryOwner, metadata, categoryKeys, apiProductIds);
     }
 
     public static Context oneShotIndexation(AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
@@ -125,6 +125,9 @@ public class ApiIndexerDomainService {
         );
         var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(apiToIndex);
         // Inverse lookup: which products contain this API? Stored in Lucene as api_product_ids for efficient search.
+        //So: indexing uses an inverse lookup from API Product store (by apiId), not a column on the API.
+        // The API definition/table stays unchanged; only the index gains api_product_ids.
+        // so if i add api-id "467318654398789dgf37" to api-product, we re-index that 1 API (and the product).
         Set<String> apiProductIds = apiProductQueryService
             .findByApiId(apiToIndex.getId())
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -21,7 +21,6 @@ import static java.util.Map.entry;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
-import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -119,13 +118,13 @@ public class CreateApiProductUseCase {
 
         apiProductIndexerDomainService.index(oneShotIndexation(auditInfo), created, primaryOwner);
 
-        List<Api> apisToReindex = apiIds
-            .stream()
-            .flatMap(apiId -> apiCrudService.findById(apiId).stream())
-            .toList();
-        var indexation = ApiIndexerDomainService.oneShotIndexation(auditInfo);
-        for (Api api : apisToReindex) {
-            apiIndexerDomainService.index(indexation, api);
+        // Re-index APIs if product was created with apiIds so Lucene api_product_ids includes this product.
+        // When created with empty apiIds (typical UI flow), this is a no-op.
+        if (!apiIds.isEmpty()) {
+            var indexation = ApiIndexerDomainService.oneShotIndexation(auditInfo);
+            for (String apiId : apiIds) {
+                apiCrudService.findById(apiId).ifPresent(api -> apiIndexerDomainService.index(indexation, api));
+            }
         }
 
         publishDeployEvent(auditInfo, created);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -19,6 +19,9 @@ import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexer
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -53,6 +56,8 @@ public class CreateApiProductUseCase {
 
     private final ApiProductQueryService apiProductQueryService;
     private final ApiProductCrudService apiProductCrudService;
+    private final ApiCrudService apiCrudService;
+    private final ApiIndexerDomainService apiIndexerDomainService;
     private final ValidateApiProductService validateApiProductService;
     private final AuditDomainService auditService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
@@ -113,6 +118,15 @@ public class CreateApiProductUseCase {
         apiProductPrimaryOwnerDomainService.createApiProductPrimaryOwnerMembership(created.getId(), primaryOwner, auditInfo);
 
         apiProductIndexerDomainService.index(oneShotIndexation(auditInfo), created, primaryOwner);
+
+        List<Api> apisToReindex = apiIds
+            .stream()
+            .flatMap(apiId -> apiCrudService.findById(apiId).stream())
+            .toList();
+        var indexation = ApiIndexerDomainService.oneShotIndexation(auditInfo);
+        for (Api api : apisToReindex) {
+            apiIndexerDomainService.index(indexation, api);
+        }
 
         publishDeployEvent(auditInfo, created);
         createAuditLog(created, auditInfo);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
@@ -19,7 +19,10 @@ import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexer
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -36,6 +39,7 @@ import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.EventType;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +49,8 @@ import lombok.RequiredArgsConstructor;
 public class DeleteApiProductUseCase {
 
     private final ApiProductCrudService apiProductCrudService;
+    private final ApiCrudService apiCrudService;
+    private final ApiIndexerDomainService apiIndexerDomainService;
     private final AuditDomainService auditService;
     private final ApiProductQueryService apiProductQueryService;
     private final ValidateApiProductService validateApiProductService;
@@ -66,8 +72,20 @@ public class DeleteApiProductUseCase {
 
         publishUndeployEvent(input.auditInfo(), apiProduct);
 
+        // Save apiIds before delete - we need them for re-indexing (findByApiId won't return deleted product after).
+        Set<String> apiIdsToReindex = apiProduct.getApiIds() != null ? Set.copyOf(apiProduct.getApiIds()) : Set.of();
+
         apiProductCrudService.delete(input.apiProductId());
         apiProductIndexerDomainService.delete(oneShotIndexation(input.auditInfo()), apiProduct);
+
+        List<Api> apisToReindex = apiIdsToReindex
+            .stream()
+            .flatMap(apiId -> apiCrudService.findById(apiId).stream())
+            .toList();
+        var indexation = ApiIndexerDomainService.oneShotIndexation(input.auditInfo());
+        for (Api api : apisToReindex) {
+            apiIndexerDomainService.index(indexation, api);
+        }
         createAuditLog(input.apiProductId, input.auditInfo());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -19,7 +19,10 @@ import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexer
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -43,9 +46,11 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -55,6 +60,8 @@ import lombok.RequiredArgsConstructor;
 public class UpdateApiProductUseCase {
 
     private final ApiProductCrudService apiProductCrudService;
+    private final ApiCrudService apiCrudService;
+    private final ApiIndexerDomainService apiIndexerDomainService;
     private final AuditDomainService auditService;
     private final ApiProductQueryService apiProductQueryService;
     private final ValidateApiProductService validateApiProductService;
@@ -102,6 +109,25 @@ public class UpdateApiProductUseCase {
         existingApiProduct.update(updateApiProduct);
 
         ApiProduct updated = apiProductCrudService.update(existingApiProduct);
+
+        // Re-index APIs whose product membership changed so Lucene api_product_ids stays in sync.
+        // Removed APIs: api_product_ids must drop this product. Added APIs: api_product_ids must include it.
+        Set<String> beforeIds = beforeUpdate.getApiIds() != null ? beforeUpdate.getApiIds() : Set.of();
+        Set<String> afterIds = updated.getApiIds() != null ? updated.getApiIds() : Set.of();
+        Set<String> removed = new HashSet<>(beforeIds);
+        removed.removeAll(afterIds);
+        Set<String> added = new HashSet<>(afterIds);
+        added.removeAll(beforeIds);
+
+        List<String> apiIdsToReindex = Stream.concat(removed.stream(), added.stream()).toList();
+        List<Api> apisToReindex = apiIdsToReindex
+            .stream()
+            .flatMap(apiId -> apiCrudService.findById(apiId).stream())
+            .toList();
+        var indexation = ApiIndexerDomainService.oneShotIndexation(input.auditInfo());
+        for (Api api : apisToReindex) {
+            apiIndexerDomainService.index(indexation, api);
+        }
 
         PrimaryOwnerEntity primaryOwner = null;
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -111,6 +111,7 @@ public class UpdateApiProductUseCase {
         ApiProduct updated = apiProductCrudService.update(existingApiProduct);
 
         // Re-index APIs whose product membership changed so Lucene api_product_ids stays in sync.
+        // so if i add api-id "467318654398789dgf37" to api-product, we re-index that 1 API (and the product).
         // Removed APIs: api_product_ids must drop this product. Added APIs: api_product_ids must include it.
         Set<String> beforeIds = beforeUpdate.getApiIds() != null ? beforeUpdate.getApiIds() : Set.of();
         Set<String> afterIds = updated.getApiIds() != null ? updated.getApiIds() : Set.of();
@@ -119,8 +120,8 @@ public class UpdateApiProductUseCase {
         Set<String> added = new HashSet<>(afterIds);
         added.removeAll(beforeIds);
 
-        List<String> apiIdsToReindex = Stream.concat(removed.stream(), added.stream()).toList();
-        List<Api> apisToReindex = apiIdsToReindex
+        List<String> apiIdsToReindex = Stream.concat(removed.stream(), added.stream()).toList(); // get the list of API IDs to re-index. union of removed and added (only IDs that changed).
+        List<Api> apisToReindex = apiIdsToReindex // load the full Api entity for each of those IDs (so we can re-index them).
             .stream()
             .flatMap(apiId -> apiCrudService.findById(apiId).stream())
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
@@ -43,6 +43,13 @@ public class IndexableApi implements Indexable {
     /** API categories' keys */
     private Collection<String> categoryKeys;
 
+    /**
+     * IDs of API Products that contain this API. Indexed in Lucene as api_product_ids
+     * so we can filter "APIs in product X" with a single lookup instead of loading all API IDs.
+     */
+    @Builder.Default
+    private Collection<String> apiProductIds = null;
+
     @Override
     public String getId() {
         return api.getId();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -115,6 +115,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_HAS_HEALTH_CHECK,
         FIELD_DEFINITION_VERSION,
         FIELD_ALLOW_IN_API_PRODUCTS,
+        FIELD_API_PRODUCT_IDS, // Allow query: api_product_ids:product-123
     };
 
     public ApiDocumentSearcher(IndexWriter indexWriter) {
@@ -401,7 +402,8 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             !FIELD_ORIGIN.equals(term.field()) &&
             !FIELD_HAS_HEALTH_CHECK.equals(term.field()) &&
             !FIELD_DEFINITION_VERSION.equals(term.field()) &&
-            !FIELD_ALLOW_IN_API_PRODUCTS.equals(term.field())
+            !FIELD_ALLOW_IN_API_PRODUCTS.equals(term.field()) &&
+            !FIELD_API_PRODUCT_IDS.equals(term.field())
         ) {
             text = text.toLowerCase();
             field = field.concat("_lowercase");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -111,6 +111,8 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
     public static final String FIELD_VISIBILITY = "visibility";
     public static final String FIELD_VISIBILITY_SORTED = "visibility_sorted";
     public static final String FIELD_ALLOW_IN_API_PRODUCTS = "allow_in_api_products";
+    /** Multi-valued field: each API Product ID that contains this API. Enables efficient "APIs in product X" search. */
+    public static final String FIELD_API_PRODUCT_IDS = "api_product_ids";
 
     private final ApiService apiService;
     private final Collator collator = Collator.getInstance(Locale.ENGLISH);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -137,6 +137,14 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
             doc.add(new SortedDocValuesField(FIELD_CATEGORIES_DESC_SORTED, toSortedValue(categoriesDesc)));
         }
 
+        // api_product_ids: multi-valued field (one StringField per product ID, like tags). Lucene builds inverted index
+        // so "product-1" -> [api-1, api-2]. At search time: filter api_product_ids:product-1 = single TermQuery.
+        if (indexableApi.getApiProductIds() != null && !indexableApi.getApiProductIds().isEmpty()) {
+            for (String productId : indexableApi.getApiProductIds()) {
+                doc.add(new StringField(FIELD_API_PRODUCT_IDS, productId, Field.Store.NO)); // Each product = one index entry
+            }
+        }
+
         if (api.getCreatedAt() != null) {
             doc.add(new LongPoint(FIELD_CREATED_AT, api.getCreatedAt().toInstant().toEpochMilli()));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.CreateCategoryApiDomainServiceInMemory;
@@ -135,6 +136,7 @@ public class ImportDefinitionCreateDomainServiceTestInitializer {
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                 apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             ),
             apiMetadataDomainService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainServiceTest.java
@@ -22,6 +22,7 @@ import fixtures.core.model.MembershipFixtures;
 import fixtures.core.model.MetadataFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
@@ -59,6 +60,7 @@ class ApiIndexerDomainServiceTest {
 
     ApiCategoryQueryServiceInMemory apiCategoryQueryService = new ApiCategoryQueryServiceInMemory();
     ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory();
+    ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
     MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
@@ -77,6 +79,7 @@ class ApiIndexerDomainServiceTest {
                 userCrudService
             ),
             apiCategoryQueryService,
+            apiProductQueryService,
             null
         );
 
@@ -168,6 +171,7 @@ class ApiIndexerDomainServiceTest {
                     apiToIndex,
                     null,
                     Map.ofEntries(Map.entry("api-name", apiToIndex.getName()), Map.entry("support", "")),
+                    Set.of(),
                     Set.of()
                 )
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
@@ -27,6 +27,7 @@ import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.IndexerInMemory;
@@ -137,6 +138,7 @@ class UpdateFederatedApiDomainServiceTest {
                 ),
                 apiPrimaryOwnerService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             )
         );
@@ -300,7 +302,8 @@ class UpdateFederatedApiDomainServiceTest {
                     updatedApi,
                     new PrimaryOwnerEntity(MY_MEMBER_ID, MEMBER_EMAIL, MEMBER_EMAIL, PrimaryOwnerEntity.Type.USER),
                     Map.of(),
-                    Collections.emptySet()
+                    Collections.emptySet(),
+                    null
                 )
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
@@ -147,6 +147,7 @@ class UpdateNativeApiDomainServiceTest {
                 ),
                 apiPrimaryOwnerService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             )
         );
@@ -347,7 +348,8 @@ class UpdateNativeApiDomainServiceTest {
                     updatedApi,
                     new PrimaryOwnerEntity(MY_MEMBER_ID, MEMBER_EMAIL, MEMBER_EMAIL, PrimaryOwnerEntity.Type.USER),
                     Map.of(),
-                    Collections.emptySet()
+                    Collections.emptySet(),
+                    null
                 )
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTestInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTestInitializer.java
@@ -22,6 +22,7 @@ import fakes.FakeApiImagesService;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
@@ -123,6 +124,7 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
             new ApiMetadataDecoderDomainService(apiMetadataQueryServiceInMemory, new FreemarkerTemplateProcessor()),
             apiPrimaryOwnerDomainService,
             new ApiCategoryQueryServiceInMemory(),
+            new ApiProductQueryServiceInMemory(),
             indexer
         );
         updateNativeApiDomainService = new UpdateNativeApiDomainService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
@@ -27,6 +27,7 @@ import fixtures.core.model.NewApiFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.CreateCategoryApiDomainServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
@@ -169,6 +170,7 @@ class CreateHttpApiUseCaseTest {
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                 apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditService),
@@ -265,7 +267,8 @@ class CreateHttpApiUseCaseTest {
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                         Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                        Collections.emptySet()
+                        Collections.emptySet(),
+                        null
                     )
                 );
         });
@@ -301,7 +304,8 @@ class CreateHttpApiUseCaseTest {
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                         Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                        Collections.emptySet()
+                        Collections.emptySet(),
+                        null
                     )
                 );
         });
@@ -350,7 +354,8 @@ class CreateHttpApiUseCaseTest {
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                         Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                        Collections.emptySet()
+                        Collections.emptySet(),
+                        null
                     )
                 );
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
@@ -27,6 +27,7 @@ import fixtures.core.model.NewApiFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.CreateCategoryApiDomainServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
@@ -166,6 +167,7 @@ class CreateNativeApiUseCaseTest {
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                 apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditService),
@@ -268,7 +270,8 @@ class CreateNativeApiUseCaseTest {
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                         Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                        Collections.emptySet()
+                        Collections.emptySet(),
+                        null
                     )
                 );
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -48,6 +48,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -451,6 +452,7 @@ class ImportApiCRDUseCaseTest {
                 ),
                 apiPrimaryOwnerService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             )
         );
@@ -575,6 +577,7 @@ class ImportApiCRDUseCaseTest {
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                 apiPrimaryOwnerDomainService,
                 apiCategoryQueryService,
+                new ApiProductQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditDomainService),
@@ -643,7 +646,8 @@ class ImportApiCRDUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(ACTOR_USER_ID, "devops@gravitee.io", "devops@gravitee.io", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", "devops@gravitee.io")),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -667,7 +671,8 @@ class ImportApiCRDUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(ACTOR_USER_ID, "devops@gravitee.io", "devops@gravitee.io", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", "devops@gravitee.io")),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -248,7 +248,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -284,7 +285,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -320,7 +322,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -349,7 +352,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -662,7 +666,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });
@@ -691,7 +696,8 @@ class ImportApiDefinitionUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, USER_EMAIL, "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", USER_EMAIL)),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
@@ -32,6 +32,7 @@ import fixtures.core.model.PlanFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
@@ -143,6 +144,7 @@ class MigrateApiUseCaseTest {
     private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     private final ApiCategoryQueryServiceInMemory apiCategoryQueryService = new ApiCategoryQueryServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
     private final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
     private final PageQueryService pageQueryService = mock(PageQueryService.class);
     private final EventManager eventManager = mock(EventManager.class);
@@ -163,6 +165,7 @@ class MigrateApiUseCaseTest {
         new ApiMetadataDecoderDomainService(apiMetadataQueryService, new FreemarkerTemplateProcessor()),
         apiPrimaryOwnerDomainService,
         apiCategoryQueryService,
+        apiProductQueryService,
         indexer
     );
     private final ApiStateDomainService apiStateDomainService = new ApiStateDomainServiceLegacyWrapper(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
@@ -125,6 +125,7 @@ class RollbackApiUseCaseTest {
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainServiceLegacyWrapper.class);
     private final ApiMetadataQueryServiceInMemory metadataQueryService = new ApiMetadataQueryServiceInMemory();
     private final ApiCategoryQueryServiceInMemory apiCategoryQueryService = new ApiCategoryQueryServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
     private final IndexerInMemory indexer = new IndexerInMemory();
     private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
@@ -179,6 +180,7 @@ class RollbackApiUseCaseTest {
             new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
             this.apiPrimaryOwnerDomainService,
             apiCategoryQueryService,
+            apiProductQueryService,
             indexer
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
@@ -25,6 +25,7 @@ import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.InMemoryAlternative;
@@ -131,6 +132,7 @@ class UpdateFederatedApiUseCaseTest {
                 ),
                 apiPrimaryOwnerService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
@@ -30,6 +30,7 @@ import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
@@ -179,6 +180,7 @@ public class UpdateNativeApiUseCaseTest {
                 ),
                 apiPrimaryOwnerService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -36,6 +36,7 @@ import inmemory.MembershipQueryServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -82,6 +83,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private final ApiIndexerDomainService apiIndexerDomainService = mock(ApiIndexerDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
 
     private CreateApiProductUseCase createApiProductUseCase;
@@ -126,6 +128,8 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
         createApiProductUseCase = new CreateApiProductUseCase(
             apiProductQueryService,
             apiProductCrudService,
+            apiCrudService,
+            apiIndexerDomainService,
             validateApiProductService,
             auditService,
             apiProductPrimaryOwnerDomainService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
@@ -34,6 +34,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.IndexerInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -60,6 +61,7 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
     private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final ApiIndexerDomainService apiIndexerDomainService = mock(ApiIndexerDomainService.class);
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
     private DeleteApiProductUseCase deleteApiProductUseCase;
@@ -75,6 +77,8 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
         );
         deleteApiProductUseCase = new DeleteApiProductUseCase(
             apiProductCrudService,
+            apiCrudService,
+            apiIndexerDomainService,
             auditService,
             apiProductQueryService,
             validateApiProductService,
@@ -124,6 +128,8 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
         var realIndexerDomainService = new ApiProductIndexerDomainService(primaryOwnerDomainService, indexer);
         var useCaseWithRealIndexer = new DeleteApiProductUseCase(
             apiProductCrudService,
+            apiCrudService,
+            mock(ApiIndexerDomainService.class),
             new io.gravitee.apim.core.audit.domain_service.AuditDomainService(
                 auditCrudService,
                 userCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -35,6 +35,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
@@ -68,6 +69,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private final ApiIndexerDomainService apiIndexerDomainService = mock(ApiIndexerDomainService.class);
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService = mock(ApiProductPrimaryOwnerDomainService.class);
@@ -86,6 +88,8 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
         updateApiProductUseCase = new UpdateApiProductUseCase(
             apiProductCrudService,
+            apiCrudService,
+            apiIndexerDomainService,
             auditService,
             apiProductQueryService,
             validateApiProductService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCaseTest.java
@@ -31,6 +31,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -203,6 +204,7 @@ class DeleteIngestedApisUseCaseTest {
             apiMetadataDecoderDomainService,
             apiPrimaryOwnerDomainService,
             apiCategoryQueryServiceInMemory,
+            new ApiProductQueryServiceInMemory(),
             indexer
         );
 
@@ -490,7 +492,7 @@ class DeleteIngestedApisUseCaseTest {
     void should_delete_api_index() {
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
         var apiToDelete = ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build();
-        var apiToIndex = new IndexableApi(apiToDelete, primaryOwner, null, null);
+        var apiToIndex = new IndexableApi(apiToDelete, primaryOwner, null, null, null);
         indexer.initWith(List.of(apiToIndex));
         apiCrudServiceInMemory.initWith(List.of(apiToDelete));
         var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
@@ -37,6 +37,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AsyncJobCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -266,6 +267,7 @@ class IngestFederatedApisUseCaseTest {
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                 apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
+                new ApiProductQueryServiceInMemory(),
                 indexer
             ),
             apiMetadataDomainService,
@@ -331,6 +333,7 @@ class IngestFederatedApisUseCaseTest {
             new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
             apiPrimaryOwnerDomainService,
             new ApiCategoryQueryServiceInMemory(),
+            new ApiProductQueryServiceInMemory(),
             indexer
         );
 
@@ -527,7 +530,8 @@ class IngestFederatedApisUseCaseTest {
                             expectedApi,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.of(),
-                            Set.of()
+                            Set.of(),
+                            null
                         )
                     );
             });
@@ -781,7 +785,8 @@ class IngestFederatedApisUseCaseTest {
                             expectedApi,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.of(),
-                            Collections.emptySet()
+                            Collections.emptySet(),
+                            null
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
@@ -28,6 +28,7 @@ import inmemory.A2aAgentFetcherInMemory;
 import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.AsyncJobCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.CreateCategoryApiDomainServiceInMemory;
@@ -175,6 +176,7 @@ class StartIngestIntegrationApisUseCaseTest {
         new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
         apiPrimaryOwnerDomainService,
         apiCategoryQueryService1,
+        new ApiProductQueryServiceInMemory(),
         indexer
     );
 
@@ -246,6 +248,7 @@ class StartIngestIntegrationApisUseCaseTest {
             new ApiMetadataDecoderDomainService(metadataQueryService1, new FreemarkerTemplateProcessor()),
             apiPrimaryOwnerService,
             apiCategoryQueryService2,
+            new ApiProductQueryServiceInMemory(),
             indexer
         )
     );
@@ -256,6 +259,7 @@ class StartIngestIntegrationApisUseCaseTest {
             new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
             apiPrimaryOwnerDomainService,
             apiCategoryQueryService,
+            new ApiProductQueryServiceInMemory(),
             indexer
         ),
         new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditDomainService),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -103,7 +103,8 @@ public class IndexableApiDocumentTransformerTest {
             Api.builder().id(API_ID).lifecycleState(Api.LifecycleState.STARTED).build(),
             PRIMARY_OWNER,
             Map.of(),
-            Set.of()
+            Set.of(),
+            null
         );
 
         // When
@@ -124,7 +125,8 @@ public class IndexableApiDocumentTransformerTest {
             ApiFixtures.aProxyApiV4().toBuilder().labels(List.of("Label1, Label2")).build(),
             PRIMARY_OWNER,
             Map.of(),
-            Set.of("category1", "category2")
+            Set.of("category1", "category2"),
+            null
         );
 
         // When
@@ -186,7 +188,7 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_transform_primary_owner_info() {
         // Given
-        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of(), Set.of());
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of(), Set.of(), null);
 
         // When
         var result = cut.transform(indexable);
@@ -207,7 +209,8 @@ public class IndexableApiDocumentTransformerTest {
             ApiFixtures.aProxyApiV4(),
             PRIMARY_OWNER,
             Map.of("metadata1", "value1", "metadata2", "value2"),
-            Set.of()
+            Set.of(),
+            null
         );
 
         // When
@@ -224,7 +227,7 @@ public class IndexableApiDocumentTransformerTest {
     void should_throw_when_not_V4_api() {
         // Given
         var apiV1 = Api.builder().id(API_ID).lifecycleState(Api.LifecycleState.STARTED).definitionVersion(DefinitionVersion.V1).build();
-        var indexable = new IndexableApi(apiV1, PRIMARY_OWNER, Map.of(), Set.of());
+        var indexable = new IndexableApi(apiV1, PRIMARY_OWNER, Map.of(), Set.of(), null);
 
         // When
         var throwable = catchThrowable(() -> cut.transform(indexable));
@@ -246,7 +249,8 @@ public class IndexableApiDocumentTransformerTest {
                 .build(),
             PRIMARY_OWNER,
             Map.of(),
-            Set.of("Category1", "Category2")
+            Set.of("Category1", "Category2"),
+            null
         );
 
         // When
@@ -294,7 +298,8 @@ public class IndexableApiDocumentTransformerTest {
             ApiFixtures.aNativeApi().toBuilder().id(API_ID).description("A Description").labels(List.of("Label1, Label2")).build(),
             PRIMARY_OWNER,
             Map.of(),
-            Set.of("Category1", "Category2")
+            Set.of("Category1", "Category2"),
+            null
         );
 
         // When
@@ -362,7 +367,7 @@ public class IndexableApiDocumentTransformerTest {
                     .build()
             )
             .build();
-        var indexable = new IndexableApi(api, PRIMARY_OWNER, Map.of(), Set.of());
+        var indexable = new IndexableApi(api, PRIMARY_OWNER, Map.of(), Set.of(), null);
         var result = cut.transform(indexable);
         assertThat(result.getFields("paths_lowercase")[0].stringValue()).isEqualTo("/testpath");
         assertThat(result.getFields("hosts_lowercase")[0].stringValue()).isEqualTo("api.testhost.com");
@@ -441,7 +446,13 @@ public class IndexableApiDocumentTransformerTest {
         void should_transform_v2_api_with_same_fields_as_api_document_transformer() {
             // Given
             var v2Api = createV2ApiWithFullData();
-            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of("metadata1", "value1"), Set.of("category1", "category2"));
+            var indexableApi = new IndexableApi(
+                v2Api,
+                PRIMARY_OWNER,
+                Map.of("metadata1", "value1"),
+                Set.of("category1", "category2"),
+                null
+            );
             var genericApiEntity = convertToGenericApiEntity(v2Api);
 
             // When
@@ -456,7 +467,7 @@ public class IndexableApiDocumentTransformerTest {
         void should_handle_v2_api_paths_correctly() {
             // Given
             var v2Api = createV2ApiWithPaths();
-            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of(), null);
             var genericApiEntity = convertToGenericApiEntity(v2Api);
 
             // When
@@ -484,7 +495,7 @@ public class IndexableApiDocumentTransformerTest {
         void should_handle_v2_api_tags_correctly() {
             // Given
             var v2Api = createV2ApiWithTags();
-            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of(), null);
             var genericApiEntity = convertToGenericApiEntity(v2Api);
 
             // When
@@ -512,7 +523,7 @@ public class IndexableApiDocumentTransformerTest {
         void should_handle_v2_api_health_check_correctly() {
             // Given
             var v2Api = createV2ApiWithHealthCheck();
-            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of(), null);
             var genericApiEntity = convertToGenericApiEntity(v2Api);
             when(apiService.hasHealthCheckEnabled(any(), eq(false))).thenReturn(true);
 
@@ -530,7 +541,7 @@ public class IndexableApiDocumentTransformerTest {
         void should_handle_v2_api_origin_context_correctly() {
             // Given
             var v2Api = createV2ApiWithOriginContext();
-            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of());
+            var indexableApi = new IndexableApi(v2Api, PRIMARY_OWNER, Map.of(), Set.of(), null);
             var genericApiEntity = convertToGenericApiEntity(v2Api);
 
             // When

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializerTest.java
@@ -320,7 +320,7 @@ public class SearchIndexInitializerTest {
                 lenient()
                     .when(apiIndexerDomainService.toIndexableApi(any(Indexer.IndexationContext.class), any()))
                     .thenAnswer(invocation ->
-                        new IndexableApi(invocation.getArgument(1), null, Collections.emptyMap(), Collections.emptyList())
+                        new IndexableApi(invocation.getArgument(1), null, Collections.emptyMap(), Collections.emptyList(), null)
                     );
             } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {
                 lenient()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12975

## Description

- Add apiProductId to ApiSearchQuery in backend
- ApisResource resolves apiProductId to API IDs and applies filter
- Refactor api-product-apis component to use apis/_search with apiProductId
- Replace client-side filtering/pagination with server-side search


https://github.com/user-attachments/assets/bb527bf7-e10b-403c-9749-fe8277598e0e

