### PR TITLE
fix: improve query parameter handling in router navigation

### DIFF
--- a/gravitee-apim-portal-webui/src/app/app.component.ts
+++ b/gravitee-apim-portal-webui/src/app/app.component.ts
@@ -327,7 +327,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     } else {
       const urlTree = this.router.parseUrl(route.path);
       const path = urlTree.root.children[PRIMARY_OUTLET].segments.join('/');
-      this.router.navigate([path], { queryParams: urlTree.queryParams });
+      this.router.navigate([path], { queryParams: urlTree.queryParams, queryParamsHandling: 'merge' });
     }
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12956

### Root cause
When switching tabs (e.g. General → Documentation), onNavChange in AppComponent was called with a path like catalog/api/123/doc that has no query params

### Description

In app.component.ts, navigation now preserves query params when the target path has none.

### Additional context

Pre Fix behaviour: 

https://github.com/user-attachments/assets/b2891413-32f8-4b10-aab3-56f40aa17cb8

Post Fix Behaviour: 

https://github.com/user-attachments/assets/83dfe27d-3a4a-4426-8a5b-ba9c0d99d1e8



