### PR TITLE
fix: 500 errors for subscription actions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
@@ -112,10 +112,19 @@ public class GenerateApiKeyDomainService {
     }
 
     private boolean isKeyExistFor(String apiKeyValue, SubscriptionEntity subscription) {
-        String apiId = subscription.getApiId();
-        log.debug("Check if an API Key can be created for api {} and application {}", apiId, subscription.getApplicationId());
+        String referenceId = subscription.getReferenceId();
+        String referenceType = subscription.getReferenceType() != null ? subscription.getReferenceType().name() : null;
+        log.debug(
+            "Check if an API Key can be created for reference {} (type {}) and application {}",
+            referenceId,
+            referenceType,
+            subscription.getApplicationId()
+        );
 
-        return apiKeyQueryService.findByKeyAndApiId(apiKeyValue, apiId).isEmpty();
+        if (referenceId != null && referenceType != null) {
+            return apiKeyQueryService.findByKeyAndReferenceIdAndReferenceType(apiKeyValue, referenceId, referenceType).isEmpty();
+        }
+        return apiKeyQueryService.findByKeyAndApiId(apiKeyValue, subscription.getApiId()).isEmpty();
     }
 
     private ApiKeyEntity findOrGenerate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/crud_service/ApiProductCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/crud_service/ApiProductCrudService.java
@@ -16,10 +16,13 @@
 package io.gravitee.apim.core.api_product.crud_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import java.util.Collection;
+import java.util.List;
 
 public interface ApiProductCrudService {
     ApiProduct create(ApiProduct apiProduct);
     void delete(String id);
     ApiProduct update(ApiProduct updateApiProduct);
     ApiProduct get(String id);
+    List<ApiProduct> findByIds(Collection<String> ids);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
@@ -175,7 +175,9 @@ public class CloseSubscriptionDomainService {
         AuditInfo auditInfo,
         SubscriptionAuditEvent event
     ) {
-        String referenceId = subscriptionEntity.getReferenceId();
+        String referenceId = subscriptionEntity.getReferenceId() != null
+            ? subscriptionEntity.getReferenceId()
+            : subscriptionEntity.getApiId();
         boolean isApiProduct = SubscriptionReferenceType.API_PRODUCT == subscriptionEntity.getReferenceType();
         var createdAt = event == SubscriptionAuditEvent.SUBSCRIPTION_CLOSED
             ? updatedSubscription.getUpdatedAt()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCase.java
@@ -16,56 +16,55 @@
 package io.gravitee.apim.core.subscription.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.ApiFieldFilter;
-import io.gravitee.apim.core.api.model.ApiSearchCriteria;
-import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Set;
 
 @UseCase
 public class CloseExpiredSubscriptionsUseCase {
 
     private final SubscriptionQueryService subscriptionQueryService;
-    private final ApiQueryService apiQueryService;
     private final EnvironmentCrudService environmentCrudService;
+    private final ApiCrudService apiCrudService;
+    private final ApiProductCrudService apiProductCrudService;
     private final CloseSubscriptionDomainService closeSubscriptionDomainService;
 
     public CloseExpiredSubscriptionsUseCase(
         SubscriptionQueryService subscriptionQueryService,
-        ApiQueryService apiQueryService,
         EnvironmentCrudService environmentCrudService,
+        ApiCrudService apiCrudService,
+        ApiProductCrudService apiProductCrudService,
         CloseSubscriptionDomainService closeSubscriptionDomainService
     ) {
         this.subscriptionQueryService = subscriptionQueryService;
-        this.apiQueryService = apiQueryService;
         this.environmentCrudService = environmentCrudService;
+        this.apiCrudService = apiCrudService;
+        this.apiProductCrudService = apiProductCrudService;
         this.closeSubscriptionDomainService = closeSubscriptionDomainService;
     }
 
     public Output execute(Input input) {
-        var toClose = subscriptionQueryService.findExpiredSubscriptions();
+        var expiredSubscriptions = subscriptionQueryService.findExpiredSubscriptions();
+        var environmentIdByApiOrProductId = buildEnvironmentIdMap(expiredSubscriptions);
 
-        var apiIds = toClose.stream().map(SubscriptionEntity::getApiId).toList();
-        var apis = apiQueryService
-            .search(
-                ApiSearchCriteria.builder().ids(apiIds).build(),
-                null,
-                ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build()
-            )
-            .collect(Collectors.toMap(Api::getId, api -> api));
-
-        var closed = toClose
+        var closedSubscriptions = expiredSubscriptions
             .stream()
             .map(subscription -> {
-                var environment = environmentCrudService.get(apis.get(subscription.getApiId()).getEnvironmentId());
-
+                var environmentId = resolveEnvironmentId(subscription, environmentIdByApiOrProductId);
+                var environment = environmentCrudService.get(environmentId);
                 var auditInfo = AuditInfo.builder()
                     .organizationId(environment.getOrganizationId())
                     .environmentId(environment.getId())
@@ -76,7 +75,55 @@ public class CloseExpiredSubscriptionsUseCase {
             })
             .toList();
 
-        return new Output(closed);
+        return new Output(closedSubscriptions);
+    }
+
+    private Map<String, String> buildEnvironmentIdMap(List<SubscriptionEntity> subscriptions) {
+        Set<String> apiIds = new HashSet<>();
+        Set<String> apiProductIds = new HashSet<>();
+
+        for (var subscription : subscriptions) {
+            var referenceId = getEffectiveReferenceId(subscription);
+            if (referenceId == null) {
+                continue;
+            }
+            if (subscription.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
+                apiProductIds.add(referenceId);
+            } else {
+                apiIds.add(referenceId);
+            }
+        }
+
+        var environmentIdByApiOrProductId = new HashMap<String, String>();
+        if (!apiIds.isEmpty()) {
+            apiCrudService
+                .findByIds(List.copyOf(apiIds))
+                .forEach(api -> environmentIdByApiOrProductId.put(api.getId(), api.getEnvironmentId()));
+        }
+        if (!apiProductIds.isEmpty()) {
+            apiProductCrudService
+                .findByIds(apiProductIds)
+                .forEach(apiProduct -> environmentIdByApiOrProductId.put(apiProduct.getId(), apiProduct.getEnvironmentId()));
+        }
+        return environmentIdByApiOrProductId;
+    }
+
+    private String getEffectiveReferenceId(SubscriptionEntity subscription) {
+        return subscription.getReferenceType() != null && subscription.getReferenceId() != null
+            ? subscription.getReferenceId()
+            : subscription.getApiId();
+    }
+
+    private String resolveEnvironmentId(SubscriptionEntity subscription, Map<String, String> environmentIdByApiOrProductId) {
+        // Always derive environment from API/Product
+        var apiOrProductId = getEffectiveReferenceId(subscription);
+        var environmentId = apiOrProductId != null ? environmentIdByApiOrProductId.get(apiOrProductId) : null;
+        if (environmentId == null) {
+            throw new IllegalStateException(
+                "Subscription %s has no resolvable referenceId/apiId to determine environment".formatted(subscription.getId())
+            );
+        }
+        return environmentId;
     }
 
     public record Input(AuditActor auditActor) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api_product/ApiProductCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api_product/ApiProductCrudServiceImpl.java
@@ -24,6 +24,9 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -91,5 +94,17 @@ public class ApiProductCrudServiceImpl implements ApiProductCrudService {
             log.error("An error occurred while finding Api Product by id {}", id, e);
         }
         throw new ApiProductNotFoundException(id);
+    }
+
+    @Override
+    public List<ApiProduct> findByIds(Collection<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        try {
+            return apiProductsRepository.findByIds(ids).stream().map(ApiProductAdapter.INSTANCE::toModel).collect(Collectors.toList());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to find API Products by ids", e);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -770,6 +770,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         NotificationParamsBuilder paramsBuilder
     ) {
         subscriptions.forEach(subscription -> {
+            // Notifications are not applicable for API Product subscriptions (TODO: implement notifications for API Product subscriptions)
+            if (isApiProductSubscription(subscription)) {
+                return;
+            }
             GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
             GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, subscription.getApi());
             PrimaryOwnerEntity owner = application.getPrimaryOwner();
@@ -782,5 +786,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .build();
             notifierService.trigger(executionContext, apiHook, genericApiModel.getId(), params);
         });
+    }
+
+    private boolean isApiProductSubscription(SubscriptionEntity subscription) {
+        var referenceType = subscription.getReferenceType();
+        return referenceType != null && SubscriptionReferenceType.API_PRODUCT.name().equals(referenceType);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductCrudServiceInMemory.java
@@ -16,10 +16,12 @@
 package inmemory;
 
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
-import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.stream.Collectors;
 
 public class ApiProductCrudServiceInMemory extends AbstractCrudServiceInMemory<ApiProduct> implements ApiProductCrudService {
 
@@ -52,5 +54,16 @@ public class ApiProductCrudServiceInMemory extends AbstractCrudServiceInMemory<A
             .filter(apiProduct -> id.equals(apiProduct.getId()))
             .findFirst()
             .get();
+    }
+
+    @Override
+    public List<ApiProduct> findByIds(Collection<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return storage
+            .stream()
+            .filter(apiProduct -> ids.contains(apiProduct.getId()))
+            .collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -272,6 +273,47 @@ class GenerateApiKeyDomainServiceTest {
 
         // Then
         assertThat(throwable).isInstanceOf(ApiKeyAlreadyExistingException.class);
+    }
+
+    @Test
+    void should_create_api_product_audit_when_subscription_is_api_product() {
+        // Given
+        var apiProductId = "product-1";
+        var apiProductSubscription = SUBSCRIPTION_1.toBuilder()
+            .referenceId(apiProductId)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .apiId(null)
+            .build();
+
+        // When
+        service.generate(apiProductSubscription, AUDIT_INFO, "custom-key");
+
+        // Then
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "patch")
+            .anyMatch(
+                audit ->
+                    audit.getReferenceType() == AuditEntity.AuditReferenceType.API_PRODUCT &&
+                    apiProductId.equals(audit.getReferenceId()) &&
+                    audit.getProperties().containsKey("API_PRODUCT") &&
+                    apiProductId.equals(audit.getProperties().get("API_PRODUCT")) &&
+                    ApiKeyAuditEvent.APIKEY_CREATED.name().equals(audit.getEvent())
+            );
+    }
+
+    @Test
+    void generateForFederated_creates_federated_api_key() {
+        var apiProductSubscription = SUBSCRIPTION_1.toBuilder()
+            .referenceId("product-1")
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .apiId(null)
+            .build();
+
+        service.generateForFederated(apiProductSubscription, AUDIT_INFO, "federated-key");
+
+        assertThat(apiKeyCrudService.storage()).anyMatch(
+            key -> "federated-key".equals(key.getKey()) && key.getSubscriptions().contains(SUBSCRIPTION_ID_1)
+        );
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCaseTest.java
@@ -23,7 +23,7 @@ import fixtures.core.model.SubscriptionFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
-import inmemory.ApiQueryServiceInMemory;
+import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
@@ -40,6 +40,7 @@ import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditEntity;
@@ -70,7 +71,7 @@ class CloseExpiredSubscriptionsUseCaseTest {
     private static final AuditActor AUDIT_ACTOR = AuditActor.builder().userId(USER_ID).build();
 
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
-    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
+    private final ApiProductCrudServiceInMemory apiProductCrudService = new ApiProductCrudServiceInMemory();
     private final EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
     private final SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
     private final SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory(subscriptionCrudService);
@@ -118,8 +119,9 @@ class CloseExpiredSubscriptionsUseCaseTest {
 
         usecase = new CloseExpiredSubscriptionsUseCase(
             subscriptionQueryService,
-            apiQueryService,
             environmentCrudService,
+            apiCrudService,
+            apiProductCrudService,
             new CloseSubscriptionDomainService(
                 subscriptionCrudService,
                 applicationCrudService,
@@ -143,19 +145,27 @@ class CloseExpiredSubscriptionsUseCaseTest {
         );
         givenExistingPlans(
             List.of(
-                PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan1").apiId("api1").build(),
-                PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan2").apiId("api2").build()
+                PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan1").apiId("api1").referenceId("api1").build(),
+                PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan2").apiId("api2").referenceId("api2").build(),
+                PlanFixtures.HttpV4.anApiKey()
+                    .toBuilder()
+                    .id("plan-product1")
+                    .referenceId("product1")
+                    .referenceType(io.gravitee.rest.api.model.v4.plan.GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .build()
             )
         );
         givenExistingApplication(
             List.of(BaseApplicationEntity.builder().id("app1").build(), BaseApplicationEntity.builder().id("app2").build())
         );
+        givenExistingApiProducts(List.of(ApiProduct.builder().id("product1").environmentId("env1").build()));
     }
 
     @AfterEach
     void tearDown() {
         Stream.of(
-            apiQueryService,
+            apiCrudService,
+            apiProductCrudService,
             environmentCrudService,
             subscriptionCrudService,
             auditCrudServiceInMemory,
@@ -264,6 +274,60 @@ class CloseExpiredSubscriptionsUseCaseTest {
     }
 
     @Test
+    void should_close_expired_api_product_subscription() {
+        var now = Instant.now();
+        givenExistingSubscriptions(
+            List.of(
+                SubscriptionFixtures.aSubscription()
+                    .toBuilder()
+                    .id("s1")
+                    .referenceId("product1")
+                    .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                    .planId("plan-product1")
+                    .applicationId("app1")
+                    .status(SubscriptionEntity.Status.ACCEPTED)
+                    .endingAt(now.minusSeconds(30).atZone(ZoneId.systemDefault()))
+                    .build()
+            )
+        );
+
+        var result = usecase.execute(new CloseExpiredSubscriptionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.closedSubscriptions())
+            .hasSize(1)
+            .extracting(SubscriptionEntity::getStatus)
+            .containsExactly(SubscriptionEntity.Status.CLOSED);
+    }
+
+    @Test
+    void should_close_legacy_subscription_with_apiId_only() {
+        // Legacy subscriptions may have apiId set but referenceId/referenceType null
+        var now = Instant.now();
+        givenExistingSubscriptions(
+            List.of(
+                SubscriptionFixtures.aSubscription()
+                    .toBuilder()
+                    .id("s-legacy")
+                    .apiId("api1")
+                    .referenceId(null)
+                    .referenceType(null)
+                    .planId("plan1")
+                    .applicationId("app1")
+                    .status(SubscriptionEntity.Status.ACCEPTED)
+                    .endingAt(now.minusSeconds(30).atZone(ZoneId.systemDefault()))
+                    .build()
+            )
+        );
+
+        var result = usecase.execute(new CloseExpiredSubscriptionsUseCase.Input(AUDIT_ACTOR));
+
+        assertThat(result.closedSubscriptions())
+            .hasSize(1)
+            .extracting(SubscriptionEntity::getStatus)
+            .containsExactly(SubscriptionEntity.Status.CLOSED);
+    }
+
+    @Test
     void should_do_nothing_when_no_subscription_to_close() {
         // Given
         var now = Instant.now();
@@ -316,6 +380,10 @@ class CloseExpiredSubscriptionsUseCaseTest {
 
     private void givenExistingApplication(List<BaseApplicationEntity> applications) {
         applicationCrudService.initWith(applications);
+    }
+
+    private void givenExistingApiProducts(List<ApiProduct> apiProducts) {
+        apiProductCrudService.initWith(apiProducts);
     }
 
     private void givenExistingSubscriptions(List<SubscriptionEntity> subscriptions) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -37,6 +37,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.ApiModel;
@@ -904,6 +905,81 @@ public class ApiKeyServiceTest {
             apiKeyToCreate,
             apiId,
             io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API.name(),
+            applicationId
+        );
+
+        assertFalse(canCreate);
+    }
+
+    @Test
+    public void shouldRenew_without_triggering_notifier_for_api_product_subscription() throws TechnicalException {
+        ApiKey apiKey = new ApiKey();
+        apiKey.setId(API_KEY);
+        apiKey.setKey("123-456-789");
+        apiKey.setCreatedAt(new Date());
+        apiKey.setApplication(APPLICATION_ID);
+        apiKey.setSubscriptions(List.of(SUBSCRIPTION_ID));
+
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId(SUBSCRIPTION_ID);
+        subscription.setEndingAt(Date.from(new Date().toInstant().plus(1, ChronoUnit.DAYS)));
+        subscription.setPlan(PLAN_ID);
+        subscription.setApplication(APPLICATION_ID);
+        subscription.setApi("api-123");
+        subscription.setStatus(SubscriptionStatus.PAUSED);
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        subscription.setReferenceId("product-1");
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setId(APPLICATION_ID);
+        application.setApiKeyMode(ApiKeyMode.UNSPECIFIED);
+
+        PlanEntity plan = new PlanEntity();
+        plan.setSecurity(PlanSecurityType.API_KEY);
+
+        when(apiKeyGenerator.generate()).thenReturn(API_KEY);
+        when(subscriptionService.findById(subscription.getId())).thenReturn(subscription);
+        when(subscriptionService.findByIdIn(List.of(SUBSCRIPTION_ID))).thenReturn(Set.of(subscription));
+        when(apiKeyRepository.create(any())).thenAnswer(returnsFirstArg());
+        when(apiKeyRepository.findBySubscription(SUBSCRIPTION_ID)).thenReturn(Collections.singleton(apiKey));
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(plan);
+
+        apiKeyService.renew(GraviteeContext.getExecutionContext(), subscription);
+
+        verify(apiKeyRepository, times(1)).create(any());
+        verify(notifierService, never()).trigger(eq(GraviteeContext.getExecutionContext()), eq(ApiHook.APIKEY_RENEWED), any(), any());
+    }
+
+    @Test
+    public void canCreate_should_return_false_when_key_exists_for_same_api_product() throws Exception {
+        String apiKeyToCreate = "apikey-i-want-to-create";
+        String apiProductId = "product-1";
+        String applicationId = "my-application-id";
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setId(applicationId);
+
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("subscription-1");
+        subscriptionEntity.setApplication(applicationId);
+        subscriptionEntity.setReferenceId(apiProductId);
+        subscriptionEntity.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setSubscriptions(List.of("subscription-1"));
+        existingApiKey.setApplication(applicationId);
+        existingApiKey.setKey(apiKeyToCreate);
+
+        when(apiKeyRepository.findByKeyAndEnvironmentId(apiKeyToCreate, ENVIRONMENT_ID)).thenReturn(List.of(existingApiKey));
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(applicationId))).thenReturn(application);
+        when(subscriptionService.findByIdIn(List.of("subscription-1"))).thenReturn(Set.of(subscriptionEntity));
+
+        boolean canCreate = apiKeyService.canCreate(
+            GraviteeContext.getExecutionContext(),
+            apiKeyToCreate,
+            apiProductId,
+            SubscriptionReferenceType.API_PRODUCT.name(),
             applicationId
         );
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13004

## Description

## Code Changes

| Area | File | Problem | Fix |
|------|------|---------|-----|
| Accept | `GenerateApiKeyDomainService` | `isKeyExistFor` used `findByKeyAndApiId(subscription.getApiId())` which is null for API Products | Use `referenceId`/`referenceType` and `findByKeyAndReferenceIdAndReferenceType` for API Products |
| Accept | `ApiKeyServiceImpl` | Renew triggered `APIKEY_RENEWED` via `apiTemplateService.findByIdForTemplates(subscription.getApi())` which fails for API Products | Skip notification for API Product subscriptions |
| Accept | `ApiKeyServiceImpl` | `canCreate` did not handle API Product reference type | Add handling for API Product subscriptions |
| Close expired | `CloseExpiredSubscriptionsUseCase` | Environment resolved via `apis.get(subscription.getApiId())` which is null for API Products | Add `getEnvironment(subscription)` that uses `ApiProductCrudService` or `ApiCrudService` based on `referenceType` |
| Close expired | `CloseExpiredSubscriptionsUseCase` | Used `ApiQueryService` for API lookup | Replace with `ApiCrudService` + `ApiProductCrudService` |

